### PR TITLE
fix: Don't overwrite manually-edited release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          generate_release_notes: true
+          generate_release_notes: ${{ github.event_name == 'push' }}
           files: release-assets/*
           append_body: ${{ github.event_name == 'push' }}
           body: |


### PR DESCRIPTION
## Summary

The `release.yaml` workflow runs both on `release` as well as `push` to `main` branch trigger.

When a release is manually created (`release` event), we don't want the workflow that adds the artifacts to overwrite the release notes again. This fixes that.