### PR TITLE
refac: Move `ANA_PRERELEASES` config to config.rs and set default to false

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,9 @@ ana config
 | `ANA_AUTH_CLIENT_ID` | *(Anaconda's ID)* | OAuth client ID |
 | `ANA_SSL_VERIFY` | `true` | Verify SSL certificates |
 | `ANA_OPEN_BROWSER` | `true` | Auto-open browser during login |
+| `ANA_USE_HTTPS` | `true` | Use HTTPS (set `false` for HTTP) |
+| `ANA_KEYRING_PATH` | `~/.ana/keyring` | Path to keyring file for API keys |
+| `ANA_PRERELEASES` | `false` | Include prereleases in update checks |
 
 ## Precedence
 

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -155,6 +155,7 @@ mod tests {
             open_browser: false,
             keyring_path: path,
             use_https: true,
+            include_prereleases: false,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@
 //! | `ANA_SSL_VERIFY`     | `true`          | SSL certificate verification   |
 //! | `ANA_OPEN_BROWSER`   | `true`          | Auto-open browser during login |
 //! | `ANA_USE_HTTPS`      | `true`          | Use HTTPS (set false for HTTP) |
+//! | `ANA_PRERELEASES`    | `false`         | Include prereleases in updates |
 //!
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
@@ -26,6 +27,7 @@ const DEFAULT_CLIENT_ID: &str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a";
 const DEFAULT_SSL_VERIFY: bool = true;
 const DEFAULT_OPEN_BROWSER: bool = true;
 const DEFAULT_USE_HTTPS: bool = true;
+const DEFAULT_INCLUDE_PRERELEASES: bool = false;
 
 /// Global configuration for ana.
 #[derive(Debug, Clone, PartialEq)]
@@ -47,6 +49,9 @@ pub struct Config {
 
     /// Whether to use HTTPS (set false for HTTP, e.g. testing)
     pub use_https: bool,
+
+    /// Whether to include prereleases when checking for updates
+    pub include_prereleases: bool,
 }
 
 impl Default for Config {
@@ -67,6 +72,8 @@ impl Config {
             .map(PathBuf::from)
             .unwrap_or_else(|_| default_keyring_path());
         let use_https = parse_bool_env("ANA_USE_HTTPS", DEFAULT_USE_HTTPS);
+        let include_prereleases =
+            parse_bool_env("ANA_PRERELEASES", DEFAULT_INCLUDE_PRERELEASES);
 
         Self {
             domain,
@@ -75,6 +82,7 @@ impl Config {
             open_browser,
             keyring_path,
             use_https,
+            include_prereleases,
         }
     }
 
@@ -158,6 +166,7 @@ mod tests {
             open_browser,
             keyring_path: default_keyring_path(),
             use_https: true,
+            include_prereleases: false,
         }
     }
 
@@ -322,5 +331,29 @@ mod tests {
         let mut config = test_config("example.com", true, true);
         config.use_https = false;
         assert_eq!(config.base_url(), "http://example.com");
+    }
+
+    #[test]
+    fn test_config_load_include_prereleases_false_from_env() {
+        temp_env::with_var("ANA_PRERELEASES", Some("false"), || {
+            let config = Config::load();
+            assert!(!config.include_prereleases);
+        });
+    }
+
+    #[test]
+    fn test_config_default_include_prereleases_is_false() {
+        temp_env::with_var("ANA_PRERELEASES", None::<&str>, || {
+            let config = Config::load();
+            assert!(!config.include_prereleases);
+        });
+    }
+
+    #[test]
+    fn test_config_load_include_prereleases_true_from_env() {
+        temp_env::with_var("ANA_PRERELEASES", Some("true"), || {
+            let config = Config::load();
+            assert!(config.include_prereleases);
+        });
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::env;
 use std::io::{Read, Write};
 
+use crate::config::Config;
 use crate::input::prompt_yes_no;
 
 // We track the repo for releases
@@ -78,14 +79,6 @@ pub struct Release {
     pub prerelease: bool,
     #[serde(default)]
     pub assets: Vec<Asset>,
-}
-
-const DEFAULT_INCLUDE_PRERELEASES: bool = false;
-
-pub fn include_prereleases() -> bool {
-    env::var("ANA_PRERELEASES")
-        .map(|v| v.to_lowercase() != "false")
-        .unwrap_or(DEFAULT_INCLUDE_PRERELEASES)
 }
 
 fn get_asset_name() -> Result<String, Error> {
@@ -178,11 +171,11 @@ fn fetch_releases() -> Result<Vec<Release>, Error> {
 }
 
 pub fn fetch_available_releases() -> Result<Vec<Release>, Error> {
-    let include_pre = include_prereleases();
+    let config = Config::load();
     let mut releases: Vec<_> = fetch_releases()?
         .into_iter()
         .filter(|r| parse_version(&r.tag_name).is_ok())
-        .filter(|r| include_pre || !r.prerelease)
+        .filter(|r| config.include_prereleases || !r.prerelease)
         .collect();
     releases.sort_by(|a, b| {
         let va = parse_version(&a.tag_name).unwrap();

--- a/src/update.rs
+++ b/src/update.rs
@@ -80,7 +80,7 @@ pub struct Release {
     pub assets: Vec<Asset>,
 }
 
-const DEFAULT_INCLUDE_PRERELEASES: bool = true;
+const DEFAULT_INCLUDE_PRERELEASES: bool = false;
 
 pub fn include_prereleases() -> bool {
     env::var("ANA_PRERELEASES")


### PR DESCRIPTION
## Summary
- Move `ANA_PRERELEASES` environment variable handling from `update.rs` to `config.rs`
- Change default from `true` to `false` (prereleases excluded by default)
- Add `include_prereleases` field to `Config` struct for consistent configuration pattern

## Test plan
- [x] All existing tests pass
- [x] Added tests for `include_prereleases` config loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)