### PR TITLE
feat: Add ability to self-update in place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "ana"
 version = "0.0.0"
 dependencies = [
+ "indicatif",
  "indoc",
  "reqwest",
  "self-replace",
@@ -73,6 +74,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +96,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -457,6 +477,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +612,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1138,6 +1183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1384,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,1674 @@ version = 4
 [[package]]
 name = "ana"
 version = "0.0.0"
+dependencies = [
+ "reqwest",
+ "self-replace",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "ana"
 version = "0.0.0"
 dependencies = [
+ "indoc",
  "reqwest",
  "self-replace",
  "semver",
@@ -453,6 +454,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.0.0" # Placeholder - actual version derived from git tags via build
 edition = "2024"
 
 [dependencies]
+reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
+self-replace = "1.5"
+semver = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # Placeholder - actual version derived from git tags via build
 edition = "2024"
 
 [dependencies]
+indoc = "2"
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 self-replace = "1.5"
 semver = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # Placeholder - actual version derived from git tags via build
 edition = "2024"
 
 [dependencies]
+indicatif = "0.17"
 indoc = "2"
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 self-replace = "1.5"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    // Re-run build.rs if PKG_VERSION changes
+    println!("cargo:rerun-if-env-changed=PKG_VERSION");
+
     // Version is passed via PKG_VERSION environment variable.
     // This should be set by CI or locally via: PKG_VERSION=$(python scripts/get_version.py)
     // Falls back to CARGO_PKG_VERSION if not set.

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,21 +66,21 @@ fn run_self_update(force: bool) {
     };
 
     match check {
-        update::UpdateCheck::Available { from, release } => {
+        update::UpdateCheck::Available(release) => {
             if !force {
-                let message = format!("Update {} -> {}?", from, release.tag_name);
+                let message = format!("Update {} -> {}?", VERSION, release.tag_name);
                 if !prompt_yes_no(&message) {
                     println!("Update cancelled.");
                     return;
                 }
             }
             match update::apply_update(&release) {
-                Ok(()) => println!("Updated successfully: {} -> {}", from, release.tag_name),
+                Ok(()) => println!("Updated successfully: {} -> {}", VERSION, release.tag_name),
                 Err(e) => eprintln!("Failed to update: {}", e),
             }
         }
-        update::UpdateCheck::AlreadyUpToDate(v) => {
-            println!("Already up to date ({})", v);
+        update::UpdateCheck::AlreadyUpToDate => {
+            println!("Already up to date ({})", VERSION);
         }
         update::UpdateCheck::NoReleases => {
             println!("No releases available.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn parse_args(args: &[String]) -> Result<Command, String> {
             }
             match args[2].as_str() {
                 "update" => {
-                    if args.iter().any(|a| a == "--show-available") {
+                    if args.iter().any(|a| a == "--list") {
                         Ok(Command::SelfShowAvailable)
                     } else if args.iter().any(|a| a == "--check") {
                         Ok(Command::SelfUpdateCheck)
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_self_update_show_available() {
         assert!(matches!(
-            parse_args(&args(&["ana", "self", "update", "--show-available"])),
+            parse_args(&args(&["ana", "self", "update", "--list"])),
             Ok(Command::SelfShowAvailable)
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod update;
 
 use indoc::formatdoc;
+use std::io::{self, Write};
 
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
@@ -43,19 +44,46 @@ fn print_version() {
     println!("{}", VERSION);
 }
 
-fn run_self_update() {
-    match update::perform_update(VERSION) {
-        Ok(update::UpdateResult::Updated { from, to }) => {
-            println!("Updated successfully: {} -> {}", from, to);
+fn prompt_yes_no(message: &str) -> bool {
+    print!("{} [y/N] ", message);
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+fn run_self_update(force: bool) {
+    let check = match update::check_update(VERSION) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to check for updates: {}", e);
+            return;
         }
-        Ok(update::UpdateResult::AlreadyUpToDate(v)) => {
+    };
+
+    match check {
+        update::UpdateCheck::Available { from, release } => {
+            if !force {
+                let message = format!("Update {} -> {}?", from, release.tag_name);
+                if !prompt_yes_no(&message) {
+                    println!("Update cancelled.");
+                    return;
+                }
+            }
+            match update::apply_update(&release) {
+                Ok(()) => println!("Updated successfully: {} -> {}", from, release.tag_name),
+                Err(e) => eprintln!("Failed to update: {}", e),
+            }
+        }
+        update::UpdateCheck::AlreadyUpToDate(v) => {
             println!("Already up to date ({})", v);
         }
-        Ok(update::UpdateResult::NoReleases) => {
+        update::UpdateCheck::NoReleases => {
             println!("No releases available.");
-        }
-        Err(e) => {
-            eprintln!("Failed to update: {}", e);
         }
     }
 }
@@ -90,7 +118,7 @@ enum Command {
     Help,
     SelfHelp,
     Version,
-    SelfUpdate,
+    SelfUpdate { force: bool },
     SelfUpdateCheck,
     SelfShowAvailable,
 }
@@ -119,7 +147,8 @@ fn parse_args(args: &[String]) -> Result<Command, String> {
                     } else if args.iter().any(|a| a == "--check") {
                         Ok(Command::SelfUpdateCheck)
                     } else {
-                        Ok(Command::SelfUpdate)
+                        let force = args.iter().any(|a| a == "--yes" || a == "-y");
+                        Ok(Command::SelfUpdate { force })
                     }
                 }
                 cmd => Err(format!("Unknown self command: {}", cmd)),
@@ -134,7 +163,7 @@ fn run(args: &[String]) -> Result<(), String> {
         Command::Help => print_usage(),
         Command::SelfHelp => print_self_usage(),
         Command::Version => print_version(),
-        Command::SelfUpdate => run_self_update(),
+        Command::SelfUpdate { force } => run_self_update(force),
         Command::SelfUpdateCheck => update::check_for_update(VERSION),
         Command::SelfShowAvailable => show_available_versions(),
     }
@@ -212,7 +241,23 @@ mod tests {
     fn test_self_update() {
         assert!(matches!(
             parse_args(&args(&["ana", "self", "update"])),
-            Ok(Command::SelfUpdate)
+            Ok(Command::SelfUpdate { force: false })
+        ));
+    }
+
+    #[test]
+    fn test_self_update_yes() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self", "update", "--yes"])),
+            Ok(Command::SelfUpdate { force: true })
+        ));
+    }
+
+    #[test]
+    fn test_self_update_yes_short() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self", "update", "-y"])),
+            Ok(Command::SelfUpdate { force: true })
         ));
     }
 
@@ -243,6 +288,10 @@ mod tests {
     fn test_unknown_self_command() {
         let result = parse_args(&args(&["ana", "self", "unknown"]));
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Unknown self command: unknown"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unknown self command: unknown")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ enum Command {
     SelfHelp,
     Version,
     SelfUpdate,
+    SelfUpdateCheck,
     SelfShowAvailable,
 }
 
@@ -115,6 +116,8 @@ fn parse_args(args: &[String]) -> Result<Command, String> {
                 "update" => {
                     if args.iter().any(|a| a == "--show-available") {
                         Ok(Command::SelfShowAvailable)
+                    } else if args.iter().any(|a| a == "--check") {
+                        Ok(Command::SelfUpdateCheck)
                     } else {
                         Ok(Command::SelfUpdate)
                     }
@@ -132,6 +135,7 @@ fn run(args: &[String]) -> Result<(), String> {
         Command::SelfHelp => print_self_usage(),
         Command::Version => print_version(),
         Command::SelfUpdate => run_self_update(),
+        Command::SelfUpdateCheck => update::check_for_update(VERSION),
         Command::SelfShowAvailable => show_available_versions(),
     }
     Ok(())
@@ -224,6 +228,14 @@ mod tests {
         assert!(matches!(
             parse_args(&args(&["ana", "self", "update", "--show-available"])),
             Ok(Command::SelfShowAvailable)
+        ));
+    }
+
+    #[test]
+    fn test_self_update_check() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self", "update", "--check"])),
+            Ok(Command::SelfUpdateCheck)
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod update;
+
 use indoc::formatdoc;
 
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
@@ -46,7 +48,34 @@ fn run_self_update() {
 }
 
 fn show_available_versions() {
-    print!("Available versions here!")
+    let releases = match update::fetch_releases() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to fetch releases: {}", e);
+            return;
+        }
+    };
+
+    let mut releases: Vec<_> = releases
+        .into_iter()
+        .filter(|r| update::parse_version(&r.tag_name).is_ok())
+        .collect();
+
+    releases.sort_by(|a, b| {
+        let va = update::parse_version(&a.tag_name).unwrap();
+        let vb = update::parse_version(&b.tag_name).unwrap();
+        vb.cmp(&va)
+    });
+
+    let current_tag = format!("v{}", VERSION);
+    for release in releases {
+        let marker = if release.tag_name == current_tag {
+            " *"
+        } else {
+            ""
+        };
+        println!("{}{}", release.tag_name, marker);
+    }
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,69 +1,100 @@
+use indoc::formatdoc;
+
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
 
+fn usage() -> String {
+    formatdoc! {"
+        {APPLICATION} {VERSION}
+
+        Usage: {APPLICATION} [command] [options]
+
+        Commands:
+          self           Manage the {APPLICATION} installation
+
+        Options:
+          -V, --version  Print version
+          -h, --help     Print help"
+    }
+}
+
+fn self_usage() -> String {
+    formatdoc! {"
+        Manage the installation
+
+        Usage: {APPLICATION} self <command> [options]
+
+        Commands:
+          update    Update {APPLICATION} to the latest version"
+    }
+}
+
 fn print_usage() {
-    println!("{} {}", APPLICATION, VERSION);
-    println!();
-    println!("Usage: {} [command] [options]", APPLICATION);
-    println!();
-    println!("Commands:");
-    println!("  self           Manage the ana installation");
-    println!();
-    println!("Options:");
-    println!("  -V, --version  Print version");
-    println!("  -h, --help     Print help");
+    println!("{}", usage());
 }
 
 fn print_self_usage() {
-    println!("Manage the ana installation");
-    println!();
-    println!("Usage: {} self <command> [options]", APPLICATION);
-    println!();
-    println!("Commands:");
-    println!("  update    Update ana to the latest version");
+    println!("{}", self_usage());
+}
+
+fn print_version() {
+    println!("{}", VERSION);
 }
 
 fn run_self_update() {
     print!("Running the update!")
 }
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
+#[derive(Debug)]
+enum Command {
+    Help,
+    SelfHelp,
+    Version,
+    SelfUpdate,
+}
 
+fn parse_args(args: &[String]) -> Result<Command, String> {
     // Display help
     if args.len() <= 1 || args.iter().any(|a| a == "--help" || a == "-h") {
-        print_usage();
-        return;
+        return Ok(Command::Help);
     }
 
     // Display version
     if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!("{}", VERSION);
-        return;
+        return Ok(Command::Version);
     }
 
     // Handle subcommands
     match args[1].as_str() {
         "self" => {
             if args.len() < 3 {
-                print_self_usage();
-                return;
+                return Ok(Command::SelfHelp);
             }
             match args[2].as_str() {
-                "update" => {
-                    run_self_update();
-                    return;
-                }
-                cmd => {
-                    eprintln!("Unknown self command: {}", cmd);
-                    std::process::exit(1);
-                }
+                "update" => Ok(Command::SelfUpdate),
+                cmd => Err(format!("Unknown self command: {}", cmd)),
             }
         }
-        cmd => {
-            eprintln!("Unknown command: {}", cmd);
-            std::process::exit(1);
-        }
+        cmd => Err(format!("Unknown command: {}", cmd)),
+    }
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    match parse_args(args)? {
+        Command::Help => print_usage(),
+        Command::SelfHelp => print_self_usage(),
+        Command::Version => print_version(),
+        Command::SelfUpdate => run_self_update(),
+    }
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if let Err(msg) = run(&args) {
+        eprintln!("{}", msg);
+        std::process::exit(1);
     }
 }
 
@@ -71,8 +102,72 @@ fn main() {
 mod tests {
     use super::*;
 
+    fn args(input: &[&str]) -> Vec<String> {
+        input.iter().map(|s| s.to_string()).collect()
+    }
+
     #[test]
     fn test_version_is_set() {
         assert!(!VERSION.is_empty());
+    }
+
+    #[test]
+    fn test_no_args_parses_to_help() {
+        assert!(matches!(parse_args(&args(&["ana"])), Ok(Command::Help)));
+    }
+
+    #[test]
+    fn test_help_flag() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "--help"])),
+            Ok(Command::Help)
+        ));
+    }
+
+    #[test]
+    fn test_help_flag_short() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "-h"])),
+            Ok(Command::Help)
+        ));
+    }
+
+    #[test]
+    fn test_version_flag() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "--version"])),
+            Ok(Command::Version)
+        ));
+    }
+
+    #[test]
+    fn test_version_flag_short() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "-V"])),
+            Ok(Command::Version)
+        ));
+    }
+
+    #[test]
+    fn test_self_no_subcommand() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self"])),
+            Ok(Command::SelfHelp)
+        ));
+    }
+
+    #[test]
+    fn test_self_update() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self", "update"])),
+            Ok(Command::SelfUpdate)
+        ));
+    }
+
+    #[test]
+    fn test_unknown_command() {
+        let result = parse_args(&args(&["ana", "foo"]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown command: foo"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,10 +56,17 @@ fn show_available_versions() {
         }
     };
 
+    let include_prereleases = update::include_prereleases();
     let mut releases: Vec<_> = releases
         .into_iter()
         .filter(|r| update::parse_version(&r.tag_name).is_ok())
+        .filter(|r| include_prereleases || !r.prerelease)
         .collect();
+
+    if releases.is_empty() {
+        println!("No releases available.");
+        return;
+    }
 
     releases.sort_by(|a, b| {
         let va = update::parse_version(&a.tag_name).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,53 @@ fn print_version() {
 }
 
 fn run_self_update() {
-    print!("Running the update!")
+    let releases = match update::fetch_available_releases() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to fetch releases: {}", e);
+            return;
+        }
+    };
+
+    let latest = match releases.first() {
+        Some(r) => r,
+        None => {
+            println!("No releases available.");
+            return;
+        }
+    };
+
+    let current = match update::parse_version(VERSION) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to parse current version: {}", e);
+            return;
+        }
+    };
+
+    let latest_version = match update::parse_version(&latest.tag_name) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to parse latest version: {}", e);
+            return;
+        }
+    };
+
+    if latest_version <= current {
+        println!("Already up to date ({})", VERSION);
+        return;
+    }
+
+    let download_url = match update::get_download_url(latest) {
+        Ok(url) => url,
+        Err(e) => {
+            eprintln!("Failed to get download URL: {}", e);
+            return;
+        }
+    };
+
+    println!("Update available: {} -> {}", VERSION, latest.tag_name);
+    println!("Download URL: {}", download_url);
 }
 
 fn show_available_versions() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,57 +44,19 @@ fn print_version() {
 }
 
 fn run_self_update() {
-    let releases = match update::fetch_available_releases() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Failed to fetch releases: {}", e);
-            return;
+    match update::perform_update(VERSION) {
+        Ok(update::UpdateResult::Updated { from, to }) => {
+            println!("Updated successfully: {} -> {}", from, to);
         }
-    };
-
-    let latest = match releases.first() {
-        Some(r) => r,
-        None => {
+        Ok(update::UpdateResult::AlreadyUpToDate(v)) => {
+            println!("Already up to date ({})", v);
+        }
+        Ok(update::UpdateResult::NoReleases) => {
             println!("No releases available.");
-            return;
         }
-    };
-
-    let current = match update::parse_version(VERSION) {
-        Ok(v) => v,
         Err(e) => {
-            eprintln!("Failed to parse current version: {}", e);
-            return;
+            eprintln!("Failed to update: {}", e);
         }
-    };
-
-    let latest_version = match update::parse_version(&latest.tag_name) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Failed to parse latest version: {}", e);
-            return;
-        }
-    };
-
-    if latest_version <= current {
-        println!("Already up to date ({})", VERSION);
-        return;
-    }
-
-    let asset = match update::get_asset_for_platform(latest) {
-        Ok(a) => a,
-        Err(e) => {
-            eprintln!("Failed to find asset: {}", e);
-            return;
-        }
-    };
-
-    println!("Update available: {} -> {}", VERSION, latest.tag_name);
-    println!("Downloading {}...", asset.name);
-
-    match update::download_and_replace(asset) {
-        Ok(()) => println!("Updated successfully!"),
-        Err(e) => eprintln!("Failed to update: {}", e),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,4 +276,11 @@ mod tests {
             Ok(Command::SelfUpdateCheck)
         ));
     }
+
+    #[test]
+    fn test_unknown_self_command() {
+        let result = parse_args(&args(&["ana", "self", "unknown"]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown self command: unknown"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,34 @@
+const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
 
 fn greeting() -> &'static str {
     "Hello, world!"
+}
+
+fn print_usage() {
+    println!("{} {}", APPLICATION, VERSION);
+    println!();
+    println!("Usage: {} [command] [options]", APPLICATION);
+    println!();
+    println!("Commands:");
+    println!("  self           Manage the ana installation");
+    println!();
+    println!("Options:");
+    println!("  -V, --version  Print version");
+    println!("  -h, --help     Print help");
+}
+
+fn print_self_usage() {
+    println!("Manage the ana installation");
+    println!();
+    println!("Usage: {} self <command> [options]", APPLICATION);
+    println!();
+    println!("Commands:");
+    println!("  update    Update ana to the latest version");
+}
+
+fn run_self_update() {
+    print!("Running the update!")
 }
 
 fn main() {
@@ -10,6 +37,36 @@ fn main() {
     if args.iter().any(|a| a == "--version" || a == "-V") {
         println!("{}", VERSION);
         return;
+    }
+
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_usage();
+        return;
+    }
+
+    if args.len() > 1 {
+        match args[1].as_str() {
+            "self" => {
+                if args.len() < 3 {
+                    print_self_usage();
+                    return;
+                }
+                match args[2].as_str() {
+                    "update" => {
+                        run_self_update();
+                        return;
+                    }
+                    cmd => {
+                        eprintln!("Unknown self command: {}", cmd);
+                        std::process::exit(1);
+                    }
+                }
+            }
+            cmd => {
+                eprintln!("Unknown command: {}", cmd);
+                std::process::exit(1);
+            }
+        }
     }
 
     println!("{}", greeting());

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,12 +45,17 @@ fn run_self_update() {
     print!("Running the update!")
 }
 
+fn show_available_versions() {
+    print!("Available versions here!")
+}
+
 #[derive(Debug)]
 enum Command {
     Help,
     SelfHelp,
     Version,
     SelfUpdate,
+    SelfShowAvailable,
 }
 
 fn parse_args(args: &[String]) -> Result<Command, String> {
@@ -71,7 +76,13 @@ fn parse_args(args: &[String]) -> Result<Command, String> {
                 return Ok(Command::SelfHelp);
             }
             match args[2].as_str() {
-                "update" => Ok(Command::SelfUpdate),
+                "update" => {
+                    if args.iter().any(|a| a == "--show-available") {
+                        Ok(Command::SelfShowAvailable)
+                    } else {
+                        Ok(Command::SelfUpdate)
+                    }
+                }
                 cmd => Err(format!("Unknown self command: {}", cmd)),
             }
         }
@@ -85,6 +96,7 @@ fn run(args: &[String]) -> Result<(), String> {
         Command::SelfHelp => print_self_usage(),
         Command::Version => print_version(),
         Command::SelfUpdate => run_self_update(),
+        Command::SelfShowAvailable => show_available_versions(),
     }
     Ok(())
 }
@@ -169,5 +181,13 @@ mod tests {
         let result = parse_args(&args(&["ana", "foo"]));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown command: foo"));
+    }
+
+    #[test]
+    fn test_self_update_show_available() {
+        assert!(matches!(
+            parse_args(&args(&["ana", "self", "update", "--show-available"])),
+            Ok(Command::SelfShowAvailable)
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn run_self_update() {
 }
 
 fn show_available_versions() {
-    let releases = match update::fetch_releases() {
+    let releases = match update::fetch_available_releases() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to fetch releases: {}", e);
@@ -56,23 +56,10 @@ fn show_available_versions() {
         }
     };
 
-    let include_prereleases = update::include_prereleases();
-    let mut releases: Vec<_> = releases
-        .into_iter()
-        .filter(|r| update::parse_version(&r.tag_name).is_ok())
-        .filter(|r| include_prereleases || !r.prerelease)
-        .collect();
-
     if releases.is_empty() {
         println!("No releases available.");
         return;
     }
-
-    releases.sort_by(|a, b| {
-        let va = update::parse_version(&a.tag_name).unwrap();
-        let vb = update::parse_version(&b.tag_name).unwrap();
-        vb.cmp(&va)
-    });
 
     let current_tag = format!("v{}", VERSION);
     for release in releases {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
 
-fn greeting() -> &'static str {
-    "Hello, world!"
-}
-
 fn print_usage() {
     println!("{} {}", APPLICATION, VERSION);
     println!();
@@ -34,52 +30,46 @@ fn run_self_update() {
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
+    // Display help
+    if args.len() <= 1 || args.iter().any(|a| a == "--help" || a == "-h") {
+        print_usage();
+        return;
+    }
+
+    // Display version
     if args.iter().any(|a| a == "--version" || a == "-V") {
         println!("{}", VERSION);
         return;
     }
 
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        print_usage();
-        return;
-    }
-
-    if args.len() > 1 {
-        match args[1].as_str() {
-            "self" => {
-                if args.len() < 3 {
-                    print_self_usage();
+    // Handle subcommands
+    match args[1].as_str() {
+        "self" => {
+            if args.len() < 3 {
+                print_self_usage();
+                return;
+            }
+            match args[2].as_str() {
+                "update" => {
+                    run_self_update();
                     return;
                 }
-                match args[2].as_str() {
-                    "update" => {
-                        run_self_update();
-                        return;
-                    }
-                    cmd => {
-                        eprintln!("Unknown self command: {}", cmd);
-                        std::process::exit(1);
-                    }
+                cmd => {
+                    eprintln!("Unknown self command: {}", cmd);
+                    std::process::exit(1);
                 }
             }
-            cmd => {
-                eprintln!("Unknown command: {}", cmd);
-                std::process::exit(1);
-            }
+        }
+        cmd => {
+            eprintln!("Unknown command: {}", cmd);
+            std::process::exit(1);
         }
     }
-
-    println!("{}", greeting());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_greeting() {
-        assert_eq!(greeting(), "Hello, world!");
-    }
 
     #[test]
     fn test_version_is_set() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,16 +81,21 @@ fn run_self_update() {
         return;
     }
 
-    let download_url = match update::get_download_url(latest) {
-        Ok(url) => url,
+    let asset = match update::get_asset_for_platform(latest) {
+        Ok(a) => a,
         Err(e) => {
-            eprintln!("Failed to get download URL: {}", e);
+            eprintln!("Failed to find asset: {}", e);
             return;
         }
     };
 
     println!("Update available: {} -> {}", VERSION, latest.tag_name);
-    println!("Download URL: {}", download_url);
+    println!("Downloading {}...", asset.name);
+
+    match update::download_asset(asset) {
+        Ok(path) => println!("Downloaded to: {}", path.display()),
+        Err(e) => eprintln!("Failed to download: {}", e),
+    }
 }
 
 fn show_available_versions() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,9 @@ fn run_self_update() {
     println!("Update available: {} -> {}", VERSION, latest.tag_name);
     println!("Downloading {}...", asset.name);
 
-    match update::download_asset(asset) {
-        Ok(path) => println!("Downloaded to: {}", path.display()),
-        Err(e) => eprintln!("Failed to download: {}", e),
+    match update::download_and_replace(asset) {
+        Ok(()) => println!("Updated successfully!"),
+        Err(e) => eprintln!("Failed to update: {}", e),
     }
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -64,13 +64,13 @@ impl From<reqwest::Error> for Error {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Asset {
     pub name: String,
     pub url: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Release {
     pub tag_name: String,
     pub prerelease: bool,
@@ -190,13 +190,13 @@ pub fn fetch_available_releases() -> Result<Vec<Release>, Error> {
     Ok(releases)
 }
 
-enum UpdateStatus {
-    UpdateAvailable(String),
-    UpToDate,
+pub enum UpdateCheck {
+    Available { from: String, release: Release },
+    AlreadyUpToDate(String),
     NoReleases,
 }
 
-fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateStatus, Error> {
+fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateCheck, Error> {
     let current = parse_version(current_version)?;
 
     let latest = releases
@@ -210,67 +210,42 @@ fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateSt
 
     let latest = match latest {
         Some(r) => r,
-        None => return Ok(UpdateStatus::NoReleases),
+        None => return Ok(UpdateCheck::NoReleases),
     };
 
     let latest_version = parse_version(&latest.tag_name).unwrap();
 
     if latest_version > current {
-        Ok(UpdateStatus::UpdateAvailable(latest.tag_name))
+        Ok(UpdateCheck::Available {
+            from: current_version.to_string(),
+            release: latest,
+        })
     } else {
-        Ok(UpdateStatus::UpToDate)
+        Ok(UpdateCheck::AlreadyUpToDate(current_version.to_string()))
     }
 }
 
-pub enum UpdateResult {
-    Updated { from: String, to: String },
-    AlreadyUpToDate(String),
-    NoReleases,
-}
-
-pub fn perform_update(current_version_str: &str) -> Result<UpdateResult, Error> {
+pub fn check_update(current_version: &str) -> Result<UpdateCheck, Error> {
     let releases = fetch_available_releases()?;
+    find_update(releases, current_version)
+}
 
-    // TODO: Add feature for `ana self update <explcit-version>`
-    let latest_release = match releases.first() {
-        Some(r) => r,
-        None => return Ok(UpdateResult::NoReleases),
-    };
-
-    let current_version = parse_version(current_version_str)?;
-    let latest_version = parse_version(&latest_release.tag_name)?;
-
-    if latest_version <= current_version {
-        return Ok(UpdateResult::AlreadyUpToDate(current_version.to_string()));
-    }
-
-    let asset = get_asset_for_platform(latest_release)?;
+pub fn apply_update(release: &Release) -> Result<(), Error> {
+    let asset = get_asset_for_platform(release)?;
     println!("Downloading {} ({})", asset.name, asset.url);
     download_and_replace(asset)?;
-
-    Ok(UpdateResult::Updated {
-        from: current_version.to_string(),
-        to: latest_release.tag_name.clone(),
-    })
+    Ok(())
 }
 
 pub fn check_for_update(current_version: &str) {
-    let releases = match fetch_available_releases() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Failed to fetch releases: {}", e);
-            return;
+    match check_update(current_version) {
+        Ok(UpdateCheck::Available { from, release }) => {
+            println!("Update available: {} -> {}", from, release.tag_name);
         }
-    };
-
-    match find_update(releases, current_version) {
-        Ok(UpdateStatus::UpdateAvailable(tag)) => {
-            println!("Update available: {} -> {}", current_version, tag);
+        Ok(UpdateCheck::AlreadyUpToDate(v)) => {
+            println!("Already up to date ({})", v);
         }
-        Ok(UpdateStatus::UpToDate) => {
-            println!("Already up to date ({})", current_version);
-        }
-        Ok(UpdateStatus::NoReleases) => {
+        Ok(UpdateCheck::NoReleases) => {
             println!("No releases available.");
         }
         Err(e) => {
@@ -333,21 +308,21 @@ mod tests {
     fn test_find_update_available() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
+        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2"));
     }
 
     #[test]
     fn test_find_update_already_up_to_date() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
         let result = find_update(releases, "0.0.2").unwrap();
-        assert!(matches!(result, UpdateStatus::UpToDate));
+        assert!(matches!(result, UpdateCheck::AlreadyUpToDate(_)));
     }
 
     #[test]
     fn test_find_update_no_releases() {
         let releases = vec![];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateStatus::NoReleases));
+        assert!(matches!(result, UpdateCheck::NoReleases));
     }
 
     #[test]
@@ -359,7 +334,7 @@ mod tests {
             make_release("v0.0.2.dev1", true),
         ];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2.dev1"));
+        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2.dev1"));
     }
 
     #[test]
@@ -367,7 +342,7 @@ mod tests {
         // When prereleases are filtered out before calling find_update
         let releases = vec![make_release("v0.0.1", false)];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateStatus::UpToDate));
+        assert!(matches!(result, UpdateCheck::AlreadyUpToDate(_)));
     }
 
     #[test]
@@ -385,7 +360,7 @@ mod tests {
             make_release("v0.0.2", false),
         ];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
+        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2"));
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -325,4 +325,65 @@ mod tests {
         let result = find_update(releases, "0.0.1").unwrap();
         assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
     }
+
+    #[test]
+    fn test_get_asset_name_returns_platform_specific_name() {
+        // This test verifies get_asset_name returns a valid result on supported platforms
+        let result = get_asset_name();
+        // On CI/dev machines (macOS arm64, linux x86_64, windows x86_64), this should succeed
+        if result.is_ok() {
+            let name = result.unwrap();
+            assert!(
+                name == "ana-darwin-arm64"
+                    || name == "ana-linux-x86_64"
+                    || name == "ana-windows-x86_64.exe"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_asset_for_platform_finds_matching_asset() {
+        let release = Release {
+            tag_name: "v1.0.0".to_string(),
+            prerelease: false,
+            assets: vec![
+                Asset {
+                    name: "ana-darwin-arm64".to_string(),
+                    url: "https://example.com/darwin".to_string(),
+                },
+                Asset {
+                    name: "ana-linux-x86_64".to_string(),
+                    url: "https://example.com/linux".to_string(),
+                },
+                Asset {
+                    name: "ana-windows-x86_64.exe".to_string(),
+                    url: "https://example.com/windows".to_string(),
+                },
+            ],
+        };
+
+        let result = get_asset_for_platform(&release);
+        // On supported platforms, should find the matching asset
+        if let Ok(asset) = result {
+            assert!(release.assets.iter().any(|a| a.name == asset.name));
+        }
+    }
+
+    #[test]
+    fn test_get_asset_for_platform_returns_error_when_not_found() {
+        let release = Release {
+            tag_name: "v1.0.0".to_string(),
+            prerelease: false,
+            assets: vec![Asset {
+                name: "ana-unknown-platform".to_string(),
+                url: "https://example.com/unknown".to_string(),
+            }],
+        };
+
+        let result = get_asset_for_platform(&release);
+        // On supported platforms, should return AssetNotFound since our platform isn't in assets
+        if get_asset_name().is_ok() {
+            assert!(matches!(result, Err(Error::AssetNotFound(_))));
+        }
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -11,6 +11,22 @@ fn get_github_token() -> Result<String, Error> {
     }
 }
 
+fn github_client() -> Result<reqwest::blocking::Client, Error> {
+    let token = get_github_token()?;
+    reqwest::blocking::Client::builder()
+        .user_agent("ana-cli")
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", token).parse().unwrap(),
+            );
+            headers
+        })
+        .build()
+        .map_err(|e| Error::Http(e.to_string()))
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     Http(String),
@@ -95,14 +111,10 @@ pub fn get_asset_for_platform(release: &Release) -> Result<&Asset, Error> {
 }
 
 pub fn download_and_replace(asset: &Asset) -> Result<(), Error> {
-    let token = get_github_token()?;
-
-    let client = reqwest::blocking::Client::new();
+    let client = github_client()?;
     let response = client
         .get(&asset.url)
-        .header("User-Agent", "ana-cli")
         .header("Accept", "application/octet-stream")
-        .header("Authorization", format!("Bearer {}", token))
         .send()?
         .error_for_status()?;
 
@@ -131,14 +143,11 @@ pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {
 }
 
 fn fetch_releases() -> Result<Vec<Release>, Error> {
-    let token = get_github_token()?;
-    let client = reqwest::blocking::Client::new();
+    let client = github_client()?;
     let url = format!("https://api.github.com/repos/{}/releases", GITHUB_REPO);
     let releases: Vec<Release> = client
         .get(&url)
-        .header("User-Agent", "ana-cli")
         .header("Accept", "application/vnd.github+json")
-        .header("Authorization", format!("Bearer {}", token))
         .send()?
         .error_for_status()?
         .json()?;

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,15 +4,11 @@ use std::env;
 // We track the repo for releases
 const GITHUB_REPO: &str = "anaconda/ana-cli";
 
-fn get_github_token() -> Result<String, Error> {
-    match env::var("GITHUB_TOKEN") {
-        Ok(token) if !token.is_empty() => Ok(token),
-        _ => Err(Error::MissingToken),
-    }
-}
-
 fn github_client() -> Result<reqwest::blocking::Client, Error> {
-    let token = get_github_token()?;
+    let token = match env::var("GITHUB_TOKEN") {
+        Ok(token) if !token.is_empty() => token,
+        _ => return Err(Error::MissingToken),
+    };
     reqwest::blocking::Client::builder()
         .user_agent("ana-cli")
         .default_headers({

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,7 @@
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 use std::env;
+use std::io::{Read, Write};
 
 // We track the repo for releases
 const GITHUB_REPO: &str = "anaconda/ana-cli";
@@ -108,17 +110,40 @@ pub fn get_asset_for_platform(release: &Release) -> Result<&Asset, Error> {
 
 pub fn download_and_replace(asset: &Asset) -> Result<(), Error> {
     let client = github_client()?;
-    let response = client
+    let mut response = client
         .get(&asset.url)
         .header("Accept", "application/octet-stream")
         .send()?
         .error_for_status()?;
 
-    let bytes = response.bytes()?;
+    let total_size = response.content_length().unwrap_or(0);
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{bar:40.cyan/blue} {bytes}/{total_bytes} ({eta})")
+            .unwrap()
+            .progress_chars("=> "),
+    );
 
     let temp_dir = std::env::temp_dir();
     let temp_path = temp_dir.join(&asset.name);
-    std::fs::write(&temp_path, &bytes).map_err(|e| Error::Io(e.to_string()))?;
+    let mut file = std::fs::File::create(&temp_path).map_err(|e| Error::Io(e.to_string()))?;
+
+    let mut buffer = [0u8; 8192];
+    loop {
+        let n = response
+            .read(&mut buffer)
+            .map_err(|e| Error::Io(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buffer[..n])
+            .map_err(|e| Error::Io(e.to_string()))?;
+        pb.inc(n as u64);
+    }
+
+    pb.finish_and_clear();
 
     // Replace the running binary in-place
     self_replace::self_replace(&temp_path).map_err(|e| Error::Io(e.to_string()))?;
@@ -220,7 +245,7 @@ pub fn perform_update(current_version_str: &str) -> Result<UpdateResult, Error> 
     }
 
     let asset = get_asset_for_platform(latest_release)?;
-    println!("Downloading {}...", asset.name);
+    println!("Downloading {} ({})", asset.name, asset.url);
     download_and_replace(asset)?;
 
     Ok(UpdateResult::Updated {

--- a/src/update.rs
+++ b/src/update.rs
@@ -82,15 +82,33 @@ fn get_asset_name() -> Result<String, Error> {
     }
 }
 
-pub fn get_download_url(release: &Release) -> Result<String, Error> {
+pub fn get_asset_for_platform(release: &Release) -> Result<&Asset, Error> {
     let asset_name = get_asset_name()?;
 
     release
         .assets
         .iter()
         .find(|a| a.name == asset_name)
-        .map(|a| a.url.clone())
         .ok_or(Error::AssetNotFound(asset_name))
+}
+
+pub fn download_asset(asset: &Asset) -> Result<std::path::PathBuf, Error> {
+    let token = get_github_token()?;
+
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get(&asset.url)
+        .header("User-Agent", "ana-cli")
+        .header("Accept", "application/octet-stream")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()?
+        .error_for_status()?;
+
+    let bytes = response.bytes()?;
+    let path = std::path::PathBuf::from(&asset.name);
+    std::fs::write(&path, &bytes).map_err(|e| Error::Http(e.to_string()))?;
+
+    Ok(path)
 }
 
 pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -16,6 +16,8 @@ pub enum Error {
     Http(String),
     VersionParse(String),
     MissingToken,
+    AssetNotFound(String),
+    UnsupportedPlatform(String),
 }
 
 impl std::fmt::Display for Error {
@@ -30,6 +32,12 @@ impl std::fmt::Display for Error {
                 )?;
                 writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
             }
+            Error::AssetNotFound(platform) => {
+                write!(f, "No release asset found for platform: {}", platform)
+            }
+            Error::UnsupportedPlatform(info) => {
+                write!(f, "Unsupported platform: {}", info)
+            }
         }
     }
 }
@@ -41,9 +49,17 @@ impl From<reqwest::Error> for Error {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Asset {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Release {
     pub tag_name: String,
     pub prerelease: bool,
+    #[serde(default)]
+    pub assets: Vec<Asset>,
 }
 
 const DEFAULT_INCLUDE_PRERELEASES: bool = true;
@@ -52,6 +68,29 @@ pub fn include_prereleases() -> bool {
     env::var("ANA_PRERELEASES")
         .map(|v| v.to_lowercase() != "false")
         .unwrap_or(DEFAULT_INCLUDE_PRERELEASES)
+}
+
+fn get_asset_name() -> Result<String, Error> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    match (os, arch) {
+        ("macos", "aarch64") => Ok("ana-darwin-arm64".to_string()),
+        ("linux", "x86_64") => Ok("ana-linux-x86_64".to_string()),
+        ("windows", "x86_64") => Ok("ana-windows-x86_64.exe".to_string()),
+        _ => Err(Error::UnsupportedPlatform(format!("{}-{}", os, arch))),
+    }
+}
+
+pub fn get_download_url(release: &Release) -> Result<String, Error> {
+    let asset_name = get_asset_name()?;
+
+    release
+        .assets
+        .iter()
+        .find(|a| a.name == asset_name)
+        .map(|a| a.url.clone())
+        .ok_or(Error::AssetNotFound(asset_name))
 }
 
 pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {
@@ -199,6 +238,7 @@ mod tests {
         Release {
             tag_name: tag.to_string(),
             prerelease,
+            assets: vec![],
         }
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -46,6 +46,14 @@ pub struct Release {
     pub prerelease: bool,
 }
 
+const DEFAULT_INCLUDE_PRERELEASES: bool = true;
+
+pub fn include_prereleases() -> bool {
+    env::var("ANA_PRERELEASES")
+        .map(|v| v.to_lowercase() != "false")
+        .unwrap_or(DEFAULT_INCLUDE_PRERELEASES)
+}
+
 pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {
     // Convert a tag associated with a GitHub release into a semantic version
     let version_str = tag.strip_prefix('v').unwrap_or(tag);

--- a/src/update.rs
+++ b/src/update.rs
@@ -66,7 +66,7 @@ pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {
     semver::Version::parse(&normalized).map_err(|_| Error::VersionParse(tag.to_string()))
 }
 
-pub fn fetch_releases() -> Result<Vec<Release>, Error> {
+fn fetch_releases() -> Result<Vec<Release>, Error> {
     let token = get_github_token()?;
     let client = reqwest::blocking::Client::new();
     let url = format!("https://api.github.com/repos/{}/releases", GITHUB_REPO);
@@ -81,23 +81,33 @@ pub fn fetch_releases() -> Result<Vec<Release>, Error> {
     Ok(releases)
 }
 
+pub fn fetch_available_releases() -> Result<Vec<Release>, Error> {
+    let include_pre = include_prereleases();
+    let mut releases: Vec<_> = fetch_releases()?
+        .into_iter()
+        .filter(|r| parse_version(&r.tag_name).is_ok())
+        .filter(|r| include_pre || !r.prerelease)
+        .collect();
+    releases.sort_by(|a, b| {
+        let va = parse_version(&a.tag_name).unwrap();
+        let vb = parse_version(&b.tag_name).unwrap();
+        vb.cmp(&va) // Descending order (newest first)
+    });
+    Ok(releases)
+}
+
 enum UpdateStatus {
     UpdateAvailable(String),
     UpToDate,
     NoReleases,
 }
 
-fn find_update(
-    releases: Vec<Release>,
-    current_version: &str,
-    include_prereleases: bool,
-) -> Result<UpdateStatus, Error> {
+fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateStatus, Error> {
     let current = parse_version(current_version)?;
 
     let latest = releases
         .into_iter()
         .filter(|r| parse_version(&r.tag_name).is_ok())
-        .filter(|r| include_prereleases || !r.prerelease)
         .max_by(|a, b| {
             let va = parse_version(&a.tag_name).unwrap();
             let vb = parse_version(&b.tag_name).unwrap();
@@ -119,7 +129,7 @@ fn find_update(
 }
 
 pub fn check_for_update(current_version: &str) {
-    let releases = match fetch_releases() {
+    let releases = match fetch_available_releases() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to fetch releases: {}", e);
@@ -127,7 +137,7 @@ pub fn check_for_update(current_version: &str) {
         }
     };
 
-    match find_update(releases, current_version, include_prereleases()) {
+    match find_update(releases, current_version) {
         Ok(UpdateStatus::UpdateAvailable(tag)) => {
             println!("Update available: {} -> {}", current_version, tag);
         }
@@ -195,50 +205,48 @@ mod tests {
     #[test]
     fn test_find_update_available() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
-        let result = find_update(releases, "0.0.1", true).unwrap();
+        let result = find_update(releases, "0.0.1").unwrap();
         assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
     }
 
     #[test]
     fn test_find_update_already_up_to_date() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
-        let result = find_update(releases, "0.0.2", true).unwrap();
+        let result = find_update(releases, "0.0.2").unwrap();
         assert!(matches!(result, UpdateStatus::UpToDate));
     }
 
     #[test]
     fn test_find_update_no_releases() {
         let releases = vec![];
-        let result = find_update(releases, "0.0.1", true).unwrap();
+        let result = find_update(releases, "0.0.1").unwrap();
         assert!(matches!(result, UpdateStatus::NoReleases));
     }
 
     #[test]
-    fn test_find_update_excludes_prereleases() {
+    fn test_find_update_with_prereleases() {
+        // When prereleases are in the list, find_update finds the latest
+        // (filtering happens in fetch_available_releases, not find_update)
         let releases = vec![
             make_release("v0.0.1", false),
             make_release("v0.0.2.dev1", true),
         ];
-        // With prereleases excluded, should be up to date
-        let result = find_update(releases, "0.0.1", false).unwrap();
-        assert!(matches!(result, UpdateStatus::UpToDate));
+        let result = find_update(releases, "0.0.1").unwrap();
+        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2.dev1"));
     }
 
     #[test]
-    fn test_find_update_includes_prereleases() {
-        let releases = vec![
-            make_release("v0.0.1", false),
-            make_release("v0.0.2.dev1", true),
-        ];
-        // With prereleases included, should find update
-        let result = find_update(releases, "0.0.1", true).unwrap();
-        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2.dev1"));
+    fn test_find_update_without_prereleases() {
+        // When prereleases are filtered out before calling find_update
+        let releases = vec![make_release("v0.0.1", false)];
+        let result = find_update(releases, "0.0.1").unwrap();
+        assert!(matches!(result, UpdateStatus::UpToDate));
     }
 
     #[test]
     fn test_find_update_invalid_current_version() {
         let releases = vec![make_release("v0.0.1", false)];
-        let result = find_update(releases, "invalid", true);
+        let result = find_update(releases, "invalid");
         assert!(matches!(result, Err(Error::VersionParse(_))));
     }
 
@@ -249,7 +257,7 @@ mod tests {
             make_release("not-a-version", false),
             make_release("v0.0.2", false),
         ];
-        let result = find_update(releases, "0.0.1", true).unwrap();
+        let result = find_update(releases, "0.0.1").unwrap();
         assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -197,6 +197,38 @@ fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateSt
     }
 }
 
+pub enum UpdateResult {
+    Updated { from: String, to: String },
+    AlreadyUpToDate(String),
+    NoReleases,
+}
+
+pub fn perform_update(current_version_str: &str) -> Result<UpdateResult, Error> {
+    let releases = fetch_available_releases()?;
+
+    // TODO: Add feature for `ana self update <explcit-version>`
+    let latest_release = match releases.first() {
+        Some(r) => r,
+        None => return Ok(UpdateResult::NoReleases),
+    };
+
+    let current_version = parse_version(current_version_str)?;
+    let latest_version = parse_version(&latest_release.tag_name)?;
+
+    if latest_version <= current_version {
+        return Ok(UpdateResult::AlreadyUpToDate(current_version.to_string()));
+    }
+
+    let asset = get_asset_for_platform(latest_release)?;
+    println!("Downloading {}...", asset.name);
+    download_and_replace(asset)?;
+
+    Ok(UpdateResult::Updated {
+        from: current_version.to_string(),
+        to: latest_release.tag_name.clone(),
+    })
+}
+
 pub fn check_for_update(current_version: &str) {
     let releases = match fetch_available_releases() {
         Ok(r) => r,

--- a/src/update.rs
+++ b/src/update.rs
@@ -14,6 +14,7 @@ fn get_github_token() -> Result<String, Error> {
 #[derive(Debug, PartialEq)]
 pub enum Error {
     Http(String),
+    Io(String),
     VersionParse(String),
     MissingToken,
     AssetNotFound(String),
@@ -24,6 +25,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Http(msg) => write!(f, "HTTP error: {}", msg),
+            Error::Io(msg) => write!(f, "IO error: {}", msg),
             Error::VersionParse(v) => write!(f, "Failed to parse version: {}", v),
             Error::MissingToken => {
                 writeln!(
@@ -92,7 +94,7 @@ pub fn get_asset_for_platform(release: &Release) -> Result<&Asset, Error> {
         .ok_or(Error::AssetNotFound(asset_name))
 }
 
-pub fn download_asset(asset: &Asset) -> Result<std::path::PathBuf, Error> {
+pub fn download_and_replace(asset: &Asset) -> Result<(), Error> {
     let token = get_github_token()?;
 
     let client = reqwest::blocking::Client::new();
@@ -105,10 +107,15 @@ pub fn download_asset(asset: &Asset) -> Result<std::path::PathBuf, Error> {
         .error_for_status()?;
 
     let bytes = response.bytes()?;
-    let path = std::path::PathBuf::from(&asset.name);
-    std::fs::write(&path, &bytes).map_err(|e| Error::Http(e.to_string()))?;
 
-    Ok(path)
+    let temp_dir = std::env::temp_dir();
+    let temp_path = temp_dir.join(&asset.name);
+    std::fs::write(&temp_path, &bytes).map_err(|e| Error::Io(e.to_string()))?;
+
+    // Replace the running binary in-place
+    self_replace::self_replace(&temp_path).map_err(|e| Error::Io(e.to_string()))?;
+
+    Ok(())
 }
 
 pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -191,8 +191,8 @@ pub fn fetch_available_releases() -> Result<Vec<Release>, Error> {
 }
 
 pub enum UpdateCheck {
-    Available { from: String, release: Release },
-    AlreadyUpToDate(String),
+    Available(Release),
+    AlreadyUpToDate,
     NoReleases,
 }
 
@@ -216,12 +216,9 @@ fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateCh
     let latest_version = parse_version(&latest.tag_name).unwrap();
 
     if latest_version > current {
-        Ok(UpdateCheck::Available {
-            from: current_version.to_string(),
-            release: latest,
-        })
+        Ok(UpdateCheck::Available(latest))
     } else {
-        Ok(UpdateCheck::AlreadyUpToDate(current_version.to_string()))
+        Ok(UpdateCheck::AlreadyUpToDate)
     }
 }
 
@@ -239,11 +236,11 @@ pub fn apply_update(release: &Release) -> Result<(), Error> {
 
 pub fn check_for_update(current_version: &str) {
     match check_update(current_version) {
-        Ok(UpdateCheck::Available { from, release }) => {
-            println!("Update available: {} -> {}", from, release.tag_name);
+        Ok(UpdateCheck::Available(release)) => {
+            println!("Update available: {} -> {}", current_version, release.tag_name);
         }
-        Ok(UpdateCheck::AlreadyUpToDate(v)) => {
-            println!("Already up to date ({})", v);
+        Ok(UpdateCheck::AlreadyUpToDate) => {
+            println!("Already up to date ({})", current_version);
         }
         Ok(UpdateCheck::NoReleases) => {
             println!("No releases available.");
@@ -308,14 +305,14 @@ mod tests {
     fn test_find_update_available() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2"));
+        assert!(matches!(result, UpdateCheck::Available(release) if release.tag_name == "v0.0.2"));
     }
 
     #[test]
     fn test_find_update_already_up_to_date() {
         let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
         let result = find_update(releases, "0.0.2").unwrap();
-        assert!(matches!(result, UpdateCheck::AlreadyUpToDate(_)));
+        assert!(matches!(result, UpdateCheck::AlreadyUpToDate));
     }
 
     #[test]
@@ -334,7 +331,7 @@ mod tests {
             make_release("v0.0.2.dev1", true),
         ];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2.dev1"));
+        assert!(matches!(result, UpdateCheck::Available(release) if release.tag_name == "v0.0.2.dev1"));
     }
 
     #[test]
@@ -342,7 +339,7 @@ mod tests {
         // When prereleases are filtered out before calling find_update
         let releases = vec![make_release("v0.0.1", false)];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateCheck::AlreadyUpToDate(_)));
+        assert!(matches!(result, UpdateCheck::AlreadyUpToDate));
     }
 
     #[test]
@@ -360,7 +357,7 @@ mod tests {
             make_release("v0.0.2", false),
         ];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateCheck::Available { release, .. } if release.tag_name == "v0.0.2"));
+        assert!(matches!(result, UpdateCheck::Available(release) if release.tag_name == "v0.0.2"));
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -81,6 +81,68 @@ pub fn fetch_releases() -> Result<Vec<Release>, Error> {
     Ok(releases)
 }
 
+enum UpdateStatus {
+    UpdateAvailable(String),
+    UpToDate,
+    NoReleases,
+}
+
+fn find_update(
+    releases: Vec<Release>,
+    current_version: &str,
+    include_prereleases: bool,
+) -> Result<UpdateStatus, Error> {
+    let current = parse_version(current_version)?;
+
+    let latest = releases
+        .into_iter()
+        .filter(|r| parse_version(&r.tag_name).is_ok())
+        .filter(|r| include_prereleases || !r.prerelease)
+        .max_by(|a, b| {
+            let va = parse_version(&a.tag_name).unwrap();
+            let vb = parse_version(&b.tag_name).unwrap();
+            va.cmp(&vb)
+        });
+
+    let latest = match latest {
+        Some(r) => r,
+        None => return Ok(UpdateStatus::NoReleases),
+    };
+
+    let latest_version = parse_version(&latest.tag_name).unwrap();
+
+    if latest_version > current {
+        Ok(UpdateStatus::UpdateAvailable(latest.tag_name))
+    } else {
+        Ok(UpdateStatus::UpToDate)
+    }
+}
+
+pub fn check_for_update(current_version: &str) {
+    let releases = match fetch_releases() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to fetch releases: {}", e);
+            return;
+        }
+    };
+
+    match find_update(releases, current_version, include_prereleases()) {
+        Ok(UpdateStatus::UpdateAvailable(tag)) => {
+            println!("Update available: {} -> {}", current_version, tag);
+        }
+        Ok(UpdateStatus::UpToDate) => {
+            println!("Already up to date ({})", current_version);
+        }
+        Ok(UpdateStatus::NoReleases) => {
+            println!("No releases available.");
+        }
+        Err(e) => {
+            eprintln!("Failed to check for update: {}", e);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +183,73 @@ mod tests {
     fn test_parse_version_invalid() {
         let result = parse_version("not-a-version");
         assert!(matches!(result, Err(Error::VersionParse(_))));
+    }
+
+    fn make_release(tag: &str, prerelease: bool) -> Release {
+        Release {
+            tag_name: tag.to_string(),
+            prerelease,
+        }
+    }
+
+    #[test]
+    fn test_find_update_available() {
+        let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
+        let result = find_update(releases, "0.0.1", true).unwrap();
+        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
+    }
+
+    #[test]
+    fn test_find_update_already_up_to_date() {
+        let releases = vec![make_release("v0.0.1", false), make_release("v0.0.2", false)];
+        let result = find_update(releases, "0.0.2", true).unwrap();
+        assert!(matches!(result, UpdateStatus::UpToDate));
+    }
+
+    #[test]
+    fn test_find_update_no_releases() {
+        let releases = vec![];
+        let result = find_update(releases, "0.0.1", true).unwrap();
+        assert!(matches!(result, UpdateStatus::NoReleases));
+    }
+
+    #[test]
+    fn test_find_update_excludes_prereleases() {
+        let releases = vec![
+            make_release("v0.0.1", false),
+            make_release("v0.0.2.dev1", true),
+        ];
+        // With prereleases excluded, should be up to date
+        let result = find_update(releases, "0.0.1", false).unwrap();
+        assert!(matches!(result, UpdateStatus::UpToDate));
+    }
+
+    #[test]
+    fn test_find_update_includes_prereleases() {
+        let releases = vec![
+            make_release("v0.0.1", false),
+            make_release("v0.0.2.dev1", true),
+        ];
+        // With prereleases included, should find update
+        let result = find_update(releases, "0.0.1", true).unwrap();
+        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2.dev1"));
+    }
+
+    #[test]
+    fn test_find_update_invalid_current_version() {
+        let releases = vec![make_release("v0.0.1", false)];
+        let result = find_update(releases, "invalid", true);
+        assert!(matches!(result, Err(Error::VersionParse(_))));
+    }
+
+    #[test]
+    fn test_find_update_skips_invalid_release_tags() {
+        let releases = vec![
+            make_release("v0.0.1", false),
+            make_release("not-a-version", false),
+            make_release("v0.0.2", false),
+        ];
+        let result = find_update(releases, "0.0.1", true).unwrap();
+        assert!(matches!(result, UpdateStatus::UpdateAvailable(tag) if tag == "v0.0.2"));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,117 @@
+use serde::Deserialize;
+use std::env;
+
+// We track the repo for releases
+const GITHUB_REPO: &str = "anaconda/ana-cli";
+
+fn get_github_token() -> Result<String, Error> {
+    match env::var("GITHUB_TOKEN") {
+        Ok(token) if !token.is_empty() => Ok(token),
+        _ => Err(Error::MissingToken),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    Http(String),
+    VersionParse(String),
+    MissingToken,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Http(msg) => write!(f, "HTTP error: {}", msg),
+            Error::VersionParse(v) => write!(f, "Failed to parse version: {}", v),
+            Error::MissingToken => {
+                writeln!(
+                    f,
+                    "GITHUB_TOKEN not set. Required for accessing private repo."
+                )?;
+                writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
+            }
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(e: reqwest::Error) -> Self {
+        Error::Http(e.to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Release {
+    pub tag_name: String,
+    pub prerelease: bool,
+}
+
+pub fn parse_version(tag: &str) -> Result<semver::Version, Error> {
+    // Convert a tag associated with a GitHub release into a semantic version
+    let version_str = tag.strip_prefix('v').unwrap_or(tag);
+    // Convert .devN to -dev.N for semver compatibility
+    let normalized = if let Some((base, dev_num)) = version_str.split_once(".dev") {
+        format!("{}-dev.{}", base, dev_num)
+    } else {
+        version_str.to_string()
+    };
+    semver::Version::parse(&normalized).map_err(|_| Error::VersionParse(tag.to_string()))
+}
+
+pub fn fetch_releases() -> Result<Vec<Release>, Error> {
+    let token = get_github_token()?;
+    let client = reqwest::blocking::Client::new();
+    let url = format!("https://api.github.com/repos/{}/releases", GITHUB_REPO);
+    let releases: Vec<Release> = client
+        .get(&url)
+        .header("User-Agent", "ana-cli")
+        .header("Accept", "application/vnd.github+json")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()?
+        .error_for_status()?
+        .json()?;
+    Ok(releases)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_releases_missing_token_error() {
+        // This test will fail if GITHUB_TOKEN is set in the environment
+        // In CI, ensure it's not set, or skip this test
+        if env::var("GITHUB_TOKEN").is_ok() {
+            return; // Skip test if token is set
+        }
+        let result = fetch_releases();
+        assert_eq!(result.unwrap_err(), Error::MissingToken);
+    }
+
+    #[test]
+    fn test_parse_version_stable() {
+        let version = parse_version("v1.2.3").unwrap();
+        assert_eq!(version, semver::Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn test_parse_version_dev() {
+        let version = parse_version("v0.0.2.dev5").unwrap();
+        assert_eq!(version.major, 0);
+        assert_eq!(version.minor, 0);
+        assert_eq!(version.patch, 2);
+        assert!(!version.pre.is_empty());
+    }
+
+    #[test]
+    fn test_parse_version_without_v_prefix() {
+        let version = parse_version("1.0.0").unwrap();
+        assert_eq!(version, semver::Version::new(1, 0, 0));
+    }
+
+    #[test]
+    fn test_parse_version_invalid() {
+        let result = parse_version("not-a-version");
+        assert!(matches!(result, Err(Error::VersionParse(_))));
+    }
+}


### PR DESCRIPTION
## Summary

Adds self-update functionality to `ana` CLI, allowing users to check for and install updates directly from the command line. This PR is deliberately minimal, with the goal only of allowing explicit check and update in-place. The intent is to establish the end-to-end patterns for how we track available versions, and then download the appropriate artifact if an update is possible.

This unlocks future features around update notification, automation, etc. but those are enhancements that are explicitly deferred.

We also use a custom CLI parsing approach, rather than a framework. We will do that separately, and more intentionally.

### Usage

The feature is implemented under the `ana self` subcommand. The interface is subject to change without warning!

- `ana self update` - Downloads and installs the latest version, replacing the running binary in-place. User will be prompted for confirmation.
- `ana self update --yes/-y` - Same as above, but without user confirmation
- `ana self update --check` - Checks if a newer version is available without installing
- `ana self update --list` - Lists all available releases, marking the current version

### Implementation

- Fetches releases from GitHub API via this repo (requires `GITHUB_TOKEN` for private repo access right now). You can use `export GITHUB_TOKEN=$(gh auth token)` if you have the `gh` CLI installed.
- Supports filtering pre-releases via `ANA_PRERELEASES=false` environment variable. Default (currently) is to show pre-releases. We will flip the default once we are more mature. Later, this will be configurable.
- Platform detection for darwin-arm64, linux-x86_64, and windows-x86_64
- Progress bar during download with ETA
- Semantic version comparison for determining update availability

### Added dependencies

This PR looks huge because of `Cargo.lock`, but the actual implementation is quite small. I have added several dependencies, which are all common and will be needed later. Specifically:

- **reqwest** - HTTP client for fetching releases from GitHub API (blocking mode with JSON and rustls-tls) (we may need to go with async later, but for now this is simplest approach)
- **serde** / **serde_json** - JSON deserialization for API responses
- **semver** - Semantic version parsing and comparison
- **self-replace** - Replace the running binary in-place during updates
- **indicatif** - Progress bar for download status
- **indoc** - Multi-line string formatting for help text (compile-time macros only)

### How to test this

There is a bootstrapping issue in that this feature can't be used until a release is available with it, from which subsequent releases can be updated-to. Here is the best way to try it out from this branch:

* Pull down this PR
* Run `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.1 pixi run build-debug`, which will compile to `./target/debug/ana`. The `SETUPTOOLS_SCM_PRETEND_VERSION` is required to mock building an older version.
* If you want, you can put that on `PATH`: `export PATH=./target/debug:$PATH`
* Update the binary: `./target/debug/ana self update`

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-354](https://anaconda.atlassian.net/browse/CLI-354)

[CLI-354]: https://anaconda.atlassian.net/browse/CLI-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ