### PR TITLE
refac: Auto-generate config table from struct fields

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ const DEFAULT_USE_HTTPS: bool = true;
 const DEFAULT_INCLUDE_PRERELEASES: bool = false;
 
 /// Global configuration for ana.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Config {
     /// The domain for authentication (e.g., "anaconda.com")
     pub domain: String,
@@ -185,10 +185,19 @@ impl Config {
             Cell::new("Setting").add_attribute(Attribute::Bold),
             Cell::new("Value").add_attribute(Attribute::Bold),
         ]);
-        table.add_row(["domain", &self.domain]);
-        table.add_row(["client_id", &self.client_id]);
-        table.add_row(["ssl_verify", bool_to_str(self.ssl_verify)]);
-        table.add_row(["open_browser", bool_to_str(self.open_browser)]);
+
+        if let Ok(serde_json::Value::Object(map)) = serde_json::to_value(self) {
+            for (key, value) in map {
+                let value_str = match value {
+                    serde_json::Value::String(s) => s,
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    _ => value.to_string(),
+                };
+                table.add_row([key, value_str]);
+            }
+        }
+
         println!("{table}");
     }
 }
@@ -199,11 +208,6 @@ fn default_keyring_path() -> PathBuf {
         .expect("Could not determine home directory")
         .join(".ana")
         .join("keyring")
-}
-
-/// Convert a boolean to a string.
-fn bool_to_str(val: bool) -> &'static str {
-    if val { "true" } else { "false" }
 }
 
 /// Parse a boolean from a string value.


### PR DESCRIPTION
## Summary
- Add `Serialize` derive to `Config` struct
- Use `serde_json::to_value` to iterate over struct fields automatically
- Remove manual row additions and unused `bool_to_str` helper

This eliminates the need to manually update `print_table` when adding new config options.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (61 tests)
- [x] Verified `ana config` displays all fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)