### PR TITLE
feat: Add integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ jobs:
         run: |
           pixi run test
 
-      - name: Run tests for install script
-        run: |
-          pixi run test-install-script
-
       - name: Build as standalone binary
         run: |
           pixi run build-release
+
+      - name: Run integration tests
+        run: |
+          pixi run test-integration
 
       - name: Build as conda package
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,14 @@ repos:
       - id: pretty-format-json
         args: [--autofix]
       - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
+    hooks:
+      # lint & attempt to correct failures (e.g. pyupgrade)
+      - id: ruff-check
+        args: [--fix]
+      # compatible replacement for black
+      - id: ruff-format
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.16.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: help test
+
+help:  ## Display help on all Makefile targets
+	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
+
+test:  ## Run all the unit tests
+	pixi run test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: help test
+.PHONY: help test test-integration
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
 
 test:  ## Run all the unit tests
 	pixi run test
+
+test-integration:  ## Run CLI integration tests
+	pixi run test-integration

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,6 +32,7 @@ description = "Build the standalone Rust binary in release mode"
 cmd = "python scripts/with_version.py cargo test"
 description = "Run the unit tests"
 
-[tasks.test-install-script]
+[tasks.test-integration]
 cmd = "pytest tests -v"
+depends-on = ["build-release"]
 description = "Run integration tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,20 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # Version derived from git tags (e.g., v0.1.0 -> 0.1.0)
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+ignore = ["E501"]
+select = ["F", "E", "W", "I", "UP", "TID"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.isort]
+force-single-line = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["TID252"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -34,3 +37,52 @@ def fake_home(tmp_path: Path) -> Path:
     fish_config.mkdir(parents=True)
     (fish_config / "config.fish").touch()
     return home
+
+
+@pytest.fixture(scope="session")
+def ana_binary() -> Path | None:
+    """Find the ana binary in standard locations.
+
+    Search order:
+    1. ANA_BINARY_PATH environment variable
+    2. target/release/ana (release build)
+    3. target/debug/ana (debug build)
+    """
+    if env_path := os.getenv("ANA_BINARY_PATH"):
+        path = Path(env_path)
+        if path.exists() and path.is_file():
+            return path
+
+    for subpath in ["target/release/ana", "target/debug/ana"]:
+        binary = REPO_ROOT / subpath
+        if binary.exists():
+            return binary
+
+    return None
+
+
+AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@pytest.fixture(scope="session")
+def run_ana(ana_binary: Path | None) -> AnaRunner:
+    """Provide a function to run the ana binary."""
+    if ana_binary is None:
+        pytest.skip(
+            "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
+        )
+
+    def _run(
+        *args: str,
+        env: dict[str, str] | None = None,
+        input: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(ana_binary), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            input=input,
+        )
+
+    return _run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for integration tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _find_repo_root() -> Path:
+    """Find the repository root by looking for .git directory."""
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError("Could not find repository root")
+
+
+REPO_ROOT = _find_repo_root()
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    """Provide a fake HOME directory for test isolation.
+
+    Creates shell config files for testing profile modifications.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    # Create shell config files
+    (home / ".bashrc").touch()
+    (home / ".zshrc").touch()
+    fish_config = home / ".config" / "fish"
+    fish_config.mkdir(parents=True)
+    (fish_config / "config.fish").touch()
+    return home

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,18 @@ def fake_home(tmp_path: Path) -> Path:
     return home
 
 
+@pytest.fixture
+def env_isolated(fake_home: Path) -> dict[str, str]:
+    """Provide an isolated environment without ANA_* or GITHUB_TOKEN vars."""
+    env = {
+        key: val
+        for key, val in os.environ.copy().items()
+        if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
+    }
+    env["HOME"] = str(fake_home)
+    return env
+
+
 @pytest.fixture(scope="session")
 def ana_binary() -> Path | None:
     """Find the ana binary in standard locations.
@@ -64,9 +76,9 @@ def ana_binary() -> Path | None:
 AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
 
 
-@pytest.fixture(scope="session")
-def run_ana(ana_binary: Path | None) -> AnaRunner:
-    """Provide a function to run the ana binary."""
+@pytest.fixture
+def run_ana(ana_binary: Path | None, env_isolated: dict[str, str]) -> AnaRunner:
+    """Provide a function to run the ana binary with isolated environment."""
     if ana_binary is None:
         pytest.skip(
             "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
@@ -77,6 +89,8 @@ def run_ana(ana_binary: Path | None) -> AnaRunner:
         env: dict[str, str] | None = None,
         input: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        # Start with isolated environment and update with argument if available
+        env = {**env_isolated, **(env or {})}
         return subprocess.run(
             [str(ana_binary), *args],
             capture_output=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,9 +72,10 @@ class TestSelfCommand:
         assert result.returncode == 0
         assert "Usage: ana self <command>" in result.stdout
 
-    def test_self_update_listed(self, run_ana: AnaRunner) -> None:
+    def test_self_shows_update_command(self, run_ana: AnaRunner) -> None:
         result = run_ana("self")
         assert "update" in result.stdout
+        assert "Update ana to the latest version" in result.stdout
 
 
 class TestSelfUpdateNoToken:
@@ -91,6 +92,16 @@ class TestSelfUpdateNoToken:
 
     def test_update_without_token(self, run_ana: AnaRunner) -> None:
         result = run_ana("self", "update")
+        assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
+
+    def test_update_with_yes_flag_without_token(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "update", "--yes")
+        # --yes flag should be recognized, still fails due to missing token
+        assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
+
+    def test_update_with_y_flag_without_token(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "update", "-y")
+        # -y flag should be recognized, still fails due to missing token
         assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,33 @@ class TestVersion:
         version = result.stdout.strip()
         # Should match semver pattern (possibly with dev suffix like .dev0)
         assert re.match(r"\d+\.\d+\.\d+", version)
+
+
+class TestSelfCommand:
+    """Tests for 'ana self' subcommand."""
+
+    def test_self_shows_usage(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self")
+        assert result.returncode == 0
+        assert "Usage: ana self <command>" in result.stdout
+
+    def test_self_update_listed(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self")
+        assert "update" in result.stdout
+
+
+class TestSelfUpdateNoToken:
+    """Tests for self update commands without GITHUB_TOKEN."""
+
+    def test_update_check_without_token(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "update", "--check")
+        # Should fail or show error about missing token
+        assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
+
+    def test_update_list_without_token(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "update", "--list")
+        assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
+
+    def test_update_without_token(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "update")
+        assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+"""Integration tests for the ana CLI."""
+
+from __future__ import annotations
+
+from conftest import AnaRunner
+
+
+class TestHelp:
+    """Tests for --help output."""
+
+    def test_help_flag(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--help")
+        assert result.returncode == 0
+        assert "Usage: ana [command] [options]" in result.stdout
+
+    def test_help_short_flag(self, run_ana: AnaRunner) -> None:
+        result = run_ana("-h")
+        assert result.returncode == 0
+        assert "Usage: ana [command] [options]" in result.stdout
+
+    def test_no_args_shows_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana()
+        assert result.returncode == 0
+        assert "Usage: ana [command] [options]" in result.stdout
+
+    def test_help_shows_self_command(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--help")
+        assert "self" in result.stdout
+        assert "Manage the ana installation" in result.stdout
+
+    def test_help_shows_options(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--help")
+        assert "--version" in result.stdout
+        assert "--help" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,13 @@ class TestHelp:
         assert result.returncode == 0
         assert "Usage: ana [command] [options]" in result.stdout
 
+    def test_help_shows_version_in_header(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--help")
+        # Header should be "ana {version}" on first line
+        first_line = result.stdout.split("\n")[0]
+        assert first_line.startswith("ana ")
+        assert re.match(r"ana \d+\.\d+\.\d+", first_line)
+
     def test_help_shows_self_command(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
         assert "self" in result.stdout
@@ -32,8 +39,8 @@ class TestHelp:
 
     def test_help_shows_options(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
-        assert "--version" in result.stdout
-        assert "--help" in result.stdout
+        assert "-V, --version" in result.stdout
+        assert "-h, --help" in result.stdout
 
 
 class TestVersion:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,3 +85,17 @@ class TestSelfUpdateNoToken:
     def test_update_without_token(self, run_ana: AnaRunner) -> None:
         result = run_ana("self", "update")
         assert "GITHUB_TOKEN" in result.stderr or result.returncode != 0
+
+
+class TestArgumentErrors:
+    """Tests for CLI argument parsing and error handling."""
+
+    def test_unknown_command(self, run_ana: AnaRunner) -> None:
+        result = run_ana("foobar")
+        assert result.returncode == 1
+        assert "Unknown command: foobar" in result.stderr
+
+    def test_unknown_self_command(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "foobar")
+        assert result.returncode == 1
+        assert "Unknown self command: foobar" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from conftest import AnaRunner
 
 
@@ -32,3 +34,24 @@ class TestHelp:
         result = run_ana("--help")
         assert "--version" in result.stdout
         assert "--help" in result.stdout
+
+
+class TestVersion:
+    """Tests for --version output."""
+
+    def test_version_flag(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--version")
+        assert result.returncode == 0
+        assert result.stdout.strip()  # Not empty
+
+    def test_version_short_flag(self, run_ana: AnaRunner) -> None:
+        result = run_ana("-V")
+        assert result.returncode == 0
+        assert result.stdout.strip()  # Not empty
+
+    def test_version_format(self, run_ana: AnaRunner) -> None:
+        result = run_ana("--version")
+        assert result.returncode == 0
+        version = result.stdout.strip()
+        # Should match semver pattern (possibly with dev suffix like .dev0)
+        assert re.match(r"\d+\.\d+\.\d+", version)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import http.server
 import os
 import socketserver
-import subprocess
 import stat
+import subprocess
 import sys
 import threading
 from functools import partial
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-
 from conftest import REPO_ROOT
 
 if TYPE_CHECKING:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from conftest import REPO_ROOT
+
 if TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -24,17 +26,6 @@ pytestmark = pytest.mark.skipif(
     reason="install.sh is a shell script that only runs on Linux/macOS",
 )
 
-
-def _find_repo_root() -> Path:
-    """Find the repository root by looking for .git directory."""
-    path = Path(__file__).resolve()
-    for parent in path.parents:
-        if (parent / ".git").exists():
-            return parent
-    raise RuntimeError("Could not find repository root")
-
-
-REPO_ROOT = _find_repo_root()
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
 
 # Create a simple mock binary script that responds to --version and --help
@@ -56,20 +47,6 @@ def install_dir(tmp_path: Path) -> Path:
     d = tmp_path / "bin"
     d.mkdir()
     return d
-
-
-@pytest.fixture
-def fake_home(tmp_path: Path) -> Path:
-    """Provide a fake HOME directory to isolate shell profile modifications."""
-    home = tmp_path / "home"
-    home.mkdir()
-    # Create shell config files
-    (home / ".bashrc").touch()
-    (home / ".zshrc").touch()
-    fish_config = home / ".config" / "fish"
-    fish_config.mkdir(parents=True)
-    (fish_config / "config.fish").touch()
-    return home
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

* Adds integration tests around the CLI surface. This is in preparation for refactoring around the `clap` CLI framework, so I want to get the foundations in place first.
* Adds `ruff` configuration and pre-commit hooks

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-369](https://anaconda.atlassian.net/browse/CLI-369)


[CLI-369]: https://anaconda.atlassian.net/browse/CLI-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ