### PR TITLE
feat: Add histogram telemetry for command execution duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "indoc",
+ "libc",
  "reqwest 0.12.28",
  "reqwest 0.13.2",
  "self-replace",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use anaconda_otel_rs::signals::{increment_counter, shutdown_telemetry};
+use std::time::Instant;
+
+use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
 use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
@@ -67,14 +69,18 @@ impl Action {
         attrs.insert("command".to_string(), name.into());
         increment_counter("cli_command_invoked", 1, attrs.clone());
 
+        let start = Instant::now();
         let result = self.run();
+        let duration_ms = start.elapsed().as_millis() as f64;
 
         match &result {
             Ok(_) => {
-                increment_counter("cli_command_success", 1, attrs);
+                increment_counter("cli_command_success", 1, attrs.clone());
+                record_histogram("cli_command_success_duration_ms", duration_ms, attrs);
             }
             Err(_) => {
-                increment_counter("cli_command_failure", 1, attrs);
+                increment_counter("cli_command_failure", 1, attrs.clone());
+                record_histogram("cli_command_failure_duration_ms", duration_ms, attrs);
             }
         }
 


### PR DESCRIPTION
## Summary
- Add timing measurement around command execution using `std::time::Instant`
- Record duration histograms via `record_histogram` from anaconda-otel-rs
- Separate metrics for success (`cli_command_success_duration_ms`) and failure (`cli_command_failure_duration_ms`)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (61 tests)
- [ ] Verify histogram metrics are exported correctly in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)