### PR TITLE
refac: Add clap CLI framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "ana"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "indicatif",
  "indoc",
  "reqwest",
@@ -13,6 +14,56 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -66,6 +117,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -502,19 +599,25 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
+name = "is_terminal_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -595,6 +698,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -905,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1208,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # Placeholder - actual version derived from git tags via build
 edition = "2024"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 indicatif = "0.18"
 indoc = "2"
 reqwest = { version = "0.13.2", features = ["blocking", "json", "native-tls"], default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: help test test-integration
+.PHONY: help debug test test-integration
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
+
+debug:  ## Build the debug binary
+	pixi run build-debug
 
 test:  ## Run all the unit tests
 	pixi run test

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,100 @@
+use clap::{Parser, Subcommand};
+use indoc::formatdoc;
+
+use crate::VERSION;
+
+pub fn parse() -> Result<Cli, clap::Error> {
+    Cli::try_parse()
+}
+
+#[derive(Parser)]
+#[command(
+    name = "ana",
+    version = VERSION,
+    about = "",
+    long_about = None,
+    subcommand_required = false,
+    arg_required_else_help = false,
+    disable_help_subcommand = true,
+    override_usage = "ana [command] [options]",
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Manage the ana installation
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana self <command> [options]"
+    )]
+    Self_ {
+        #[command(subcommand)]
+        command: Option<SelfCommands>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SelfCommands {
+    /// Update ana to the latest version
+    Update {
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
+
+        /// Check if an update is available
+        #[arg(long, conflicts_with_all = ["yes", "list"])]
+        check: bool,
+
+        /// List available versions
+        #[arg(long, conflicts_with_all = ["yes", "check"])]
+        list: bool,
+    },
+}
+
+pub fn print_main_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        ana {VERSION}
+
+        Usage: ana [command] [options]
+
+        Commands:
+          self           Manage the ana installation
+
+        Options:
+          -V, --version  Print version
+          -h, --help     Print help
+        "}
+    );
+}
+
+pub fn print_self_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        Manage the installation
+
+        Usage: ana self <command> [options]
+
+        Commands:
+          update    Update ana to the latest version
+        "}
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn test_cli_parses() {
+        // Verify clap setup is valid
+        Cli::command().debug_assert();
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,56 +3,63 @@ use indoc::formatdoc;
 
 use crate::VERSION;
 
-pub fn parse() -> Result<Cli, clap::Error> {
-    Cli::try_parse()
+/// Action to be performed, returned by parse()
+pub enum Action {
+    ShowHelp,
+    ShowSelfHelp,
+    ShowVersion,
+    Update { force: bool },
+    CheckForUpdate,
+    ShowAvailableVersions,
 }
 
-#[derive(Parser)]
-#[command(
-    name = "ana",
-    version = VERSION,
-    about = "",
-    long_about = None,
-    subcommand_required = false,
-    arg_required_else_help = false,
-    disable_help_subcommand = true,
-    override_usage = "ana [command] [options]",
-)]
-pub struct Cli {
-    #[command(subcommand)]
-    pub command: Option<Commands>,
+/// Parse CLI arguments and return the action to perform.
+/// Exits the process on unrecoverable errors (unknown commands, etc.)
+pub fn parse() -> Action {
+    match Cli::try_parse() {
+        Ok(cli) => match cli.command {
+            None => Action::ShowHelp,
+            Some(Commands::Self_ { command }) => match command {
+                None => Action::ShowSelfHelp,
+                Some(SelfCommands::Update { yes, check, list }) => {
+                    if check {
+                        Action::CheckForUpdate
+                    } else if list {
+                        Action::ShowAvailableVersions
+                    } else {
+                        Action::Update { force: yes }
+                    }
+                }
+            },
+        },
+        Err(e) => handle_parse_error(e),
+    }
 }
 
-#[derive(Subcommand)]
-pub enum Commands {
-    /// Manage the ana installation
-    #[command(
-        subcommand_required = false,
-        arg_required_else_help = false,
-        override_usage = "ana self <command> [options]"
-    )]
-    Self_ {
-        #[command(subcommand)]
-        command: Option<SelfCommands>,
-    },
-}
+fn handle_parse_error(e: clap::Error) -> Action {
+    if e.kind() == clap::error::ErrorKind::DisplayHelp {
+        return Action::ShowHelp;
+    }
+    if e.kind() == clap::error::ErrorKind::DisplayVersion {
+        return Action::ShowVersion;
+    }
 
-#[derive(Subcommand)]
-pub enum SelfCommands {
-    /// Update ana to the latest version
-    Update {
-        /// Skip confirmation prompt
-        #[arg(short = 'y', long = "yes")]
-        yes: bool,
+    // Handle unknown subcommand errors with custom format
+    let err_str = e.to_string();
+    if err_str.contains("unrecognized subcommand") {
+        let args: Vec<String> = std::env::args().collect();
+        if args.len() > 1 && args[1] == "self" {
+            if args.len() > 2 {
+                eprintln!("Unknown self command: {}", args[2]);
+            }
+        } else if args.len() > 1 {
+            eprintln!("Unknown command: {}", args[1]);
+        }
+        std::process::exit(1);
+    }
 
-        /// Check if an update is available
-        #[arg(long, conflicts_with_all = ["yes", "list"])]
-        check: bool,
-
-        /// List available versions
-        #[arg(long, conflicts_with_all = ["yes", "check"])]
-        list: bool,
-    },
+    // For other errors, use clap's error handling
+    e.exit();
 }
 
 pub fn print_main_help() {
@@ -85,6 +92,54 @@ pub fn print_self_help() {
           update    Update ana to the latest version
         "}
     );
+}
+
+#[derive(Parser)]
+#[command(
+    name = "ana",
+    version = VERSION,
+    about = "",
+    long_about = None,
+    subcommand_required = false,
+    arg_required_else_help = false,
+    disable_help_subcommand = true,
+    override_usage = "ana [command] [options]",
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Manage the ana installation
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana self <command> [options]"
+    )]
+    Self_ {
+        #[command(subcommand)]
+        command: Option<SelfCommands>,
+    },
+}
+
+#[derive(Subcommand)]
+enum SelfCommands {
+    /// Update ana to the latest version
+    Update {
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
+
+        /// Check if an update is available
+        #[arg(long, conflicts_with_all = ["yes", "list"])]
+        check: bool,
+
+        /// List available versions
+        #[arg(long, conflicts_with_all = ["yes", "check"])]
+        list: bool,
+    },
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ mod update;
 
 use clap::{Parser, Subcommand};
 use indoc::formatdoc;
-use std::io::{self, Write};
 
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
@@ -86,74 +85,6 @@ fn print_self_help() {
         "}
     );
 }
-fn prompt_yes_no(message: &str) -> bool {
-    print!("{} [y/N] ", message);
-    io::stdout().flush().unwrap();
-
-    let mut input = String::new();
-    if io::stdin().read_line(&mut input).is_err() {
-        return false;
-    }
-
-    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
-}
-
-fn run_self_update(force: bool) {
-    let check = match update::check_update(VERSION) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Failed to check for updates: {}", e);
-            return;
-        }
-    };
-
-    match check {
-        update::UpdateCheck::Available(release) => {
-            if !force {
-                let message = format!("Update {} -> {}?", VERSION, release.tag_name);
-                if !prompt_yes_no(&message) {
-                    println!("Update cancelled.");
-                    return;
-                }
-            }
-            match update::apply_update(&release) {
-                Ok(()) => println!("Updated successfully: {} -> {}", VERSION, release.tag_name),
-                Err(e) => eprintln!("Failed to update: {}", e),
-            }
-        }
-        update::UpdateCheck::AlreadyUpToDate => {
-            println!("Already up to date ({})", VERSION);
-        }
-        update::UpdateCheck::NoReleases => {
-            println!("No releases available.");
-        }
-    }
-}
-
-fn show_available_versions() {
-    let releases = match update::fetch_available_releases() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Failed to fetch releases: {}", e);
-            return;
-        }
-    };
-
-    if releases.is_empty() {
-        println!("No releases available.");
-        return;
-    }
-
-    let current_tag = format!("v{}", VERSION);
-    for release in releases {
-        let marker = if release.tag_name == current_tag {
-            " *"
-        } else {
-            ""
-        };
-        println!("{}{}", release.tag_name, marker);
-    }
-}
 
 fn main() {
     // Handle custom error messages for unknown commands
@@ -175,9 +106,9 @@ fn main() {
                         if check {
                             update::check_for_update(VERSION);
                         } else if list {
-                            show_available_versions();
+                            update::show_available_versions(VERSION);
                         } else {
-                            run_self_update(yes);
+                            update::run_update(VERSION, yes);
                         }
                     }
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,94 +1,13 @@
+mod cli;
 mod update;
 
-use clap::{Parser, Subcommand};
-use indoc::formatdoc;
+use cli::{print_main_help, print_self_help, Commands, SelfCommands};
 
-const APPLICATION: &str = env!("CARGO_PKG_NAME");
-const VERSION: &str = env!("PKG_VERSION");
-
-#[derive(Parser)]
-#[command(
-    name = APPLICATION,
-    version = VERSION,
-    about = "",
-    long_about = None,
-    subcommand_required = false,
-    arg_required_else_help = false,
-    disable_help_subcommand = true,
-    override_usage = "ana [command] [options]",
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Manage the ana installation
-    #[command(
-        subcommand_required = false,
-        arg_required_else_help = false,
-        override_usage = "ana self <command> [options]"
-    )]
-    Self_ {
-        #[command(subcommand)]
-        command: Option<SelfCommands>,
-    },
-}
-
-#[derive(Subcommand)]
-enum SelfCommands {
-    /// Update ana to the latest version
-    Update {
-        /// Skip confirmation prompt
-        #[arg(short = 'y', long = "yes")]
-        yes: bool,
-
-        /// Check if an update is available
-        #[arg(long, conflicts_with_all = ["yes", "list"])]
-        check: bool,
-
-        /// List available versions
-        #[arg(long, conflicts_with_all = ["yes", "check"])]
-        list: bool,
-    },
-}
-
-fn print_main_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        ana {VERSION}
-
-        Usage: ana [command] [options]
-
-        Commands:
-          self           Manage the ana installation
-
-        Options:
-          -V, --version  Print version
-          -h, --help     Print help
-        "}
-    );
-}
-
-fn print_self_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        Manage the installation
-
-        Usage: ana self <command> [options]
-
-        Commands:
-          update    Update ana to the latest version
-        "}
-    );
-}
+pub const VERSION: &str = env!("PKG_VERSION");
 
 fn main() {
     // Handle custom error messages for unknown commands
-    let result = Cli::try_parse();
+    let result = cli::parse();
 
     match result {
         Ok(cli) => {
@@ -149,16 +68,9 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::CommandFactory;
 
     #[test]
     fn test_version_is_set() {
         assert!(!VERSION.is_empty());
-    }
-
-    #[test]
-    fn test_cli_parses() {
-        // Verify clap setup is valid
-        Cli::command().debug_assert();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,59 @@
 mod update;
 
+use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use std::io::{self, Write};
 
 const APPLICATION: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("PKG_VERSION");
+
+#[derive(Parser)]
+#[command(
+    name = APPLICATION,
+    version = VERSION,
+    about = "",
+    long_about = None,
+    subcommand_required = false,
+    arg_required_else_help = false,
+    disable_help_subcommand = true,
+    override_usage = "ana [command] [options]",
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Manage the ana installation
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana self <command> [options]"
+    )]
+    Self_ {
+        #[command(subcommand)]
+        command: Option<SelfCommands>,
+    },
+}
+
+#[derive(Subcommand)]
+enum SelfCommands {
+    /// Update ana to the latest version
+    Update {
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
+
+        /// Check if an update is available
+        #[arg(long, conflicts_with_all = ["yes", "list"])]
+        check: bool,
+
+        /// List available versions
+        #[arg(long, conflicts_with_all = ["yes", "check"])]
+        list: bool,
+    },
+}
 
 fn usage() -> String {
     formatdoc! {"

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,37 @@ fn print_version() {
     println!("{}", VERSION);
 }
 
+fn print_main_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        ana {VERSION}
+
+        Usage: ana [command] [options]
+
+        Commands:
+          self           Manage the ana installation
+
+        Options:
+          -V, --version  Print version
+          -h, --help     Print help
+        "}
+    );
+}
+
+fn print_self_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        Manage the installation
+
+        Usage: ana self <command> [options]
+
+        Commands:
+          update    Update ana to the latest version
+        "}
+    );
+}
 fn prompt_yes_no(message: &str) -> bool {
     print!("{} [y/N] ", message);
     io::stdout().flush().unwrap();
@@ -162,79 +193,70 @@ fn show_available_versions() {
     }
 }
 
-#[derive(Debug)]
-enum Command {
-    Help,
-    SelfHelp,
-    Version,
-    SelfUpdate { force: bool },
-    SelfUpdateCheck,
-    SelfShowAvailable,
-}
+fn main() {
+    // Handle custom error messages for unknown commands
+    let result = Cli::try_parse();
 
-fn parse_args(args: &[String]) -> Result<Command, String> {
-    // Display help
-    if args.len() <= 1 || args.iter().any(|a| a == "--help" || a == "-h") {
-        return Ok(Command::Help);
-    }
-
-    // Display version
-    if args.iter().any(|a| a == "--version" || a == "-V") {
-        return Ok(Command::Version);
-    }
-
-    // Handle subcommands
-    match args[1].as_str() {
-        "self" => {
-            if args.len() < 3 {
-                return Ok(Command::SelfHelp);
-            }
-            match args[2].as_str() {
-                "update" => {
-                    if args.iter().any(|a| a == "--list") {
-                        Ok(Command::SelfShowAvailable)
-                    } else if args.iter().any(|a| a == "--check") {
-                        Ok(Command::SelfUpdateCheck)
-                    } else {
-                        let force = args.iter().any(|a| a == "--yes" || a == "-y");
-                        Ok(Command::SelfUpdate { force })
-                    }
+    match result {
+        Ok(cli) => {
+            match cli.command {
+                None => {
+                    // No command provided - show help
+                    print_main_help();
                 }
-                cmd => Err(format!("Unknown self command: {}", cmd)),
+                Some(Commands::Self_ { command }) => match command {
+                    None => {
+                        // `ana self` with no subcommand - show self help
+                        print_self_help();
+                    }
+                    Some(SelfCommands::Update { yes, check, list }) => {
+                        if check {
+                            update::check_for_update(VERSION);
+                        } else if list {
+                            show_available_versions();
+                        } else {
+                            run_self_update(yes);
+                        }
+                    }
+                },
             }
         }
-        cmd => Err(format!("Unknown command: {}", cmd)),
-    }
-}
+        Err(e) => {
+            // Check if it's a help or version request
+            if e.kind() == clap::error::ErrorKind::DisplayHelp {
+                print_main_help();
+                return;
+            }
+            if e.kind() == clap::error::ErrorKind::DisplayVersion {
+                println!("{}", VERSION);
+                return;
+            }
 
-fn run(args: &[String]) -> Result<(), String> {
-    match parse_args(args)? {
-        Command::Help => print_usage(),
-        Command::SelfHelp => print_self_usage(),
-        Command::Version => print_version(),
-        Command::SelfUpdate { force } => run_self_update(force),
-        Command::SelfUpdateCheck => update::check_for_update(VERSION),
-        Command::SelfShowAvailable => show_available_versions(),
-    }
-    Ok(())
-}
+            // Handle unknown subcommand errors with custom format
+            let err_str = e.to_string();
+            if err_str.contains("unrecognized subcommand") {
+                // Extract the unknown command name
+                let args: Vec<String> = std::env::args().collect();
+                if args.len() > 1 && args[1] == "self" {
+                    if args.len() > 2 {
+                        eprintln!("Unknown self command: {}", args[2]);
+                    }
+                } else if args.len() > 1 {
+                    eprintln!("Unknown command: {}", args[1]);
+                }
+                std::process::exit(1);
+            }
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
-
-    if let Err(msg) = run(&args) {
-        eprintln!("{}", msg);
-        std::process::exit(1);
+            // For other errors, use clap's error handling
+            e.exit();
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn args(input: &[&str]) -> Vec<String> {
-        input.iter().map(|s| s.to_string()).collect()
-    }
+    use clap::CommandFactory;
 
     #[test]
     fn test_version_is_set() {
@@ -242,105 +264,8 @@ mod tests {
     }
 
     #[test]
-    fn test_no_args_parses_to_help() {
-        assert!(matches!(parse_args(&args(&["ana"])), Ok(Command::Help)));
-    }
-
-    #[test]
-    fn test_help_flag() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "--help"])),
-            Ok(Command::Help)
-        ));
-    }
-
-    #[test]
-    fn test_help_flag_short() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "-h"])),
-            Ok(Command::Help)
-        ));
-    }
-
-    #[test]
-    fn test_version_flag() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "--version"])),
-            Ok(Command::Version)
-        ));
-    }
-
-    #[test]
-    fn test_version_flag_short() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "-V"])),
-            Ok(Command::Version)
-        ));
-    }
-
-    #[test]
-    fn test_self_no_subcommand() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self"])),
-            Ok(Command::SelfHelp)
-        ));
-    }
-
-    #[test]
-    fn test_self_update() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self", "update"])),
-            Ok(Command::SelfUpdate { force: false })
-        ));
-    }
-
-    #[test]
-    fn test_self_update_yes() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self", "update", "--yes"])),
-            Ok(Command::SelfUpdate { force: true })
-        ));
-    }
-
-    #[test]
-    fn test_self_update_yes_short() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self", "update", "-y"])),
-            Ok(Command::SelfUpdate { force: true })
-        ));
-    }
-
-    #[test]
-    fn test_unknown_command() {
-        let result = parse_args(&args(&["ana", "foo"]));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Unknown command: foo"));
-    }
-
-    #[test]
-    fn test_self_update_show_available() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self", "update", "--list"])),
-            Ok(Command::SelfShowAvailable)
-        ));
-    }
-
-    #[test]
-    fn test_self_update_check() {
-        assert!(matches!(
-            parse_args(&args(&["ana", "self", "update", "--check"])),
-            Ok(Command::SelfUpdateCheck)
-        ));
-    }
-
-    #[test]
-    fn test_unknown_self_command() {
-        let result = parse_args(&args(&["ana", "self", "unknown"]));
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .contains("Unknown self command: unknown")
-        );
+    fn test_cli_parses() {
+        // Verify clap setup is valid
+        Cli::command().debug_assert();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,67 +1,16 @@
 mod cli;
 mod update;
 
-use cli::{print_main_help, print_self_help, Commands, SelfCommands};
-
 pub const VERSION: &str = env!("PKG_VERSION");
 
 fn main() {
-    // Handle custom error messages for unknown commands
-    let result = cli::parse();
-
-    match result {
-        Ok(cli) => {
-            match cli.command {
-                None => {
-                    // No command provided - show help
-                    print_main_help();
-                }
-                Some(Commands::Self_ { command }) => match command {
-                    None => {
-                        // `ana self` with no subcommand - show self help
-                        print_self_help();
-                    }
-                    Some(SelfCommands::Update { yes, check, list }) => {
-                        if check {
-                            update::check_for_update(VERSION);
-                        } else if list {
-                            update::show_available_versions(VERSION);
-                        } else {
-                            update::run_update(VERSION, yes);
-                        }
-                    }
-                },
-            }
-        }
-        Err(e) => {
-            // Check if it's a help or version request
-            if e.kind() == clap::error::ErrorKind::DisplayHelp {
-                print_main_help();
-                return;
-            }
-            if e.kind() == clap::error::ErrorKind::DisplayVersion {
-                println!("{}", VERSION);
-                return;
-            }
-
-            // Handle unknown subcommand errors with custom format
-            let err_str = e.to_string();
-            if err_str.contains("unrecognized subcommand") {
-                // Extract the unknown command name
-                let args: Vec<String> = std::env::args().collect();
-                if args.len() > 1 && args[1] == "self" {
-                    if args.len() > 2 {
-                        eprintln!("Unknown self command: {}", args[2]);
-                    }
-                } else if args.len() > 1 {
-                    eprintln!("Unknown command: {}", args[1]);
-                }
-                std::process::exit(1);
-            }
-
-            // For other errors, use clap's error handling
-            e.exit();
-        }
+    match cli::parse() {
+        cli::Action::ShowHelp => cli::print_main_help(),
+        cli::Action::ShowSelfHelp => cli::print_self_help(),
+        cli::Action::ShowVersion => println!("{}", VERSION),
+        cli::Action::Update { force } => update::run_update(VERSION, force),
+        cli::Action::CheckForUpdate => update::check_for_update(VERSION),
+        cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,44 +55,6 @@ enum SelfCommands {
     },
 }
 
-fn usage() -> String {
-    formatdoc! {"
-        {APPLICATION} {VERSION}
-
-        Usage: {APPLICATION} [command] [options]
-
-        Commands:
-          self           Manage the {APPLICATION} installation
-
-        Options:
-          -V, --version  Print version
-          -h, --help     Print help"
-    }
-}
-
-fn self_usage() -> String {
-    formatdoc! {"
-        Manage the installation
-
-        Usage: {APPLICATION} self <command> [options]
-
-        Commands:
-          update    Update {APPLICATION} to the latest version"
-    }
-}
-
-fn print_usage() {
-    println!("{}", usage());
-}
-
-fn print_self_usage() {
-    println!("{}", self_usage());
-}
-
-fn print_version() {
-    println!("{}", VERSION);
-}
-
 fn print_main_help() {
     println!(
         "{}",

--- a/src/update.rs
+++ b/src/update.rs
@@ -251,6 +251,76 @@ pub fn check_for_update(current_version: &str) {
     }
 }
 
+fn prompt_yes_no(message: &str) -> bool {
+    use std::io::Write;
+    print!("{} [y/N] ", message);
+    std::io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+pub fn run_update(current_version: &str, force: bool) {
+    let check = match check_update(current_version) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to check for updates: {}", e);
+            return;
+        }
+    };
+
+    match check {
+        UpdateCheck::Available(release) => {
+            if !force {
+                let message = format!("Update {} -> {}?", current_version, release.tag_name);
+                if !prompt_yes_no(&message) {
+                    println!("Update cancelled.");
+                    return;
+                }
+            }
+            match apply_update(&release) {
+                Ok(()) => println!("Updated successfully: {} -> {}", current_version, release.tag_name),
+                Err(e) => eprintln!("Failed to update: {}", e),
+            }
+        }
+        UpdateCheck::AlreadyUpToDate => {
+            println!("Already up to date ({})", current_version);
+        }
+        UpdateCheck::NoReleases => {
+            println!("No releases available.");
+        }
+    }
+}
+
+pub fn show_available_versions(current_version: &str) {
+    let releases = match fetch_available_releases() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to fetch releases: {}", e);
+            return;
+        }
+    };
+
+    if releases.is_empty() {
+        println!("No releases available.");
+        return;
+    }
+
+    let current_tag = format!("v{}", current_version);
+    for release in releases {
+        let marker = if release.tag_name == current_tag {
+            " *"
+        } else {
+            ""
+        };
+        println!("{}{}", release.tag_name, marker);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Refactors the CLI parsing to use the `clap` framework. This is a much more solid foundation than our existing manual parsing. While the main modules are refactored, the interface is unchanged. This is validated using integration tests.

The new code structure is:

* `cli.rs` - CLI parsing
* `main.rs` - primary entrypoint and dispatch to action functions
* `update.rs` - self-contained behavior around the self-update functionality
