### PR TITLE
chore(deps): Add Renovate configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,12 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-json
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: end-of-file-fixer
+      - id: pretty-format-json
+        args: [--autofix]
       - id: trailing-whitespace
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.16.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>anaconda/renovate-config"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a basic Renovate configuration file, inheriting from [`anaconda/renovate-config`](https://github.com/anaconda/renovate-config).

This was re-created from #1, which was closed because of the `main` branch history rewrite.