### PR TITLE
feat: Add `install.sh` for linux/macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,10 @@ jobs:
         run: |
           pixi run test
 
+      - name: Run tests for install script
+        run: |
+          pixi run test-install-script
+
       - name: Build as standalone binary
         run: |
           pixi run build-release

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ target
 # build output
 output/
 target/
+bin/
 
 # local dev config
 .claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
     rev: 0.37.0
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/pixi.lock
+++ b/pixi.lock
@@ -27,6 +27,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.12.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py314h7fe84b3_0.conda
@@ -47,6 +48,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
@@ -98,6 +100,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -107,6 +110,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -172,6 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.12.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.5-py314h2cafa77_0.conda
@@ -190,6 +195,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
@@ -226,6 +232,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -235,6 +242,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -317,6 +325,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
@@ -354,6 +363,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-12.1.1-py314h61b30b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -363,6 +373,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -1055,6 +1066,15 @@ packages:
   license_family: APACHE
   size: 33781
   timestamp: 1736252433366
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
+  md5: 9614359868482abba1bd15ce465e3c42
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 13387
+  timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
   sha256: 3cc991f0f09dfd00d2626e745ba68da03e4f1dcbb7b36dd20f7a7373643cd5d5
   md5: d59568bad316413c89831456e691de29
@@ -2185,6 +2205,16 @@ packages:
   license_family: MIT
   size: 25646
   timestamp: 1773199142345
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25877
+  timestamp: 1764896838868
 - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
   sha256: 5b81b7516d4baf43d0c185896b245fa7384b25dc5615e7baa504b7fa4e07b706
   md5: 7f3ac694319c7eaf81a0325d6405e974
@@ -2356,6 +2386,25 @@ packages:
   license_family: BSD
   size: 21085
   timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+  md5: 2b694bad8a50dc2f712f5368de866480
+  depends:
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - colorama >=0.4
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  size: 299581
+  timestamp: 1765062031645
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
   build_number: 101
   sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,6 +5,7 @@ platforms = ["osx-arm64", "linux-64", "win-64"]
 
 [dependencies]
 pre-commit = ">=4.5.1,<5"
+pytest = ">=8"
 python = ">=3.10"
 rattler-build = ">=0.61.1,<0.62"
 rust = "*"
@@ -30,3 +31,7 @@ description = "Build the standalone Rust binary in release mode"
 [tasks.test]
 cmd = "python scripts/with_version.py cargo test"
 description = "Run the unit tests"
+
+[tasks.test-install-script]
+cmd = "pytest tests -v"
+description = "Run integration tests"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,9 @@
 # Installer script for ana.
 #
 # Usage:
+#
+#   TODO: The URLs below will be updated once the final URLs are determined.
+#
 #   Direct download:
 #   > curl -fsSL https://anaconda.com/ana/install.sh | sh
 #   or:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,12 +165,19 @@ main() {
         err "Downloaded file is empty. Check the URL or try again."
     fi
 
-    if [ "${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}" = "true" ]; then
-        info "Verifying checksum"
-        verify_checksum "$_checksum_url" "$_tmp" "$_auth_header"
-    else
-        warn "Checksum verification disabled"
-    fi
+    local _verify_checksum="${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}"
+    case "$_verify_checksum" in
+        true|1)
+            info "Verifying checksum"
+            verify_checksum "$_checksum_url" "$_tmp" "$_auth_header"
+            ;;
+        false|0)
+            warn "Checksum verification disabled"
+            ;;
+        *)
+            err "Invalid ANA_VERIFY_CHECKSUM value '%s'. Must be 'true', 'false', '1', or '0'." "$_verify_checksum"
+            ;;
+    esac
 
     chmod +x "$_tmp"
     mkdir -p "$_install_dir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -368,6 +368,7 @@ install_binary() {
 update_shell_profile() {
     local _dir="$1" _line
 
+    # Already in $PATH
     if echo "$PATH" | tr ':' '\n' | grep -qx "$_dir" 2>/dev/null; then
         return 0
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# shellcheck disable=SC3043  # 'local' is widely supported even if not strictly POSIX
 # Installer script for ana.
 #
 # Usage:
@@ -13,6 +12,7 @@
 #
 # Run with --help for full usage information.
 
+# shellcheck disable=SC3043  # 'local' is widely supported even if not strictly POSIX
 set -eu
 
 # The __wrap__ function ensures that we download the entire function definition before

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,7 @@
 #   ANA_INSTALL_DIR       — where to place the binary (default: ~/.local/bin)
 #   ANA_VERSION           — version to install, without "v" prefix (default: latest)
 #   ANA_NO_PATH_UPDATE    — set to non-empty to skip shell profile modification
+#   ANA_VERIFY_CHECKSUM   — set to "true" to verify checksum (default: false)
 #   ANA_REQUEST_TOKEN     — GitHub token for authenticated requests (default: tries `gh auth token`)
 
 set -eu
@@ -57,8 +58,13 @@ main() {
         err "Downloaded file is empty. Check the URL or try again."
     fi
 
-    info "Verifying checksum"
-    verify_checksum "$_url" "$_tmp" "$_auth_header"
+    # TODO: Enable checksum verification by default once .sha256 files are published
+    if [ "${ANA_VERIFY_CHECKSUM:-false}" = "true" ]; then
+        info "Verifying checksum"
+        verify_checksum "$_url" "$_tmp" "$_auth_header"
+    else
+        warn "Checksum verification disabled"
+    fi
 
     chmod +x "$_tmp"
     mkdir -p "$_install_dir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,8 +30,7 @@ BINARY_NAME="ana"
 # Defaults (can be overridden via environment variables or CLI options)
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 DEFAULT_VERSION="latest"
-# TODO: Enable checksum verification by default once .sha256 files are published
-DEFAULT_VERIFY_CHECKSUM="false"
+DEFAULT_VERIFY_CHECKSUM="true"
 
 usage() {
     # Replace $HOME with ~ for display
@@ -55,7 +54,7 @@ Options:
 Environment variables:
   ANA_INSTALL_DIR          Same as --install-dir
   ANA_VERSION              Same as --version
-  ANA_VERIFY_CHECKSUM      Set to "true" to verify checksum
+  ANA_VERIFY_CHECKSUM      Set to "false" to skip checksum verification
   ANA_NO_PATH_UPDATE       Set to non-empty to skip PATH update
   ANA_FORCE_INSTALL        Set to non-empty to overwrite without prompting
   GITHUB_TOKEN             Same as --token
@@ -123,7 +122,7 @@ main() {
     ensure_cmd chmod
     ensure_cmd mkdir
 
-    local _os _arch _target _version _install_dir _url _tmp _auth_header
+    local _os _arch _target _version _install_dir _url _checksum_url _tmp _auth_header
 
     _os="$(detect_os)"
     _arch="$(detect_arch)"
@@ -136,17 +135,21 @@ main() {
     # ANA_BASE_URL can override the download URL (useful for testing)
     if [ -n "${ANA_BASE_URL:-}" ]; then
         _url="${ANA_BASE_URL}/${_asset_name}"
+        _checksum_url="${_url}.sha256"
         _auth_header=""
     else
         _auth_header="$(get_auth_header)"
         # Private repo: use GitHub API to resolve asset URL
         if [ -n "$_auth_header" ]; then
             _url="$(resolve_github_asset_url "$_version" "$_asset_name" "$_auth_header")"
+            _checksum_url="$(resolve_github_asset_url "$_version" "${_asset_name}.sha256" "$_auth_header" 2>/dev/null)" || _checksum_url=""
         # Public repo: use direct download URL
         elif [ "$_version" = "latest" ]; then
             _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
+            _checksum_url="${_url}.sha256"
         else
             _url="https://github.com/${REPO}/releases/download/v${_version#v}/${_asset_name}"
+            _checksum_url="${_url}.sha256"
         fi
     fi
 
@@ -164,7 +167,7 @@ main() {
 
     if [ "${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}" = "true" ]; then
         info "Verifying checksum"
-        verify_checksum "$_url" "$_tmp" "$_auth_header"
+        verify_checksum "$_checksum_url" "$_tmp" "$_auth_header"
     else
         warn "Checksum verification disabled"
     fi
@@ -311,10 +314,15 @@ download() {
 }
 
 verify_checksum() {
-    local _url="$1" _file="$2" _auth_header="${3:-}" _expected _actual _tmp_sha
+    local _checksum_url="$1" _file="$2" _auth_header="${3:-}" _expected _actual _tmp_sha
+
+    if [ -z "$_checksum_url" ]; then
+        warn "Checksum file not available, skipping verification"
+        return 0
+    fi
 
     _tmp_sha="$(mktemp "${TMPDIR:-/tmp}/.ana_sha.XXXXXXXX")"
-    if ! download "${_url}.sha256" "$_tmp_sha" "$_auth_header" 2>/dev/null; then
+    if ! download "$_checksum_url" "$_tmp_sha" "$_auth_header" 2>/dev/null; then
         warn "Checksum file not available, skipping verification"
         rm -f "$_tmp_sha"
         return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,7 +82,7 @@ main() {
     fi
 
     printf "\n"
-    info "Done! Run 'ana --help' to get started."
+    info "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started."
     printf "\n"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,29 +122,31 @@ main() {
     ensure_cmd chmod
     ensure_cmd mkdir
 
-    local _os _arch _target _version _install_dir _url _checksum_url _tmp _auth_header
-
+    # Detect platform
+    local _os _arch _target
     _os="$(detect_os)"
     _arch="$(detect_arch)"
     _target="$(map_target "$_os" "$_arch")"
-    _version="${ANA_VERSION:-$DEFAULT_VERSION}"
-    _install_dir="${ANA_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
 
+    # Configuration
+    local _version="${ANA_VERSION:-$DEFAULT_VERSION}"
+    local _install_dir="${ANA_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
     local _asset_name="ana-${_target}"
 
-    # ANA_BASE_URL can override the download URL (useful for testing)
+    # Resolve download URLs
+    local _url _checksum_url _auth_header=""
     if [ -n "${ANA_BASE_URL:-}" ]; then
+        # ANA_BASE_URL can override the download URL (useful for testing)
         _url="${ANA_BASE_URL}/${_asset_name}"
         _checksum_url="${_url}.sha256"
-        _auth_header=""
     else
         _auth_header="$(get_auth_header)"
-        # Private repo: use GitHub API to resolve asset URL
         if [ -n "$_auth_header" ]; then
+            # Private repo: use GitHub API to resolve asset URL
             _url="$(resolve_github_asset_url "$_version" "$_asset_name" "$_auth_header")"
             _checksum_url="$(resolve_github_asset_url "$_version" "${_asset_name}.sha256" "$_auth_header" 2>/dev/null)" || _checksum_url=""
-        # Public repo: use direct download URL
         elif [ "$_version" = "latest" ]; then
+            # Public repo: use direct download URL
             _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
             _checksum_url="${_url}.sha256"
         else
@@ -153,11 +155,12 @@ main() {
         fi
     fi
 
-    _tmp="$(mktemp "${TMPDIR:-/tmp}/.ana_install.XXXXXXXX")"
-    trap 'rm -f "$_tmp"' EXIT
-
     info "Installing ana for %s %s" "$_os" "$_arch"
     info "Downloading %s" "$_url"
+
+    local _tmp
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/.ana_install.XXXXXXXX")"
+    trap 'rm -f "$_tmp"' EXIT
 
     download "$_url" "$_tmp" "$_auth_header"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -280,19 +280,19 @@ ensure_cmd() {
 info() {
     local _fmt="$1"; shift
     # shellcheck disable=SC2059
-    printf "  \033[1;32m>\033[0m $_fmt\n" "$@"
+    printf "\033[1;32m>\033[0m $_fmt\n" "$@"
 }
 
 warn() {
     local _fmt="$1"; shift
     # shellcheck disable=SC2059
-    printf "  \033[1;33m!\033[0m $_fmt\n" "$@" >&2
+    printf "\033[1;33m!\033[0m $_fmt\n" "$@" >&2
 }
 
 err() {
     local _fmt="$1"; shift
     # shellcheck disable=SC2059
-    printf "  \033[1;31mx\033[0m $_fmt\n" "$@" >&2
+    printf "\033[1;31mx\033[0m $_fmt\n" "$@" >&2
     exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,17 +43,17 @@ Install the ana CLI tool.
 Options:
   -d, --install-dir DIR   Install directory (default: ${_display_dir})
   -v, --version VERSION   Version to install (default: ${DEFAULT_VERSION})
-  -t, --token TOKEN       GitHub token for private repo access
       --verify-checksum   Verify checksum after download (default: ${DEFAULT_VERIFY_CHECKSUM})
       --no-path-update    Skip shell profile modification
+  -t, --token TOKEN       GitHub token for private repo access
   -h, --help              Show this help message
 
 Environment variables:
   ANA_INSTALL_DIR         Same as --install-dir
   ANA_VERSION             Same as --version
-  ANA_REQUEST_TOKEN       Same as --token
   ANA_VERIFY_CHECKSUM     Set to "true" to verify checksum
   ANA_NO_PATH_UPDATE      Set to non-empty to skip PATH update
+  GITHUB_TOKEN            Same as --token
 
 Examples:
   # Direct download via pipe:
@@ -86,7 +86,7 @@ parse_args() {
                 ;;
             -t|--token)
                 [ $# -ge 2 ] || err "Missing argument for $1"
-                ANA_REQUEST_TOKEN="$2"
+                GITHUB_TOKEN="$2"
                 shift 2
                 ;;
             --verify-checksum)
@@ -203,15 +203,17 @@ map_target() {
 get_auth_header() {
     local _token
 
-    # Use ANA_REQUEST_TOKEN if provided, otherwise try gh auth token
-    if [ -n "${ANA_REQUEST_TOKEN:-}" ]; then
-        _token="$ANA_REQUEST_TOKEN"
+    # Use GITHUB_TOKEN if provided, otherwise try gh auth token
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        _token="$GITHUB_TOKEN"
     elif check_cmd gh; then
         _token="$(gh auth token 2>/dev/null)" || true
     fi
 
     if [ -n "${_token:-}" ]; then
         printf 'Authorization: token %s' "$_token"
+    else
+        err "Must provide GitHub token to access private repo."
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,10 @@
 
 set -eu
 
+# The __wrap__ function ensures that we download the entire function definition before
+# execution. This is important when piping a downloaded script into sh, to avoid partial
+# script execution if download of the script fails. We download the entire function
+# definition and then initially call it.
 __wrap__() {
 
 REPO="anaconda/ana-cli"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,27 +179,7 @@ main() {
             ;;
     esac
 
-    chmod +x "$_tmp"
-    mkdir -p "$_install_dir"
-
-    local _dest="${_install_dir}/${BINARY_NAME}"
-    if [ -f "$_dest" ] && [ -z "${ANA_FORCE_INSTALL:-}" ]; then
-        if [ -t 0 ]; then
-            printf "  %s already exists. Overwrite? [y/N] " "$_dest"
-            read -r _reply
-            case "$_reply" in
-                [Yy]|[Yy][Ee][Ss]) ;;
-                *) err "Installation cancelled." ;;
-            esac
-        else
-            err "%s already exists. Use --force to overwrite." "$_dest"
-        fi
-    fi
-
-    mv -f "$_tmp" "$_dest"
-    trap - EXIT
-
-    info "Installed ana to %s/%s" "$_install_dir" "$BINARY_NAME"
+    install_binary "$_tmp" "$_install_dir"
 
     if [ -z "${ANA_NO_PATH_UPDATE:-}" ]; then
         update_shell_profile "$_install_dir"
@@ -352,6 +332,32 @@ verify_checksum() {
     fi
 
     info "Checksum OK"
+}
+
+install_binary() {
+    local _src="$1" _install_dir="$2"
+    local _dest="${_install_dir}/${BINARY_NAME}"
+
+    chmod +x "$_src"
+    mkdir -p "$_install_dir"
+
+    if [ -f "$_dest" ] && [ -z "${ANA_FORCE_INSTALL:-}" ]; then
+        if [ -t 0 ]; then
+            printf "  %s already exists. Overwrite? [y/N] " "$_dest"
+            read -r _reply
+            case "$_reply" in
+                [Yy]|[Yy][Ee][Ss]) ;;
+                *) err "Installation cancelled." ;;
+            esac
+        else
+            err "%s already exists. Use --force to overwrite." "$_dest"
+        fi
+    fi
+
+    mv -f "$_src" "$_dest"
+    trap - EXIT
+
+    info "Installed ana to %s" "$_dest"
 }
 
 update_shell_profile() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,7 +170,7 @@ download() {
         CURL_OPTS="--silent"
         WGET_OPTS="--no-verbose"
     else
-        CURL_OPTS=""
+        CURL_OPTS="--progress-bar"
         WGET_OPTS="--show-progress"
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,7 +176,7 @@ main() {
         update_shell_profile "$_install_dir"
     fi
 
-    printf "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started."
+    printf "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started.\n"
 }
 
 detect_os() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,12 @@ __wrap__() {
 REPO="anaconda/ana-cli"
 BINARY_NAME="ana"
 
+# Defaults (can be overridden via environment variables)
+DEFAULT_INSTALL_DIR="$HOME/.local/bin"
+DEFAULT_VERSION="latest"
+# TODO: Enable checksum verification by default once .sha256 files are published
+DEFAULT_VERIFY_CHECKSUM="false"
+
 main() {
     ensure_cmd uname
     ensure_cmd chmod
@@ -33,8 +39,8 @@ main() {
     _os="$(detect_os)"
     _arch="$(detect_arch)"
     _target="$(map_target "$_os" "$_arch")"
-    _version="${ANA_VERSION:-latest}"
-    _install_dir="${ANA_INSTALL_DIR:-$HOME/.local/bin}"
+    _version="${ANA_VERSION:-$DEFAULT_VERSION}"
+    _install_dir="${ANA_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
     _auth_header="$(get_auth_header)"
 
     local _asset_name="ana-${_target}"
@@ -61,8 +67,7 @@ main() {
         err "Downloaded file is empty. Check the URL or try again."
     fi
 
-    # TODO: Enable checksum verification by default once .sha256 files are published
-    if [ "${ANA_VERIFY_CHECKSUM:-false}" = "true" ]; then
+    if [ "${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}" = "true" ]; then
         info "Verifying checksum"
         verify_checksum "$_url" "$_tmp" "$_auth_header"
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,19 +165,7 @@ main() {
         err "Downloaded file is empty. Check the URL or try again."
     fi
 
-    local _verify_checksum="${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}"
-    case "$_verify_checksum" in
-        true|1)
-            info "Verifying checksum"
-            verify_checksum "$_checksum_url" "$_tmp" "$_auth_header"
-            ;;
-        false|0)
-            warn "Checksum verification disabled"
-            ;;
-        *)
-            err "Invalid ANA_VERIFY_CHECKSUM value '%s'. Must be 'true', 'false', '1', or '0'." "$_verify_checksum"
-            ;;
-    esac
+    verify_checksum "$_checksum_url" "$_tmp" "$_auth_header"
 
     install_binary "$_tmp" "$_install_dir"
 
@@ -301,13 +289,28 @@ download() {
 }
 
 verify_checksum() {
-    local _checksum_url="$1" _file="$2" _auth_header="${3:-}" _expected _actual _tmp_sha
+    local _checksum_url="$1" _file="$2" _auth_header="${3:-}"
+    local _verify="${ANA_VERIFY_CHECKSUM:-$DEFAULT_VERIFY_CHECKSUM}"
+
+    case "$_verify" in
+        false|0)
+            warn "Checksum verification disabled"
+            return 0
+            ;;
+        true|1) ;;
+        *)
+            err "Invalid ANA_VERIFY_CHECKSUM value '%s'. Must be 'true', 'false', '1', or '0'." "$_verify"
+            ;;
+    esac
+
+    info "Verifying checksum"
 
     if [ -z "$_checksum_url" ]; then
         warn "Checksum file not available, skipping verification"
         return 0
     fi
 
+    local _expected _actual _tmp_sha
     _tmp_sha="$(mktemp "${TMPDIR:-/tmp}/.ana_sha.XXXXXXXX")"
     if ! download "$_checksum_url" "$_tmp_sha" "$_auth_header" 2>/dev/null; then
         warn "Checksum file not available, skipping verification"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,18 +127,24 @@ main() {
     _target="$(map_target "$_os" "$_arch")"
     _version="${ANA_VERSION:-$DEFAULT_VERSION}"
     _install_dir="${ANA_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-    _auth_header="$(get_auth_header)"
 
     local _asset_name="ana-${_target}"
 
-    # Private repo: use GitHub API to resolve asset URL
-    # Public repo: use direct download URL
-    if [ -n "$_auth_header" ]; then
-        _url="$(resolve_github_asset_url "$_version" "$_asset_name" "$_auth_header")"
-    elif [ "$_version" = "latest" ]; then
-        _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
+    # ANA_BASE_URL can override the download URL (useful for testing)
+    if [ -n "${ANA_BASE_URL:-}" ]; then
+        _url="${ANA_BASE_URL}/${_asset_name}"
+        _auth_header=""
     else
-        _url="https://github.com/${REPO}/releases/download/v${_version#v}/${_asset_name}"
+        _auth_header="$(get_auth_header)"
+        # Private repo: use GitHub API to resolve asset URL
+        if [ -n "$_auth_header" ]; then
+            _url="$(resolve_github_asset_url "$_version" "$_asset_name" "$_auth_header")"
+        # Public repo: use direct download URL
+        elif [ "$_version" = "latest" ]; then
+            _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
+        else
+            _url="https://github.com/${REPO}/releases/download/v${_version#v}/${_asset_name}"
+        fi
     fi
 
     _tmp="$(mktemp "${TMPDIR:-/tmp}/.ana_install.XXXXXXXX")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
-# Installer script for ana
+# Installer script for ana.
 #
 # Usage:
-#   curl -fsSL https://anaconda.com/ana/install.sh | sh
-#   wget -qO- https://anaconda.com/ana/install.sh | sh
+#   Direct download:
+#   > curl -fsSL https://anaconda.com/ana/install.sh | sh
+#   or:
+#   > wget -qO- https://anaconda.com/ana/install.sh | sh
 #
-# Options (via environment variables):
-#   ANA_INSTALL_DIR       — where to place the binary (default: ~/.local/bin)
-#   ANA_VERSION           — version to install, without "v" prefix (default: latest)
-#   ANA_NO_PATH_UPDATE    — set to non-empty to skip shell profile modification
-#   ANA_VERIFY_CHECKSUM   — set to "true" to verify checksum (default: false)
-#   ANA_REQUEST_TOKEN     — GitHub token for authenticated requests (default: tries `gh auth token`)
+#   Direct script invocation:
+#   > ./install.sh [OPTIONS]
+#
+# Run with --help for full usage information.
 
 set -eu
 
@@ -23,13 +23,92 @@ __wrap__() {
 REPO="anaconda/ana-cli"
 BINARY_NAME="ana"
 
-# Defaults (can be overridden via environment variables)
+# Defaults (can be overridden via environment variables or CLI options)
 DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 DEFAULT_VERSION="latest"
 # TODO: Enable checksum verification by default once .sha256 files are published
 DEFAULT_VERIFY_CHECKSUM="false"
 
+usage() {
+    # Replace $HOME with ~ for display
+    local _display_dir
+    _display_dir="$(echo "$DEFAULT_INSTALL_DIR" | sed "s|^$HOME|~|")"
+
+    cat <<EOF
+Usage: install.sh [OPTIONS]
+
+Install the ana CLI tool.
+
+Options:
+  -d, --install-dir DIR   Install directory (default: ${_display_dir})
+  -v, --version VERSION   Version to install (default: ${DEFAULT_VERSION})
+  -t, --token TOKEN       GitHub token for private repo access
+      --verify-checksum   Verify checksum after download (default: ${DEFAULT_VERIFY_CHECKSUM})
+      --no-path-update    Skip shell profile modification
+  -h, --help              Show this help message
+
+Environment variables:
+  ANA_INSTALL_DIR         Same as --install-dir
+  ANA_VERSION             Same as --version
+  ANA_REQUEST_TOKEN       Same as --token
+  ANA_VERIFY_CHECKSUM     Set to "true" to verify checksum
+  ANA_NO_PATH_UPDATE      Set to non-empty to skip PATH update
+
+Examples:
+  # Direct download via pipe:
+  > curl -fsSL https://anaconda.com/ana/install.sh | sh
+
+  # Script invocation with options:
+  > ./install.sh --version 1.0.0 --install-dir /usr/local/bin
+
+  # Script invocation with environment variables:
+  > ANA_VERSION=1.0.0 ./install.sh
+EOF
+}
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -d|--install-dir)
+                [ $# -ge 2 ] || err "Missing argument for $1"
+                ANA_INSTALL_DIR="$2"
+                shift 2
+                ;;
+            -v|--version)
+                [ $# -ge 2 ] || err "Missing argument for $1"
+                ANA_VERSION="$2"
+                shift 2
+                ;;
+            -t|--token)
+                [ $# -ge 2 ] || err "Missing argument for $1"
+                ANA_REQUEST_TOKEN="$2"
+                shift 2
+                ;;
+            --verify-checksum)
+                ANA_VERIFY_CHECKSUM="true"
+                shift
+                ;;
+            --no-path-update)
+                ANA_NO_PATH_UPDATE="1"
+                shift
+                ;;
+            -*)
+                err "Unknown option: %s\nRun 'install.sh --help' for usage." "$1"
+                ;;
+            *)
+                err "Unexpected argument: %s\nRun 'install.sh --help' for usage." "$1"
+                ;;
+        esac
+    done
+}
+
 main() {
+    parse_args "$@"
+
     ensure_cmd uname
     ensure_cmd chmod
     ensure_cmd mkdir
@@ -300,4 +379,4 @@ err() {
 }
 
 main "$@"
-} && __wrap__
+} && __wrap__ "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,6 @@
 #   ANA_INSTALL_DIR       — where to place the binary (default: ~/.local/bin)
 #   ANA_VERSION           — version to install, without "v" prefix (default: latest)
 #   ANA_NO_PATH_UPDATE    — set to non-empty to skip shell profile modification
-#   ANA_NO_BOOTSTRAP      — set to non-empty to skip running `ana bootstrap`
 #   ANA_REQUEST_TOKEN     — GitHub token for authenticated requests (default: tries `gh auth token`)
 
 set -eu
@@ -70,12 +69,6 @@ main() {
 
     if [ -z "${ANA_NO_PATH_UPDATE:-}" ]; then
         update_shell_profile "$_install_dir"
-    fi
-
-    if [ -z "${ANA_NO_BOOTSTRAP:-}" ]; then
-        printf "\n"
-        info "Running ana bootstrap..."
-        "${_install_dir}/${BINARY_NAME}" bootstrap
     fi
 
     printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -254,7 +254,7 @@ resolve_github_asset_url() {
     local _version="$1" _asset_name="$2" _auth_header="$3" _api_url _response _asset_url
 
     if [ "$_version" = "latest" ]; then
-        _api_url="https://api.github.com/repos/${REPO}/releases/latest"
+        _api_url="https://api.github.com/repos/${REPO}/releases/tags/latest"
     else
         _api_url="https://api.github.com/repos/${REPO}/releases/tags/v${_version#v}"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,10 +218,9 @@ detect_arch() {
 map_target() {
     local _os="$1" _arch="$2"
     case "${_os}-${_arch}" in
-        # FIX(mattkram): Fix the mappings and document to ensure consistency
-        # linux-x86_64)   echo "x86_64-unknown-linux-gnu" ;;
-        # linux-aarch64)  echo "aarch64-unknown-linux-gnu" ;;
-        # macos-x86_64)   echo "x86_64-apple-darwin" ;;
+        linux-x86_64)   echo "linux-x86_64" ;;
+        linux-aarch64)  echo "linux-aarch64" ;;
+        macos-x86_64)   echo "darwin-x86_64" ;;
         macos-aarch64)  echo "darwin-arm64" ;;
         *)              err "No prebuilt binary for %s %s" "$_os" "$_arch" ;;
     esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -344,9 +344,6 @@ install_binary() {
     local _src="$1" _install_dir="$2"
     local _dest="${_install_dir}/${BINARY_NAME}"
 
-    chmod +x "$_src"
-    mkdir -p "$_install_dir"
-
     if [ -f "$_dest" ] && [ -z "${ANA_FORCE_INSTALL:-}" ]; then
         if [ -t 0 ]; then
             printf "  %s already exists. Overwrite? [y/N] " "$_dest"
@@ -360,6 +357,8 @@ install_binary() {
         fi
     fi
 
+    chmod +x "$_src"
+    mkdir -p "$_install_dir"
     mv -f "$_src" "$_dest"
     trap - EXIT
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,22 +24,21 @@ main() {
     need_cmd chmod
     need_cmd mkdir
 
-    setup_auth_headers
-
-    local _os _arch _target _version _install_dir _url _tmp
+    local _os _arch _target _version _install_dir _url _tmp _auth_header
 
     _os="$(detect_os)"
     _arch="$(detect_arch)"
     _target="$(map_target "$_os" "$_arch")"
     _version="${ANA_VERSION:-latest}"
     _install_dir="${ANA_INSTALL_DIR:-$HOME/.local/bin}"
+    _auth_header="$(get_auth_header)"
 
     local _asset_name="ana-${_target}"
 
     # Private repo: use GitHub API to resolve asset URL
     # Public repo: use direct download URL
-    if [ -n "${ANA_REQUEST_HEADERS:-}" ]; then
-        _url="$(resolve_github_asset_url "$_version" "$_asset_name")"
+    if [ -n "$_auth_header" ]; then
+        _url="$(resolve_github_asset_url "$_version" "$_asset_name" "$_auth_header")"
     elif [ "$_version" = "latest" ]; then
         _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
     else
@@ -53,14 +52,14 @@ main() {
     info "Installing ana for %s %s" "$_os" "$_arch"
     info "Downloading %s" "$_url"
 
-    download "$_url" "$_tmp"
+    download "$_url" "$_tmp" "$_auth_header"
 
     if [ ! -s "$_tmp" ]; then
         err "Downloaded file is empty. Check the URL or try again."
     fi
 
     info "Verifying checksum"
-    verify_checksum "$_url" "$_tmp"
+    verify_checksum "$_url" "$_tmp" "$_auth_header"
 
     chmod +x "$_tmp"
     mkdir -p "$_install_dir"
@@ -116,7 +115,7 @@ map_target() {
     esac
 }
 
-setup_auth_headers() {
+get_auth_header() {
     local _token
 
     # Use ANA_REQUEST_TOKEN if provided, otherwise try gh auth token
@@ -127,8 +126,7 @@ setup_auth_headers() {
     fi
 
     if [ -n "${_token:-}" ]; then
-        ANA_REQUEST_HEADERS="Authorization: token ${_token}"
-        export ANA_REQUEST_HEADERS
+        printf 'Authorization: token %s' "$_token"
     fi
 }
 
@@ -137,7 +135,7 @@ setup_auth_headers() {
 # We must use the API to get the asset URL instead.
 
 resolve_github_asset_url() {
-    local _version="$1" _asset_name="$2" _api_url _response _asset_url
+    local _version="$1" _asset_name="$2" _auth_header="$3" _api_url _response _asset_url
 
     if [ "$_version" = "latest" ]; then
         _api_url="https://api.github.com/repos/${REPO}/releases/latest"
@@ -145,7 +143,7 @@ resolve_github_asset_url() {
         _api_url="https://api.github.com/repos/${REPO}/releases/tags/v${_version#v}"
     fi
 
-    _response="$(curl -fsSL -H "$ANA_REQUEST_HEADERS" "$_api_url")" || {
+    _response="$(curl -fsSL -H "$_auth_header" "$_api_url")" || {
         err "Failed to fetch release info from GitHub API"
     }
 
@@ -163,7 +161,7 @@ resolve_github_asset_url() {
 # --- End private repo support ---
 
 download() {
-    local _url="$1" _dest="$2"
+    local _url="$1" _dest="$2" _auth_header="${3:-}"
 
     if [ ! -t 1 ]; then
         CURL_OPTS="--silent"
@@ -176,8 +174,8 @@ download() {
     if check_cmd curl; then
         local _http_code
         _http_code="$(curl -fSL $CURL_OPTS \
-            ${ANA_REQUEST_HEADERS:+-H "$ANA_REQUEST_HEADERS"} \
-            ${ANA_REQUEST_HEADERS:+-H "Accept: application/octet-stream"} \
+            ${_auth_header:+-H "$_auth_header"} \
+            ${_auth_header:+-H "Accept: application/octet-stream"} \
             "$_url" --output "$_dest" --write-out "%{http_code}")" || {
             err "Download failed. Is curl working? URL: %s" "$_url"
         }
@@ -186,8 +184,8 @@ download() {
         fi
     elif check_cmd wget; then
         wget $WGET_OPTS \
-            ${ANA_REQUEST_HEADERS:+--header="$ANA_REQUEST_HEADERS"} \
-            ${ANA_REQUEST_HEADERS:+--header="Accept: application/octet-stream"} \
+            ${_auth_header:+--header="$_auth_header"} \
+            ${_auth_header:+--header="Accept: application/octet-stream"} \
             --output-document="$_dest" "$_url" || {
             err "Download failed. Is wget working? URL: %s" "$_url"
         }
@@ -197,10 +195,10 @@ download() {
 }
 
 verify_checksum() {
-    local _url="$1" _file="$2" _expected _actual _tmp_sha
+    local _url="$1" _file="$2" _auth_header="${3:-}" _expected _actual _tmp_sha
 
     _tmp_sha="$(mktemp "${TMPDIR:-/tmp}/.ana_sha.XXXXXXXX")"
-    if ! download "${_url}.sha256" "$_tmp_sha" 2>/dev/null; then
+    if ! download "${_url}.sha256" "$_tmp_sha" "$_auth_header" 2>/dev/null; then
         warn "Checksum file not available, skipping verification"
         rm -f "$_tmp_sha"
         return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,7 @@ Options:
       --verify-checksum   Verify checksum after download (default: ${DEFAULT_VERIFY_CHECKSUM})
       --no-path-update    Skip shell profile modification
   -t, --token TOKEN       GitHub token for private repo access
+  -f, --force             Overwrite existing installation without prompting
   -h, --help              Show this help message
 
 Environment variables:
@@ -53,6 +54,7 @@ Environment variables:
   ANA_VERSION             Same as --version
   ANA_VERIFY_CHECKSUM     Set to "true" to verify checksum
   ANA_NO_PATH_UPDATE      Set to non-empty to skip PATH update
+  ANA_FORCE_INSTALL       Set to non-empty to overwrite without prompting
   GITHUB_TOKEN            Same as --token
 
 Examples:
@@ -95,6 +97,10 @@ parse_args() {
                 ;;
             --no-path-update)
                 ANA_NO_PATH_UPDATE="1"
+                shift
+                ;;
+            -f|--force)
+                ANA_FORCE_INSTALL="1"
                 shift
                 ;;
             -*)
@@ -156,7 +162,22 @@ main() {
 
     chmod +x "$_tmp"
     mkdir -p "$_install_dir"
-    mv -f "$_tmp" "${_install_dir}/${BINARY_NAME}"
+
+    local _dest="${_install_dir}/${BINARY_NAME}"
+    if [ -f "$_dest" ] && [ -z "${ANA_FORCE_INSTALL:-}" ]; then
+        if [ -t 0 ]; then
+            printf "  %s already exists. Overwrite? [y/N] " "$_dest"
+            read -r _reply
+            case "$_reply" in
+                [Yy]|[Yy][Ee][Ss]) ;;
+                *) err "Installation cancelled." ;;
+            esac
+        else
+            err "%s already exists. Use --force to overwrite." "$_dest"
+        fi
+    fi
+
+    mv -f "$_tmp" "$_dest"
     trap - EXIT
 
     info "Installed ana to %s/%s" "$_install_dir" "$BINARY_NAME"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC3043  # 'local' is widely supported even if not strictly POSIX
 # Installer script for ana.
 #
 # Usage:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,7 +80,7 @@ main() {
         update_shell_profile "$_install_dir"
     fi
 
-    info "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started."
+    printf "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started."
 }
 
 detect_os() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,299 @@
+#!/bin/sh
+# Installer script for ana
+#
+# Usage:
+#   curl -fsSL https://anaconda.com/ana/install.sh | sh
+#   wget -qO- https://anaconda.com/ana/install.sh | sh
+#
+# Options (via environment variables):
+#   ANA_INSTALL_DIR       — where to place the binary (default: ~/.local/bin)
+#   ANA_VERSION           — version to install, without "v" prefix (default: latest)
+#   ANA_NO_PATH_UPDATE    — set to non-empty to skip shell profile modification
+#   ANA_NO_BOOTSTRAP      — set to non-empty to skip running `ana bootstrap`
+#   ANA_REQUEST_TOKEN     — GitHub token for authenticated requests (default: tries `gh auth token`)
+
+set -eu
+
+__wrap__() {
+
+REPO="anaconda/ana-cli"
+BINARY_NAME="ana"
+
+main() {
+    need_cmd uname
+    need_cmd chmod
+    need_cmd mkdir
+
+    setup_auth_headers
+
+    local _os _arch _target _version _install_dir _url _tmp
+
+    _os="$(detect_os)"
+    _arch="$(detect_arch)"
+    _target="$(map_target "$_os" "$_arch")"
+    _version="${ANA_VERSION:-latest}"
+    _install_dir="${ANA_INSTALL_DIR:-$HOME/.local/bin}"
+
+    local _asset_name="ana-${_target}"
+
+    # Private repo: use GitHub API to resolve asset URL
+    # Public repo: use direct download URL
+    if [ -n "${ANA_REQUEST_HEADERS:-}" ]; then
+        _url="$(resolve_github_asset_url "$_version" "$_asset_name")"
+    elif [ "$_version" = "latest" ]; then
+        _url="https://github.com/${REPO}/releases/latest/download/${_asset_name}"
+    else
+        _url="https://github.com/${REPO}/releases/download/v${_version#v}/${_asset_name}"
+    fi
+
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/.ana_install.XXXXXXXX")"
+    trap 'rm -f "$_tmp"' EXIT
+
+    printf "\n"
+    info "Installing ana for %s %s" "$_os" "$_arch"
+    info "Downloading %s" "$_url"
+
+    download "$_url" "$_tmp"
+
+    if [ ! -s "$_tmp" ]; then
+        err "Downloaded file is empty. Check the URL or try again."
+    fi
+
+    info "Verifying checksum"
+    verify_checksum "$_url" "$_tmp"
+
+    chmod +x "$_tmp"
+    mkdir -p "$_install_dir"
+    mv -f "$_tmp" "${_install_dir}/${BINARY_NAME}"
+    trap - EXIT
+
+    info "Installed ana to %s/%s" "$_install_dir" "$BINARY_NAME"
+
+    if [ -z "${ANA_NO_PATH_UPDATE:-}" ]; then
+        update_shell_profile "$_install_dir"
+    fi
+
+    if [ -z "${ANA_NO_BOOTSTRAP:-}" ]; then
+        printf "\n"
+        info "Running ana bootstrap..."
+        "${_install_dir}/${BINARY_NAME}" bootstrap
+    fi
+
+    printf "\n"
+    info "Done! Run 'ana --help' to get started."
+    printf "\n"
+}
+
+detect_os() {
+    local _os
+    _os="$(uname -s)"
+    case "$_os" in
+        Linux)  echo "linux" ;;
+        Darwin) echo "macos" ;;
+        *)      err "Unsupported operating system: %s" "$_os" ;;
+    esac
+}
+
+detect_arch() {
+    local _arch
+    _arch="$(uname -m)"
+    case "$_arch" in
+        x86_64|amd64)   echo "x86_64" ;;
+        aarch64|arm64)  echo "aarch64" ;;
+        *)              err "Unsupported architecture: %s" "$_arch" ;;
+    esac
+}
+
+map_target() {
+    local _os="$1" _arch="$2"
+    case "${_os}-${_arch}" in
+        # FIX(mattkram): Fix the mappings and document to ensure consistency
+        # linux-x86_64)   echo "x86_64-unknown-linux-gnu" ;;
+        # linux-aarch64)  echo "aarch64-unknown-linux-gnu" ;;
+        # macos-x86_64)   echo "x86_64-apple-darwin" ;;
+        macos-aarch64)  echo "darwin-arm64" ;;
+        *)              err "No prebuilt binary for %s %s" "$_os" "$_arch" ;;
+    esac
+}
+
+setup_auth_headers() {
+    local _token
+
+    # Use ANA_REQUEST_TOKEN if provided, otherwise try gh auth token
+    if [ -n "${ANA_REQUEST_TOKEN:-}" ]; then
+        _token="$ANA_REQUEST_TOKEN"
+    elif check_cmd gh; then
+        _token="$(gh auth token 2>/dev/null)" || true
+    fi
+
+    if [ -n "${_token:-}" ]; then
+        ANA_REQUEST_HEADERS="Authorization: token ${_token}"
+        export ANA_REQUEST_HEADERS
+    fi
+}
+
+# --- Private repo support (remove this section when repo is public) ---
+# GitHub's /releases/download/ URLs don't work for private repos even with auth.
+# We must use the API to get the asset URL instead.
+
+resolve_github_asset_url() {
+    local _version="$1" _asset_name="$2" _api_url _response _asset_url
+
+    if [ "$_version" = "latest" ]; then
+        _api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    else
+        _api_url="https://api.github.com/repos/${REPO}/releases/tags/v${_version#v}"
+    fi
+
+    _response="$(curl -fsSL -H "$ANA_REQUEST_HEADERS" "$_api_url")" || {
+        err "Failed to fetch release info from GitHub API"
+    }
+
+    # Parse asset URL from JSON without jq
+    # Looks for: "name": "ana-darwin-arm64" ... "url": "https://api.github.com/.../assets/12345"
+    _asset_url="$(printf '%s' "$_response" | grep -B5 "\"name\": \"${_asset_name}\"" | grep '"url":' | head -1 | sed 's/.*"url": "\([^"]*\)".*/\1/')"
+
+    if [ -z "$_asset_url" ]; then
+        err "Asset '%s' not found in release %s" "$_asset_name" "$_version"
+    fi
+
+    printf '%s' "$_asset_url"
+}
+
+# --- End private repo support ---
+
+download() {
+    local _url="$1" _dest="$2"
+
+    if [ ! -t 1 ]; then
+        CURL_OPTS="--silent"
+        WGET_OPTS="--no-verbose"
+    else
+        CURL_OPTS=""
+        WGET_OPTS="--show-progress"
+    fi
+
+    if check_cmd curl; then
+        local _http_code
+        _http_code="$(curl -fSL $CURL_OPTS \
+            ${ANA_REQUEST_HEADERS:+-H "$ANA_REQUEST_HEADERS"} \
+            ${ANA_REQUEST_HEADERS:+-H "Accept: application/octet-stream"} \
+            "$_url" --output "$_dest" --write-out "%{http_code}")" || {
+            err "Download failed. Is curl working? URL: %s" "$_url"
+        }
+        if [ "$_http_code" -lt 200 ] || [ "$_http_code" -gt 299 ]; then
+            err "Download failed with HTTP %s: %s" "$_http_code" "$_url"
+        fi
+    elif check_cmd wget; then
+        wget $WGET_OPTS \
+            ${ANA_REQUEST_HEADERS:+--header="$ANA_REQUEST_HEADERS"} \
+            ${ANA_REQUEST_HEADERS:+--header="Accept: application/octet-stream"} \
+            --output-document="$_dest" "$_url" || {
+            err "Download failed. Is wget working? URL: %s" "$_url"
+        }
+    else
+        err "Need curl or wget to download files"
+    fi
+}
+
+verify_checksum() {
+    local _url="$1" _file="$2" _expected _actual _tmp_sha
+
+    _tmp_sha="$(mktemp "${TMPDIR:-/tmp}/.ana_sha.XXXXXXXX")"
+    if ! download "${_url}.sha256" "$_tmp_sha" 2>/dev/null; then
+        warn "Checksum file not available, skipping verification"
+        rm -f "$_tmp_sha"
+        return 0
+    fi
+
+    _expected="$(awk '{print $1}' "$_tmp_sha")"
+    rm -f "$_tmp_sha"
+
+    if check_cmd sha256sum; then
+        _actual="$(sha256sum "$_file" | awk '{print $1}')"
+    elif check_cmd shasum; then
+        _actual="$(shasum -a 256 "$_file" | awk '{print $1}')"
+    else
+        warn "No sha256sum or shasum found, skipping verification"
+        return 0
+    fi
+
+    if [ "$_expected" != "$_actual" ]; then
+        err "Checksum mismatch!\n  expected: %s\n  actual:   %s" "$_expected" "$_actual"
+    fi
+
+    info "Checksum OK"
+}
+
+update_shell_profile() {
+    local _dir="$1" _line
+
+    if echo "$PATH" | tr ':' '\n' | grep -qx "$_dir" 2>/dev/null; then
+        return 0
+    fi
+
+    _line="export PATH=\"${_dir}:\$PATH\""
+
+    case "$(basename "${SHELL:-}")" in
+        bash)
+            append_line_if_missing "$HOME/.bashrc" "$_line"
+            ;;
+        zsh)
+            append_line_if_missing "$HOME/.zshrc" "$_line"
+            ;;
+        fish)
+            _line="set -gx PATH \"${_dir}\" \$PATH"
+            append_line_if_missing "$HOME/.config/fish/config.fish" "$_line"
+            ;;
+        *)
+            warn "%s is not in your PATH." "$_dir"
+            warn "Add it with:  %s" "$_line"
+            return 0
+            ;;
+    esac
+}
+
+append_line_if_missing() {
+    local _file="$1" _line="$2"
+
+    if [ -f "$_file" ] && grep -Fxq "$_line" "$_file" 2>/dev/null; then
+        return 0
+    fi
+
+    [ -f "$_file" ] || touch "$_file"
+
+    printf '\n%s\n' "$_line" >> "$_file"
+    info "Updated %s — restart your shell or run:  source %s" "$_file" "$_file"
+}
+
+check_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"; then
+        err "Required command not found: %s" "$1"
+    fi
+}
+
+info() {
+    local _fmt="$1"; shift
+    # shellcheck disable=SC2059
+    printf "  \033[1;32m>\033[0m $_fmt\n" "$@"
+}
+
+warn() {
+    local _fmt="$1"; shift
+    # shellcheck disable=SC2059
+    printf "  \033[1;33m!\033[0m $_fmt\n" "$@" >&2
+}
+
+err() {
+    local _fmt="$1"; shift
+    # shellcheck disable=SC2059
+    printf "  \033[1;31mx\033[0m $_fmt\n" "$@" >&2
+    exit 1
+}
+
+main "$@"
+} && __wrap__

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -231,7 +231,7 @@ resolve_github_asset_url() {
     fi
 
     _response="$(curl -fsSL -H "$_auth_header" "$_api_url")" || {
-        err "Failed to fetch release info from GitHub API"
+        err "Failed to fetch release info from GitHub API for version: (%s)" "$_version"
     }
 
     # Parse asset URL from JSON without jq

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,21 +41,21 @@ Usage: install.sh [OPTIONS]
 Install the ana CLI tool.
 
 Options:
-  -d, --install-dir DIR   Install directory (default: ${_display_dir})
-  -v, --version VERSION   Version to install (default: ${DEFAULT_VERSION})
-      --verify-checksum   Verify checksum after download (default: ${DEFAULT_VERIFY_CHECKSUM})
-      --no-path-update    Skip shell profile modification
-  -t, --token TOKEN       GitHub token for private repo access
-  -f, --force             Overwrite existing installation without prompting
-  -h, --help              Show this help message
+  -d, --install-dir DIR    Install directory (default: ${_display_dir})
+  -v, --version VERSION    Version to install (default: ${DEFAULT_VERSION})
+      --no-verify-checksum Disable checksum validation after download (default: false)
+      --no-path-update     Skip shell profile modification
+  -t, --token TOKEN        GitHub token for private repo access
+  -f, --force              Overwrite existing installation without prompting
+  -h, --help               Show this help message
 
 Environment variables:
-  ANA_INSTALL_DIR         Same as --install-dir
-  ANA_VERSION             Same as --version
-  ANA_VERIFY_CHECKSUM     Set to "true" to verify checksum
-  ANA_NO_PATH_UPDATE      Set to non-empty to skip PATH update
-  ANA_FORCE_INSTALL       Set to non-empty to overwrite without prompting
-  GITHUB_TOKEN            Same as --token
+  ANA_INSTALL_DIR          Same as --install-dir
+  ANA_VERSION              Same as --version
+  ANA_VERIFY_CHECKSUM      Set to "true" to verify checksum
+  ANA_NO_PATH_UPDATE       Set to non-empty to skip PATH update
+  ANA_FORCE_INSTALL        Set to non-empty to overwrite without prompting
+  GITHUB_TOKEN             Same as --token
 
 Examples:
   # Direct download via pipe:
@@ -91,8 +91,8 @@ parse_args() {
                 GITHUB_TOKEN="$2"
                 shift 2
                 ;;
-            --verify-checksum)
-                ANA_VERIFY_CHECKSUM="true"
+            --no-verify-checksum)
+                ANA_VERIFY_CHECKSUM="false"
                 shift
                 ;;
             --no-path-update)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,9 +24,9 @@ REPO="anaconda/ana-cli"
 BINARY_NAME="ana"
 
 main() {
-    need_cmd uname
-    need_cmd chmod
-    need_cmd mkdir
+    ensure_cmd uname
+    ensure_cmd chmod
+    ensure_cmd mkdir
 
     local _os _arch _target _version _install_dir _url _tmp _auth_header
 
@@ -271,7 +271,7 @@ check_cmd() {
     command -v "$1" >/dev/null 2>&1
 }
 
-need_cmd() {
+ensure_cmd() {
     if ! check_cmd "$1"; then
         err "Required command not found: %s" "$1"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,6 @@ main() {
     _tmp="$(mktemp "${TMPDIR:-/tmp}/.ana_install.XXXXXXXX")"
     trap 'rm -f "$_tmp"' EXIT
 
-    printf "\n"
     info "Installing ana for %s %s" "$_os" "$_arch"
     info "Downloading %s" "$_url"
 
@@ -81,9 +80,7 @@ main() {
         update_shell_profile "$_install_dir"
     fi
 
-    printf "\n"
     info "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started."
-    printf "\n"
 }
 
 detect_os() {
@@ -252,6 +249,7 @@ update_shell_profile() {
             return 0
             ;;
     esac
+    printf "\n"
 }
 
 append_line_if_missing() {

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -245,6 +245,17 @@ class TestGithubTokenEnvVar:
         assert result.returncode == 1
         assert "GitHub API" in result.stderr or "Download failed" in result.stderr
 
+    def test_github_token_missing_errors(self, env_isolated: dict[str, str]) -> None:
+        """Test that missing GitHub token produces an error."""
+        # Ensure no token is available
+        env_isolated.pop("GITHUB_TOKEN", None)
+        # Set PATH to only include essential system paths (no gh CLI)
+        env_isolated["PATH"] = "/usr/bin:/bin"
+
+        result = run_script(env=env_isolated)
+        assert result.returncode == 1
+        assert "GitHub token" in result.stderr or "token" in result.stderr.lower()
+
 
 class TestInstallation:
     """Tests for installation using mock server."""

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -440,3 +440,44 @@ class TestShellProfileUpdate:
 
         # Should be the same (no duplicate entries)
         assert zshrc_after_first == zshrc_after_second
+
+
+class TestBinaryVerification:
+    """Tests to verify the installed mock binary works."""
+
+    def test_installed_binary_runs(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test that the installed binary actually runs."""
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        # Run the installed binary
+        binary = install_dir / "ana"
+        result = subprocess.run(
+            [str(binary), "--version"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "0.0.0-mock" in result.stdout
+
+    def test_installed_binary_help(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test that the installed binary shows help."""
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        binary = install_dir / "ana"
+        result = subprocess.run(
+            [str(binary), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "Mock ana CLI for testing" in result.stdout

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -348,3 +348,84 @@ class TestForceInstall:
         # Second install (should succeed due to env var)
         result = run_script(env=env_with_mock_server)
         assert result.returncode == 0
+
+
+class TestShellProfileUpdate:
+    """Tests for shell profile modification."""
+
+    def test_no_path_update_flag(
+        self,
+        env_with_mock_server: dict[str, str],
+        fake_home: Path,
+    ) -> None:
+        """Test --no-path-update prevents shell profile modification."""
+        del env_with_mock_server["ANA_NO_PATH_UPDATE"]
+
+        zshrc_before = (fake_home / ".zshrc").read_text()
+
+        result = run_script("--no-path-update", env=env_with_mock_server)
+        assert result.returncode == 0
+
+        zshrc_after = (fake_home / ".zshrc").read_text()
+        assert zshrc_before == zshrc_after
+
+    def test_no_path_update_env_var(
+        self,
+        env_with_mock_server: dict[str, str],
+        fake_home: Path,
+    ) -> None:
+        """Test ANA_NO_PATH_UPDATE prevents shell profile modification."""
+        env_with_mock_server["ANA_NO_PATH_UPDATE"] = "1"
+
+        zshrc_before = (fake_home / ".zshrc").read_text()
+
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        zshrc_after = (fake_home / ".zshrc").read_text()
+        assert zshrc_before == zshrc_after
+
+    def test_path_update_modifies_profile(
+        self,
+        env_with_mock_server: dict[str, str],
+        fake_home: Path,
+        install_dir: Path,
+    ) -> None:
+        """Test that path update modifies the shell profile."""
+        del env_with_mock_server["ANA_NO_PATH_UPDATE"]
+        # Set SHELL to zsh for predictable behavior
+        env_with_mock_server["SHELL"] = "/bin/zsh"
+
+        zshrc = fake_home / ".zshrc"
+        zshrc_before = zshrc.read_text()
+
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        zshrc_after = zshrc.read_text()
+        assert zshrc_before != zshrc_after
+        assert str(install_dir) in zshrc_after
+        assert "export PATH=" in zshrc_after
+
+    def test_path_update_idempotent(
+        self,
+        env_with_mock_server: dict[str, str],
+        fake_home: Path,
+        install_dir: Path,
+    ) -> None:
+        """Test that running install twice doesn't duplicate PATH entry."""
+        del env_with_mock_server["ANA_NO_PATH_UPDATE"]
+        env_with_mock_server["SHELL"] = "/bin/zsh"
+
+        # First install
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+        zshrc_after_first = (fake_home / ".zshrc").read_text()
+
+        # Second install
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+        zshrc_after_second = (fake_home / ".zshrc").read_text()
+
+        # Should be the same (no duplicate entries)
+        assert zshrc_after_first == zshrc_after_second

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -19,6 +20,41 @@ def _find_repo_root() -> Path:
 
 REPO_ROOT = _find_repo_root()
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
+
+
+@pytest.fixture
+def install_dir(tmp_path: Path) -> Path:
+    """Provide a temporary installation directory."""
+    d = tmp_path / "bin"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    """Provide a fake HOME directory to isolate shell profile modifications."""
+    home = tmp_path / "home"
+    home.mkdir()
+    # Create shell config files
+    (home / ".bashrc").touch()
+    (home / ".zshrc").touch()
+    fish_config = home / ".config" / "fish"
+    fish_config.mkdir(parents=True)
+    (fish_config / "config.fish").touch()
+    return home
+
+
+@pytest.fixture
+def env_isolated(fake_home: Path, install_dir: Path) -> dict[str, str]:
+    """Provide an isolated environment that won't modify real shell configs."""
+    env = {
+        key: val for key, val in os.environ.copy().items() if not key.startswith("ANA_")
+    }
+
+    env["HOME"] = str(fake_home)
+    env["ANA_INSTALL_DIR"] = str(install_dir)
+    env["ANA_NO_PATH_UPDATE"] = "1"  # Extra safety
+    return env
 
 
 def run_script(

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -151,7 +151,7 @@ class TestHelp:
         result = run_script("--help")
         assert "--install-dir" in result.stdout
         assert "--version" in result.stdout
-        assert "--verify-checksum" in result.stdout
+        assert "--no-verify-checksum" in result.stdout
         assert "--no-path-update" in result.stdout
         assert "--token" in result.stdout
         assert "--force" in result.stdout
@@ -278,3 +278,16 @@ class TestInstallation:
 
         assert result.returncode == 0
         assert (install_dir / "ana").exists()
+
+    def test_checksum_verification_disabled_warning(
+        self,
+        env_with_mock_server: dict[str, str],
+    ) -> None:
+        """Test that checksum verification disabled warning is shown."""
+        result = run_script("--no-verify-checksum", env=env_with_mock_server)
+
+        assert result.returncode == 0
+        assert (
+            "Checksum verification disabled" in result.stderr
+            or "Checksum verification disabled" in result.stdout
+        )

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -316,6 +316,17 @@ class TestInstallation:
             or "Checksum verification disabled" in result.stdout
         )
 
+    def test_checksum_verification_invalid_value_errors(
+        self,
+        env_with_mock_server: dict[str, str],
+    ) -> None:
+        """Test that invalid ANA_VERIFY_CHECKSUM values raise an error."""
+        env_with_mock_server["ANA_VERIFY_CHECKSUM"] = "blargh"
+        result = run_script(env=env_with_mock_server)
+
+        assert result.returncode == 1
+        assert "Invalid ANA_VERIFY_CHECKSUM" in result.stderr
+
 
 class TestForceInstall:
     """Tests for --force flag behavior."""

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -88,12 +88,18 @@ def env_isolated(fake_home: Path, install_dir: Path) -> dict[str, str]:
 @pytest.fixture(scope="session")
 def mock_server(tmp_path_factory: pytest.TempPathFactory) -> Generator[str, None, None]:
     """Start a local HTTP server to host mock binaries."""
+    import hashlib
+
     # Create mock binaries for different platforms
     root = tmp_path_factory.mktemp("mock_server")
     for platform in SUPPORTED_PLATFORMS:
         binary = root / f"ana-{platform}"
         binary.write_text(MOCK_BINARY_SCRIPT)
         binary.chmod(EXECUTABLE_MODE)
+        # Create corresponding checksum file
+        checksum = hashlib.sha256(MOCK_BINARY_SCRIPT.encode()).hexdigest()
+        checksum_file = root / f"ana-{platform}.sha256"
+        checksum_file.write_text(f"{checksum}  ana-{platform}\n")
 
     class QuietHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         """HTTP request handler that suppresses logging."""

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import http.server
 import os
+import socketserver
 import subprocess
+import stat
+import threading
+from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def _find_repo_root() -> Path:
@@ -20,6 +29,18 @@ def _find_repo_root() -> Path:
 
 REPO_ROOT = _find_repo_root()
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
+
+# Create a simple mock binary script that responds to --version and --help
+MOCK_BINARY_SCRIPT = """\
+#!/bin/sh
+case "$1" in
+    --version) echo "0.0.0-mock" ;;
+    --help) echo "Mock ana CLI for testing" ;;
+    *) echo "mock ana" ;;
+esac
+"""
+EXECUTABLE_MODE = 0o755  # rwxr-xr-x
+SUPPORTED_PLATFORMS = ["darwin-arm64", "darwin-x86_64", "linux-x86_64", "linux-aarch64"]
 
 
 @pytest.fixture
@@ -55,6 +76,46 @@ def env_isolated(fake_home: Path, install_dir: Path) -> dict[str, str]:
     env["ANA_INSTALL_DIR"] = str(install_dir)
     env["ANA_NO_PATH_UPDATE"] = "1"  # Extra safety
     return env
+
+
+@pytest.fixture(scope="session")
+def mock_server(tmp_path_factory: pytest.TempPathFactory) -> Generator[str, None, None]:
+    """Start a local HTTP server to host mock binaries."""
+    # Create mock binaries for different platforms
+    root = tmp_path_factory.mktemp("mock_server")
+    for platform in SUPPORTED_PLATFORMS:
+        binary = root / f"ana-{platform}"
+        binary.write_text(MOCK_BINARY_SCRIPT)
+        binary.chmod(EXECUTABLE_MODE)
+
+    class QuietHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+        """HTTP request handler that suppresses logging."""
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass  # Suppress logging
+
+    handler = partial(QuietHTTPRequestHandler, directory=str(root))
+
+    # Use port 0 to let the OS pick an available port
+    with socketserver.TCPServer(("127.0.0.1", 0), handler) as server:
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+
+        yield f"http://127.0.0.1:{port}"
+
+        server.shutdown()
+
+
+@pytest.fixture
+def env_with_mock_server(
+    env_isolated: dict[str, str],
+    mock_server: str,
+) -> dict[str, str]:
+    """Provide isolated environment with mock server URL."""
+    env_isolated["ANA_BASE_URL"] = mock_server
+    return env_isolated
 
 
 def run_script(
@@ -176,3 +237,44 @@ class TestGithubTokenEnvVar:
         # Should try to use the token (will fail at API call)
         assert result.returncode == 1
         assert "GitHub API" in result.stderr or "Download failed" in result.stderr
+
+
+class TestInstallation:
+    """Tests for installation using mock server."""
+
+    def test_successful_install(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test successful installation of a specific version."""
+        result = run_script(env=env_with_mock_server)
+
+        expected_binary = install_dir / "ana"
+
+        assert result.returncode == 0
+        assert "Installing ana for" in result.stdout
+        assert f"Installed ana to {expected_binary}" in result.stdout
+        assert "Done!" in result.stdout
+
+        # Verify binary exists and is executable
+        assert expected_binary.exists()
+        assert expected_binary.stat().st_mode & stat.S_IXUSR
+
+    def test_install_with_cli_options(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test installation using CLI options."""
+        # Remove env vars to test CLI takes precedence
+        del env_with_mock_server["ANA_INSTALL_DIR"]
+
+        result = run_script(
+            "--install-dir",
+            str(install_dir),
+            env=env_with_mock_server,
+        )
+
+        assert result.returncode == 0
+        assert (install_dir / "ana").exists()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -91,3 +91,38 @@ class TestHelp:
     def test_help_shows_defaults(self, expected: str) -> None:
         result = run_script("--help")
         assert f"default: {expected})" in result.stdout
+
+
+class TestArgumentParsing:
+    """Tests for CLI argument parsing."""
+
+    def test_unknown_option_errors(self) -> None:
+        result = run_script("--unknown-option")
+        assert result.returncode == 1
+        assert "Unknown option: --unknown-option" in result.stderr
+
+    def test_unexpected_argument_errors(self) -> None:
+        result = run_script("unexpected_arg")
+        assert result.returncode == 1
+        assert "Unexpected argument: unexpected_arg" in result.stderr
+
+    def test_missing_install_dir_argument(self) -> None:
+        result = run_script("--install-dir")
+        assert result.returncode == 1
+        assert "Missing argument" in result.stderr
+
+    def test_missing_version_argument(self) -> None:
+        result = run_script("--version")
+        assert result.returncode == 1
+        assert "Missing argument" in result.stderr
+
+    def test_missing_token_argument(self) -> None:
+        result = run_script("--token")
+        assert result.returncode == 1
+        assert "Missing argument" in result.stderr
+
+    def test_short_flags_work(self) -> None:
+        # -h is tested above, test -d and -v require more setup
+        # Just verify -h works as a smoke test for short flags
+        result = run_script("-h")
+        assert result.returncode == 0

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,93 @@
+"""Integration tests for the install.sh script."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _find_repo_root() -> Path:
+    """Find the repository root by looking for .git directory."""
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError("Could not find repository root")
+
+
+REPO_ROOT = _find_repo_root()
+SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def run_script(
+    *args: str,
+    env: dict[str, str] | None = None,
+    input: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the install script with given arguments."""
+    return subprocess.run(
+        ["sh", str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=input,
+    )
+
+
+class TestHelp:
+    """Tests for --help output."""
+
+    def test_help_short_flag(self) -> None:
+        result = run_script("-h")
+        assert result.returncode == 0
+        assert "Usage: install.sh [OPTIONS]" in result.stdout
+        assert "Install the ana CLI tool." in result.stdout
+
+    def test_help_long_flag(self) -> None:
+        result = run_script("--help")
+        assert result.returncode == 0
+        assert "Usage: install.sh [OPTIONS]" in result.stdout
+
+    def test_help_shows_all_options(self) -> None:
+        result = run_script("--help")
+        assert "--install-dir" in result.stdout
+        assert "--version" in result.stdout
+        assert "--verify-checksum" in result.stdout
+        assert "--no-path-update" in result.stdout
+        assert "--token" in result.stdout
+        assert "--force" in result.stdout
+        assert "--help" in result.stdout
+
+    def test_help_shows_environment_variables(self) -> None:
+        result = run_script("--help")
+        assert "ANA_INSTALL_DIR" in result.stdout
+        assert "ANA_VERSION" in result.stdout
+        assert "ANA_VERIFY_CHECKSUM" in result.stdout
+        assert "ANA_NO_PATH_UPDATE" in result.stdout
+        assert "ANA_FORCE_INSTALL" in result.stdout
+        assert "GITHUB_TOKEN" in result.stdout
+
+    def test_help_shows_examples(self) -> None:
+        result = run_script("--help")
+        assert "Examples:" in result.stdout
+        assert "curl" in result.stdout
+
+    @pytest.mark.parametrize(
+        "expected",
+        [
+            pytest.param("~/.local/bin", id="install-dir"),
+            pytest.param("latest", id="version"),
+            pytest.param(
+                "true",
+                id="verify-checksum",
+                marks=pytest.mark.xfail(
+                    reason="Checksum verification disabled until .sha256 files published"
+                ),
+            ),
+        ],
+    )
+    def test_help_shows_defaults(self, expected: str) -> None:
+        result = run_script("--help")
+        assert f"default: {expected})" in result.stdout

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -7,6 +7,7 @@ import os
 import socketserver
 import subprocess
 import stat
+import sys
 import threading
 from functools import partial
 from pathlib import Path
@@ -16,6 +17,12 @@ import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+# Skip all tests in this module on Windows
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="install.sh is a shell script that only runs on Linux/macOS",
+)
 
 
 def _find_repo_root() -> Path:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -291,3 +291,53 @@ class TestInstallation:
             "Checksum verification disabled" in result.stderr
             or "Checksum verification disabled" in result.stdout
         )
+
+
+class TestForceInstall:
+    """Tests for --force flag behavior."""
+
+    def test_overwrite_without_force_fails_non_tty(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test that overwriting without --force fails in non-TTY mode."""
+        # First install
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        # Try to install again without --force
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 1
+        assert "already exists" in result.stderr
+        assert "--force" in result.stderr
+
+    def test_overwrite_with_force_succeeds(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test that overwriting with --force succeeds."""
+        # First install
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        # Second install with --force
+        result = run_script("--force", env=env_with_mock_server)
+        assert result.returncode == 0
+
+    def test_force_via_env_var(
+        self,
+        env_with_mock_server: dict[str, str],
+        install_dir: Path,
+    ) -> None:
+        """Test ANA_FORCE_INSTALL environment variable."""
+        env_with_mock_server["ANA_FORCE_INSTALL"] = "1"
+
+        # First install
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0
+
+        # Second install (should succeed due to env var)
+        result = run_script(env=env_with_mock_server)
+        assert result.returncode == 0

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -433,8 +433,8 @@ class TestShellProfileUpdate:
         assert result.returncode == 0
         zshrc_after_first = (fake_home / ".zshrc").read_text()
 
-        # Second install
-        result = run_script(env=env_with_mock_server)
+        # Second install (--force to overwrite existing binary)
+        result = run_script("--force", env=env_with_mock_server)
         assert result.returncode == 0
         zshrc_after_second = (fake_home / ".zshrc").read_text()
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -126,3 +126,17 @@ class TestArgumentParsing:
         # Just verify -h works as a smoke test for short flags
         result = run_script("-h")
         assert result.returncode == 0
+
+
+# TODO(mattkram): Remove this test class once we don't need GitHub tokens
+class TestGithubTokenEnvVar:
+    """Tests for environment variable handling."""
+
+    def test_github_token_env_var(self, env_isolated: dict[str, str]) -> None:
+        """Test that GITHUB_TOKEN is recognized."""
+        env_isolated["GITHUB_TOKEN"] = "test_token_12345"
+        # This will fail because the token is fake, but we can check it tried to use it
+        result = run_script(env=env_isolated)
+        # Should try to use the token (will fail at API call)
+        assert result.returncode == 1
+        assert "GitHub API" in result.stderr or "Download failed" in result.stderr


### PR DESCRIPTION
## Summary

Adds a new installation script at `scripts/install.sh`. The intent is that users would use this (once we have static hosting infrastructure in place) like:

```shell
curl -fsSL https://anaconda.com/install.sh | sh
```

> [!NOTE]
> URL is To be determined

The script can also be downloaded and executed like `sh install.sh`. It implements a simple CLI, which can be shown with `sh install.sh -h`. The output is reproduced below:

```shell
Usage: install.sh [OPTIONS]

Install the ana CLI tool.

Options:
  -d, --install-dir DIR    Install directory (default: ~/.local/bin)
  -v, --version VERSION    Version to install (default: latest)
      --no-verify-checksum Disable checksum validation after download (default: false)
      --no-path-update     Skip shell profile modification
  -t, --token TOKEN        GitHub token for private repo access
  -f, --force              Overwrite existing installation without prompting
  -h, --help               Show this help message

Environment variables:
  ANA_INSTALL_DIR          Same as --install-dir
  ANA_VERSION              Same as --version
  ANA_VERIFY_CHECKSUM      Set to "false" to skip checksum verification
  ANA_NO_PATH_UPDATE       Set to non-empty to skip PATH update
  ANA_FORCE_INSTALL        Set to non-empty to overwrite without prompting
  GITHUB_TOKEN             Same as --token

Examples:
  # Direct download via pipe:
  > curl -fsSL https://anaconda.com/ana/install.sh | sh

  # Script invocation with options:
  > ./install.sh --version 1.0.0 --install-dir /usr/local/bin

  # Script invocation with environment variables:
  > ANA_VERSION=1.0.0 ./install.sh
```

This script is limited to macOS and Linux for now. We will add a Windows Powershell script later.

The script is tested via `pytest`, which 

### How to test

You can access the install script from this branch by passing in a GitHub token. If you use `gh`, you can do:

```shell
export GITHUB_TOKEN=$(gh auth token)
 
curl -fsSL \
    -H "Authorization: token $GITHUB_TOKEN" \
    -H "Accept: application/vnd.github.raw" \
    "https://api.github.com/repos/anaconda/ana-cli/contents/scripts/install.sh?ref=feat/install-script" \
    | sh -s -- --token $GITHUB_TOKEN -d ./bin

./bin/ana --version
```

You can also explicitly put `--version 0.0.2.dev9` at the end to pick a particular release.

### Demo

Here is a full working demo (using the script from this branch), which demonstrates:

* Clean install from `install.sh` of an older version
* Self update to a newer version

<img width="1736" height="866" alt="image" src="https://github.com/user-attachments/assets/477d1e61-48d4-49ae-8b96-d68e93581f47" />

Jira: [CLI-360](https://anaconda.atlassian.net/browse/CLI-360)

[CLI-360]: https://anaconda.atlassian.net/browse/CLI-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ