### PR TITLE
fix: Pass secrets to CI workflow in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   publish-to-anaconda-dot-org:
     name: Publish to Anaconda.org


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the CI workflow call in the release workflow
- Fixes the release pipeline by ensuring `PRIVATE_REPO_TOKEN` is available for configuring git access to private repos

## Test plan
- [ ] Verify the release workflow runs successfully on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)