### PR TITLE
feat: Add authentication commands

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -1,4 +1,4 @@
-//! Authentication actions (login, logout).
+//! Authentication actions (login, logout, whoami).
 
 use std::thread;
 use std::time::Duration;
@@ -12,11 +12,60 @@ use crate::config::Config;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Build an HTTP client with standard settings.
-fn build_client() -> Result<reqwest::blocking::Client, AuthError> {
-    Ok(reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()?)
+/// HTTP client with configuration and optional authentication.
+pub struct ApiClient {
+    client: reqwest::blocking::Client,
+    config: Config,
+    api_key: Option<String>,
+}
+
+impl ApiClient {
+    /// Create a new API client, loading credentials from the keyring if available.
+    pub fn new() -> Result<Self, AuthError> {
+        let config = Config::load();
+        let api_key = get_api_key(&config)?;
+        let client = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()?;
+
+        Ok(Self {
+            client,
+            config,
+            api_key,
+        })
+    }
+
+    /// Check if the client has valid credentials.
+    pub fn is_authenticated(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    /// Get the configured domain.
+    pub fn domain(&self) -> &str {
+        &self.config.domain
+    }
+
+    /// Make an authenticated GET request to an API endpoint.
+    pub fn get(&self, path: &str) -> Result<reqwest::blocking::Response, AuthError> {
+        let url = format!("https://{}{}", self.config.domain, path);
+        let mut request = self.client.get(&url);
+
+        if let Some(ref api_key) = self.api_key {
+            request = request.bearer_auth(api_key);
+        }
+
+        Ok(request.send()?)
+    }
+
+    /// Get the underlying HTTP client for custom requests.
+    pub fn raw_client(&self) -> &reqwest::blocking::Client {
+        &self.client
+    }
+
+    /// Get the configuration.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
 }
 
 /// OpenID Connect discovery document.
@@ -52,8 +101,9 @@ struct TokenErrorResponse {
 
 /// Perform the device authorization flow.
 pub fn login() -> Result<(), AuthError> {
-    let config = Config::load();
-    let client = build_client()?;
+    let api_client = ApiClient::new()?;
+    let client = api_client.raw_client();
+    let config = api_client.config();
 
     // TODO(mattkram): Better handling for common exceptions like SSL cert, etc.
     // Fetch OpenID configuration
@@ -184,18 +234,15 @@ pub fn show_api_key() -> Result<(), AuthError> {
 
 /// Display information about the logged-in user.
 pub fn whoami() -> Result<(), AuthError> {
-    let config = Config::load();
+    let client = ApiClient::new()?;
 
-    let Some(api_key) = get_api_key(&config)? else {
-        println!("Not logged in to {}", config.domain);
+    if !client.is_authenticated() {
+        println!("Not logged in to {}", client.domain());
         println!("Run `ana login` to authenticate.");
         return Ok(());
-    };
+    }
 
-    let client = build_client()?;
-
-    let url = format!("https://{}/api/account", config.domain);
-    let response = client.get(&url).bearer_auth(&api_key).send()?;
+    let response = client.get("/api/account")?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -209,7 +256,7 @@ pub fn whoami() -> Result<(), AuthError> {
     let data: serde_json::Value = response.json()?;
     let pretty = serde_json::to_string_pretty(&data).unwrap_or_default();
 
-    println!("Your info ({}):", config.domain);
+    println!("Your info ({}):", client.domain());
     println!("{}", pretty);
 
     Ok(())

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -177,6 +177,41 @@ pub fn show_api_key() -> Result<(), AuthError> {
     Ok(())
 }
 
+/// Display information about the logged-in user.
+pub fn whoami() -> Result<(), AuthError> {
+    let config = Config::load();
+
+    let Some(api_key) = get_api_key(&config)? else {
+        println!("Not logged in to {}", config.domain);
+        println!("Run `ana login` to authenticate.");
+        return Ok(());
+    };
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?;
+
+    let url = format!("https://{}/api/account", config.domain);
+    let response = client.get(&url).bearer_auth(&api_key).send()?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        return Err(AuthError::Authorization(format!(
+            "Failed to get account info: {} - {}",
+            status, body
+        )));
+    }
+
+    let data: serde_json::Value = response.json()?;
+    let pretty = serde_json::to_string_pretty(&data).unwrap_or_default();
+
+    println!("Your info ({}):", config.domain);
+    println!("{}", pretty);
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -61,16 +61,6 @@ impl ApiClient {
         let url = format!("{}{}", self.config.base_url(), path);
         Ok(self.client.get(&url).send()?)
     }
-
-    /// Get the underlying HTTP client for custom requests.
-    pub fn raw_client(&self) -> &reqwest::blocking::Client {
-        &self.client
-    }
-
-    /// Get the configuration.
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
 }
 
 /// OpenID Connect discovery document.
@@ -106,9 +96,14 @@ struct TokenErrorResponse {
 
 /// Perform the device authorization flow.
 pub fn login() -> Result<(), AuthError> {
-    let api_client = ApiClient::new()?;
-    let client = api_client.raw_client();
-    let config = api_client.config();
+    // We use a new, unauthenticated client instead of ApiClient, since
+    // login by definition happens first. It ends up being simpler to do
+    // this, at least for now, because the auth flow needs to follow direct
+    // URLs from openid-configuration etc.
+    let config = Config::load();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?;
 
     // TODO(mattkram): Better handling for common exceptions like SSL cert, etc.
     // Fetch OpenID configuration

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -12,6 +12,13 @@ use crate::config::Config;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Build an HTTP client with standard settings.
+fn build_client() -> Result<reqwest::blocking::Client, AuthError> {
+    Ok(reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?)
+}
+
 /// OpenID Connect discovery document.
 #[derive(Debug, Deserialize)]
 struct OpenIdConfig {
@@ -46,9 +53,7 @@ struct TokenErrorResponse {
 /// Perform the device authorization flow.
 pub fn login() -> Result<(), AuthError> {
     let config = Config::load();
-    let client = reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
+    let client = build_client()?;
 
     // TODO(mattkram): Better handling for common exceptions like SSL cert, etc.
     // Fetch OpenID configuration
@@ -187,9 +192,7 @@ pub fn whoami() -> Result<(), AuthError> {
         return Ok(());
     };
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
+    let client = build_client()?;
 
     let url = format!("https://{}/api/account", config.domain);
     let response = client.get(&url).bearer_auth(&api_key).send()?;

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -3,6 +3,7 @@
 use std::thread;
 use std::time::Duration;
 
+use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
 
 use super::api_keys::create_api_key;
@@ -24,8 +25,18 @@ impl ApiClient {
     pub fn new() -> Result<Self, AuthError> {
         let config = Config::load();
         let api_key = get_api_key(&config)?;
+
+        let mut default_headers = HeaderMap::new();
+        if let Some(ref key) = api_key {
+            let mut auth_value = HeaderValue::from_str(&format!("Bearer {}", key))
+                .map_err(|_| AuthError::InvalidKey)?;
+            auth_value.set_sensitive(true); // keeps it out of debug logs
+            default_headers.insert(header::AUTHORIZATION, auth_value);
+        }
+
         let client = reqwest::blocking::Client::builder()
             .timeout(REQUEST_TIMEOUT)
+            .default_headers(default_headers)
             .build()?;
 
         Ok(Self {
@@ -48,13 +59,7 @@ impl ApiClient {
     /// Make an authenticated GET request to an API endpoint.
     pub fn get(&self, path: &str) -> Result<reqwest::blocking::Response, AuthError> {
         let url = format!("{}{}", self.config.base_url(), path);
-        let mut request = self.client.get(&url);
-
-        if let Some(ref api_key) = self.api_key {
-            request = request.bearer_auth(api_key);
-        }
-
-        Ok(request.send()?)
+        Ok(self.client.get(&url).send()?)
     }
 
     /// Get the underlying HTTP client for custom requests.

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -47,7 +47,7 @@ impl ApiClient {
 
     /// Make an authenticated GET request to an API endpoint.
     pub fn get(&self, path: &str) -> Result<reqwest::blocking::Response, AuthError> {
-        let url = format!("https://{}{}", self.config.domain, path);
+        let url = format!("{}{}", self.config.base_url(), path);
         let mut request = self.client.get(&url);
 
         if let Some(ref api_key) = self.api_key {

--- a/src/auth/errors.rs
+++ b/src/auth/errors.rs
@@ -18,6 +18,9 @@ pub enum AuthError {
 
     #[error("Keyring error: {0}")]
     Keyring(String),
+
+    #[error("Invalid API key")]
+    InvalidKey,
 }
 
 #[cfg(test)]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,4 +5,4 @@ mod api_keys;
 mod errors;
 mod keyring;
 
-pub use actions::{login, logout, show_api_key};
+pub use actions::{login, logout, show_api_key, whoami};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ pub enum Action {
     Login,
     Logout,
     ShowApiKey,
+    Whoami,
     Update { force: bool },
     CheckForUpdate,
     ShowAvailableVersions,
@@ -27,11 +28,13 @@ pub fn parse() -> Action {
             Some(Commands::Config) => Action::ShowConfig,
             Some(Commands::Login) => Action::Login,
             Some(Commands::Logout) => Action::Logout,
+            Some(Commands::Whoami) => Action::Whoami,
             Some(Commands::Auth { command }) => match command {
                 None => Action::ShowAuthHelp,
                 Some(AuthCommands::ApiKey) => Action::ShowApiKey,
                 Some(AuthCommands::Login) => Action::Login,
                 Some(AuthCommands::Logout) => Action::Logout,
+                Some(AuthCommands::Whoami) => Action::Whoami,
             },
             Some(Commands::Self_ { command }) => match command {
                 None => Action::ShowSelfHelp,
@@ -89,6 +92,7 @@ pub fn print_main_help() {
           config         Show current configuration
           login          Log in to Anaconda
           logout         Log out from Anaconda
+          whoami         Display information about the logged-in user
           self           Manage the ana installation
 
         Options:
@@ -124,6 +128,7 @@ pub fn print_auth_help() {
           api-key   Display the API key for the logged-in user
           login     Log in to Anaconda
           logout    Log out from Anaconda
+          whoami    Display information about the logged-in user
         "}
     );
 }
@@ -166,6 +171,9 @@ enum Commands {
     /// Log out from Anaconda
     Logout,
 
+    /// Display information about the logged-in user
+    Whoami,
+
     /// Manage the ana installation
     #[command(
         subcommand_required = false,
@@ -188,6 +196,9 @@ enum AuthCommands {
 
     /// Log out from Anaconda
     Logout,
+
+    /// Display information about the logged-in user
+    Whoami,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,12 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        cli::Action::Whoami => {
+            if let Err(e) = auth::whoami() {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
         cli::Action::Update { force } => update::run_update(VERSION, force),
         cli::Action::CheckForUpdate => update::check_for_update(VERSION),
         cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -163,6 +163,52 @@ class TestAuthHelp:
         assert "api-key" in result.stdout
         assert "login" in result.stdout
         assert "logout" in result.stdout
+        assert "whoami" in result.stdout
+
+
+class TestWhoami:
+    """Tests for 'ana whoami' command."""
+
+    def test_whoami_when_logged_in(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """Whoami should display user info when logged in."""
+        run_ana("login", env=auth_env)
+        result = run_ana("whoami", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Your info ({mock_auth_server.domain}):" in result.stdout
+        assert "testuser" in result.stdout
+        assert "test@example.com" in result.stdout
+
+    def test_whoami_when_not_logged_in(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """Whoami should show helpful message when not logged in."""
+        result = run_ana("whoami", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Not logged in to {mock_auth_server.domain}" in result.stdout
+        assert "Run `ana login` to authenticate." in result.stdout
+
+    def test_whoami_via_auth_subcommand(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """'ana auth whoami' should work the same as 'ana whoami'."""
+        run_ana("login", env=auth_env)
+        result = run_ana("auth", "whoami", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Your info ({mock_auth_server.domain}):" in result.stdout
 
 
 class TestMultipleDomains:


### PR DESCRIPTION
## Summary

Here, we add the final authentication commands, providing near-functional parity with `anaconda-auth`. We only implement device flow and file-based keyring for now. System keyring integration will come later, but the PKCE flow will not be reproduced in `ana`.

### Dependent PRs

This PR was originally quite large (~1700 lines), but was split instead into several smaller layered PRs, which are designed to be reviewed and merged in this order:

* #47: Adds minimal configuration support
* #49: Adds login command supporting device flow
* #50: Adds API key storage mechanism and commands for retrieval and logout
* This PR: Adds the final `ana whoami` command, including a basic `ApiClient` for making authenticated requests

### Changes

A summary of aggregated changes is below. In totality, the PR sequence provides round-trip support around required authentication commands:

- Add authentication commands: `login`, `logout`, `whoami`, and `auth api-key`
- Implement OAuth 2.0 Device Authorization Grant (RFC 8628) for login flow
- Add keyring storage compatible with anaconda-auth's JSON format
- Add `ApiClient` struct for authenticated HTTP requests
- Support both top-level commands (`ana login`) and namespaced (`ana auth login`)

## Implementation summary

The implementation adds two main functional modules: `config` and `auth`. The layout is:

- **auth/actions.rs**: login/logout/whoami/show_api_key implementations + ApiClient
- **auth/keyring.rs**: JSON keyring with base64-encoded credentials (multi-domain support)
- **auth/api_keys.rs**: API key creation after OAuth flow
- **config.rs**: Added `keyring_path` field (default: `~/.ana/keyring`, override: `ANA_KEYRING_PATH`)
- **cli.rs**: Added `auth` subcommand group and top-level auth commands

The structure supports extension down the road as we add more features, but is deliberately constrained.

## Configuration

The implementation provides defaults, and each field can be overridden by an environment variable. For example, `ANA_AUTH_DOMAIN=anaconda.com` will log into production. We are defaulting to `stage.anaconda.com` for now.

## Command summary

- [ ] `ana login` (or `ana auth login`) completes device flow and saves API key to disk
- [ ] `ana logout` (or `ana auth logout`) removes API key from keyring. Deletes the file if it becomes empty.
- [ ] `ana whoami` (or `ana auth whoami`) displays user info (or helpful message if not logged in)
- [ ] `ana auth api-key` prints API key (or helpful message if not logged in)
- [ ] `ana config` shows the configuration
- [ ] Keyring format compatible with `~/.anaconda/keyring`

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-350](https://anaconda.atlassian.net/browse/CLI-350)


[CLI-350]: https://anaconda.atlassian.net/browse/CLI-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ