### PR TITLE
feat: Add utilities and commands for API key storage and retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,10 @@ version = 4
 name = "ana"
 version = "0.0.0"
 dependencies = [
+ "base64",
  "clap",
  "comfy-table",
+ "dirs",
  "indicatif",
  "indoc",
  "reqwest",
@@ -16,6 +18,7 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror",
  "webbrowser",
 ]
@@ -241,6 +244,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +395,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -749,6 +784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1304,7 +1365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0" # Placeholder - actual version derived from git tags via build
 edition = "2024"
 
 [dependencies]
+base64 = "0.22"
+dirs = "6"
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 indicatif = "0.18"
@@ -18,3 +20,4 @@ webbrowser = "1"
 
 [dev-dependencies]
 temp-env = "0.3"
+tempfile = "3"

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
-use super::keyring::{delete_api_key, save_api_key};
+use super::keyring::{delete_api_key, get_api_key, save_api_key};
 use crate::config::Config;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -159,6 +159,21 @@ pub fn logout() -> Result<(), AuthError> {
     let config = Config::load();
     delete_api_key(&config)?;
     println!("Logged out from {}", config.domain);
+    Ok(())
+}
+
+/// Display the API key for the current domain.
+pub fn show_api_key() -> Result<(), AuthError> {
+    let config = Config::load();
+
+    match get_api_key(&config)? {
+        Some(key) => println!("{}", key),
+        None => {
+            println!("Not logged in to {}", config.domain);
+            println!("Run `ana login` to authenticate.");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -1,4 +1,4 @@
-//! OAuth 2.0 Device Authorization Grant (RFC 8628) implementation.
+//! Authentication actions (login, logout).
 
 use std::thread;
 use std::time::Duration;

--- a/src/auth/errors.rs
+++ b/src/auth/errors.rs
@@ -15,6 +15,9 @@ pub enum AuthError {
 
     #[error("Missing endpoint in OpenID configuration: {0}")]
     MissingEndpoint(String),
+
+    #[error("Keyring error: {0}")]
+    Keyring(String),
 }
 
 #[cfg(test)]
@@ -34,5 +37,8 @@ mod tests {
             err.to_string(),
             "Missing endpoint in OpenID configuration: device_authorization_endpoint"
         );
+
+        let err = AuthError::Keyring("file not found".to_string());
+        assert_eq!(err.to_string(), "Keyring error: file not found");
     }
 }

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -241,6 +241,30 @@ mod tests {
     }
 
     #[test]
+    fn test_get_api_key_returns_correct_domain() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+
+        // Save keys for multiple domains
+        let config_a = test_config_with_keyring(keyring_path.clone(), "a.com");
+        let config_b = test_config_with_keyring(keyring_path.clone(), "b.com");
+        let config_c = test_config_with_keyring(keyring_path.clone(), "c.com");
+
+        save_api_key(&config_a, "key-for-a").unwrap();
+        save_api_key(&config_b, "key-for-b").unwrap();
+        save_api_key(&config_c, "key-for-c").unwrap();
+
+        // Each config should only return its own key
+        assert_eq!(get_api_key(&config_a).unwrap(), Some("key-for-a".to_string()));
+        assert_eq!(get_api_key(&config_b).unwrap(), Some("key-for-b".to_string()));
+        assert_eq!(get_api_key(&config_c).unwrap(), Some("key-for-c".to_string()));
+
+        // A domain with no key should return None
+        let config_unknown = test_config_with_keyring(keyring_path.clone(), "unknown.com");
+        assert_eq!(get_api_key(&config_unknown).unwrap(), None);
+    }
+
+    #[test]
     fn test_keyring_json_format() {
         let dir = tempfile::tempdir().unwrap();
         let keyring_path = dir.path().join("keyring");

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -1,0 +1,280 @@
+//! API key storage using a JSON file-based keyring.
+//!
+//! Compatible with anaconda-auth's keyring format.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+
+use base64::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::errors::AuthError;
+use crate::config::Config;
+
+// TODO(mattkram): Decide whether now is the time to rename this key, or whether
+//                 we even need it in JSON files case (probably)
+const KEYRING_KEY: &str = "Anaconda Cloud";
+const CREDENTIAL_VERSION: u32 = 2;
+
+/// Top-level keyring structure.
+type Keyring = HashMap<String, HashMap<String, String>>;
+
+/// Credential stored in the keyring (before base64 encoding).
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Credential {
+    domain: String,
+    api_key: String,
+    repo_tokens: Vec<String>,
+    version: u32,
+}
+
+/// Save an API key to the keyring file.
+pub fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
+    let path = &config.keyring_path;
+
+    // Create parent directories if they don't exist
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| keyring_io_error("create directory", e))?;
+    }
+
+    // TODO(mattkram): The keyring access should be encapsulated in a struct
+
+    // Load existing keyring or create new one
+    let mut keyring = load_keyring(config)?;
+
+    // Create credential and encode
+    let credential = Credential {
+        domain: config.domain.clone(),
+        api_key: api_key.to_string(),
+        repo_tokens: vec![],
+        version: CREDENTIAL_VERSION,
+    };
+    let credential_json =
+        serde_json::to_string(&credential).map_err(|e| AuthError::Keyring(e.to_string()))?;
+    let encoded = BASE64_STANDARD.encode(credential_json);
+
+    // Insert into keyring
+    keyring
+        .entry(KEYRING_KEY.to_string())
+        .or_default()
+        .insert(config.domain.clone(), encoded);
+
+    // Write keyring
+    let keyring_json =
+        serde_json::to_string(&keyring).map_err(|e| AuthError::Keyring(e.to_string()))?;
+    fs::write(path, keyring_json).map_err(|e| keyring_io_error("write", e))?;
+
+    Ok(())
+}
+
+/// Get the API key from the keyring file.
+pub fn get_api_key(config: &Config) -> Result<Option<String>, AuthError> {
+    let keyring = load_keyring(config)?;
+
+    let Some(domains) = keyring.get(KEYRING_KEY) else {
+        return Ok(None);
+    };
+
+    let Some(encoded) = domains.get(&config.domain) else {
+        return Ok(None);
+    };
+
+    let decoded = BASE64_STANDARD
+        .decode(encoded)
+        .map_err(|e| AuthError::Keyring(format!("Failed to decode credential: {}", e)))?;
+
+    let credential: Credential = serde_json::from_slice(&decoded)
+        .map_err(|e| AuthError::Keyring(format!("Failed to parse credential: {}", e)))?;
+
+    Ok(Some(credential.api_key))
+}
+
+/// Delete the API key from the keyring file.
+pub fn delete_api_key(config: &Config) -> Result<(), AuthError> {
+    let path = &config.keyring_path;
+
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let mut keyring = load_keyring(config)?;
+
+    if let Some(domains) = keyring.get_mut(KEYRING_KEY) {
+        domains.remove(&config.domain);
+
+        // Remove the top-level key if no domains remain
+        if domains.is_empty() {
+            keyring.remove(KEYRING_KEY);
+        }
+    }
+
+    if keyring.is_empty() {
+        // Remove file if keyring is empty
+        fs::remove_file(path).map_err(|e| keyring_io_error("delete", e))?;
+    } else {
+        // Write updated keyring
+        let keyring_json =
+            serde_json::to_string(&keyring).map_err(|e| AuthError::Keyring(e.to_string()))?;
+        fs::write(path, keyring_json).map_err(|e| keyring_io_error("write", e))?;
+    }
+
+    Ok(())
+}
+
+/// Load the keyring from disk, or return an empty one if it doesn't exist.
+fn load_keyring(config: &Config) -> Result<Keyring, AuthError> {
+    let path = &config.keyring_path;
+
+    if !path.exists() {
+        return Ok(Keyring::new());
+    }
+
+    let contents = fs::read_to_string(path).map_err(|e| keyring_io_error("read", e))?;
+    let keyring: Keyring =
+        serde_json::from_str(&contents).map_err(|e| AuthError::Keyring(e.to_string()))?;
+
+    Ok(keyring)
+}
+
+/// Helper to create an AuthError from an IO error.
+fn keyring_io_error(operation: &str, error: io::Error) -> AuthError {
+    AuthError::Keyring(format!("Failed to {} keyring: {}", operation, error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config_with_keyring(path: PathBuf, domain: &str) -> Config {
+        Config {
+            domain: domain.to_string(),
+            client_id: "test-client".to_string(),
+            ssl_verify: true,
+            open_browser: false,
+            keyring_path: path,
+            use_https: true,
+        }
+    }
+
+    #[test]
+    fn test_save_and_get_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config_with_keyring(keyring_path, "test.com");
+
+        // Initially no key
+        assert_eq!(get_api_key(&config).unwrap(), None);
+
+        // Save a key
+        save_api_key(&config, "test-api-key-12345").unwrap();
+
+        // Retrieve the key
+        assert_eq!(
+            get_api_key(&config).unwrap(),
+            Some("test-api-key-12345".to_string())
+        );
+    }
+
+    #[test]
+    fn test_save_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("nested").join("dirs").join("keyring");
+        let config = test_config_with_keyring(keyring_path.clone(), "test.com");
+
+        save_api_key(&config, "test-key").unwrap();
+
+        assert!(keyring_path.exists());
+    }
+
+    #[test]
+    fn test_delete_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config_with_keyring(keyring_path.clone(), "test.com");
+
+        // Save then delete
+        save_api_key(&config, "test-key").unwrap();
+        assert!(keyring_path.exists());
+
+        delete_api_key(&config).unwrap();
+        // File should be removed since keyring is empty
+        assert!(!keyring_path.exists());
+    }
+
+    #[test]
+    fn test_delete_nonexistent_keyring() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("nonexistent");
+        let config = test_config_with_keyring(keyring_path, "test.com");
+
+        // Should not error when deleting nonexistent file
+        delete_api_key(&config).unwrap();
+    }
+
+    #[test]
+    fn test_multiple_domains() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+
+        let config1 = test_config_with_keyring(keyring_path.clone(), "domain1.com");
+        let config2 = test_config_with_keyring(keyring_path.clone(), "domain2.com");
+
+        // Save keys for both domains
+        save_api_key(&config1, "key1").unwrap();
+        save_api_key(&config2, "key2").unwrap();
+
+        // Both should be retrievable
+        assert_eq!(get_api_key(&config1).unwrap(), Some("key1".to_string()));
+        assert_eq!(get_api_key(&config2).unwrap(), Some("key2".to_string()));
+
+        // Delete one, other should remain
+        delete_api_key(&config1).unwrap();
+        assert_eq!(get_api_key(&config1).unwrap(), None);
+        assert_eq!(get_api_key(&config2).unwrap(), Some("key2".to_string()));
+        assert!(keyring_path.exists()); // File still exists
+
+        // Delete the other
+        delete_api_key(&config2).unwrap();
+        assert!(!keyring_path.exists()); // File removed
+    }
+
+    #[test]
+    fn test_keyring_json_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config_with_keyring(keyring_path.clone(), "example.com");
+
+        save_api_key(&config, "my-api-key").unwrap();
+
+        // Read raw file and verify structure
+        let contents = fs::read_to_string(&keyring_path).unwrap();
+        let keyring: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+        // Should have "Anaconda Cloud" -> "example.com" -> base64
+        let encoded = keyring["Anaconda Cloud"]["example.com"].as_str().unwrap();
+        let decoded = BASE64_STANDARD.decode(encoded).unwrap();
+        let credential: Credential = serde_json::from_slice(&decoded).unwrap();
+
+        assert_eq!(credential.domain, "example.com");
+        assert_eq!(credential.api_key, "my-api-key");
+        assert_eq!(credential.version, 2);
+        assert!(credential.repo_tokens.is_empty());
+    }
+
+    #[test]
+    fn test_credential_serialization() {
+        let credential = Credential {
+            domain: "test.com".to_string(),
+            api_key: "ak-123".to_string(),
+            repo_tokens: vec![],
+            version: 2,
+        };
+
+        let json = serde_json::to_string(&credential).unwrap();
+        let parsed: Credential = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(credential, parsed);
+    }
+}

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
-use super::keyring::save_api_key;
+use super::keyring::{delete_api_key, save_api_key};
 use crate::config::Config;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -152,6 +152,14 @@ pub fn login() -> Result<(), AuthError> {
             }
         }
     }
+}
+
+/// Log out by removing the API key for the current domain.
+pub fn logout() -> Result<(), AuthError> {
+    let config = Config::load();
+    delete_api_key(&config)?;
+    println!("Logged out from {}", config.domain);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
+use super::keyring::save_api_key;
 use crate::config::Config;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -122,9 +123,10 @@ pub fn login() -> Result<(), AuthError> {
             // Create API key
             println!("Creating API key...");
             let api_key = create_api_key(&client, &config, &token.access_token)?;
-            println!();
-            println!("API Key: {}", api_key);
-            // TODO: Store API key securely
+
+            // Save to keyring
+            save_api_key(&config, &api_key)?;
+            println!("API key saved to {}", config.keyring_path.display());
             return Ok(());
         }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,4 +5,4 @@ mod errors;
 mod keyring;
 mod login;
 
-pub use login::login;
+pub use login::{login, logout};

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,4 +5,4 @@ mod api_keys;
 mod errors;
 mod keyring;
 
-pub use actions::{login, logout};
+pub use actions::{login, logout, show_api_key};

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,8 +1,8 @@
 //! Authentication module.
 
+mod actions;
 mod api_keys;
 mod errors;
 mod keyring;
-mod login;
 
-pub use login::{login, logout};
+pub use actions::{login, logout};

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,6 +2,7 @@
 
 mod api_keys;
 mod errors;
+mod keyring;
 mod login;
 
 pub use login::login;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub enum Action {
     ShowConfig,
     Login,
     Logout,
+    ShowApiKey,
     Update { force: bool },
     CheckForUpdate,
     ShowAvailableVersions,
@@ -28,6 +29,7 @@ pub fn parse() -> Action {
             Some(Commands::Logout) => Action::Logout,
             Some(Commands::Auth { command }) => match command {
                 None => Action::ShowAuthHelp,
+                Some(AuthCommands::ApiKey) => Action::ShowApiKey,
                 Some(AuthCommands::Login) => Action::Login,
                 Some(AuthCommands::Logout) => Action::Logout,
             },
@@ -119,6 +121,7 @@ pub fn print_auth_help() {
         Usage: ana auth <command> [options]
 
         Commands:
+          api-key   Display the API key for the logged-in user
           login     Log in to Anaconda
           logout    Log out from Anaconda
         "}
@@ -177,6 +180,9 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum AuthCommands {
+    /// Display the API key for the logged-in user
+    ApiKey,
+
     /// Log in to Anaconda
     Login,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ pub enum Action {
     ShowVersion,
     ShowConfig,
     Login,
+    Logout,
     Update { force: bool },
     CheckForUpdate,
     ShowAvailableVersions,
@@ -23,6 +24,7 @@ pub fn parse() -> Action {
             None => Action::ShowHelp,
             Some(Commands::Config) => Action::ShowConfig,
             Some(Commands::Login) => Action::Login,
+            Some(Commands::Logout) => Action::Logout,
             Some(Commands::Self_ { command }) => match command {
                 None => Action::ShowSelfHelp,
                 Some(SelfCommands::Update { yes, check, list }) => {
@@ -77,6 +79,7 @@ pub fn print_main_help() {
         Commands:
           config         Show current configuration
           login          Log in to Anaconda
+          logout         Log out from Anaconda
           self           Manage the ana installation
 
         Options:
@@ -123,6 +126,9 @@ enum Commands {
 
     /// Log in to Anaconda
     Login,
+
+    /// Log out from Anaconda
+    Logout,
 
     /// Manage the ana installation
     #[command(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use crate::VERSION;
 pub enum Action {
     ShowHelp,
     ShowSelfHelp,
+    ShowAuthHelp,
     ShowVersion,
     ShowConfig,
     Login,
@@ -25,6 +26,11 @@ pub fn parse() -> Action {
             Some(Commands::Config) => Action::ShowConfig,
             Some(Commands::Login) => Action::Login,
             Some(Commands::Logout) => Action::Logout,
+            Some(Commands::Auth { command }) => match command {
+                None => Action::ShowAuthHelp,
+                Some(AuthCommands::Login) => Action::Login,
+                Some(AuthCommands::Logout) => Action::Logout,
+            },
             Some(Commands::Self_ { command }) => match command {
                 None => Action::ShowSelfHelp,
                 Some(SelfCommands::Update { yes, check, list }) => {
@@ -77,6 +83,7 @@ pub fn print_main_help() {
         Usage: ana [command] [options]
 
         Commands:
+          auth           Authentication commands
           config         Show current configuration
           login          Log in to Anaconda
           logout         Log out from Anaconda
@@ -103,6 +110,21 @@ pub fn print_self_help() {
     );
 }
 
+pub fn print_auth_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        Authentication commands
+
+        Usage: ana auth <command> [options]
+
+        Commands:
+          login     Log in to Anaconda
+          logout    Log out from Anaconda
+        "}
+    );
+}
+
 #[derive(Parser)]
 #[command(
     name = "ana",
@@ -121,6 +143,17 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Authentication commands
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana auth <command> [options]"
+    )]
+    Auth {
+        #[command(subcommand)]
+        command: Option<AuthCommands>,
+    },
+
     /// Show current configuration
     Config,
 
@@ -140,6 +173,15 @@ enum Commands {
         #[command(subcommand)]
         command: Option<SelfCommands>,
     },
+}
+
+#[derive(Subcommand)]
+enum AuthCommands {
+    /// Log in to Anaconda
+    Login,
+
+    /// Log out from Anaconda
+    Logout,
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@
 
 use comfy_table::{modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL, Attribute, Cell, Table};
 use std::env;
+use std::path::PathBuf;
 
 // TODO(mattkram): Update default to anaconda.com before public release
 const DEFAULT_DOMAIN: &str = "stage.anaconda.com";
@@ -41,6 +42,9 @@ pub struct Config {
     /// Whether to automatically open browser during login
     pub open_browser: bool,
 
+    /// Path to the keyring file for storing API keys
+    pub keyring_path: PathBuf,
+
     /// Whether to use HTTPS (set false for HTTP, e.g. testing)
     pub use_https: bool,
 }
@@ -59,6 +63,9 @@ impl Config {
             env::var("ANA_AUTH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
         let ssl_verify = parse_bool_env("ANA_SSL_VERIFY", DEFAULT_SSL_VERIFY);
         let open_browser = parse_bool_env("ANA_OPEN_BROWSER", DEFAULT_OPEN_BROWSER);
+        let keyring_path = env::var("ANA_KEYRING_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| default_keyring_path());
         let use_https = parse_bool_env("ANA_USE_HTTPS", DEFAULT_USE_HTTPS);
 
         Self {
@@ -66,6 +73,7 @@ impl Config {
             client_id,
             ssl_verify,
             open_browser,
+            keyring_path,
             use_https,
         }
     }
@@ -104,6 +112,14 @@ impl Config {
     }
 }
 
+/// Get the default keyring path (~/.ana/keyring).
+fn default_keyring_path() -> PathBuf {
+    dirs::home_dir()
+        .expect("Could not determine home directory")
+        .join(".ana")
+        .join("keyring")
+}
+
 /// Convert a boolean to a string.
 fn bool_to_str(val: bool) -> &'static str {
     if val { "true" } else { "false" }
@@ -140,6 +156,7 @@ mod tests {
             client_id: DEFAULT_CLIENT_ID.to_string(),
             ssl_verify,
             open_browser,
+            keyring_path: default_keyring_path(),
             use_https: true,
         }
     }
@@ -261,6 +278,21 @@ mod tests {
             let config = Config::load();
             assert!(!config.open_browser);
         });
+    }
+
+    #[test]
+    fn test_config_load_keyring_path_from_env() {
+        temp_env::with_var("ANA_KEYRING_PATH", Some("/custom/path/keyring"), || {
+            let config = Config::load();
+            assert_eq!(config.keyring_path, PathBuf::from("/custom/path/keyring"));
+        });
+    }
+
+    #[test]
+    fn test_config_default_keyring_path() {
+        let config = Config::load();
+        // Should end with .ana/keyring
+        assert!(config.keyring_path.ends_with(".ana/keyring"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
     match cli::parse() {
         cli::Action::ShowHelp => cli::print_main_help(),
         cli::Action::ShowSelfHelp => cli::print_self_help(),
+        cli::Action::ShowAuthHelp => cli::print_auth_help(),
         cli::Action::ShowVersion => println!("{}", VERSION),
         cli::Action::ShowConfig => config::Config::load().print_table(),
         cli::Action::Login => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,12 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        cli::Action::ShowApiKey => {
+            if let Err(e) = auth::show_api_key() {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
         cli::Action::Update { force } => update::run_update(VERSION, force),
         cli::Action::CheckForUpdate => update::check_for_update(VERSION),
         cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,12 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        cli::Action::Logout => {
+            if let Err(e) = auth::logout() {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
         cli::Action::Update { force } => update::run_update(VERSION, force),
         cli::Action::CheckForUpdate => update::check_for_update(VERSION),
         cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,14 +112,22 @@ def mock_auth_server() -> Generator[MockAuthServer, None, None]:
 
 
 @pytest.fixture
+def keyring_path(tmp_path: Path) -> Path:
+    """Provide a temporary keyring file path."""
+    return tmp_path / "keyring"
+
+
+@pytest.fixture
 def auth_env(
     env_isolated: dict[str, str],
     mock_auth_server: MockAuthServer,
+    keyring_path: Path,
 ) -> dict[str, str]:
     """Environment configured to use mock auth server."""
     return {
         **env_isolated,
         "ANA_DOMAIN": mock_auth_server.domain,
+        "ANA_KEYRING_PATH": str(keyring_path),
         "ANA_OPEN_BROWSER": "false",  # Don't try to open browser in tests
         "ANA_USE_HTTPS": "false",  # Use HTTP for mock server
     }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,64 +7,205 @@ from pathlib import Path
 
 from conftest import AnaRunner
 from mock_auth_server import MOCK_API_KEY
+from mock_auth_server import MockAuthServer
 
 
 class TestLogin:
     """Tests for 'ana login' command."""
 
-    def test_login_shows_verification_url(
+    def test_login_creates_keyring(
         self,
         run_ana: AnaRunner,
         auth_env: dict[str, str],
+        keyring_path: Path,
     ) -> None:
-        """Login should display verification URL to user."""
+        """Login should create keyring file with API key."""
         result = run_ana("login", env=auth_env)
 
         assert result.returncode == 0
         assert "To authenticate, visit:" in result.stdout
+        assert "Successfully authenticated!" in result.stdout
+        assert "API key saved to" in result.stdout
+        assert keyring_path.exists()
 
-    def test_login_shows_success_message(
+    def test_login_keyring_format(
         self,
         run_ana: AnaRunner,
         auth_env: dict[str, str],
+        keyring_path: Path,
+        mock_auth_server: MockAuthServer,
     ) -> None:
-        """Login should show success message after authentication."""
-        result = run_ana("login", env=auth_env)
+        """Login should create keyring in anaconda-auth compatible format."""
+        run_ana("login", env=auth_env)
+
+        keyring_data = json.loads(keyring_path.read_text())
+        assert "Anaconda Cloud" in keyring_data
+        assert mock_auth_server.domain in keyring_data["Anaconda Cloud"]
+
+    def test_login_via_auth_subcommand(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        keyring_path: Path,
+    ) -> None:
+        """'ana auth login' should work the same as 'ana login'."""
+        result = run_ana("auth", "login", env=auth_env)
 
         assert result.returncode == 0
         assert "Successfully authenticated!" in result.stdout
+        assert keyring_path.exists()
 
-    def test_login_retrieves_api_key(
+
+class TestLogout:
+    """Tests for 'ana logout' command."""
+
+    def test_logout_removes_key(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        keyring_path: Path,
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """Logout should remove API key from keyring."""
+        # First login
+        run_ana("login", env=auth_env)
+        assert keyring_path.exists()
+
+        # Then logout
+        result = run_ana("logout", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Logged out from {mock_auth_server.domain}" in result.stdout
+        # Keyring should be deleted when empty
+        assert not keyring_path.exists()
+
+    def test_logout_when_not_logged_in(
         self,
         run_ana: AnaRunner,
         auth_env: dict[str, str],
     ) -> None:
-        """Login should store API key in keyring."""
-        import base64
-
-        result = run_ana("login", env=auth_env)
+        """Logout when not logged in should succeed silently."""
+        result = run_ana("logout", env=auth_env)
 
         assert result.returncode == 0
-        # Verify API key is stored in keyring file
-        keyring_path = Path(auth_env["HOME"]) / ".ana" / "keyring"
-        assert keyring_path.exists(), "Keyring file should be created"
-        keyring_data = json.loads(keyring_path.read_text())
-        domain = auth_env["ANA_DOMAIN"]
-        # Keyring format: {"Anaconda Cloud": {"domain": "base64-encoded-credential"}}
-        assert "Anaconda Cloud" in keyring_data
-        assert domain in keyring_data["Anaconda Cloud"]
-        credential = json.loads(
-            base64.b64decode(keyring_data["Anaconda Cloud"][domain])
-        )
-        assert credential["api_key"] == MOCK_API_KEY
 
-    def test_login_shows_creating_api_key_message(
+    def test_logout_via_auth_subcommand(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        keyring_path: Path,
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """'ana auth logout' should work the same as 'ana logout'."""
+        run_ana("login", env=auth_env)
+        result = run_ana("auth", "logout", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Logged out from {mock_auth_server.domain}" in result.stdout
+
+
+class TestApiKey:
+    """Tests for 'ana auth api-key' command."""
+
+    def test_api_key_when_logged_in(
         self,
         run_ana: AnaRunner,
         auth_env: dict[str, str],
     ) -> None:
-        """Login should show message when creating API key."""
-        result = run_ana("login", env=auth_env)
+        """Api-key should print the API key when logged in."""
+        run_ana("login", env=auth_env)
+        result = run_ana("auth", "api-key", env=auth_env)
 
         assert result.returncode == 0
-        assert "Creating API key..." in result.stdout
+        assert MOCK_API_KEY in result.stdout
+
+    def test_api_key_when_not_logged_in(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """Api-key should show helpful message when not logged in."""
+        result = run_ana("auth", "api-key", env=auth_env)
+
+        assert result.returncode == 0
+        assert f"Not logged in to {mock_auth_server.domain}" in result.stdout
+        assert "Run `ana login` to authenticate." in result.stdout
+
+    def test_api_key_output_is_clean(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+    ) -> None:
+        """Api-key output should be just the key (for piping)."""
+        run_ana("login", env=auth_env)
+        result = run_ana("auth", "api-key", env=auth_env)
+
+        # Should be just the key with a newline
+        assert result.stdout.strip() == MOCK_API_KEY
+
+
+class TestAuthHelp:
+    """Tests for 'ana auth' help output."""
+
+    def test_auth_shows_help(self, run_ana: AnaRunner) -> None:
+        """'ana auth' should show auth command help."""
+        result = run_ana("auth")
+
+        assert result.returncode == 0
+        assert "Authentication commands" in result.stdout
+        assert "Usage: ana auth <command>" in result.stdout
+
+    def test_auth_shows_subcommands(self, run_ana: AnaRunner) -> None:
+        """Auth help should list subcommands."""
+        result = run_ana("auth")
+
+        assert "api-key" in result.stdout
+        assert "login" in result.stdout
+        assert "logout" in result.stdout
+
+
+class TestMultipleDomains:
+    """Tests for multi-domain keyring support."""
+
+    def test_login_to_multiple_domains(
+        self,
+        run_ana: AnaRunner,
+        env_isolated: dict[str, str],
+        keyring_path: Path,
+    ) -> None:
+        """Should be able to login to multiple domains."""
+        with MockAuthServer() as server1, MockAuthServer() as server2:
+            env1 = {
+                **env_isolated,
+                "ANA_DOMAIN": server1.domain,
+                "ANA_KEYRING_PATH": str(keyring_path),
+                "ANA_OPEN_BROWSER": "false",
+                "ANA_USE_HTTPS": "false",
+            }
+            env2 = {
+                **env_isolated,
+                "ANA_DOMAIN": server2.domain,
+                "ANA_KEYRING_PATH": str(keyring_path),
+                "ANA_OPEN_BROWSER": "false",
+                "ANA_USE_HTTPS": "false",
+            }
+
+            # Login to both
+            run_ana("login", env=env1)
+            run_ana("login", env=env2)
+
+            # Both should be in keyring
+            keyring_data = json.loads(keyring_path.read_text())
+            assert server1.domain in keyring_data["Anaconda Cloud"]
+            assert server2.domain in keyring_data["Anaconda Cloud"]
+
+            # Logout from one, other should remain
+            run_ana("logout", env=env1)
+            keyring_data = json.loads(keyring_path.read_text())
+            assert server1.domain not in keyring_data["Anaconda Cloud"]
+            assert server2.domain in keyring_data["Anaconda Cloud"]
+
+            # Logout from other, keyring file deleted since no more credentials stored
+            run_ana("logout", env=env2)
+            assert not keyring_path.exists()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from conftest import AnaRunner
 from mock_auth_server import MOCK_API_KEY
 
@@ -36,12 +39,24 @@ class TestLogin:
         run_ana: AnaRunner,
         auth_env: dict[str, str],
     ) -> None:
-        """Login should retrieve and display API key."""
+        """Login should store API key in keyring."""
+        import base64
+
         result = run_ana("login", env=auth_env)
 
         assert result.returncode == 0
-        # TODO: Replace this check with keyring verification once keyring storage is implemented
-        assert MOCK_API_KEY in result.stdout
+        # Verify API key is stored in keyring file
+        keyring_path = Path(auth_env["HOME"]) / ".ana" / "keyring"
+        assert keyring_path.exists(), "Keyring file should be created"
+        keyring_data = json.loads(keyring_path.read_text())
+        domain = auth_env["ANA_DOMAIN"]
+        # Keyring format: {"Anaconda Cloud": {"domain": "base64-encoded-credential"}}
+        assert "Anaconda Cloud" in keyring_data
+        assert domain in keyring_data["Anaconda Cloud"]
+        credential = json.loads(
+            base64.b64decode(keyring_data["Anaconda Cloud"][domain])
+        )
+        assert credential["api_key"] == MOCK_API_KEY
 
     def test_login_shows_creating_api_key_message(
         self,


### PR DESCRIPTION
## Summary

- Add keyring storage for API keys (compatible with anaconda-auth JSON format)
- Add `ana auth` command group with `login`, `logout`, and `api-key` subcommands
- Add `keyring_path` config field (default: `~/.ana/keyring`, override via `ANA_KEYRING_PATH`)
- Add integration tests using mock OAuth server

## Details

The keyring stores credentials in a JSON file with base64-encoded entries per domain, matching the format used by anaconda-auth for compatibility. The `ana auth api-key` command retrieves the stored key directly from the keyring.

**New commands:**
- `ana auth login` - alias for `ana login`
- `ana auth logout` - alias for `ana logout`  
- `ana auth api-key` - display the stored API key for the current domain

## Test plan

- [x] `cargo test` passes (57 tests)
- [x] Manual test: `ana login` stores key, `ana auth api-key` retrieves it, `ana logout` removes it
- [x] Verify keyring file format matches anaconda-auth

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-374](https://anaconda.atlassian.net/browse/CLI-374)


[CLI-374]: https://anaconda.atlassian.net/browse/CLI-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ