### PR TITLE
feat: Generate sha256 checksum files and add "latest" release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,6 +103,13 @@ jobs:
           mv binaries/binary-macos-latest/ana release-assets/ana-darwin-arm64
           mv binaries/binary-windows-latest/ana.exe release-assets/ana-windows-x86_64.exe
 
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          for file in *; do
+            sha256sum "$file" > "${file}.sha256"
+          done
+
       - name: Create or update release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
             sha256sum "$file" > "${file}.sha256"
           done
 
-      - name: Create or update release
+      - name: Create or update versioned release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ steps.version.outputs.version }}
@@ -122,3 +122,16 @@ jobs:
           body: |
             ---
             *Automated prerelease from main branch.*
+
+      - name: Update latest release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: latest
+          name: Latest Release
+          prerelease: true
+          make_latest: false
+          files: release-assets/*
+          body: |
+            This release always points to the most recent build.
+
+            **Version:** ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

The installation script in #36 requires `.sha256` files for each generated binary artifact. It also defaults to the `latest` release if an explicit is not provided.

Here, we update the release workflow to do both of these things. Once the resulting release is published, #36 will be updated to reflect.

Jira: [CLI-359](https://anaconda.atlassian.net/browse/CLI-359)

[CLI-359]: https://anaconda.atlassian.net/browse/CLI-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ