### PR TITLE
chore: Ignore Renovate bot from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -25,3 +25,5 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+    authors:
+      - anaconda-renovate[bot]


### PR DESCRIPTION
## Summary

Ignore the `anaconda-renovate[bot]` user when generating automated release notes.
