### PR TITLE
chore: Add templates for pull requests and releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+## Summary
+
+<!--Link the Jira ticket number below, or delete it if there's none.-->
+Jira: CLI-XXXX

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,3 +22,6 @@ changelog:
     - title: Other Changes
       labels:
         - '*'
+  exclude:
+    labels:
+      - ignore-for-release

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - feat
+    - title: Bug Fixes
+      labels:
+        - fix
+    - title: Documentation
+      labels:
+        - docs
+    - title: Maintenance
+      labels:
+        - chore
+        - refac
+        - ci
+        - build
+        - test
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - name: Apply conventional commit labels
         uses: bcoe/conventional-release-labels@v1
+        with:
+          ignored_types: "['build']"

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,3 +1,5 @@
+# Automatically applies labels to PRs based on conventional commit prefixes in the title.
+# Labels are used by release.yml to categorize changes in auto-generated release notes.
 name: Auto-label PR
 
 on:
@@ -13,7 +15,46 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Apply conventional commit labels
-        uses: bcoe/conventional-release-labels@v1
+      - name: Apply conventional commit label
+        uses: actions/github-script@v7
         with:
-          ignored_types: '["build"]'
+          script: |
+            const title = context.payload.pull_request.title;
+
+            // Extract type from conventional commit format: type(scope): description
+            const match = title.match(/^([a-z]+)(\((.*)\))?:/);
+            if (!match) {
+              console.log('No conventional commit type found in title');
+              return;
+            }
+
+            const type = match[1];
+            console.log(`Found conventional commit type: ${type}`)
+
+            // Map prefix to label (use same name if not specified)
+            const labelMap = {
+              'refac': 'refactor',
+              'feat': 'feature',
+            };
+
+            // Types to ignore (won't get a label)
+            const ignoredTypes = ['build'];
+
+            if (ignoredTypes.includes(type)) {
+              console.log(`Type "${type}" is ignored`);
+              return;
+            }
+
+            const label = labelMap[type] || type;
+
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [label]
+              });
+              console.log(`Applied label: ${label}`);
+            } catch (error) {
+              console.log(`Failed to apply label "${label}": ${error.message}`);
+            }

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,0 +1,17 @@
+name: Auto-label PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply conventional commit labels
+        uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -7,7 +7,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -32,7 +32,7 @@ jobs:
             const type = match[1];
             console.log(`Found conventional commit type: ${type}`)
 
-            // Types to ignore (won't get a label)
+            // Types to ignore (will get a special label)
             const ignoredTypes = ['build'];
 
             // Construct the label based on whether type is ignored or not.

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -35,18 +35,10 @@ jobs:
             // Types to ignore (won't get a label)
             const ignoredTypes = ['build'];
 
-            if (ignoredTypes.includes(type)) {
-              console.log(`Type "${type}" is ignored`);
-              return;
-            }
-
-            // Map prefix to label (use same name if not specified)
-            const labelMap = {
-              'refac': 'refactor',
-              'feat': 'feature',
-            };
-
-            const label = labelMap[type] || type;
+            // Construct the label based on whether type is ignored or not.
+            // If not ignored, the type is used as the label.
+            const isIgnored = ignoredTypes.includes(type);
+            const label = isIgnored ? "ignore-for-release" : type;
 
             try {
               await github.rest.issues.addLabels({

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -23,7 +23,8 @@ jobs:
             const title = context.payload.pull_request.title;
 
             // Extract type from conventional commit format: type(scope): description
-            const match = title.match(/^([a-z]+)(\((.*)\))?:/);
+            // The scope part '(scope)' is optional, but the colon is not.
+            const match = title.match(/^([a-z]+)(\(.*\))?:/);
             if (!match) {
               console.log('No conventional commit type found in title');
               return;

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: Apply conventional commit labels
         uses: bcoe/conventional-release-labels@v1
         with:
-          ignored_types: "['build']"
+          ignored_types: '["build"]'

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -32,12 +32,6 @@ jobs:
             const type = match[1];
             console.log(`Found conventional commit type: ${type}`)
 
-            // Map prefix to label (use same name if not specified)
-            const labelMap = {
-              'refac': 'refactor',
-              'feat': 'feature',
-            };
-
             // Types to ignore (won't get a label)
             const ignoredTypes = ['build'];
 
@@ -45,6 +39,12 @@ jobs:
               console.log(`Type "${type}" is ignored`);
               return;
             }
+
+            // Map prefix to label (use same name if not specified)
+            const labelMap = {
+              'refac': 'refactor',
+              'feat': 'feature',
+            };
 
             const label = labelMap[type] || type;
 


### PR DESCRIPTION
## Summary

We add two new templates: 

* Pull request template
* GitHub release template (for generating the changelog)

Additionally, since the GitHub changelog template requires labels, we add a new workflow that applies the PR title conventional commit type as a label for each PR.

Jira: [CLI-341](https://anaconda.atlassian.net/browse/CLI-341)

[CLI-341]: https://anaconda.atlassian.net/browse/CLI-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ