### PR TITLE
feat: Update Renovate config to support pixi-version in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -36,7 +36,6 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
-          # TODO: Track with Renovate?
           pixi-version: v0.39.5
 
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "commitMessageLowerCase": "never",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "prefix-dev/pixi",
+      "description": "Upgrade pixi version in a GitHub workflow",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "pixi-version:\\s*(?<currentValue>v[\\d.]+)"
+      ]
+    }
+  ],
   "extends": [
     "local>anaconda/renovate-config"
   ]


### PR DESCRIPTION
## Summary

Updates the Renovate configuration to track the releases at `prefix-dev/pixi` when specifying the version of `pixi` to use in the GitHub Actions workflow(s).

This allows us to explicitly pin the version, with updates guarded by CI, but tracking the upstream changes.