### PR TITLE
feat: Add telemetry for CLI command execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git for private repos
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Configure git for private repos
         run: |
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,22 @@ pixi run build-debug
 pixi run test
 ```
 
+## Configuring Private Git URL
+
+This project depends on private repositories. Configure git to authenticate when fetching these dependencies:
+
+```bash
+git config --global url."https://x-access-token:<YOUR_GITHUB_TOKEN>@github.com/".insteadOf "https://github.com/"
+```
+
+Replace `<YOUR_GITHUB_TOKEN>` with a [personal access token](https://github.com/settings/tokens) that has `repo` scope. Alternatively, use SSH:
+
+```bash
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+
+This rewrites GitHub HTTPS URLs to use your configured authentication method.
+
 ## Reporting Issues
 
 Open a GitHub Issue for bug reports and feature requests. Include enough detail to reproduce the problem: OS, platform, ana version (`ana --version`), and the command that triggered the issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ana"
 version = "0.0.0"
 dependencies = [
+ "anaconda-otel-rs",
  "clap",
  "indicatif",
  "indoc",
- "reqwest",
+ "reqwest 0.13.2",
  "self-replace",
  "semver",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "anaconda-otel-rs"
+version = "0.1.0"
+source = "git+https://github.com/anaconda/anaconda-otel-rs#f90811de7e83e34788694da50b3d3614b806d335"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "hex",
+ "hostname",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "parking_lot",
+ "regex",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sysinfo",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -73,10 +121,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -89,6 +154,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -117,6 +191,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -193,6 +280,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +343,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -284,10 +431,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -309,11 +478,34 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -324,7 +516,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -349,6 +541,23 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -447,6 +656,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -614,6 +847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +870,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -654,10 +902,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -691,6 +957,33 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -750,10 +1043,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -789,6 +1210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +1238,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,9 +1271,136 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reqwest"
@@ -860,6 +1440,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +1500,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -980,10 +1591,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1051,16 +1704,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1082,9 +1779,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1095,6 +1806,49 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -1149,7 +1903,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1159,6 +1925,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1166,6 +1978,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -1216,10 +2034,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1368,10 +2198,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1570,6 +2494,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "indoc",
+ "reqwest 0.12.28",
  "reqwest 0.13.2",
  "self-replace",
  "semver",
@@ -30,6 +31,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror",
+ "tracing-subscriber",
  "webbrowser",
 ]
 
@@ -293,6 +295,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -438,6 +450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +485,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -614,6 +641,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +746,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -708,6 +755,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -744,9 +807,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1087,6 +1152,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1575,23 +1646,31 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1640,6 +1719,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,12 +1765,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1723,7 +1840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1898,6 +2015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,6 +2064,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2043,12 +2187,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2250,6 +2417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,7 +2622,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
@@ -2549,6 +2722,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,9 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +579,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -584,17 +598,6 @@ dependencies = [
  "libc",
  "r-efi 5.3.0",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -950,12 +953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
-dependencies = [
- "cfg-if",
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,10 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+]
 
 [[package]]
 name = "objc2"
@@ -1314,6 +1314,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,14 +1599,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -2285,6 +2290,8 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ self-replace = "1.5"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,14 @@ serde_json = "1.0"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
 webbrowser = "1"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 temp-env = "0.3"
 tempfile = "3"
+
+# Force reqwest 0.12 (used by opentelemetry-otlp) to include TLS support
+[dependencies.reqwest012]
+package = "reqwest"
+version = "0.12"
+features = ["blocking", "native-tls"]

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -155,6 +155,10 @@ mod tests {
             open_browser: false,
             keyring_path: path,
             use_https: true,
+            metrics_endpoint: "https://metrics.example.com".to_string(),
+            metrics_export_interval_ms: 1000,
+            metrics_console_exporter: false,
+            metrics_skip_internet_check: true,
         }
     }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -6,3 +6,4 @@ mod errors;
 mod keyring;
 
 pub use actions::{login, logout, show_api_key, whoami};
+pub use keyring::get_api_key;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
 use crate::VERSION;
+use crate::auth;
 use crate::config::{self, Config};
 use crate::update;
 
@@ -38,8 +39,13 @@ impl Action {
         match self {
             Action::ShowHelp => "help",
             Action::ShowSelfHelp => "self.help",
+            Action::ShowAuthHelp => "auth.help",
             Action::ShowVersion => "version",
             Action::ShowConfig => "config",
+            Action::Login => "login",
+            Action::Logout => "logout",
+            Action::ShowApiKey => "auth.api-key",
+            Action::Whoami => "whoami",
             Action::Update { .. } => "self.update",
             Action::CheckForUpdate => "self.update.check",
             Action::ShowAvailableVersions => "self.update.list",
@@ -77,10 +83,22 @@ impl Action {
                 print_self_help();
                 Ok(())
             }
+            Action::ShowAuthHelp => {
+                print_auth_help();
+                Ok(())
+            }
             Action::ShowVersion => {
                 println!("{}", VERSION);
                 Ok(())
             }
+            Action::ShowConfig => {
+                Config::load().print_table();
+                Ok(())
+            }
+            Action::Login => Ok(auth::login()?),
+            Action::Logout => Ok(auth::logout()?),
+            Action::ShowApiKey => Ok(auth::show_api_key()?),
+            Action::Whoami => Ok(auth::whoami()?),
             Action::Update { force } => {
                 update::run_update(VERSION, force);
                 Ok(())
@@ -91,10 +109,6 @@ impl Action {
             }
             Action::ShowAvailableVersions => {
                 update::show_available_versions(VERSION);
-                Ok(())
-            }
-            Action::ShowConfig => {
-                Config::load().print_table();
                 Ok(())
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anaconda_otel_rs::signals::increment_counter;
+use anaconda_otel_rs::signals::{increment_counter, shutdown_telemetry};
 use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
@@ -10,9 +10,17 @@ use crate::config::{self, Config};
 use crate::update;
 
 pub fn execute() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     config::setup_telemetry();
 
-    if let Err(e) = parse().execute() {
+    let result = parse().execute();
+
+    shutdown_telemetry();
+
+    if let Err(e) = result {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
@@ -57,16 +65,16 @@ impl Action {
         let name = self.match_action_name();
         let mut attrs = HashMap::new();
         attrs.insert("command".to_string(), name.into());
-        increment_counter("cli.command.invoked", 1, attrs.clone());
+        increment_counter("cli_command_invoked", 1, attrs.clone());
 
         let result = self.run();
 
         match &result {
             Ok(_) => {
-                increment_counter("cli.command.success", 1, attrs);
+                increment_counter("cli_command_success", 1, attrs);
             }
             Err(_) => {
-                increment_counter("cli.command.failure", 1, attrs);
+                increment_counter("cli_command_failure", 1, attrs);
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
+
+use anaconda_otel_rs::signals::increment_counter;
 use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
 use crate::VERSION;
+use crate::update;
 
 /// Action to be performed, returned by parse()
 pub enum Action {
@@ -11,6 +15,69 @@ pub enum Action {
     Update { force: bool },
     CheckForUpdate,
     ShowAvailableVersions,
+}
+
+impl Action {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Action::ShowHelp => "help",
+            Action::ShowSelfHelp => "self.help",
+            Action::ShowVersion => "version",
+            Action::Update { .. } => "self.update",
+            Action::CheckForUpdate => "self.update.check",
+            Action::ShowAvailableVersions => "self.update.list",
+        }
+    }
+
+    /// Execute the action with telemetry middleware
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let name = self.name();
+        let mut attrs = HashMap::new();
+        attrs.insert("command".to_string(), name.into());
+        increment_counter("cli.command.invoked", 1, attrs.clone());
+
+        let result = self.run();
+
+        match &result {
+            Ok(_) => {
+                increment_counter("cli.command.success", 1, attrs);
+            }
+            Err(_) => {
+                increment_counter("cli.command.failure", 1, attrs);
+            }
+        }
+
+        result
+    }
+
+    fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            Action::ShowHelp => {
+                print_main_help();
+                Ok(())
+            }
+            Action::ShowSelfHelp => {
+                print_self_help();
+                Ok(())
+            }
+            Action::ShowVersion => {
+                println!("{}", VERSION);
+                Ok(())
+            }
+            Action::Update { force } => {
+                update::run_update(VERSION, force);
+                Ok(())
+            }
+            Action::CheckForUpdate => {
+                update::check_for_update(VERSION);
+                Ok(())
+            }
+            Action::ShowAvailableVersions => {
+                update::show_available_versions(VERSION);
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Parse CLI arguments and return the action to perform.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ pub enum Action {
 }
 
 impl Action {
-    pub fn name(&self) -> &'static str {
+    fn match_action_name(&self) -> &'static str {
         match self {
             Action::ShowHelp => "help",
             Action::ShowSelfHelp => "self.help",
@@ -43,7 +43,7 @@ impl Action {
 
     /// Execute the action with telemetry middleware
     pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let name = self.name();
+        let name = self.match_action_name();
         let mut attrs = HashMap::new();
         attrs.insert("command".to_string(), name.into());
         increment_counter("cli.command.invoked", 1, attrs.clone());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,17 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
 use crate::VERSION;
-use crate::config::Config;
+use crate::config::{self, Config};
 use crate::update;
+
+pub fn execute() {
+    config::setup_telemetry();
+
+    if let Err(e) = parse().execute() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
 
 /// Action to be performed, returned by parse()
 pub enum Action {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,12 +5,16 @@
 //!
 //! # Environment Variables
 //!
-//! | Variable             | Default         | Description                    |
-//! |----------------------|-----------------|--------------------------------|
-//! | `ANA_DOMAIN`         | `anaconda.com`  | Authentication domain          |
-//! | `ANA_AUTH_CLIENT_ID` | (Anaconda's ID) | OAuth client ID                |
-//! | `ANA_SSL_VERIFY`     | `true`          | SSL certificate verification   |
-//! | `ANA_OPEN_BROWSER`   | `true`          | Auto-open browser during login |
+//! | Variable                        | Default                    | Description                    |
+//! |---------------------------------|----------------------------|--------------------------------|
+//! | `ANA_DOMAIN`                    | `anaconda.com`             | Authentication domain          |
+//! | `ANA_AUTH_CLIENT_ID`            | (Anaconda's ID)            | OAuth client ID                |
+//! | `ANA_SSL_VERIFY`                | `true`                     | SSL certificate verification   |
+//! | `ANA_OPEN_BROWSER`              | `true`                     | Auto-open browser during login |
+//! | `ANA_METRICS_ENDPOINT`          | (Anaconda metrics URL)     | OpenTelemetry metrics endpoint |
+//! | `ANA_METRICS_EXPORT_INTERVAL_MS`| `1000`                     | Metrics export interval in ms  |
+//! | `ANA_METRICS_CONSOLE_EXPORTER`  | `false`                    | Enable console metrics exporter|
+//! | `ANA_METRICS_SKIP_INTERNET_CHECK`| `true`                    | Skip internet connectivity check|
 //!
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
@@ -28,20 +32,19 @@ pub fn setup_telemetry() {
 }
 
 fn try_setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Configuration::new(
-        Some("https://metrics.auth.anacondaconnect.com/v1/metrics"),
-        None,
-    )?;
+    let app_config = Config::load();
 
-    let api_key = env::var("OTEL_API_KEY").ok();
-    config.set_auth_token(api_key);
-    config.set_console_exporter(false);
-    config.set_metrics_export_interval_ms(1000);
-    config.skip_internet_check = true;
+    let mut otel_config = Configuration::new(Some(&app_config.metrics_endpoint), None)?;
+
+    // TODO: Add API key here
+    otel_config.set_auth_token(None);
+    otel_config.set_console_exporter(app_config.metrics_console_exporter);
+    otel_config.set_metrics_export_interval_ms(app_config.metrics_export_interval_ms);
+    otel_config.skip_internet_check = app_config.metrics_skip_internet_check;
 
     let attrs = ResourceAttributes::new("ana-cli", VERSION)?;
 
-    initialize_telemetry(config, attrs, vec!["metrics"])
+    initialize_telemetry(otel_config, attrs, vec!["metrics"])
         .map_err(|e| format!("Telemetry initialization failed: {}", e))?;
 
     Ok(())
@@ -52,6 +55,10 @@ const DEFAULT_DOMAIN: &str = "stage.anaconda.com";
 const DEFAULT_CLIENT_ID: &str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a";
 const DEFAULT_SSL_VERIFY: bool = true;
 const DEFAULT_OPEN_BROWSER: bool = true;
+const DEFAULT_METRICS_ENDPOINT: &str = "https://metrics.auth.anacondaconnect.com/v1/metrics";
+const DEFAULT_METRICS_EXPORT_INTERVAL_MS: i64 = 1000;
+const DEFAULT_METRICS_CONSOLE_EXPORTER: bool = false;
+const DEFAULT_METRICS_SKIP_INTERNET_CHECK: bool = true;
 
 /// Global configuration for ana.
 #[derive(Debug, Clone, PartialEq)]
@@ -67,6 +74,18 @@ pub struct Config {
 
     /// Whether to automatically open browser during login
     pub open_browser: bool,
+
+    /// OpenTelemetry metrics endpoint URL
+    pub metrics_endpoint: String,
+
+    /// Metrics export interval in milliseconds
+    pub metrics_export_interval_ms: i64,
+
+    /// Enable console metrics exporter
+    pub metrics_console_exporter: bool,
+
+    /// Skip internet connectivity check
+    pub metrics_skip_internet_check: bool,
 }
 
 impl Default for Config {
@@ -83,12 +102,26 @@ impl Config {
             env::var("ANA_AUTH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
         let ssl_verify = parse_bool_env("ANA_SSL_VERIFY", DEFAULT_SSL_VERIFY);
         let open_browser = parse_bool_env("ANA_OPEN_BROWSER", DEFAULT_OPEN_BROWSER);
+        let metrics_endpoint =
+            env::var("ANA_METRICS_ENDPOINT").unwrap_or_else(|_| DEFAULT_METRICS_ENDPOINT.to_string());
+        let metrics_export_interval_ms = env::var("ANA_METRICS_EXPORT_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_METRICS_EXPORT_INTERVAL_MS);
+        let metrics_console_exporter =
+            parse_bool_env("ANA_METRICS_CONSOLE_EXPORTER", DEFAULT_METRICS_CONSOLE_EXPORTER);
+        let metrics_skip_internet_check =
+            parse_bool_env("ANA_METRICS_SKIP_INTERNET_CHECK", DEFAULT_METRICS_SKIP_INTERNET_CHECK);
 
         Self {
             domain,
             client_id,
             ssl_verify,
             open_browser,
+            metrics_endpoint,
+            metrics_export_interval_ms,
+            metrics_console_exporter,
+            metrics_skip_internet_check,
         }
     }
 }
@@ -147,6 +180,10 @@ mod tests {
             client_id: DEFAULT_CLIENT_ID.to_string(),
             ssl_verify,
             open_browser,
+            metrics_endpoint: DEFAULT_METRICS_ENDPOINT.to_string(),
+            metrics_export_interval_ms: DEFAULT_METRICS_EXPORT_INTERVAL_MS,
+            metrics_console_exporter: DEFAULT_METRICS_CONSOLE_EXPORTER,
+            metrics_skip_internet_check: DEFAULT_METRICS_SKIP_INTERNET_CHECK,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,9 @@
 use anaconda_otel_rs::{
     attributes::ResourceAttributes, config::Configuration, signals::initialize_telemetry,
 };
-use comfy_table::{modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL, Attribute, Cell, Table};
+use comfy_table::{
+    Attribute, Cell, Table, modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL,
+};
 use std::env;
 use std::path::PathBuf;
 
@@ -111,16 +113,20 @@ impl Config {
             env::var("ANA_AUTH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
         let ssl_verify = parse_bool_env("ANA_SSL_VERIFY", DEFAULT_SSL_VERIFY);
         let open_browser = parse_bool_env("ANA_OPEN_BROWSER", DEFAULT_OPEN_BROWSER);
-        let metrics_endpoint =
-            env::var("ANA_METRICS_ENDPOINT").unwrap_or_else(|_| DEFAULT_METRICS_ENDPOINT.to_string());
+        let metrics_endpoint = env::var("ANA_METRICS_ENDPOINT")
+            .unwrap_or_else(|_| DEFAULT_METRICS_ENDPOINT.to_string());
         let metrics_export_interval_ms = env::var("ANA_METRICS_EXPORT_INTERVAL_MS")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_METRICS_EXPORT_INTERVAL_MS);
-        let metrics_console_exporter =
-            parse_bool_env("ANA_METRICS_CONSOLE_EXPORTER", DEFAULT_METRICS_CONSOLE_EXPORTER);
-        let metrics_skip_internet_check =
-            parse_bool_env("ANA_METRICS_SKIP_INTERNET_CHECK", DEFAULT_METRICS_SKIP_INTERNET_CHECK);
+        let metrics_console_exporter = parse_bool_env(
+            "ANA_METRICS_CONSOLE_EXPORTER",
+            DEFAULT_METRICS_CONSOLE_EXPORTER,
+        );
+        let metrics_skip_internet_check = parse_bool_env(
+            "ANA_METRICS_SKIP_INTERNET_CHECK",
+            DEFAULT_METRICS_SKIP_INTERNET_CHECK,
+        );
         let keyring_path = env::var("ANA_KEYRING_PATH")
             .map(PathBuf::from)
             .unwrap_or_else(|_| default_keyring_path());

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@
 //! | `ANA_METRICS_CONSOLE_EXPORTER`   | `false`                    | Enable console metrics exporter|
 //! | `ANA_METRICS_SKIP_INTERNET_CHECK`| `true`                     | Skip internet connectivity check|
 //! | `ANA_USE_HTTPS`                  | `true`                     | Use HTTPS (set false for HTTP) |
+//! | `ANA_ENABLE_TELEMETRY`           | `true`                     | Enable/disable telemetry        |
 //!
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
@@ -33,6 +34,9 @@ use crate::VERSION;
 use crate::auth;
 
 pub fn setup_telemetry() {
+    if !parse_bool_env("ANA_ENABLE_TELEMETRY", true) {
+        return;
+    }
     let _ = try_setup_telemetry();
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,37 @@
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
 
+use anaconda_otel_rs::{
+    attributes::ResourceAttributes, config::Configuration, signals::initialize_telemetry,
+};
 use comfy_table::{modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL, Attribute, Cell, Table};
 use std::env;
+
+use crate::VERSION;
+
+pub fn setup_telemetry() {
+    let _ = try_setup_telemetry();
+}
+
+fn try_setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = Configuration::new(
+        Some("https://metrics.auth.anacondaconnect.com/v1/metrics"),
+        None,
+    )?;
+
+    let api_key = env::var("OTEL_API_KEY").ok();
+    config.set_auth_token(api_key);
+    config.set_console_exporter(false);
+    config.set_metrics_export_interval_ms(1000);
+    config.skip_internet_check = true;
+
+    let attrs = ResourceAttributes::new("ana-cli", VERSION)?;
+
+    initialize_telemetry(config, attrs, vec!["metrics"])
+        .map_err(|e| format!("Telemetry initialization failed: {}", e))?;
+
+    Ok(())
+}
 
 // TODO(mattkram): Update default to anaconda.com before public release
 const DEFAULT_DOMAIN: &str = "stage.anaconda.com";

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ use std::env;
 use std::path::PathBuf;
 
 use crate::VERSION;
+use crate::auth;
 
 pub fn setup_telemetry() {
     let _ = try_setup_telemetry();
@@ -38,8 +39,8 @@ fn try_setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut otel_config = Configuration::new(Some(&app_config.metrics_endpoint), None)?;
 
-    // TODO: Add API key here
-    otel_config.set_auth_token(None);
+    let api_key = auth::get_api_key(&app_config).ok().flatten();
+    otel_config.set_auth_token(api_key);
     otel_config.set_console_exporter(app_config.metrics_console_exporter);
     otel_config.set_metrics_export_interval_ms(app_config.metrics_export_interval_ms);
     otel_config.skip_internet_check = app_config.metrics_skip_internet_check;

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,7 @@ pub struct Config {
 
     /// Skip internet connectivity check
     pub metrics_skip_internet_check: bool,
+    
     /// Path to the keyring file for storing API keys
     pub keyring_path: PathBuf,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ pub struct Config {
 
     /// Skip internet connectivity check
     pub metrics_skip_internet_check: bool,
-    
+
     /// Path to the keyring file for storing API keys
     pub keyring_path: PathBuf,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,47 @@
+use std::env;
+
+use anaconda_otel_rs::{
+    attributes::ResourceAttributes, config::Configuration, signals::initialize_telemetry,
+};
+
 mod cli;
-mod update;
+pub(crate) mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 
+fn setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = Configuration::new(
+        Some("https://metrics.auth.anacondaconnect.com/v1/metrics"),
+        None,
+    )?;
+
+    // Set auth token from environment variable
+    let api_key = env::var("OTEL_API_KEY").ok();
+    config.set_auth_token(api_key);
+
+    // Disable console exporter to use OTLP HTTP
+    config.set_console_exporter(false);
+
+    // Set a short export interval (1 second) so we don't have to wait 60s to see results
+    config.set_metrics_export_interval_ms(1000);
+    config.skip_internet_check = true;
+
+    // 2. Setup resource attributes
+    let attrs = ResourceAttributes::new("ana-cli", VERSION)?;
+
+    // 3. Initialize telemetry with the "metrics" signal
+    initialize_telemetry(config, attrs, vec!["metrics"])
+        .map_err(|e| format!("Telemetry initialization failed: {}", e))?;
+
+    Ok(())
+}
+
 fn main() {
-    match cli::parse() {
-        cli::Action::ShowHelp => cli::print_main_help(),
-        cli::Action::ShowSelfHelp => cli::print_self_help(),
-        cli::Action::ShowVersion => println!("{}", VERSION),
-        cli::Action::Update { force } => update::run_update(VERSION, force),
-        cli::Action::CheckForUpdate => update::check_for_update(VERSION),
-        cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),
+    let _ = setup_telemetry();
+
+    if let Err(e) = cli::parse().execute() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use anaconda_otel_rs::{
 
 mod cli;
 mod config;
-pub(crate) mod update;
+mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,49 +1,11 @@
-use std::env;
-
-use anaconda_otel_rs::{
-    attributes::ResourceAttributes, config::Configuration, signals::initialize_telemetry,
-};
-
 mod cli;
 mod config;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 
-fn setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Configuration::new(
-        Some("https://metrics.auth.anacondaconnect.com/v1/metrics"),
-        None,
-    )?;
-
-    // Set auth token from environment variable
-    let api_key = env::var("OTEL_API_KEY").ok();
-    config.set_auth_token(api_key);
-
-    // Disable console exporter to use OTLP HTTP
-    config.set_console_exporter(false);
-
-    // Set a short export interval (1 second) so we don't have to wait 60s to see results
-    config.set_metrics_export_interval_ms(1000);
-    config.skip_internet_check = true;
-
-    // 2. Setup resource attributes
-    let attrs = ResourceAttributes::new("ana-cli", VERSION)?;
-
-    // 3. Initialize telemetry with the "metrics" signal
-    initialize_telemetry(config, attrs, vec!["metrics"])
-        .map_err(|e| format!("Telemetry initialization failed: {}", e))?;
-
-    Ok(())
-}
-
 fn main() {
-    let _ = setup_telemetry();
-
-    if let Err(e) = cli::parse().execute() {
-        eprintln!("Error: {}", e);
-        std::process::exit(1);
-    }
+    cli::execute();
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,40 +7,6 @@ pub const VERSION: &str = env!("PKG_VERSION");
 
 fn main() {
     cli::execute();
-    match cli::parse() {
-        cli::Action::ShowHelp => cli::print_main_help(),
-        cli::Action::ShowSelfHelp => cli::print_self_help(),
-        cli::Action::ShowAuthHelp => cli::print_auth_help(),
-        cli::Action::ShowVersion => println!("{}", VERSION),
-        cli::Action::ShowConfig => config::Config::load().print_table(),
-        cli::Action::Login => {
-            if let Err(e) = auth::login() {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
-        cli::Action::Logout => {
-            if let Err(e) = auth::logout() {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
-        cli::Action::ShowApiKey => {
-            if let Err(e) = auth::show_api_key() {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
-        cli::Action::Whoami => {
-            if let Err(e) = auth::whoami() {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
-        cli::Action::Update { force } => update::run_update(VERSION, force),
-        cli::Action::CheckForUpdate => update::check_for_update(VERSION),
-        cli::Action::ShowAvailableVersions => update::show_available_versions(VERSION),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `anaconda-otel-rs` dependency for OpenTelemetry metrics
- Implement telemetry middleware pattern on `Action` with `execute()` method
- Track command invocations, successes, and failures via `increment_counter`

## Changes
- `Action::execute()` wraps command execution with telemetry
- `Action::name()` returns command identifier for metrics
- Simplify `main()` to single `cli::parse().execute()` call
- Initialize telemetry on startup with metrics export to Anaconda Connect

## Test plan
- [x] All existing tests pass
- [ ] Verify metrics appear in telemetry backend with `OTEL_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)