### PR TITLE
ci: Add linting workflow for PR title

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -36,7 +36,7 @@ jobs:
             deps
           requireScope: false
           # Ensure subject is not empty And starts with an uppercase letter
-          subjectPattern: ^[A-Z]+$
+          subjectPattern: ^[A-Z].*$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" does not match the configured pattern.
             Please ensure your PR title follows the conventional commit format, with the subject beginning with an uppercase

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Validate PR Title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.ANACONDA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             feat

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
+permissions:
+  pull-requests: read
+
 jobs:
   validate-pr-title:
     name: Validate PR Title
@@ -19,8 +22,8 @@ jobs:
 
       - name: Validate PR Title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             feat

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Validate PR Title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ANACONDA_BOT_TOKEN }}
         with:
           types: |
             feat

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -1,0 +1,45 @@
+name: Validate PR title
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, edited, reopened]
+
+# Allow each opened PRs to validate titles concurrently
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate PR Title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        # env:
+        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            refac
+            docs
+            test
+            build
+            ci
+          scopes: |
+            foobar # First scope is not working, dummy value
+            deps
+          requireScope: false
+          # Ensure subject is not empty And starts with an uppercase letter
+          subjectPattern: ^[A-Z]+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" does not match the configured pattern.
+            Please ensure your PR title follows the conventional commit format, with the subject beginning with an uppercase
+            letter.
+          ignoreLabels: |
+            ignore-semantic-pull-request

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -9,9 +9,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
-permissions:
-  pull-requests: read
-
 jobs:
   validate-pr-title:
     name: Validate PR Title


### PR DESCRIPTION
## Summary

Here, we add a GitHub Actions workflow to enforce PR title format. The format is based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), with some customizations. Specifically, we:

* Use `refac:` instead of `refactor:`
* Use an uppercase first letter for the subject

This is to enable future niceties around the display of an automatically-generated CHANGELOG.

The full list of allowable types and scopes can be found within the workflow itself.

Jira: [CLI-339](https://anaconda.atlassian.net/browse/CLI-339)

[CLI-339]: https://anaconda.atlassian.net/browse/CLI-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ