### PR TITLE
feat: Add ability to bootstrap a standalone anaconda CLI environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,34 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +38,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ana"
@@ -24,15 +58,25 @@ dependencies = [
  "indicatif",
  "indoc",
  "libc",
- "reqwest 0.12.28",
- "reqwest 0.13.2",
+ "miette",
+ "rattler",
+ "rattler_cache",
+ "rattler_conda_types 0.43.5",
+ "rattler_lock",
+ "rattler_networking",
+ "rattler_repodata_gateway",
+ "rattler_solve",
+ "rattler_virtual_packages",
+ "reqwest",
+ "reqwest-middleware",
  "self-replace",
  "semver",
  "serde",
  "serde_json",
  "temp-env",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing-subscriber",
  "webbrowser",
 ]
@@ -58,7 +102,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -132,6 +176,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "archspec"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
+dependencies = [
+ "cfg-if",
+ "itertools 0.12.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "sysctl",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "astral_async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-fd-lock"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "pin-project",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
+name = "async-spooled-tempfile"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
+dependencies = [
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,16 +297,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -176,10 +378,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -188,12 +402,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.58"
+name = "bzip2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cache_control"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
+
+[[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -204,6 +435,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,8 +460,9 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -257,6 +506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "coalesced_map"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
+dependencies = [
+ "dashmap",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,8 +539,43 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "configparser"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
 
 [[package]]
 name = "console"
@@ -291,18 +585,8 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -328,6 +612,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -365,7 +667,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -389,6 +691,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +767,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -440,10 +812,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elsa"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -452,12 +839,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
+name = "enum-as-inner"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "cfg-if",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -465,6 +867,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -477,16 +890,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file_url"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d37aab514a05a249a5b15408dc74d716f5745a2c5daf22e40a245ffd38fa84"
+dependencies = [
+ "itertools 0.14.0",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -499,6 +984,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -522,6 +1013,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "fs-err",
+ "rustix 1.1.4",
+ "tokio",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -558,6 +1102,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +1143,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -602,6 +1160,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
 ]
@@ -613,8 +1172,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -624,9 +1185,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -638,9 +1201,22 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -654,7 +1230,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -662,12 +1238,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -675,6 +1275,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -683,10 +1288,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hostname"
@@ -696,7 +1310,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -733,10 +1347,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-cache-semantics"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129"
+dependencies = [
+ "http",
+ "http-serde",
+ "reqwest",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -809,11 +1461,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -842,12 +1492,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -855,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -868,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -882,15 +1533,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -902,15 +1553,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -926,6 +1577,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -950,9 +1607,20 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -968,7 +1636,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -999,10 +1667,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1031,9 +1723,9 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1069,15 +1761,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.93"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-patch"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "known-folders"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
@@ -1093,10 +1849,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1104,8 +1882,17 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1115,9 +1902,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1150,16 +1937,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1196,6 +2052,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,12 +2100,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1245,6 +2147,15 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1313,7 +2224,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1327,7 +2238,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -1342,8 +2253,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
- "thiserror",
+ "reqwest",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1382,8 +2293,8 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
- "thiserror",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -1393,6 +2304,27 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1412,9 +2344,59 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "path_resolver"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a4d9af27fc7240c8270eff3eeaad11bc9ff950d37be041f3e3e7ad98d3d9db"
+dependencies = [
+ "ahash",
+ "fs-err",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "proptest",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "pep440_rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
+dependencies = [
+ "once_cell",
+ "serde",
+ "unicode-width 0.2.2",
+ "unscanny",
+ "version-ranges",
+]
+
+[[package]]
+name = "pep508_rs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
+dependencies = [
+ "boxcar",
+ "indexmap 2.13.1",
+ "itertools 0.13.0",
+ "once_cell",
+ "pep440_rs",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "thiserror 1.0.69",
+ "unicode-width 0.2.2",
+ "url",
+ "urlencoding",
+ "version-ranges",
 ]
 
 [[package]]
@@ -1422,6 +2404,18 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
+ "serde",
+]
 
 [[package]]
 name = "pin-project"
@@ -1450,10 +2444,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap 2.13.1",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1463,12 +2482,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1499,6 +2524,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,10 +2559,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "purl"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad"
+dependencies = [
+ "hex",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1543,13 +2623,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1559,7 +2656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1569,6 +2666,476 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rattler"
+version = "0.39.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65279b23077bbe3363467d8f7b87784f1412f135a2d12a22e8ec2855342f9828"
+dependencies = [
+ "anyhow",
+ "console",
+ "digest",
+ "dirs",
+ "filetime",
+ "fs-err",
+ "futures",
+ "humantime",
+ "indexmap 2.13.1",
+ "indicatif",
+ "itertools 0.14.0",
+ "memchr",
+ "memmap2",
+ "once_cell",
+ "parking_lot",
+ "path_resolver",
+ "rattler_cache",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "rattler_menuinst",
+ "rattler_networking",
+ "rattler_package_streaming",
+ "rattler_shell",
+ "rayon",
+ "reflink-copy",
+ "regex",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "simple_spawn_blocking",
+ "smallvec",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rattler_cache"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8203273b73fcc38333f177c12536266409748ee69d1a821b677da5725d41def"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "dashmap",
+ "digest",
+ "dirs",
+ "fs-err",
+ "fs4",
+ "futures",
+ "itertools 0.14.0",
+ "parking_lot",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "rattler_networking",
+ "rattler_package_streaming",
+ "rattler_redaction",
+ "rayon",
+ "reqwest",
+ "reqwest-middleware",
+ "serde_json",
+ "simple_spawn_blocking",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rattler_conda_types"
+version = "0.43.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ca62ce5fb125421f001d8f1551eb4fb8c75544bb55ae9f266f1cd46dc76078"
+dependencies = [
+ "ahash",
+ "chrono",
+ "core-foundation",
+ "dirs",
+ "fancy-regex",
+ "file_url",
+ "fs-err",
+ "glob",
+ "hex",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "lazy-regex",
+ "memmap2",
+ "nom",
+ "nom-language",
+ "purl",
+ "rattler_digest",
+ "rattler_macros",
+ "rattler_redaction",
+ "regex",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "serde_yaml",
+ "simd-json",
+ "smallvec",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "rattler_conda_types"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a39a5581c4beed55bc7f85f14f80e0a740ff189d098a9c6b3ea9943af924574"
+dependencies = [
+ "ahash",
+ "chrono",
+ "core-foundation",
+ "dirs",
+ "fancy-regex",
+ "file_url",
+ "fs-err",
+ "glob",
+ "hex",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "lazy-regex",
+ "memmap2",
+ "nom",
+ "nom-language",
+ "purl",
+ "rattler_digest",
+ "rattler_macros",
+ "rattler_redaction",
+ "regex",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "serde_yaml",
+ "simd-json",
+ "smallvec",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "rattler_digest"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4109fd4ea54f1e34812f9db9166013325418ba92ff5693136afe681a56039fe"
+dependencies = [
+ "blake2",
+ "digest",
+ "generic-array",
+ "hex",
+ "md-5",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "rattler_lock"
+version = "0.26.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0764b43f793094d6842bf0b0f5e528a0a2edd0f94396a1080f8e886c3ec2ef57"
+dependencies = [
+ "ahash",
+ "chrono",
+ "file_url",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "pep440_rs",
+ "pep508_rs",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "rattler_solve",
+ "serde",
+ "serde-value",
+ "serde_repr",
+ "serde_with",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "rattler_macros"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d0d45ce3ae00333421569d2fafa4b877708a901c3cb217f8d4acfab4328df0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rattler_menuinst"
+version = "0.2.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c82a3edab99e46cce66af2e5a062f09d091528646453abb13782fd3bbc2547"
+dependencies = [
+ "chrono",
+ "configparser",
+ "dirs",
+ "fs-err",
+ "indexmap 2.13.1",
+ "known-folders",
+ "once_cell",
+ "plist",
+ "quick-xml 0.37.5",
+ "rattler_conda_types 0.43.5",
+ "rattler_shell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shlex",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicode-normalization",
+ "which",
+ "windows 0.61.3",
+ "windows-registry",
+]
+
+[[package]]
+name = "rattler_networking"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84fc0c2678b79087050509fee24590d76e6b80f2bf8cae40e0974c7be71b234"
+dependencies = [
+ "anyhow",
+ "async-once-cell",
+ "async-trait",
+ "base64",
+ "fs-err",
+ "getrandom 0.3.4",
+ "http",
+ "itertools 0.14.0",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rattler_package_streaming"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e25938a3c53d6d89e9a4fdd169047107cbc5400e439a51967414fe8d7ee427"
+dependencies = [
+ "astral-tokio-tar",
+ "astral_async_zip",
+ "async-compression",
+ "async-spooled-tempfile",
+ "bzip2",
+ "chrono",
+ "fs-err",
+ "futures",
+ "futures-util",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "num_cpus",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "rattler_networking",
+ "rattler_redaction",
+ "reqwest",
+ "reqwest-middleware",
+ "serde_json",
+ "simple_spawn_blocking",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "zip",
+ "zstd",
+]
+
+[[package]]
+name = "rattler_pty"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec435d69bcc064b5cb0f6a49d8cfc1dbed93f0ec233d4499156ae7c3bc7f90d7"
+dependencies = [
+ "libc",
+ "nix",
+ "signal-hook",
+ "tokio",
+]
+
+[[package]]
+name = "rattler_redaction"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961121cad9792daafc176a7f4caafc0fc889fb17507c23a4c86e1777a8b5e179"
+dependencies = [
+ "reqwest",
+ "reqwest-middleware",
+ "url",
+]
+
+[[package]]
+name = "rattler_repodata_gateway"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a68782f2444d4832737432508b6349811d8b65328884b8036f93d587819d2f"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "async-compression",
+ "async-fd-lock",
+ "async-trait",
+ "blake2",
+ "bytes",
+ "cache_control",
+ "cfg-if",
+ "chrono",
+ "coalesced_map",
+ "dashmap",
+ "dirs",
+ "file_url",
+ "fs-err",
+ "fslock",
+ "futures",
+ "hashbrown 0.15.5",
+ "hex",
+ "http",
+ "http-cache-semantics",
+ "humansize",
+ "humantime",
+ "itertools 0.14.0",
+ "json-patch",
+ "libc",
+ "memmap2",
+ "parking_lot",
+ "pin-project-lite",
+ "rattler_cache",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "rattler_networking",
+ "rattler_package_streaming",
+ "rattler_redaction",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "rmp-serde",
+ "self_cell",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "simple_spawn_blocking",
+ "strum",
+ "superslice",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasmtimer",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "rattler_shell"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92fed051480fa33570c8418664c4b29bca34614ef888a2f15c2342f3b050d3d"
+dependencies = [
+ "anyhow",
+ "enum_dispatch",
+ "fs-err",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "rattler_conda_types 0.43.5",
+ "rattler_pty",
+ "serde_json",
+ "shlex",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "rattler_solve"
+version = "4.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bddb1eb6f4f2afcd4710a3072aa9d6cdc90b8304d5544228da475ce33b78268"
+dependencies = [
+ "chrono",
+ "futures",
+ "humantime",
+ "itertools 0.14.0",
+ "rattler_conda_types 0.43.5",
+ "rattler_digest",
+ "resolvo",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "rattler_virtual_packages"
+version = "2.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0473463068901b2cc3412072d3bea13b5ad2b2c5fb85514934fac43fef54222f"
+dependencies = [
+ "archspec",
+ "libloading",
+ "nom",
+ "once_cell",
+ "plist",
+ "rattler_conda_types 0.44.0",
+ "regex",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "winver",
 ]
 
 [[package]]
@@ -1601,6 +3168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,7 +3184,39 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1648,7 +3256,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1662,7 +3269,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -1673,51 +3280,56 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.2"
+name = "reqwest-middleware"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
+ "anyhow",
+ "async-trait",
  "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
+ "reqwest",
  "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
+ "thiserror 1.0.69",
  "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
+]
+
+[[package]]
+name = "resolvo"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163"
+dependencies = [
+ "ahash",
+ "bitvec",
+ "elsa",
+ "event-listener",
+ "futures",
+ "indexmap 2.13.1",
+ "itertools 0.14.0",
+ "petgraph",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+dependencies = [
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1733,6 +3345,37 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1755,6 +3398,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1762,7 +3418,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1806,6 +3462,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +3498,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,7 +3534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1870,6 +3562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +3581,38 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1911,11 +3641,23 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1931,13 +3673,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.1",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1957,6 +3743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +3760,26 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
 ]
 
 [[package]]
@@ -1983,6 +3799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_spawn_blocking"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +3818,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2017,10 +3845,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superslice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -2054,6 +3930,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,28 +3955,24 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
+name = "tap"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
+name = "tar"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
- "core-foundation-sys",
+ "filetime",
  "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2107,8 +3993,37 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2117,7 +4032,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2141,20 +4067,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
+name = "time"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2169,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2217,6 +4189,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2275,13 +4248,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2383,10 +4361,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2395,10 +4397,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2419,6 +4442,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,7 +4469,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2449,10 +4491,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "rand 0.10.0",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-trait"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2461,10 +4525,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -2511,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2524,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.66"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2534,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2544,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2557,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2581,9 +4663,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2594,15 +4689,29 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.93"
+name = "wasmtimer"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2624,7 +4733,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "jni",
  "log",
  "ndk-context",
@@ -2632,6 +4741,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2667,12 +4785,64 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2681,7 +4851,20 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2692,9 +4875,31 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -2721,19 +4926,54 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
+name = "windows-numerics"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2742,7 +4982,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2751,7 +5000,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2760,7 +5009,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2769,7 +5027,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2778,15 +5051,39 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2796,9 +5093,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2814,9 +5123,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2826,15 +5147,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winver"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33"
+dependencies = [
+ "windows 0.48.0",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2864,7 +5206,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2895,7 +5237,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -2914,7 +5256,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -2926,15 +5268,34 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2943,9 +5304,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2975,18 +5336,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3002,9 +5363,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3013,9 +5374,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3024,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3034,7 +5395,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "time",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,27 @@ comfy-table = "7"
 console = "0.16"
 indicatif = "0.18"
 indoc = "2"
-reqwest = { version = "0.13.2", features = ["blocking", "json", "native-tls", "form"], default-features = false }
+miette = { version = "7.6", features = ["fancy"] }
+rattler = { version = "0.39", default-features = false, features = ["indicatif"] }
+rattler_cache = { version = "0.6", default-features = false }
+rattler_conda_types = { version = "0.43", default-features = false }
+rattler_lock = { version = "0.26", default-features = false }
+rattler_networking = { version = "0.26", default-features = false }
+rattler_repodata_gateway = { version = "0.26", default-features = false, features = ["gateway"] }
+rattler_solve = { version = "4.2", default-features = false, features = ["resolvo"] }
+rattler_virtual_packages = { version = "2.3", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "stream", "multipart", "native-tls"] }
+reqwest-middleware = "0.4"
 self-replace = "1.5"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
+tokio = { version = "1.45", features = ["rt-multi-thread", "macros"] }
 webbrowser = "1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 temp-env = "0.3"
 tempfile = "3"
-
-# Force reqwest 0.12 (used by opentelemetry-otlp) to include TLS support
-[dependencies.reqwest012]
-package = "reqwest"
-version = "0.12"
-features = ["blocking", "native-tls"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help debug test test-integration
+.PHONY: help debug test test-integration lockfiles
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
@@ -11,3 +11,6 @@ test:  ## Run all the unit tests
 
 test-integration:  ## Run CLI integration tests
 	pixi run test-integration
+
+lockfiles:  ## Regenerate all lockfiles
+	./lockfiles/lock-all.sh

--- a/lockfiles/anaconda-cli/pixi.lock
+++ b/lockfiles/anaconda-cli/pixi.lock
@@ -1,0 +1,5580 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://conda.anaconda.org/anaconda-cloud/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.5-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.13.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py313h06a4308_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.5-py313h04fe016_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.4-h7354ed3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.4-h7354ed3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.4.0-py313h3e8c6aa_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.10.2-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+      linux-aarch64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.5-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.13.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-25.4.0-py313hd43f75c_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2025.12.2-hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.5-py313haa502f6_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.4-h5b11e9f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.4-h5b11e9f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-25.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-2.23-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.19.2-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.32.5-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.4.0-py313hafdef7f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-80.10.2-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.5-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.13.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py313hca03da5_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.5-py313hae07363_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-21.1.8-hb4ce287_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.4-h50f4ffc_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.10.2-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.5-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.13.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py313haa95532_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.5-py313hbfe00f4_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.16.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.context-6.1.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.functools-4.4.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jiter-0.12.0-py313h114bc41_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.4-hd7fb8db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.14.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.5-hbb43b14_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.41.5-py313h114bc41_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.12-h39c999c_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py313h885b0b7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-ctypes-0.2.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py313hb9a58be_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-14.2.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.14-py313hb9a58be_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/semver-3.0.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.10.2-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/shellingham-1.5.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.20.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-0.20.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-standard-0.20.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_10.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda
+  sha256: 476626712f60e5ef0fe04c354727152b1ee5285d57ccd3575c7be930122bd051
+  md5: c3473ff8bdb3d124ed5ff11ec380d6f9
+  size: 3473
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
+  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
+  md5: b272288d02db5520249ca7870c2287b4
+  license: None
+  size: 2491
+  timestamp: 1617219512888
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
+  sha256: 576011048d23f2e03372263493c5529f802286ff53e8426df99a5b11cc2572f3
+  md5: 71d281e9c2192cb3fa425655a8defb85
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 21315
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
+  build_number: 51
+  sha256: 70892a5efb5803b565ba889b5479b6e866a0fabce3a7d2f648e494a9e7bff49b
+  md5: 66329dd81c60123e0d7c4c39b7ee7afe
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 1427721
+  timestamp: 1621385842900
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
+  sha256: 22acee4a47176055648cbe19f0ca8d9ee29ac8dec54d7279e0b4572bb00bffd2
+  md5: 68ae0d156d8f42f20253ab6936a58180
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - mcp >=1.26
+  - langchain-openai >=0.2.8
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117028
+  timestamp: 1773844617250
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
+  md5: a8de75045d038d62c3553bdb1a2bf2b3
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - langchain-openai >=0.2.8
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116895
+  timestamp: 1773844596952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
+  md5: 88dc2eae5116b824692db6bb9b443eed
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  - langchain-openai >=0.2.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116841
+  timestamp: 1773844602363
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
+  md5: c486692f9df9720276afb556abff5361
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - mcp >=1.26
+  - pydantic-ai >=1.50
+  - langchain-openai >=0.2.8
+  - llm >=0.22
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116690
+  timestamp: 1773844804490
+- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.5-pyhb46e38b_100.conda
+  sha256: b9d6aff29f1ea89952f8491548d8bd8e823bbdb5b5adf8c8b36a78051115b55c
+  md5: e3c78ac191246e36d9ddd1f25cd56fd7
+  depends:
+  - python >=3.8
+  constrains:
+  - conda >=23.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19548
+  timestamp: 1764636667239
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.13.0-py313h06a4308_0.conda
+  sha256: 65e1eb7ca1260fe9e4bf6d7938e7d77f2f55a842ea668a184af80acad235423d
+  md5: bbd5cbd9b4516a729a1d5414e9320ed9
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.13.0
+  - conda-token >=0.7.0
+  - conda >=23.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123443
+  timestamp: 1772491290034
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.13.0-py313hd43f75c_0.conda
+  sha256: dc2ca5a7113cef5d15bb1cd02c9d0ac4209473f644348eaf3a89068266549e0a
+  md5: d8ff02464c51742c00623f2bf9faedfb
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - conda-token >=0.7.0
+  - anaconda-cloud-auth >=0.13.0
+  - conda >=23.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123300
+  timestamp: 1772491274657
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.13.0-py313hca03da5_0.conda
+  sha256: d5510de2d87d8011ca53ccdfea822426a61e18c91734c2f81111b3a62637a3a7
+  md5: 13cade21f29fe0f03c637a141eead4fe
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - conda >=23.9.0
+  - anaconda-cloud-auth >=0.13.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124000
+  timestamp: 1772491205423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.13.0-py313haa95532_0.conda
+  sha256: 7b45ee6eb74fb208b87af61747e1a55370a0d8ba3cbbdfbf16cb853d69b3cc68
+  md5: 0e2dc841ac7bfef4e9edf6c3beca5d7f
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - conda >=23.9.0
+  - anaconda-cloud-auth >=0.13.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147880
+  timestamp: 1772491467151
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.1-py313h06a4308_0.conda
+  sha256: ddd1d4a198c7cb8c7d645a5c27c0138f405608b3eb2940759116fe4dab98b782
+  md5: efcf0008a5dd126dcba3a3e556828d50
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  - pydantic >=2.12
+  constrains:
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62015
+  timestamp: 1770385849088
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.1-py313hd43f75c_0.conda
+  sha256: a91eecb7fe7466771020afff80ffacba43ece12eeaa323773d4e79b806cfd8ec
+  md5: 086b72da7cb54bf4cea6dc1983e99dcb
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  - pydantic >=2.12
+  constrains:
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61816
+  timestamp: 1770385851744
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.1-py313hca03da5_0.conda
+  sha256: f29ca94a165e7d630ed8f6bb86685682a5ecf433f3c0f2b4c992787f30c135b7
+  md5: e92d3d70db246d174d0550ad6c291cb3
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  - pydantic >=2.12
+  constrains:
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-client >=1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62059
+  timestamp: 1770385857855
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.1-py313haa95532_0.conda
+  sha256: 08e91b48944126e062e6c29742e6d36fc4592c26b44a87fe957f6bcdb48fe185
+  md5: 33045215573e99b938bae71181e4f03d
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  - pydantic >=2.12
+  constrains:
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-client >=1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86397
+  timestamp: 1770385987813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
+  sha256: 4a979bb0b48ad2712884695a3056453fbc5208acfc6a250aa3ed049831263f5e
+  md5: 7233ba45150b5530456f5da5b9054d48
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - pillow >=10.2.0
+  - anaconda-project >=0.9.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 845691
+  timestamp: 1772491237524
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
+  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
+  md5: 0b644ecae935ac975164247e9f4d981d
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 845333
+  timestamp: 1772491214305
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
+  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
+  md5: c2a25adb6831401a65a5cdb63f88ba27
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 846994
+  timestamp: 1772491115479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
+  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
+  md5: e10dea7c74568841ed1cd5d8ec12ca92
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 870768
+  timestamp: 1772491405834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
+  sha256: 382f07779f01e3a6621b963ebd8f01b1759fd71c64cb8d47b4b1da17451e07a4
+  md5: 3d0213cea41b88c15fdf1ed04eba799c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26097
+  timestamp: 1761744946758
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
+  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
+  md5: 108a8bcd136312e83793f5cda2f350fb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26012
+  timestamp: 1761744922996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
+  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
+  md5: c0c2fb9483677bb657eda6d491e5f29c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 25909
+  timestamp: 1761744968164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
+  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
+  md5: 2c7171d6d58b9364b4406ab1c85ee50b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26185
+  timestamp: 1761745147069
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
+  sha256: f14560ae804db5d9289a4ddec171cbbacf78dd49b4a640f21fd0829ee55b333f
+  md5: fcc4b2673d3d0b0a203bf1496a694ec3
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 317979
+  timestamp: 1773134446379
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
+  md5: 910687ebf7746e8562300e8f1996edc6
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318118
+  timestamp: 1773134422321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
+  md5: 7e400853597f6d7237e927baa6706aa7
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1773134435123
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
+  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318164
+  timestamp: 1773134551978
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py313h06a4308_2.conda
+  sha256: 73c1ca0d8e6fa47c5938d3e24b8a503397c1cf234c3041150b692bd031c3f087
+  md5: 5b7ccd944d0c32bd7ca5c25ddca6a595
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 179919
+  timestamp: 1762356896210
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-25.4.0-py313hd43f75c_2.conda
+  sha256: 70dd7d7293912fd0f32d2310124c08e64c33cd704f63604c59d70df10bcd25f0
+  md5: e9ad22df47a80a787eb0374d4deac2c7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180245
+  timestamp: 1762356899330
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py313hca03da5_2.conda
+  sha256: 685ee829f011fa8216021d144cad5a55d099da6e423bed4d495ede9c1932f763
+  md5: e15bf257693be0b20cd3771bd995414f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 178953
+  timestamp: 1762356952567
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py313haa95532_2.conda
+  sha256: 1884b3f775276704186b41677f8a55ef0ee3d8d53728f1090caac8ef48f8e43a
+  md5: 9a96bb2400267b286303f8c66ee2f6ce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 179422
+  timestamp: 1762356939251
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
+  sha256: 1d13694da029eb587dcdce691e4a6a1590ac5de65f0cde234fff849fd7985168
+  md5: d309f82c145a73fedf7bc6930f689dba
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 381299
+  timestamp: 1764961365931
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
+  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
+  md5: 9dd92861bec232ccdf7869b0b05b453b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 385446
+  timestamp: 1764961345156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
+  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
+  md5: 4f002093422042d948885e06821f150b
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17.0
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375456
+  timestamp: 1764961201718
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
+  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
+  md5: 964620a4cb8353969963fbb7b045b01c
+  depends:
+  - cffi >=1.17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 355904
+  timestamp: 1764961470388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
+  sha256: 235f266d5f9c3c61748bb1af0eff21bc7ed2a2a356b97ff28d9c1135039b08b0
+  md5: f21a3ff51c1b271977f53ce956a69297
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 268384
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
+  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
+  md5: f580b2013db742598b2d59875bccf774
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 215406
+  timestamp: 1714510578082
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
+  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
+  md5: 27a1ffbd30ff6427c112a733410e2f57
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 132212
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
+  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
+  md5: 33e784123d565c38e68945f07b461282
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 91870
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.conda
+  sha256: 0c11f114b16e3b392f9e23f62ed6e48df81e1faec9bd036459edf7009bd819ac
+  md5: 4a93c43656592eb990b914fead171268
+  license: MPL-2.0
+  license_family: Other
+  size: 128414
+  timestamp: 1764713819705
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2025.12.2-hd43f75c_0.conda
+  sha256: c038da1e61ee10221bfeda44705ae8123988816884964565d9f8e6a203dcc4d2
+  md5: 340d0dd778aa10d5aa5e88eaa19fa6b2
+  license: MPL-2.0
+  license_family: Other
+  size: 128401
+  timestamp: 1764713841264
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.conda
+  sha256: f113bdecd95601254933011820037b09a52ddc31ff9221d35a58d6e2f569fde5
+  md5: 75625924c8619e480c450c97c2ee2fd7
+  license: MPL-2.0
+  license_family: Other
+  size: 128344
+  timestamp: 1764713818379
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.conda
+  sha256: f87069ec24ad9c681ac57bbe63045d627c529937fc3f3222c01e166d98386fce
+  md5: bc0118f8749f2bc514a89f3c786c890c
+  license: MPL-2.0
+  license_family: Other
+  size: 128415
+  timestamp: 1764713881285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py313h06a4308_0.conda
+  sha256: dca4a436b34e5ab1f62a2dbbd0989e03e7ef375288c10f0b3bc95f1614095dba
+  md5: 76d1efd083cb0251ec8295c355adb1e2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 152128
+  timestamp: 1767659200360
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
+  sha256: a3de2871ed01954e278c620333e134398b609eb2b40a065b5f285c33e8980ac3
+  md5: da57c7bf0bbdf1849008dbe93d75643a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151899
+  timestamp: 1767659159197
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
+  sha256: 839ea683a30bfd322076dceafaa8752882feebb654afe9ddd8595e71db99faa1
+  md5: 65d56422e29c425a3a91c8e1c17888d0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151748
+  timestamp: 1767659160370
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
+  sha256: cc1f29494f63fed7d925e545e1f8c47f51e8e06f856b4d15a40925c07e81fed5
+  md5: 5808bf0191f70eb95f0cc7d7faf7eaea
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151549
+  timestamp: 1767659399196
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
+  sha256: a16eafa37a73eb521aef93e9760f44be8f0180f9ff3e5bccbf2de8f6e762e9a0
+  md5: 48989473c291f70b074ba57b48d4eda5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 295376
+  timestamp: 1761832800589
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
+  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
+  md5: d010d105070e615750bbb51b8f2b17f5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 317809
+  timestamp: 1761832800132
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
+  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
+  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
+  depends:
+  - __osx >=12.1
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 288576
+  timestamp: 1761832806745
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
+  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
+  md5: d1e9e395ff8688288d67b89e896c2b6c
+  depends:
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 299121
+  timestamp: 1761832847099
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
+  sha256: d84312b64791eac1dad798c86110a0ac53e7d980d6d4c5d32f60ebbb82e4eb4b
+  md5: 36134f1eb9574beab525f137faa53cd7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100520
+  timestamp: 1761744847216
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
+  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
+  md5: c89d95c43d07b658088bb12631ce9132
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100336
+  timestamp: 1761744908393
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
+  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
+  md5: 6301ec890b186cbe5d8243254450651e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100213
+  timestamp: 1761744861372
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
+  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
+  md5: 9e4732d3d22b2cf01fc408696e8ebd41
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 124770
+  timestamp: 1761745054105
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
+  sha256: c743088f34421989511925c4fd47bd2d1627e0d47a9ce17ac522971456559dbf
+  md5: cd0c96b38e17a2b268d15d0b22da55b3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 327716
+  timestamp: 1764332274729
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
+  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
+  md5: 7813f91a66f3a442e803469cf76e3e1c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328923
+  timestamp: 1764332280328
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
+  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
+  md5: 7ac45ddb190136a57ad9b02e7e365ec0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328813
+  timestamp: 1764332257562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
+  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
+  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
+  depends:
+  - colorama
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328826
+  timestamp: 1764332409785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
+  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
+  md5: b73ebc8eb01ba1e79ad34303e2975694
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55002
+  timestamp: 1729036609433
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
+  sha256: d1e652dbd4390b12bcf938ece3e85636c12ab54d91a25de7dd1ac8ca84b1b8b1
+  md5: 8df01d8631f16021fe6e7f0093de07db
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284840
+  timestamp: 1762366426064
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
+  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
+  md5: 6577f526b527308e4bf66a7bdef0e7fe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285635
+  timestamp: 1762366425854
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
+  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
+  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285376
+  timestamp: 1762366427916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
+  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
+  md5: 0bf62b2027e8a656a86e1c4a7e71142c
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 309759
+  timestamp: 1762366569467
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
+  sha256: 8d1ff42b4560986c9d46ef2114cd77ae791ec4400a5ba4eb9a4b22ad540466c1
+  md5: 56c2a9c6a706a12193c0b98ef951b4b6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38518
+  timestamp: 1762361653472
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
+  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
+  md5: 313fca7b4d867f8b06df3140548f9440
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38256
+  timestamp: 1762361650200
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
+  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
+  md5: 01a0bc32a49fd331d514dfd64446fb1e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38499
+  timestamp: 1762361650835
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
+  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
+  md5: d9081bd54908ac92135e6fb20d0aade2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38102
+  timestamp: 1762361726254
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.5-py313h04fe016_1.conda
+  sha256: c76ea9750feb5fa1c2c93687f3081ce0b846136f67637c242c7919807c5fbc02
+  md5: 72960bef9c9245c6c53204182d4d4012
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=2.0.0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1706134
+  timestamp: 1772475390165
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.5-py313haa502f6_1.conda
+  sha256: d9f7492684bf43080b454161e01967a50537f53a44719d320f4b50182f119640
+  md5: 8c377ab97fd126345925f8659cd56467
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=2.0.0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1685175
+  timestamp: 1772475269379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.5-py313hae07363_1.conda
+  sha256: 6893cfd2709270fbc194edd06e45f5cecdb68a13597ca35cb83e7b0d9e988f4e
+  md5: 1e6ffa86947bdeb64c7ac5fe05f0d0ba
+  depends:
+  - __osx >=12.1
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1586741
+  timestamp: 1772475305497
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.5-py313hbfe00f4_1.conda
+  sha256: 7bd03d16cfa233140842c277ae26c12248c0f3009bb45b807b7df6f70a32948f
+  md5: f5c937e0b2250071043eeed62fa2f495
+  depends:
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1482011
+  timestamp: 1772475717834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
+  sha256: ff936d58ce18451f18cba16a8ade9365199a6321d4eb1c60c1eb1d8e3932c65b
+  md5: 4c4aef417b613e7111d90cf2348b231a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - expat >=2.7.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1259937
+  timestamp: 1756144852972
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
+  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
+  depends:
+  - expat >=2.7.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1275876
+  timestamp: 1756144876643
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
+  md5: d912068b0729930972adcaac338882c0
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 23826
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
+  sha256: 57e25d204f2e891ab2f68a776b9e21cc681adfe089ea35a18aa05e5aa950a4c7
+  md5: 1fd7ab065e9958e7bbd4d3fbf175742b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37917
+  timestamp: 1728396132498
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
+  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
+  md5: 77f95d4b0a5bf1b775dda3372544dbeb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37699
+  timestamp: 1728480059192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
+  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
+  md5: 5e948f3d746f13d209bd09a9d2fb7758
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38129
+  timestamp: 1728591870413
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
+  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
+  md5: 9a502db95e7e272d1b7ed53f03dafab2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63476
+  timestamp: 1729059201537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.4-h7354ed3_0.conda
+  sha256: 6dc018cce7a88683c5e9b8ed14906ff342e8fee7307205123c588f9775a1b026
+  md5: 575218bf09aa99037a6e3bb1f43796a8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libexpat 2.7.4 h7354ed3_0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 25302
+  timestamp: 1770062547137
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.4-h5b11e9f_0.conda
+  sha256: 1f5046b63db95b0fb4f6b6c2a7d354e03a250222ae211abbf08f9b31f13f20ba
+  md5: e9872db71aa9d7ca2655454761f32d2f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libexpat 2.7.4 h5b11e9f_0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 26199
+  timestamp: 1770062560798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
+  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
+  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64750
+  timestamp: 1761931277052
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
+  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
+  md5: 4786f45bc40fd0fb4b60c05d19e32179
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64484
+  timestamp: 1761931284057
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
+  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
+  md5: 38e110c2ae2fb67d3ef1abfc786498f9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64806
+  timestamp: 1761931279662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.16.0-py313haa95532_1.conda
+  sha256: 81e22d7167caf13f505697c0a182d428576d865c67b2f5ef0655201527302a9b
+  md5: a97fdc66e5c3a6fcb5f8818f4606f22f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64663
+  timestamp: 1761931421750
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
+  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
+  md5: 77016551f9607c23c6243632bf100507
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127896
+  timestamp: 1748526107673
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
+  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
+  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127463
+  timestamp: 1748526158318
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
+  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
+  md5: 6d33385bdc014731d4369f0d0e09af73
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129364
+  timestamp: 1748526183257
+- conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
+  sha256: d500fb5bedabbb40813f548184b7fa6f3fd92893209c0762777d8b7926e94af2
+  md5: 2262f0f3863efb10f8f4442438401a8d
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 131010
+  timestamp: 1748526313503
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
+  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
+  md5: d25af3a5cbefe54951cb3dc369b945bb
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=8.0.0,<9.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - zstandard >=0.18.0
+  - socksio >=1.0.0,<2.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217558
+  timestamp: 1760447364823
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
+  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
+  md5: 63a3ec07509610236d9ad578a3b625aa
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - zstandard >=0.18.0
+  - click >=8.0.0,<9.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216526
+  timestamp: 1760447362829
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
+  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
+  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pygments >=2.0.0,<3.0.0a0
+  - zstandard >=0.18.0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217168
+  timestamp: 1760447208891
+- conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
+  sha256: 110311c08a60e70198900b6aa5a35e7b1f2175bd3109e0a56610b75d0ea3f20f
+  md5: 55a5ebf53109994a5ac8a2f802bd8f43
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=8.0.0,<9.0.0a0
+  - zstandard >=0.18.0
+  - pygments >=2.0.0,<3.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 242095
+  timestamp: 1760447587973
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
+  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
+  md5: c8b25d0fe19ba1a7319a0221e7615265
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202882
+  timestamp: 1761911998666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
+  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
+  md5: 93b126011717941f140fd04b6dd6d37b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203848
+  timestamp: 1761912000622
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
+  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
+  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203509
+  timestamp: 1761912023966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
+  sha256: 8264d301462d3eb44c813da4c4e092fc2f32b257ef5692a00573ac4c0346d920
+  md5: 426a9add5ed691e72c893059ee0485fd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203986
+  timestamp: 1761912082836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
+  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
+  md5: c4ea3f7208a811b569bbeae8c42c5b2d
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19952
+  timestamp: 1755516354462
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
+  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
+  md5: 281677614ab4b309ddb5afd24c80cd26
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19436
+  timestamp: 1755516386420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
+  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
+  md5: f4e4bcf521aa18ee57d0607ad48f284c
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 21271
+  timestamp: 1755516531252
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
+  sha256: 7eb0c4ee04a96ad65ae0c51d58ad17d5203b76ddcd2d4702503a50127434fd27
+  md5: a8fd08b7543a5b778d2e2c29c5aa88e9
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 21078
+  timestamp: 1755516602917
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
+  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
+  md5: 54a430923247a921a5c57e330e04549f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17104
+  timestamp: 1769477866762
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
+  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
+  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17035
+  timestamp: 1769477854229
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
+  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
+  md5: 0a89e92618b4328787ef72b0d94d8808
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17072
+  timestamp: 1769477856721
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.context-6.1.0-py313haa95532_0.conda
+  sha256: 50f96dd6dc6cfefe9eb81802fdcaec8f1776e723ac8a43d825902e3d1f53e363
+  md5: 75a2698e16470e6c8ca5a80decb040f3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 16899
+  timestamp: 1769477938631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
+  md5: 9572b85d5f84049bc36867f49d498520
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23712
+  timestamp: 1768389384997
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
+  md5: 3fc0a300184c6cfbbb48735e637b6f00
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23679
+  timestamp: 1768389385039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
+  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
+  md5: 7174017dd1ce6c709a2b1d87156deb56
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24174
+  timestamp: 1768389389007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.functools-4.4.0-py313haa95532_0.conda
+  sha256: d6495ad19759532a27e73055a1f13de378af550ff07878543e252b76c095660c
+  md5: 25711ebee8c977aa282a9aa5ceea0817
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24310
+  timestamp: 1768389476340
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
+  md5: f115ef0af90b59f35ef56743955979a4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 39004
+  timestamp: 1627537099507
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
+  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
+  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 304593
+  timestamp: 1762897374551
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
+  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
+  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 298136
+  timestamp: 1762897357507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
+  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
+  md5: ef1c78fa12751c0d455245582d1cb49b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 268149
+  timestamp: 1762897357212
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jiter-0.12.0-py313h114bc41_0.conda
+  sha256: f39d48b2e608459feb932a21598c24ab04c9c32099a6aab94d5a08d7002aa082
+  md5: e4a8ded259e4807efe3f846cbc713b75
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 181327
+  timestamp: 1762897503347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
+  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
+  md5: 7125606e211300f51b43b14c7039c163
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198245
+  timestamp: 1767955393666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
+  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
+  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198026
+  timestamp: 1767955403846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
+  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
+  md5: 0be71be35e5503bdecfebf75f1fa55c0
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198501
+  timestamp: 1767955687618
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py313haa95532_0.conda
+  sha256: 74712222c6722333c45a9e2b745af71fe2739ab5a6b0ed805b6f716103576821
+  md5: 97042d9d769c8b7527882ae7edaba05a
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 223147
+  timestamp: 1767955635122
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
+  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
+  md5: 2dbc150b61f12b744cf873c285f4a418
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17079
+  timestamp: 1762788451045
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
+  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
+  md5: da59899cde4411bae19ae5f15aebe373
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16920
+  timestamp: 1762788449938
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
+  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
+  md5: 6cfee2660e901231d2fe274f02afeaf8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17167
+  timestamp: 1762788437806
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py313haa95532_0.conda
+  sha256: 28620856a54ef6885be4360f5b85633685ddb4d88b2a43b57c7bdffc19335e09
+  md5: 5c075ecdc29eda1f025dfdc4e0f6efcb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17206
+  timestamp: 1762788650578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
+  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
+  md5: 292a4c15bbd54feba358997e6d1b35db
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96597
+  timestamp: 1764588298747
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
+  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
+  md5: f303bbea09244d08acd0fad083bbd6eb
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96552
+  timestamp: 1764588304837
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
+  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
+  md5: a691a010a6df73533294e436b2edb780
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97019
+  timestamp: 1764588302845
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
+  sha256: ffaafa66cf38b5ac02048ded1a6998ac2b83bc65712b6bc7947c93b78da71bb8
+  md5: 3b95819d01e50e21001764a85f9afe81
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121625
+  timestamp: 1764588393434
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
+  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
+  md5: 6d505a62b565ff3d80d5a6662a83d54a
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-mypy >=1.0.1
+  - shtab >=1.1.0
+  - pytest-enabler >=3.4
+  - pytest-checkdocs >=2.4
+  license: MIT
+  license_family: MIT
+  size: 82797
+  timestamp: 1763637203264
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
+  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
+  md5: c96025bac150402baa006c878d604992
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-mypy >=1.0.1
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 82677
+  timestamp: 1763637208740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
+  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
+  md5: d19d185ec9fd87908b74303c8e38893f
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  - pytest-mypy >=1.0.1
+  license: MIT
+  license_family: MIT
+  size: 83253
+  timestamp: 1763637330760
+- conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
+  sha256: bea45ee837d9962996ba5bc05ed0d9e87e8d711cee9156bc2b649dadace14879
+  md5: 793935b26a9203a0e14d442c5edfe91c
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pywin32-ctypes >=0.2.0
+  constrains:
+  - pytest-mypy >=1.0.1
+  - pytest-checkdocs >=2.4
+  - shtab >=1.1.0
+  - pytest-enabler >=3.4
+  license: MIT
+  license_family: MIT
+  size: 108233
+  timestamp: 1763637248210
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
+  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
+  md5: c563bb71f4df90fc3b92cde204827564
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 742162
+  timestamp: 1773255564362
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
+  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
+  md5: 833bdaaca975deb8a858597241ecd5c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-aarch64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 783012
+  timestamp: 1773255553164
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-21.1.8-hb4ce287_0.conda
+  sha256: e385c4a432c7459e2bb5e0e0177985911076ddb30efb082883f3cc3ebab2b9c9
+  md5: e1ab9636b95bc3001d0d527205545f58
+  depends:
+  - __osx >=12.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 315688
+  timestamp: 1769526424968
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.4-h7354ed3_0.conda
+  sha256: aaeb0b0bc0ca292600e19979b38afe692bde0a8bde24031d1e1ddced76b5e46d
+  md5: 04be005097756bc24b1929f4646506ae
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.7.4.*
+  license: MIT
+  license_family: MIT
+  size: 124967
+  timestamp: 1770062545654
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.4-h5b11e9f_0.conda
+  sha256: d26e44bbccce3d138cc41fc0a733039c5acdb081fb8eed06c80f481f15b90a31
+  md5: a6356b40fb1b5b99469fa7bedc8dd175
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.7.4.*
+  license: MIT
+  license_family: MIT
+  size: 118844
+  timestamp: 1770062558544
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.4-h50f4ffc_0.conda
+  sha256: 7304c5a1207d9b8b65cbd0510830f811e23967d13d7fb02196a62a5df29f1308
+  md5: 438f079dbf8512bfcd78b597b462f8e8
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - expat 2.7.4.*
+  license: MIT
+  license_family: MIT
+  size: 111739
+  timestamp: 1770062556425
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.4-hd7fb8db_0.conda
+  sha256: 8b7458f396dd5c288b7dc98bfa99d84c1e64428b6a2b40d915249e5a1111e0c4
+  md5: 22f8d82c83bb22a5ba67f23fed7c81d2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.7.4.*
+  license: MIT
+  license_family: MIT
+  size: 123910
+  timestamp: 1770062671493
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
+  sha256: b0e7fe2e5d498bc5a2c57cf942701bba8f22ec55de55e092ffbffc40b816df88
+  md5: 70646cc713f0c43926cfdcfe9b695fe0
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 144691
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
+  sha256: 18fd986f0ef7f6a59c363e5305d06fe3f20509c39e3393fef60d722316828992
+  md5: 34c197394030fa553d97fc902585ee9b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 143394
+  timestamp: 1714483284040
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
+  sha256: 800216cb554d0beaf970fe7c3efeee7974bb76576c1c5e0ae070c57fca2bba93
+  md5: 2bec9ee4b1214a3c3e2d1f2e18725daf
+  license: MIT
+  license_family: MIT
+  size: 122887
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.conda
+  sha256: 43a437fde4c064b2f1be2342a7bc6edccbc13da6a4fb8a44d87e4e6e34c54b63
+  md5: 9807b377e11739ae3e920e10e607e460
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 124747
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
+  sha256: baf9d8d16e2a8ae7a4d1b80f2c1a932deaca1a87c677a370f6ab4688482db47b
+  md5: 01fb1b8725fc7f66312b9d409758917a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_7
+  - libgomp 15.2.0 h4751f2c_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 825084
+  timestamp: 1762772576461
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
+  sha256: 06ae831ca00e09a65ba8b5536e8b728be3eb909e0cf041ebcc542b92fa4bc969
+  md5: a31a8c63a5fe7234863f8e9dd2b20901
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_7
+  - libgomp 15.2.0 hf47c802_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 511039
+  timestamp: 1762772353789
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
+  sha256: 3a3678f17a8916777d03b83f19f673107b4a9bf55366234dcfa42edbd5173123
+  md5: 2783efb2502b9caa7f08e25fd54df899
+  depends:
+  - libgcc 15.2.0 h69a1729_7
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28356
+  timestamp: 1762772577850
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
+  sha256: e672543a5f8d8ae30c7feab3ba57a2960c46756ca24fb027e3f6284a88d44acb
+  md5: e7d01ec71523a231b0d3b83f33a2dd21
+  depends:
+  - libgcc 15.2.0 hc18542e_7
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28446
+  timestamp: 1762772355060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
+  sha256: 835e44371812c91563a00dec8bc98c460f8b9f33f50543244bc8774c446a2172
+  md5: 82025ed6da944bd419d42d9b1ff116aa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 446183
+  timestamp: 1762772542830
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
+  sha256: 69eeb9a1342df1ba18d0fa994ebf3a43a653cf48a006b8778682cf032cf1e565
+  md5: 3403656472f38870e65c29aa6065e00e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 449546
+  timestamp: 1762772309007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
+  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
+  md5: feb10f42b1a7b523acbf85461be41a3e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88085
+  timestamp: 1726088449399
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
+  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
+  md5: 8bd7f4c495a81af4914c899949e52542
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 125873
+  timestamp: 1726088467322
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
+  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
+  md5: 7b01d2d5e276a24dd44e7846406656ed
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 70527
+  timestamp: 1726088461517
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
+  sha256: 3851b0985a481e019440ee2720bdfe1a98fe4db8cd67f8cc16333a0fa40f38df
+  md5: a294b317c2e3732cafdba824a893b80c
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96993
+  timestamp: 1726088489806
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
+  sha256: 747474162ae421d680ab3374d8b11158701206d4a9c4a8f9de557dd6fc13345a
+  md5: 7dc7ec61ceea5de17f3e2c4c5f442fc6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 h69a1729_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3903663
+  timestamp: 1762772586621
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
+  sha256: 13c51fceabb26176b862042f079e74bc6bfc527a658dfd76d184bfb4c0cf5e90
+  md5: 90938778a2b6d4ba5c618b6e95b07a4b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 hc18542e_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3832701
+  timestamp: 1762772364181
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
+  sha256: 7a39becf3c7dd6016d4b6d24587071cda2afefcdf2886ad16572095261c87b90
+  md5: cf200522c0b13d64bf81035358d05f5b
+  depends:
+  - libstdcxx 15.2.0 h39759b7_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28429
+  timestamp: 1762772606373
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
+  sha256: 928ee09e47b0ec7a7125e36a604e157ae24724117dd20706e1875e3bfb273f8f
+  md5: 34e6c37bb398595bc67ef229f5e60c80
+  depends:
+  - libstdcxx 15.2.0 h9538471_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28507
+  timestamp: 1762772385720
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
+  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
+  md5: 4a6a2354414c9080327274aa514e5299
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28110
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
+  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
+  md5: 59cd225a7659291aa716c6cdae7e1363
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30035
+  timestamp: 1668082742967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
+  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
+  md5: fdf0d380fa3809a301e2dbc0d5183883
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 440690
+  timestamp: 1746022211479
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
+  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
+  md5: 28e00a696fd74b7550b7d1b8698e10af
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 443363
+  timestamp: 1746022227484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
+  sha256: 2e0a3ea3aba7ffaa9c2ce9b267b34b12859f93bde8e62cedcbbab6144776568f
+  md5: 338ee51e19ee211b7fc994d4ba88c631
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 60697
+  timestamp: 1756475934898
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
+  sha256: 8dd49d0fe4a8a309e1aa22f96ff61d203eb719710436737042f6d0336635e18f
+  md5: 7d92046a5eb7a64af7ffbd0bc5ae7366
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 66950
+  timestamp: 1756475943009
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
+  sha256: a51872f0fc7ccc4e448babffc9361a3544efe4fce31af0c63a4bb17e9f047615
+  md5: 5a533023e8ce9cae4f939e5eb9eceef7
+  depends:
+  - __osx >=11.1
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 47901
+  timestamp: 1756475936697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.conda
+  sha256: 0478d0e08e9737e6680343cd26380d8faf4f038bb59170818868cd2fb69e5481
+  md5: 1e313539489432d5edd44efbec8a4d53
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 65950
+  timestamp: 1756476045869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
+  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
+  md5: 2ee58861f2b92b868ce761abb831819d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 159495
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
+  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
+  md5: 70c4ab9462183ac4af60852d2a79fbf6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 185496
+  timestamp: 1714510593467
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
+  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
+  md5: 82202ff2e94bc301fd9c790556506bb7
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160308
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
+  sha256: 0e848b5004a9dc7a06f459cc67c404d7fb0321bf134ec7512815afafe97960b4
+  md5: 723e3ccd4ef7c58ddbfeebe69abff662
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155711
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
+  sha256: bfed5539652f10a2c344501a4d9928856b50d323fdd390c578fd08e856b7d648
+  md5: f515d22e3c87bcf86d4cd5c877bc34cd
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - sphinx-book-theme >=1,<2
+  - commonmark >=0.9,<0.10
+  - panflute >=2.3,<2.4
+  - markdown >=3.4,<3.9
+  - mistletoe >=1.0,<2.0
+  - mistune >=3.0,<4.0
+  - linkify-it-py >=1,<3
+  license: MIT
+  license_family: MIT
+  size: 242668
+  timestamp: 1767001668294
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
+  sha256: a05d920a2e8fb12ed3778262c5f089533dee6b6288e2424738ec1e7aeab95287
+  md5: 39f85b75ecca46ab04ffaed82496e0fd
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - mistune >=3.0,<4.0
+  - linkify-it-py >=1,<3
+  - panflute >=2.3,<2.4
+  - commonmark >=0.9,<0.10
+  - sphinx-book-theme >=1,<2
+  - mistletoe >=1.0,<2.0
+  - markdown >=3.4,<3.9
+  license: MIT
+  license_family: MIT
+  size: 242704
+  timestamp: 1767001694138
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
+  sha256: c8277cdfdc835839eb6c2acc162ca1f8d4357e13c32d842b282dc9654fff5e6f
+  md5: 2114d29335579a39de598a3208576547
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - mistune >=3.0,<4.0
+  - mistletoe >=1.0,<2.0
+  - sphinx-book-theme >=1,<2
+  - markdown >=3.4,<3.9
+  - commonmark >=0.9,<0.10
+  - panflute >=2.3,<2.4
+  - linkify-it-py >=1,<3
+  license: MIT
+  license_family: MIT
+  size: 243627
+  timestamp: 1767001669424
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
+  sha256: c293c76f4c1e1b3d61517cd165db9a04c871dbdd9911e7fc32df927fef22d083
+  md5: a099b975d158c47c2c38ae406f4d0659
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - linkify-it-py >=1,<3
+  - mistune >=3.0,<4.0
+  - commonmark >=0.9,<0.10
+  - panflute >=2.3,<2.4
+  - mistletoe >=1.0,<2.0
+  - sphinx-book-theme >=1,<2
+  - markdown >=3.4,<3.9
+  license: MIT
+  license_family: MIT
+  size: 268521
+  timestamp: 1767001912508
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
+  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
+  md5: 39da6986b50a3eb3cbf60c9883f4b92e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26871
+  timestamp: 1758552191170
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
+  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
+  md5: 5ab5b1fc729b44eb2872d740d95c495d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26724
+  timestamp: 1758552208116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
+  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
+  md5: cc0fbba5b4ee07d4f979149d050c864a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26834
+  timestamp: 1758552196391
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
+  sha256: c2748474cedb35b4643872288cedf94deae958ff684d17daf222bbb26bac4e79
+  md5: 6c5764715afea281b71aa53cdc81c545
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26954
+  timestamp: 1758552317465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
+  sha256: a6da3706af1a527f98e4db5e9e492836d9315825ee99336230865493ae4ee0a6
+  md5: bd0dee4808dd6acb561fce514a345c3d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 167359
+  timestamp: 1761121509531
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
+  sha256: 1f321a79e93054e15a30b78ef59a169d2c48bb81411304bdd5a08f9a6103b48f
+  md5: d8aa86705b3aa00966554fd8d3d6e3d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 168226
+  timestamp: 1761121492722
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
+  sha256: b9ab925d227d92daf0e76666bdfcd602197fce4a13ff2ae3792b86712ecce3ad
+  md5: ba0fd81d15324ef0abfb4110b83d82cc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 166259
+  timestamp: 1761121562080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
+  sha256: b0a1eee1ac57f7fc418b41ce1be5e591057ec4445e888ba5489f8fcaf184349b
+  md5: 84c4bc844419c60fb8bce4d066acd07a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 169455
+  timestamp: 1761121600827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
+  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
+  md5: b9ee8adce00b801f3767671675300a6f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154942
+  timestamp: 1728385601732
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
+  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
+  md5: 4d635e1fed6b6841ae3db1e0377a7712
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153354
+  timestamp: 1728405954288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
+  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
+  md5: 98737e4835cef677dbf6fa0d9d364968
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155808
+  timestamp: 1728586024156
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
+  sha256: 7602bb66f5702414d75f7ca4293257fad682282b5a1f83de6e127720437a6b5c
+  md5: fa4b4c9dabc5f45e04acbc44e1673b11
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180795
+  timestamp: 1739559123487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
+  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
+  md5: 0abfc090299da4bb031b84c64309757b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1137647
+  timestamp: 1753947487644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
+  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
+  md5: 7a1863281d1b73c33d04a3709fda9bda
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1203577
+  timestamp: 1753947513381
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
+  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
+  md5: d8a28b593d36653bec90bd2d78c7538b
+  depends:
+  - __osx >=11.1
+  license: MIT AND X11
+  license_family: MIT
+  size: 906808
+  timestamp: 1753947535285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
+  sha256: 0b5bf6306956956c8346844723db74144b3d278bdb62cec34a0a74d3595f5b5d
+  md5: 718b1fc51e7c834eab78ed742d720a45
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - websockets >=13,<16
+  license: Apache-2.0
+  license_family: Apache
+  size: 1048147
+  timestamp: 1767167972500
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
+  sha256: cbf21b326814a1d043b8ca3c5f5d5fec6cfc082e31d4a2e3a4b66a1837352a33
+  md5: 1f863d45456e44fda9e9d01e6ecf3679
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - websockets >=13,<16
+  - httpx_aiohttp >=0.1.9
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  - sounddevice >=0.5.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1039763
+  timestamp: 1767167972967
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
+  sha256: e669bbd6b577ee3e09db578293c262c37bc631beab5a6887c1944f9e56745b81
+  md5: 73458dbb241114ed06a5b561f7b048e5
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - websockets >=13,<16
+  - pandas-stubs >=1.1.0.11
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - pandas >=1.2.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 1050444
+  timestamp: 1767167836275
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.14.0-py313haa95532_0.conda
+  sha256: 8733722172b598c317765fa957b1f380fc89fc25745e837ff1059c75c8e33fc5
+  md5: 7871b47644f1a81af9f8a4bf98650d14
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - sounddevice >=0.5.1
+  - pandas >=1.2.3
+  - websockets >=13,<16
+  - httpx_aiohttp >=0.1.9
+  - pandas-stubs >=1.1.0.11
+  license: Apache-2.0
+  license_family: Apache
+  size: 1081595
+  timestamp: 1767168143409
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
+  sha256: 0dcbe182b4b5270e2c5b35ec90418ae7e2de7a925f8617fdc939dee732a21b8b
+  md5: 96c41caadc229cc56c4fbcb26bb5b8cd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5818141
+  timestamp: 1772119658375
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
+  sha256: 8fadf5dae2d6cf940ab38fa58d964325032fcb1f5105783e928ec3068841168a
+  md5: d3628d798e959fc4dcb6f5521f98c9da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5672689
+  timestamp: 1772119615171
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
+  sha256: 92cd3b69b02e8ca149bd387cfb168ba07d1d4f91f0921af5a280271c7aae1cad
+  md5: 1ff1b3ba66cd97c9be2819d012d58df4
+  depends:
+  - __osx >=12.1
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4948202
+  timestamp: 1772119560161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.5-hbb43b14_0.conda
+  sha256: 74838df34c6e4e0d5279a33b7d82ca287b42c45c468e9993668b94fefea1853c
+  md5: 06f0b0505049ec5179fa18c61974bcfb
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 9306859
+  timestamp: 1772121458614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py313h06a4308_1.conda
+  sha256: d938ecadac1b6468759961d423052784528d5ac5edc001fdcc6486724e8deeaa
+  md5: 816867d682a95116d8c08e63d2e65ad2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 194549
+  timestamp: 1761049096696
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-25.0-py313hd43f75c_1.conda
+  sha256: e608bae31558b64126d01214e9c094986078ce1fc2d93d292e34b2db17b3ed43
+  md5: 4ae50d03feabb307eaabe7ef9bbf3412
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 193096
+  timestamp: 1761049099243
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py313hca03da5_1.conda
+  sha256: 0dbfab794842213747fcb6f4517132724b9ef8f5c9371da260c9ca59fa8a6155
+  md5: 4972900e47725fc5030c2a71e74c1613
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 193477
+  timestamp: 1761049097455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py313haa95532_1.conda
+  sha256: 14b7628211cef4412c84f043aa333231fcffbd19b76d726bf4f5deb20167e729
+  md5: c67ee8fed5732098e4240761b614469f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 194481
+  timestamp: 1761049135983
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
+  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
+  md5: a1e79da30a6c62c6398e9bb990ee9ed6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9162
+  timestamp: 1728388115083
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
+  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
+  md5: ed391ccc6d6caaccedd5250fdeb48807
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9176
+  timestamp: 1728408515784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
+  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
+  md5: 5c6344029e52293764fd4f88d6216c07
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9307
+  timestamp: 1728592695690
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
+  sha256: 891ecf91eb86227f847743d2519f9f8c3ff70386d56b0d0507c5dc557392b101
+  md5: 1dea692228d870c3278e9797ddc0589a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 10112
+  timestamp: 1729049247460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
+  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
+  md5: e1705a98bf3338281b413e1fc8484a12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54729
+  timestamp: 1773652981831
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
+  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
+  md5: cdff168e8e1d6bbfced0f9ce18a6534a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54735
+  timestamp: 1773652976404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
+  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
+  md5: f9e7cc4e6d37a4efe63452519464e148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54951
+  timestamp: 1773653001076
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
+  sha256: 7c422f786db266a90afe84e10bc2cd2547118032fd46cbc590ef343de0fd411c
+  md5: c73cb48e85b2d4c9f6bee9b364adb4d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54633
+  timestamp: 1773653037631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
+  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
+  md5: 973a642312d2a28927aaf5b477c67250
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  license_family: MIT
+  size: 5360
+  timestamp: 1505733967605
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
+  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
+  md5: bd26b7e13996984230e8ec67f3ebd4c7
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  license_family: MIT
+  size: 7035
+  timestamp: 1615912729649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py313h06a4308_0.conda
+  sha256: 732e3ef6126f3d033e8cc8cd22ba2382118258e81c4be8f34e9dad25bd59f1a5
+  md5: 83153b618937780dfcf0eea5cf2536d8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281676
+  timestamp: 1757496057905
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-2.23-py313hd43f75c_0.conda
+  sha256: c31eae1f2f9060514cf727c5fa406c246f1f10f54e76b81a98d8959c1406770f
+  md5: 19d72f1b66cb67b0cc9f722e08e27100
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282349
+  timestamp: 1757496062859
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py313hca03da5_0.conda
+  sha256: f40cb7be188e935d453c833162b7ffe4c1761b7b53443f3a6e8a5fc07e3a3ff0
+  md5: 3f7785ee029c046c4c5c709cd077fc6e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267938
+  timestamp: 1757496068962
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py313haa95532_0.conda
+  sha256: 8e364a203e05ad1a67eaaa1173bb31a576c202397c021d9d1ad42039136a493d
+  md5: 923978c47a2274e4137fc78f552ad305
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268174
+  timestamp: 1757496186077
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
+  sha256: 6c081cbd4131236658531e64370f14aabd59335a63a6b78360505bf8ba06e885
+  md5: 95234214667460a6e4eb9cd44c5facba
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1107018
+  timestamp: 1773134413559
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
+  sha256: 075b85319122a84033ed5e8671a404878daad18d896f69b8a7e5b946f1463667
+  md5: 02a133da4f575464a6424b568d582954
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1107670
+  timestamp: 1773134406974
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
+  sha256: 263e4a340ba4b6425eca95b681181941bd060686daab3864062870e7d39fe7b5
+  md5: dffaab726a9b2000756aaebc6da806d7
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1108443
+  timestamp: 1773134360203
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
+  sha256: 923cb9aa819ea8f6b258b391c4ef4abd860ae016b793a2b1aab28ad6b7271e0b
+  md5: 57e5cd75c0aefb820229739e54e986c8
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - tzdata
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1110528
+  timestamp: 1773134450949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
+  sha256: 4964ef04532cce861183176123287df387db41329ad24a7256518b1ec1bb99b9
+  md5: d943970fbb63d8d9e6f5d805f2a6fbdf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1932101
+  timestamp: 1764009859395
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
+  sha256: f756ae4ab74fea66ac0f7b687e5ff72a736521e5d30c2959f5e06bb26b43bb92
+  md5: cb6fcb4bb58138dc49beda6d90d2f4cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1771859
+  timestamp: 1764009871699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
+  sha256: e18c0428812b74200603b8944868ad2ba753a30e1d5be86a44e84b560ad95bfb
+  md5: fb4b0939fbc6cce6be885131224f9c35
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1726048
+  timestamp: 1764009904442
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.41.5-py313h114bc41_1.conda
+  sha256: 926de8c3cf42c9eea67f7fb075331172c3399c10f7fd0d94b4f942b298eb4301
+  md5: 0b2da722db0f7799fd9537438d241594
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 1922906
+  timestamp: 1764010123974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
+  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
+  md5: 52b991b3676ad69221ac4efe952ea622
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - google-cloud-secret-manager>=2.23.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  - pyyaml >=6.0.1
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  license: MIT
+  license_family: MIT
+  size: 151041
+  timestamp: 1764165180924
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
+  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
+  md5: 8bcdca4304da9f754bfb1f5839f796dc
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - azure-identity >=1.16.0
+  - tomli >=2.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - pyyaml >=6.0.1
+  - google-cloud-secret-manager>=2.23.1
+  license: MIT
+  license_family: MIT
+  size: 150714
+  timestamp: 1764165157426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
+  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
+  md5: 4bc0da3d9e06af7ce644b3901790c1ee
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  - google-cloud-secret-manager>=2.23.1
+  - pyyaml >=6.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  license: MIT
+  license_family: MIT
+  size: 150650
+  timestamp: 1764165172452
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
+  sha256: 41e0f59c3321217f4aa6014c3411daec4264f4ea2483ac4711b90accdc8ae080
+  md5: 9be00e22c3dd90cc9dd9e183021866db
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - azure-identity >=1.16.0
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - pyyaml >=6.0.1
+  - google-cloud-secret-manager>=2.23.1
+  license: MIT
+  license_family: MIT
+  size: 150711
+  timestamp: 1764165274424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py313h06a4308_0.conda
+  sha256: db29f0617602cc1877c699d56780f3c1efa5a26f3f7358b1bf40c5b5ab0bcc9b
+  md5: 93f96a6dab840a4f2a94aa0e490ce840
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4938347
+  timestamp: 1762431427831
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.19.2-py313hd43f75c_0.conda
+  sha256: 38415d7571a4364e72380e674a1afbbd8ab4c8c7ceeb0a4d5726696ff2ae10eb
+  md5: e5ab0191e6b330e049c6de8c886243d1
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4966190
+  timestamp: 1762431431224
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py313hca03da5_0.conda
+  sha256: c38fd88505b31154b4b262a26c6a66c82d7ba57762996f675ea62d019fb9e25b
+  md5: 2f6618a70aab69fab504c16bf3b34e9d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4935461
+  timestamp: 1762431607211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py313haa95532_0.conda
+  sha256: 1e11dbe8bf9c849f006e213a31ade5d5520e129fcb356fe6033bc898f2631f1b
+  md5: 86574872504707af9eb322eac367d86f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - colorama >=0.4.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4977368
+  timestamp: 1762431482054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
+  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
+  md5: 3cbe7080967f615cd88efd025391b662
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 102773
+  timestamp: 1773773809562
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
+  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
+  md5: 9f01b187aede17a6e8b192f35472b652
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103005
+  timestamp: 1773773803703
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
+  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
+  md5: 208f064869aaa98b2340cc60eb64c58b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103272
+  timestamp: 1773773829773
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
+  sha256: 7aef9d733577597c67e2e122e275063bb1b62289943dde8fc2053e052b4669c4
+  md5: ea6817e7fbafb39b117e5d6c30f40a54
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 102610
+  timestamp: 1773773869078
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
+  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
+  md5: e1ab9ffa1588856f0bdbb204322568c4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35801
+  timestamp: 1761753024312
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
+  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
+  md5: 43da0d039f7b195466a8be650fa38424
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35803
+  timestamp: 1761753028895
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
+  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
+  md5: 16bf831da5d9b80789ca8c06f958ae2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36057
+  timestamp: 1761753032083
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
+  sha256: 80a495f4af262ca1119720a007eab7dda13008f48ba1a9e0a0b0003638dc71aa
+  md5: fbfa708fb7dba50f62e0363778296f29
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35859
+  timestamp: 1761753068122
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
+  build_number: 100
+  sha256: 558a087f71909db8c04f634af023c94d128305f1b313560bf6ed9bb404f731bf
+  md5: f0c9d56e080ab6f2838d1626225cdd37
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 33182243
+  timestamp: 1771950585257
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
+  build_number: 100
+  sha256: 3440eaa5799c8adb5cf8973c0181f114b116ba9b3ef44a9ff31fbb50575a2243
+  md5: 1d5ed28a2ac1369d7d94b834e8d3a505
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.35.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 31723170
+  timestamp: 1771950827906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
+  build_number: 100
+  sha256: cdb79b470fdce5061bfcc0188800e92361f24668d79b212d057240b0ff5ffc7a
+  md5: 19a38ad6775e08a4774572c2bbf2f187
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13569673
+  timestamp: 1771949586042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.12-h39c999c_100_cp313.conda
+  build_number: 100
+  sha256: 72ed8ba8d7ddb639d9c49b8ac6580f8e4a07ef9b70ed6e3c9bc9fa759b917195
+  md5: 56ca006b6e825a936082de534f616807
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - sqlite >=3.51.1,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16714237
+  timestamp: 1771949289066
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
+  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
+  md5: a844b3df0b11b33f4742841d25146b6c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313830
+  timestamp: 1728385377316
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
+  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
+  md5: 061428165f4369719796769975341cf7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 315827
+  timestamp: 1728405669914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
+  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
+  md5: 2ac600a5ed014f3b8fe2996b213a68e6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313686
+  timestamp: 1728585595371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
+  sha256: 76a01e3051b5ff8157a5018de495b6f1ca1adaf8854c984a15bb59c7940f1a09
+  md5: 43a3d00b9e02e3dea2bdcfec026286ac
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 314702
+  timestamp: 1729038434598
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
+  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
+  md5: 6aa550906f91d13d1371c07e9cb5c5c3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51623
+  timestamp: 1768559707638
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
+  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
+  md5: e07c79278a8a508e83e42d176ab595be
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51868
+  timestamp: 1768559706782
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
+  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
+  md5: 69ed706ac95df59f56b448091f4c40fa
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51905
+  timestamp: 1768559713789
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
+  sha256: 13d615a42829d3c12dc481c69ab5f1116c3199e288f41254349a06271ce4e9fb
+  md5: 072ed01dfef3ee838397aca7daca4909
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76112
+  timestamp: 1768559797418
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
+  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
+  md5: 213fed7b509c30119154cf77a958aa7d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253447
+  timestamp: 1763718602538
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
+  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
+  md5: b8dc8f719d9a94474d335a89ff1ab0a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253530
+  timestamp: 1763718606784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
+  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
+  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253652
+  timestamp: 1763718722391
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
+  sha256: 82a7013143a81abbf1c7657bf8b808bf0dc0a8e3a4b985eda5ad1c57526341e4
+  md5: f8d83d25272d9810a1b8f8fc36d6d6b2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 254671
+  timestamp: 1763718769611
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
+  md5: 5af1bf885def2fa779b0bb002e53651b
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157
+  timestamp: 1764349599777
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
+  md5: fb2966848729243e63cc897cb90f1eda
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101
+  timestamp: 1764349598421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
+  md5: 12e362aabff119a51f51ac3c0f3d0a84
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6010
+  timestamp: 1764349560639
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: d0a5b4e854c76a4ff354a9ce22725cff8986afff92e3fccca14a02171fccd56e
+  md5: 38fc6cb6b97bcc2dc25c8bb4803dbd73
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6092
+  timestamp: 1764349785264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
+  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
+  md5: f700a9cc4e35fd699b4df403f8f14148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 224571
+  timestamp: 1773043070463
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
+  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
+  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 223054
+  timestamp: 1773043038462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
+  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
+  md5: 7faf2150ef3d3493e3554582fec52fcb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 226666
+  timestamp: 1773042949673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
+  sha256: c56ad8b43d5b1c0839d9bb87ddbb1b969c3591d67df173fa416e38d094c8d81e
+  md5: e2698e9bf539b4e68b9b7fde985f7cdc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 226353
+  timestamp: 1773043150602
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py313h885b0b7_0.conda
+  sha256: 644f63d7691e36eb12df35a61f460fd6277fd8d52b1c257f88aa1e9812e77ef2
+  md5: e5b50a8f5162a8488417c1fd341e9bf5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  license_family: Other
+  size: 12129178
+  timestamp: 1754671076453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-ctypes-0.2.3-py313haa95532_0.conda
+  sha256: a04a371e453c389cd70a0bcc7bdb543feaafd9ed9af6ba630060b49badbd9624
+  md5: 30781774436ef59055d817435eabbd29
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55951
+  timestamp: 1768296662106
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
+  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
+  md5: 2384f037ab798b6ce6097c717a8758dc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 253759
+  timestamp: 1763465523432
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
+  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
+  md5: a9b067a53f219bf9ed2a4583154facf9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 245388
+  timestamp: 1763465541517
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
+  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
+  md5: 5ea183aac23f4bbe41412f200a70d09d
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237854
+  timestamp: 1763465528485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py313hb9a58be_0.conda
+  sha256: cdf7b48afb00e8f1c75b8009bf288015f3f894925807350c412d2b40505ff71b
+  md5: 99d3b0d7895f14c833020bae2637fbd0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 232090
+  timestamp: 1763465571269
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
+  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
+  md5: 33b7455bfa1462c42bbc9a0535070313
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19959
+  timestamp: 1760613452708
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
+  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
+  md5: d2228764ccb4ad95813f44effcaaa38a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19961
+  timestamp: 1760613342830
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
+  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
+  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 20018
+  timestamp: 1760613321490
+- conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
+  sha256: ce9cb1907f5ad2f1da9a073bf941532fcae38754ee519092d675ed2632c15eb0
+  md5: 2686c6ca4329a9d6a587103c986e7026
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 20322
+  timestamp: 1760613512213
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
+  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
+  md5: 8578e006d4ef5cb98a6cda232b3490f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 481826
+  timestamp: 1754485653893
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
+  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
+  md5: f04b3cb7ab28e886ceb012e4e9626e82
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 509455
+  timestamp: 1754485781954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
+  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
+  md5: fed853901ec41684b9e08b0c7ee4d7f0
+  depends:
+  - __osx >=11.1
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 475276
+  timestamp: 1754485689285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
+  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
+  md5: ce6e467c7e671a9214bc5d118b8e24a7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82123
+  timestamp: 1762536905383
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
+  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
+  md5: f1cd02f5cac4c78dd00805f81f7b66d8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82590
+  timestamp: 1762536906694
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
+  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
+  md5: 3fa52decbfabf965e84fd38bfb2e268f
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82518
+  timestamp: 1762536906534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
+  sha256: 175d71ed03e9e70ec164fe1f944955859f1e94b78bd068131737366f52863348
+  md5: 45abed89b4fa72b0b16dc01408537551
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82654
+  timestamp: 1762536944331
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py313h06a4308_1.conda
+  sha256: 4f29e92b850f997c5b02a819b8d7419e42539ecc6d38279b3ab4cd86f5721e3b
+  md5: fad2ba22ead9ddf78230e158ef8eac5b
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170202
+  timestamp: 1762359610460
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.32.5-py313hd43f75c_1.conda
+  sha256: c0cfe03f702ad04aa3a7dffd3c9b8ce89e0954ceb03c09298cd78c01349b9057
+  md5: 965f9883d0d197dfe214970a5c9a3788
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170701
+  timestamp: 1762359618471
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py313hca03da5_1.conda
+  sha256: e26c359108cf86d20ccf9f63882784c60f9de7646fc662d36008858cccdbe926
+  md5: d3caaa1ccfdc184a1cd00f060ffd7897
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170340
+  timestamp: 1762359612952
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py313haa95532_1.conda
+  sha256: f47b3b4105ff85f5c7e3fb26749b7d4b02cb38bd44c694cb8e40cec5d5dfd626
+  md5: bc3b3e16325fe83c22b616789d9139ef
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 171691
+  timestamp: 1762359649110
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
+  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
+  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88122
+  timestamp: 1728411680534
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
+  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
+  md5: 3f4000830e7a25be1df38114d361b976
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88285
+  timestamp: 1728500408740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
+  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
+  md5: 85f9714b8bf50cf6f9c75deb5441bba8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88498
+  timestamp: 1731721373383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
+  sha256: 522043089fc1642c8c8798864bdeaad6b7ddcdbfee8a3083fc31bdcc02577166
+  md5: b11a903414ef47b3faed42691b1d2c9d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 89136
+  timestamp: 1731731373752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
+  sha256: 4006abedbb05553a7f667566d23afbac4beea2097a96d0508c629b044affde0c
+  md5: f4775d8f7f987cff7f067c7a47c66723
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 604815
+  timestamp: 1760375652641
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
+  sha256: 3f941bc0664875e48deba64e64686f44b75b29d323063ec504a9e40c6b8c621c
+  md5: 097a66ceed127b2918383880bed077d2
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603684
+  timestamp: 1760375647067
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
+  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
+  md5: ffc0d1741d0d0dbff07518323feb64d8
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603836
+  timestamp: 1760375502207
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rich-14.2.0-py313haa95532_0.conda
+  sha256: 54308fc64559dac4eb2f486594c826aaa7ba33d984392c6ee59850491c494a4b
+  md5: 098632335698839505bc680c928fb38f
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 604180
+  timestamp: 1760375703489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
+  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
+  md5: 9630d019be2bb127699a375157124a0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 346701
+  timestamp: 1762366536075
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
+  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
+  md5: 7f93cb69d835d6256cc68d0c22843159
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 335795
+  timestamp: 1762366544737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
+  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
+  md5: 150c83ebdcae2067ae5c34a05c1da4ed
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 311962
+  timestamp: 1762366565780
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
+  sha256: e9d4ae95e182d385fad599b171f7dbdf125a385566cd551e5ae579aa6699a9f0
+  md5: 3253a635462ed5652fb9f5241e201d69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 219848
+  timestamp: 1762366911453
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
+  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
+  md5: dc961556c7bbe4e2aa959e36ab816dcd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271868
+  timestamp: 1762535994695
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
+  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
+  md5: 28b23d252e0d230044637b0f8f88cca6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271533
+  timestamp: 1762535980215
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
+  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
+  md5: b292e4688f8ac6f1c97f1f3e895f5cff
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271430
+  timestamp: 1762535976251
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
+  sha256: 4e8a117ed84fdf47dd2ef8ce7c6395af0a1310845917b4087aa98ec045796454
+  md5: 97843e1c3c45660d8aa2c6dd6a7d1fc2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271852
+  timestamp: 1762536109923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
+  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
+  md5: dad8d758af9c2b4369776c601407d9bd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 136835
+  timestamp: 1762530306911
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
+  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
+  md5: 26960af9de364b5745c254d1a6890c45
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 127958
+  timestamp: 1762530151153
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
+  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
+  md5: ca9e7978a1057363f0c36d975b764dcb
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 114492
+  timestamp: 1762530107760
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.14-py313hb9a58be_0.conda
+  sha256: 3ca28bf6841518b5004d899bd726b3f0230fd1ebfee34a9c336e6dc0cb41523c
+  md5: cac6a4b727d18eb086ea401e817043af
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 108685
+  timestamp: 1762530153943
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.4.0-py313h3e8c6aa_0.conda
+  sha256: c01e9b0bb451d26165f0362879cf7bf09e558b54eaeafdb9d8ba1bb497367814
+  md5: 4293ddebd1f1c6c083c0e0081b72e30e
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30714
+  timestamp: 1757931484918
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.4.0-py313hafdef7f_0.conda
+  sha256: 7bd58fcb738b0a2cb9f0c91c9009941c5153be96191ba0baad4a5ebf2ffbb000
+  md5: de4909f2308c163ec187a7738d0d4b15
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30874
+  timestamp: 1757931487589
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
+  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
+  md5: 985226bbcb23ebc859128ca676ad6321
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45387
+  timestamp: 1761903210853
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
+  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
+  md5: c9d0d757b916ddfd019821dbbc02a0d9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45447
+  timestamp: 1761903130898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
+  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
+  md5: 8b4a9bf142beac7513382b0a84ce51f5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45786
+  timestamp: 1761903046636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/semver-3.0.4-py313haa95532_0.conda
+  sha256: 5158570e5a5891716906743ce9eebe1a0572143dffe808ecba634e5a2c0b3859
+  md5: 2dbcf40ddf66f02858c49c67ce0fd953
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70112
+  timestamp: 1761903400398
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.10.2-py313h06a4308_0.conda
+  sha256: 17092619900889441c41b2f20fc068af4d25e0ec4d91b1bf19cbffe6792c7ac8
+  md5: 9c2048dafbf774c9f53c273a4e465110
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1776172
+  timestamp: 1770136014170
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-80.10.2-py313hd43f75c_0.conda
+  sha256: 72637bb9a86c7d997ee353f89bfeaa6ed50bf9f008c389c93a93cec6ce4b9be3
+  md5: 0c448b0f808a7ba2e8458e1e4866a519
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1776437
+  timestamp: 1770136068405
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.10.2-py313hca03da5_0.conda
+  sha256: bded46ac086c5f790886d8575a2f9f161129c566f9a121d273a73507681931e0
+  md5: 5ac5ba0e45c6dab828b5a99ef97401bd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1780055
+  timestamp: 1770136024850
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.10.2-py313haa95532_0.conda
+  sha256: 0e449a48f90efb05a067fc592dc3e16b938701fc3b0b950e80b9209245cb39c7
+  md5: 35876ca47b005cd42a7c7f13319bfd62
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1778711
+  timestamp: 1770136291847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
+  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
+  md5: 843241073919fc2c912f6ed85d14681d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23136
+  timestamp: 1761912223128
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
+  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
+  md5: d32e4a1ec001c6cef1aae68c11480c55
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23120
+  timestamp: 1761912222490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
+  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
+  md5: 58fe2f1c6896f6e26cea231b74e3888c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 22962
+  timestamp: 1761912224859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/shellingham-1.5.4-py313haa95532_0.conda
+  sha256: 1f6a915225fb3e8712d8734cae5276eb4527f93f5051f79269c1e1e4d03cd9e5
+  md5: 48a11caef15ab91bf7360541a0842d05
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23375
+  timestamp: 1761912263432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
+  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
+  md5: 648ce63d75b826e85fb8801c8b4b4e44
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37483
+  timestamp: 1744271525796
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
+  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
+  md5: 626970a8b8398716c9b9f9025eafd307
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37500
+  timestamp: 1744271573927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
+  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
+  md5: 4af6f9244bd475289f3410b1c8880ed9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 39474
+  timestamp: 1744271575294
+- conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py313haa95532_0.conda
+  sha256: fe16c893061086d4882b77d91b95efa937a831ce78bd3eb17cb18c99539b8232
+  md5: e7fc4d83bea7ee99038d43c773df475f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 38706
+  timestamp: 1744271651700
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
+  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
+  md5: face17589cf2b386d76cc870234dfe6e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17447
+  timestamp: 1764329206740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
+  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
+  md5: 219c67c8ff19787a64b06c2517d063e9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17506
+  timestamp: 1764329173905
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
+  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
+  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17410
+  timestamp: 1764329171349
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
+  sha256: 256d04f9d78737274877cd1fb9d7b15ef9efa940737cba71701ab20f9555322a
+  md5: ec4cfcc2fe1e1b4325af67997d46ba36
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17469
+  timestamp: 1764329260587
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
+  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
+  md5: c7b847a43363d2d77724b9ea04881088
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1265119
+  timestamp: 1773313781324
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
+  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
+  md5: 55600c8be72a7624ebd63e54ed72cbe0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1281272
+  timestamp: 1773313781654
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
+  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
+  md5: cf083b0b25fff8ddab995ac001076f38
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1182590
+  timestamp: 1773314600429
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
+  sha256: d9d5f8b3ba4afcf43baca9386ae69f3b7b0f1d30f35ced10bc52d61fe0d1cd28
+  md5: b273f421592da633715a1c28058d0ea9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  license_family: Other
+  size: 938682
+  timestamp: 1773313787688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
+  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3610181
+  timestamp: 1755243907117
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
+  md5: 6a7f42565108e00d27f68f4ae5751c53
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3717438
+  timestamp: 1755243976411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
+  md5: d1329e6c7292f448cdeed21290dd1035
+  depends:
+  - __osx >=11.1
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3448719
+  timestamp: 1755244020166
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
+  sha256: 2f7e9d06b513bcabce6d9ae195e45ccf94fd249edfefc591a5430a9f6f92a7fa
+  md5: ddff7b6a72958ef802f40a735e505474
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3700492
+  timestamp: 1755244051664
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
+  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
+  md5: 782987d420694bdc4a207a16db446a56
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82730
+  timestamp: 1768296500871
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
+  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
+  md5: d5ba67844244cfccfa37b1b23ec83b23
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82633
+  timestamp: 1768296495852
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
+  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
+  md5: 65d4e75c4c995d35de71b4e16174828c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82474
+  timestamp: 1768297453889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
+  sha256: cfd820f3b7c2cb7e7ff53c7110fc11d45220724457831c4b7b44e10f24b4e081
+  md5: bf2d1a34135ca0731780c7b012fa5c89
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82570
+  timestamp: 1768296694724
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
+  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
+  md5: d625085e004f964c54b88a3c6c5e8d7e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189342
+  timestamp: 1762896696002
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
+  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
+  md5: 8949c7ff2861d1b903cee84c0607eacf
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 188584
+  timestamp: 1762896685732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
+  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
+  md5: 9199e3c9a0451d04eff558d461dd1b2c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189601
+  timestamp: 1762896659686
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
+  sha256: 5ab0840c91097eb033eb73a06cae0dee6317379b1c15cff4fe9672168488d28b
+  md5: c5c83cb181bee0abb42aa29669eecee6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189958
+  timestamp: 1762896691761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
+  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
+  md5: 17b9f23e939b55ab9cab471b694a79d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 161112
+  timestamp: 1771398721582
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
+  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
+  md5: 54a2c4b9c33935687b977159f85bb4cb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160713
+  timestamp: 1771398718073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
+  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
+  md5: af4d88d628ea31190ed1432bba93b9c2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160792
+  timestamp: 1771398721170
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
+  sha256: d3fe275f6dbc5bd68277660f7cbc07ced89a4fb5198a35ce2c32bc5d02eaa042
+  md5: a797878a96f1b422ec8eee84371459f2
+  depends:
+  - colorama
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 185961
+  timestamp: 1771398813387
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
+  sha256: 0e7167d3723f10bfade1a0b6c3c59829c2bf9705d8f3ffd57bdebdc3b6ddf1ba
+  md5: e3ab7e8538a252ccb235f1cf218bda52
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216170
+  timestamp: 1728385119935
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
+  sha256: ab62d2a4692749c680612ab3330fea299ff9245a550a9d0a07bebc969b5435ba
+  md5: 7df7fc6bcb911d97032699617ee74718
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212695
+  timestamp: 1728405381017
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
+  sha256: c06d6a4a9b21b72720bbbe2bcb0d850290df50925360cdc744115e1894f5176b
+  md5: 176fa6f06b48bfbbe763addd30ff154f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213397
+  timestamp: 1728585495815
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py313haa95532_0.conda
+  sha256: 9617cced1f3dda7b511a1b19fce74ec6126de327febd3cbc096f1393b4253562
+  md5: 0a77cf43cb292b62f1021ec2f59b809c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214295
+  timestamp: 1729038177233
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
+  sha256: abf3e9b5820c78d1ca3d41b91f9b7b67d13d3e6c3f2892cc10f6f2361b3f0c3f
+  md5: d9b03aa4048c711087209d7c35e3fb32
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313h06a4308_1
+  constrains:
+  - typer-cli 0.20.0.*
+  - typer-slim 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157493
+  timestamp: 1771513026151
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
+  sha256: 72528b21b18f32ce743af2e3e2bc1518935cde1cdf36dd46fd0189e98ef3901c
+  md5: a404eaf65b18781d5e5d0f3a02db930b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313hd43f75c_1
+  constrains:
+  - typer-slim 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157663
+  timestamp: 1771513020641
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
+  sha256: fe035489f4bed2ab2fa0f51ae50faaf7c9b7390252b86123cbae4d3e45e178df
+  md5: 2a00d5da027f2f72dfd4b05c178afb29
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313hca03da5_1
+  constrains:
+  - typer-slim 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157900
+  timestamp: 1771513056344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.20.0-py313haa95532_1.conda
+  sha256: bf5f44ef827b63bdfaefef50ae2eca43e9ba0d0dc478a51deec0ef9fee8815b2
+  md5: dfab5f80445eb8659daef0ba9527f95f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313haa95532_1
+  constrains:
+  - typer-cli 0.20.0.*
+  - typer-slim 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 182475
+  timestamp: 1771513176865
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
+  sha256: 31e03fddda42d42d36db861c134ea402e4a7abe20a69a7a2b5bb07d42530737b
+  md5: 1d5785a482a13f84097ba02722141e5d
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - shellingham >=1.3.0
+  - rich >=10.11.0
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 112535
+  timestamp: 1771513011655
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
+  sha256: 7c1d7f40115ceba0cc000135f2e88a4dc41ca26615984bf01803f42de7e13647
+  md5: 06f7840d8233d7d3815c803d8950d653
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - shellingham >=1.3.0
+  - rich >=10.11.0
+  - typer-cli 0.20.0.*
+  - typer 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 112583
+  timestamp: 1771513006666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
+  sha256: 3e3e58ea2dabbc9ebe99e5a83d360c33642de0485fa07bcfa4f4bb1fa870f58b
+  md5: eaad783ddbeddae5d991cf850033e284
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - rich >=10.11.0
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 112806
+  timestamp: 1771513038567
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-0.20.0-py313haa95532_1.conda
+  sha256: dd4e5f1bc66d19d4294dd0730671f7e3a0fe6bdc5c5ab863846edd88b13b06e9
+  md5: 8ec4fad99a2260241e793af8d8ef2369
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - shellingham >=1.3.0
+  - rich >=10.11.0
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 112460
+  timestamp: 1771513097234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
+  sha256: b8a7d942b5032ecb3fd4faa83c7f51aa290d38773eb74195d7df136998aef8b6
+  md5: 9dd2ed87dd542c2ccde13c6e2e29a311
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313h06a4308_1
+  constrains:
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7309
+  timestamp: 1771513016825
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
+  sha256: 4695a00df558018887f458bd70b04c672d30d114b900444bfe845a577d8d1302
+  md5: 74f2f9f2479e83b49c21a310182f04d8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313hd43f75c_1
+  constrains:
+  - typer-cli 0.20.0.*
+  - typer 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7307
+  timestamp: 1771513011450
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
+  sha256: f10f6c39573b002cd7ed525c97e3a1033525b17e2ca9f635c7965ad1578e5d98
+  md5: 9d8e87a1f5725cf60bba4ec5094b80ae
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313hca03da5_1
+  constrains:
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7235
+  timestamp: 1771513045167
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-standard-0.20.0-py313haa95532_1.conda
+  sha256: 05bc257bcdc83b244bbd10915692690463fc8b27e40abb67115df64faaa79fc1
+  md5: 928952e95121b247487ae696bac105fd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313haa95532_1
+  constrains:
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7252
+  timestamp: 1771513106030
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
+  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
+  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11238
+  timestamp: 1756280930223
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
+  md5: 055d37ff4e41c9b9e33d2bb8919c263b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hd43f75c_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11203
+  timestamp: 1756280951293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
+  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
+  md5: 22b46f0e6d389d4199ffaa317e9c9a05
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12434
+  timestamp: 1756281597870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
+  sha256: 3503a6100d19cd88fcc28c21d6e3517f78e77f4541408266f0d6ffc2010a6ed0
+  md5: b9d604ca2915d5b5c2e71c56eddcf39e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12368
+  timestamp: 1756281409751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
+  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
+  md5: b5ea08882d6d5cca3e38a27a3575e85c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32310
+  timestamp: 1760614182019
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
+  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
+  md5: ff4e707bcf34fee0e2065cf2487e2103
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32401
+  timestamp: 1760614185275
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
+  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
+  md5: 1398c39b86119164f19498b6fbcfdb69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32465
+  timestamp: 1760614190333
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
+  sha256: 2d10e45ad212588bd03eded99708a7d2dc50f4353577c890e82a28e6e3593f2a
+  md5: e20a2281ead8112e87233f7ced446b0d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32527
+  timestamp: 1760614225492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
+  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 104756
+  timestamp: 1756280924315
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
+  md5: 017a18fc16caf581ce26bac0ad6f9efb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 101647
+  timestamp: 1756280944673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
+  md5: 3c37609330dd4baeb0f4842f02cb783e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 106009
+  timestamp: 1756281579411
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
+  sha256: 7ffee67192fba083f61c95f197fc119cb77ef83528d5d18ed2f63a881e46c0b9
+  md5: 0e3cbe58bfd973d09298bcbf2de72675
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 103139
+  timestamp: 1756281400010
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+  sha256: bab9c667cb352cdbbc895b4aa8c867221e2e98d5310d884e494540c0b5c1efce
+  md5: b46d6837d6e1ceabdf40378de048c581
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 120000
+  timestamp: 1772652196967
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
+  sha256: 9dfca4fb23f20e62a48b9c52e2fdf4d0d34bb31eb6a930c2195fcd10651b3cc3
+  md5: 15e1b10231d7d236520501fcfb440f31
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 634816
+  timestamp: 1752158202557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
+  sha256: 450d16974ba2405a26ad7da3a2a2dc4f395246427d3f3471520f7a0810e57e74
+  md5: 23108bceb7bbce3e449c9c55ecbaa296
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 357351
+  timestamp: 1767810287147
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
+  sha256: 82275c3c5f7e5eab48d74089cc207d4aa692f4a2efd30d4e992d1fd2d7775cca
+  md5: d7dea689ca62516ce02639d4663d1c53
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 357777
+  timestamp: 1767810287557
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
+  sha256: 375349eeb47983e6e2b2d2608f7141d948e5396e2906b087781d4f49df8dad0c
+  md5: 464328fc7f4e77667c63d5284e866e85
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 357592
+  timestamp: 1767810426391
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
+  sha256: f4d385f2f8c1803164a156f5122bde7d345be80b485827e2046562e1cf307da2
+  md5: 991be321d1493e7325cf42a491eb01d9
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 358116
+  timestamp: 1767810523479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_10.conda
+  sha256: d427b27e553a5caa78284a995ff9c3720b0f213a0e650fe9d3b54b4b4a65f241
+  md5: 064c529f6f598fb2225446f76687a170
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19506
+  timestamp: 1752199946483
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.conda
+  sha256: 747f5d55439e327d3b035c0078be59991ffa5683542fbcecbcc6abcfff50588a
+  md5: 13296ea2847729c01c316b089cb28337
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_10
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 845189
+  timestamp: 1752199754308
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.conda
+  sha256: fa731e65f9c6b7b9559cb93653d067658594f39d2bc5c75cae85ac2385d79d06
+  md5: 58665d8e606897afb52a202669673c40
+  depends:
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19526
+  timestamp: 1752199762272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py313haa95532_1.conda
+  sha256: 584b2c2ad3ff8284378aebf5f1abf4fca38a58ba1fe45e388abffd141928ec39
+  md5: 5e0b29b7d41654437b98ef9b47a8b5d6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PUBLIC-DOMAIN
+  size: 10272
+  timestamp: 1761746316414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
+  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
+  md5: 6298b27afae6f49f03765b2a03df2fcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 916212
+  timestamp: 1746110020649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
+  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
+  md5: e87565f2b050d575ee056f472d062383
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 950329
+  timestamp: 1746110056137
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
+  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
+  md5: a8005a9f6eb903e113cd5363e8a11459
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 13582
+  timestamp: 1745958707989
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
+  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
+  md5: 96f0df92ef31ad0aaf27b6b373e4f510
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 14118
+  timestamp: 1745958715370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
+  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
+  md5: c284a09ddfba81d9c4e740110f09ea06
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19260
+  timestamp: 1745992279492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
+  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
+  md5: 5bfda69ee113cfc8e38e0214c078ef4e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19895
+  timestamp: 1745992295156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
+  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
+  md5: 412a0d97a7a51d23326e57226189da92
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-xextproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-renderproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 594175
+  timestamp: 1746046234466
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
+  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
+  md5: 46b530510556e0b1830c40b5ac625f0e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-renderproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-xextproto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 595620
+  timestamp: 1746046239552
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
+  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
+  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 635646
+  timestamp: 1772548381644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
+  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
+  md5: 0d2e76f65075404a9c26010882e7a786
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 643308
+  timestamp: 1772548369777
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
+  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
+  md5: bc7f39bd763f6957ec91046f0e67a9f3
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 269216
+  timestamp: 1772548381049
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
+  sha256: e09005f52c41234213bd52ebd07092d945855b6d631dd709dcf35dbc71a15c63
+  md5: 70e604035b6c97b915114912f047fb2a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 271653
+  timestamp: 1772548477626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
+  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
+  md5: 39fdbf4db769e494ffb06d95680c83d8
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 76992
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
+  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
+  md5: 588d487b103786708d10c1800d048fd4
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  size: 77652
+  timestamp: 1619009841594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
+  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
+  md5: 23a9bda10db68f27fac5c379466c98b7
+  license: MIT
+  size: 73088
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
+  sha256: e197edaa90488491bd6e0eaa51329d2d93242c6acd7d0aa7b0351d4b24412368
+  md5: 959a63017c520ef9d345bd82ab344e3e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 63112
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
+  sha256: cf30f83189a30b12a9239f132ea0ce676fa822a52045adb0f9ff9b3b4d79ead6
+  md5: 9f3a877e5e0fa0fb39253a59ff824861
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libzlib 1.3.1 hb25bd0a_0
+  license: Zlib
+  license_family: OTHER
+  size: 98150
+  timestamp: 1756475939641
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
+  sha256: db213b9f69ccaf2457daabc1a92a4ce0c7aab6bba8145a2e349812cd6f0b41b4
+  md5: 58ccfae41b6e3ad4fd6961071d450f6a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libzlib 1.3.1 h998d150_0
+  license: Zlib
+  license_family: OTHER
+  size: 105760
+  timestamp: 1756475948207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
+  sha256: 0af76c0fbf1697cfd54ada59547e8d086ab113b6dfcc9360aab573a6eb711771
+  md5: eb0fb89b08890d755421c26fae5a8909
+  depends:
+  - __osx >=11.1
+  - libzlib 1.3.1 h5f15de7_0
+  license: Zlib
+  license_family: OTHER
+  size: 78512
+  timestamp: 1756475938331
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.conda
+  sha256: 116120d38011eea43cbeeb70e00b0eaa3b1c0a3f470df09aadb0d0b66aebbf60
+  md5: 4db9b3fbefe915ffb9eef8c812a98c6a
+  depends:
+  - libzlib 1.3.1 h02ab6af_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Zlib
+  license_family: OTHER
+  size: 115567
+  timestamp: 1756476083170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
+  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
+  md5: 78685aca3b481cf213b92abfbe0b2b21
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 422402
+  timestamp: 1758189113863
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
+  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
+  md5: 8d4a8433cf437f7ecc5aafa9874c2012
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 396870
+  timestamp: 1758189118512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
+  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
+  md5: b282b2aecb718102ee0bb3848514689a
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349977
+  timestamp: 1758189118260
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
+  sha256: ecc86fd8a56adb8e6cfc2f6ede240b93350cdbf7382662c6ffb12f526e4dff03
+  md5: 2fcbc03acf75dedbb17fec7ef2ba5803
+  depends:
+  - cffi >=1.17
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 337202
+  timestamp: 1758189153500
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
+  md5: 93b0e546434bfb874aeefd6bb6cf40bb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 622604
+  timestamp: 1758039176606
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
+  md5: abc05ce4daceeb1fa321b365cb847975
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 594707
+  timestamp: 1758039173244
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
+  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
+  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 471230
+  timestamp: 1758039171969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
+  sha256: c822ed29c20166934ef9c9e29b863bc382b2c3c602ac1f3a62e9af2c0495a74c
+  md5: fd829528313216f62505dd7a281230ea
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 660146
+  timestamp: 1758039218319

--- a/lockfiles/anaconda-cli/pixi.toml
+++ b/lockfiles/anaconda-cli/pixi.toml
@@ -1,0 +1,14 @@
+[workspace]
+name = "anaconda-cli"
+channels = [
+    "https://repo.anaconda.com/pkgs/main",
+    "anaconda-cloud",  # Fallback for packages not released to main
+]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = ">=3.12,<3.14"
+anaconda-auth = "*"
+anaconda-ai = "*"
+anaconda-client = "*"
+anaconda-cli-base = "*"

--- a/lockfiles/lock-all.sh
+++ b/lockfiles/lock-all.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lock all tools in the lockfiles directory
+# Usage: ./lock-all.sh [tool...]
+# If no tools specified, locks all subdirectories with pixi.toml
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+lock_tool() {
+    local tool="$1"
+    local tool_dir="$SCRIPT_DIR/$tool"
+
+    if [[ ! -f "$tool_dir/pixi.toml" ]]; then
+        echo "Skipping $tool: no pixi.toml found"
+        return 0
+    fi
+
+    echo "==> Locking $tool"
+    (cd "$tool_dir" && pixi lock)
+}
+
+if [[ $# -gt 0 ]]; then
+    # Lock specific tools
+    for tool in "$@"; do
+        lock_tool "$tool"
+    done
+else
+    # Lock all tools
+    for tool_dir in "$SCRIPT_DIR"/*/; do
+        tool="$(basename "$tool_dir")"
+        lock_tool "$tool"
+    done
+fi
+
+echo "Done."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -398,6 +398,15 @@ run_bootstrap() {
 }
 
 update_shell_profile() {
+    local _dir="$1"
+    local _ana_bin_dir="$HOME/.ana/bin"
+
+    # Add both the install directory and ~/.ana/bin (for tool symlinks)
+    add_to_path "$_dir"
+    add_to_path "$_ana_bin_dir"
+}
+
+add_to_path() {
     local _dir="$1" _line
 
     # Already in $PATH
@@ -424,7 +433,6 @@ update_shell_profile() {
             return 0
             ;;
     esac
-    printf "\n"
 }
 
 append_line_if_missing() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,6 +47,7 @@ Options:
   -v, --version VERSION    Version to install (default: ${DEFAULT_VERSION})
       --no-verify-checksum Disable checksum validation after download (default: false)
       --no-path-update     Skip shell profile modification
+      --no-bootstrap       Skip running 'ana bootstrap' after installation
   -t, --token TOKEN        GitHub token for private repo access
   -f, --force              Overwrite existing installation without prompting
   -h, --help               Show this help message
@@ -56,6 +57,7 @@ Environment variables:
   ANA_VERSION              Same as --version
   ANA_VERIFY_CHECKSUM      Set to "false" to skip checksum verification
   ANA_NO_PATH_UPDATE       Set to non-empty to skip PATH update
+  ANA_BOOTSTRAP            Set to "false" to skip bootstrap
   ANA_FORCE_INSTALL        Set to non-empty to overwrite without prompting
   GITHUB_TOKEN             Same as --token
 
@@ -99,6 +101,10 @@ parse_args() {
                 ;;
             --no-path-update)
                 ANA_NO_PATH_UPDATE="1"
+                shift
+                ;;
+            --no-bootstrap)
+                ANA_BOOTSTRAP="false"
                 shift
                 ;;
             -f|--force)
@@ -175,6 +181,8 @@ main() {
     if [ -z "${ANA_NO_PATH_UPDATE:-}" ]; then
         update_shell_profile "$_install_dir"
     fi
+
+    run_bootstrap "$_install_dir"
 
     printf "🎉 Done! Run '\033[1;36mana --help\033[0m' to get started.\n"
 }
@@ -363,6 +371,30 @@ install_binary() {
     trap - EXIT
 
     info "Installed ana to %s" "$_dest"
+}
+
+run_bootstrap() {
+    local _install_dir="$1"
+    local _ana_bin="${_install_dir}/${BINARY_NAME}"
+    local _bootstrap="${ANA_BOOTSTRAP:-true}"
+
+    case "$_bootstrap" in
+        false|0)
+            info "Skipping bootstrap (disabled)"
+            return 0
+            ;;
+        true|1) ;;
+        *)
+            err "Invalid ANA_BOOTSTRAP value '%s'. Must be 'true', 'false', '1', or '0'." "$_bootstrap"
+            ;;
+    esac
+
+    info "Running ana bootstrap..."
+    if "$_ana_bin" bootstrap; then
+        info "Bootstrap completed successfully"
+    else
+        warn "Bootstrap failed. You can run 'ana bootstrap' manually later."
+    fi
 }
 
 update_shell_profile() {

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use crate::paths;
 use crate::tools;
 
@@ -17,4 +19,30 @@ pub fn run_bootstrap() -> Result<(), String> {
 
     eprintln!("anaconda-cli installed successfully");
     Ok(())
+}
+
+pub fn run_subcommand(subcommand: &str, args: &[String]) -> Result<(), String> {
+    let anaconda_bin = paths::bin_dir().join("anaconda");
+
+    if !anaconda_bin.exists() {
+        return Err(format!(
+            "anaconda not found at {}. Run `ana bootstrap` first.",
+            anaconda_bin.display()
+        ));
+    }
+
+    let status = Command::new(&anaconda_bin)
+        .arg(subcommand)
+        .args(args)
+        .status()
+        .map_err(|e| format!("Failed to run anaconda: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "anaconda exited with code {}",
+            status.code().unwrap_or(1)
+        ))
+    }
 }

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,17 +1,20 @@
-use std::process::Command;
+use crate::paths;
+use crate::tools;
 
 pub fn run_bootstrap() -> Result<(), String> {
-    let status = Command::new("echo")
-        .arg("Hello from the bootstrapper!")
-        .status()
-        .map_err(|e| format!("Failed to run bootstrap: {}", e))?;
+    let anaconda_bin = paths::bin_dir().join("anaconda");
 
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "Bootstrap failed with exit code {}",
-            status.code().unwrap_or(1)
-        ))
+    if anaconda_bin.exists() {
+        eprintln!("anaconda-cli is already installed");
+        return Ok(());
     }
+
+    eprintln!("Installing anaconda-cli...");
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| format!("Failed to create async runtime: {}", e))?;
+    rt.block_on(tools::install::install_tool("anaconda-cli"))
+        .map_err(|e| format!("{:?}", e))?;
+
+    eprintln!("anaconda-cli installed successfully");
+    Ok(())
 }

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+
+pub fn run_bootstrap() -> Result<(), String> {
+    let status = Command::new("echo")
+        .arg("Hello from the bootstrapper!")
+        .status()
+        .map_err(|e| format!("Failed to run bootstrap: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Bootstrap failed with exit code {}",
+            status.code().unwrap_or(1)
+        ))
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 
 use crate::VERSION;
+use crate::anaconda_cli;
 use crate::auth;
 use crate::config::{self, Config};
 use crate::update;
@@ -42,6 +43,7 @@ pub enum Action {
     Update { force: bool },
     CheckForUpdate,
     ShowAvailableVersions,
+    Bootstrap,
 }
 
 impl Action {
@@ -59,6 +61,7 @@ impl Action {
             Action::Update { .. } => "self.update",
             Action::CheckForUpdate => "self.update.check",
             Action::ShowAvailableVersions => "self.update.list",
+            Action::Bootstrap => "bootstrap",
         }
     }
 
@@ -109,6 +112,7 @@ impl Action {
                 Config::load().print_table();
                 Ok(())
             }
+            Action::Bootstrap => Ok(anaconda_cli::run_bootstrap()?),
             Action::Login => Ok(auth::login()?),
             Action::Logout => Ok(auth::logout()?),
             Action::ShowApiKey => Ok(auth::show_api_key()?),
@@ -135,6 +139,7 @@ pub fn parse() -> Action {
     match Cli::try_parse() {
         Ok(cli) => match cli.command {
             None => Action::ShowHelp,
+            Some(Commands::Bootstrap) => Action::Bootstrap,
             Some(Commands::Config) => Action::ShowConfig,
             Some(Commands::Login) => Action::Login,
             Some(Commands::Logout) => Action::Logout,
@@ -199,6 +204,7 @@ pub fn print_main_help() {
 
         Commands:
           auth           Authentication commands
+          bootstrap      Install the Anaconda CLI
           config         Show current configuration
           login          Log in to Anaconda
           logout         Log out from Anaconda
@@ -271,6 +277,9 @@ enum Commands {
         #[command(subcommand)]
         command: Option<AuthCommands>,
     },
+
+    /// Install the Anaconda CLI
+    Bootstrap,
 
     /// Show current configuration
     Config,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,7 @@ pub enum Action {
     CheckForUpdate,
     ShowAvailableVersions,
     Bootstrap,
+    OrgProxy { args: Vec<String> },
 }
 
 impl Action {
@@ -62,6 +63,7 @@ impl Action {
             Action::CheckForUpdate => "self.update.check",
             Action::ShowAvailableVersions => "self.update.list",
             Action::Bootstrap => "bootstrap",
+            Action::OrgProxy { .. } => "org",
         }
     }
 
@@ -113,6 +115,7 @@ impl Action {
                 Ok(())
             }
             Action::Bootstrap => Ok(anaconda_cli::run_bootstrap()?),
+            Action::OrgProxy { args } => Ok(anaconda_cli::run_subcommand("org", &args)?),
             Action::Login => Ok(auth::login()?),
             Action::Logout => Ok(auth::logout()?),
             Action::ShowApiKey => Ok(auth::show_api_key()?),
@@ -163,6 +166,7 @@ pub fn parse() -> Action {
                     }
                 }
             },
+            Some(Commands::Org { args }) => Action::OrgProxy { args },
         },
         Err(e) => handle_parse_error(e),
     }
@@ -208,6 +212,7 @@ pub fn print_main_help() {
           config         Show current configuration
           login          Log in to Anaconda
           logout         Log out from Anaconda
+          org            Interact with anaconda.org
           whoami         Display information about the logged-in user
           self           Manage the ana installation
 
@@ -302,6 +307,17 @@ enum Commands {
     Self_ {
         #[command(subcommand)]
         command: Option<SelfCommands>,
+    },
+
+    /// Interact with anaconda.org
+    #[command(
+        trailing_var_arg = true,
+        override_usage = "ana org <command> [options]"
+    )]
+    Org {
+        /// Arguments to pass to anaconda org
+        #[arg(allow_hyphen_values = true)]
+        args: Vec<String>,
     },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,12 +202,9 @@ impl Config {
     }
 }
 
-/// Get the default keyring path (~/.ana/keyring).
+/// Get the default keyring path (~/.ana/keyring or $ANA_HOME/keyring).
 fn default_keyring_path() -> PathBuf {
-    dirs::home_dir()
-        .expect("Could not determine home directory")
-        .join(".ana")
-        .join("keyring")
+    crate::paths::ana_home().join("keyring")
 }
 
 /// Parse a boolean from a string value.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod anaconda_cli;
 mod auth;
 mod cli;
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod input;
 mod paths;
 mod qr;
+mod tools;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod cli;
 mod config;
 mod input;
+mod paths;
 mod qr;
 mod update;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+
+/// Returns the user's home directory using OS-specific environment variables.
+///
+/// - Unix (Linux, macOS): reads `HOME`
+/// - Windows: reads `USERPROFILE`
+///
+/// Panics if the environment variable is not set.
+#[cfg(unix)]
+pub fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .expect("HOME environment variable not set")
+}
+
+#[cfg(windows)]
+pub fn home_dir() -> PathBuf {
+    std::env::var("USERPROFILE")
+        .map(PathBuf::from)
+        .expect("USERPROFILE environment variable not set")
+}
+
+/// Returns the ana home directory (~/.ana or ANA_HOME).
+pub fn ana_home() -> PathBuf {
+    std::env::var("ANA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home_dir().join(".ana"))
+}
+
+/// Returns the tools directory (~/.ana/tools).
+fn tools_dir() -> PathBuf {
+    ana_home().join("tools")
+}
+
+/// Returns the prefix for a specific tool (~/.ana/tools/<name>).
+pub fn tool_prefix(name: &str) -> PathBuf {
+    tools_dir().join(name)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_home_dir_returns_path() {
+        let home = home_dir();
+        assert!(
+            home.is_absolute(),
+            "home_dir should return an absolute path"
+        );
+        assert!(!home.as_os_str().is_empty(), "home_dir should not be empty");
+    }
+
+    #[test]
+    fn test_ana_home_default() {
+        temp_env::with_var_unset("ANA_HOME", || {
+            let ana = ana_home();
+            assert!(
+                ana.ends_with(".ana"),
+                "default ana_home should end with .ana"
+            );
+            assert!(ana.is_absolute(), "ana_home should return an absolute path");
+        });
+    }
+
+    #[test]
+    fn test_ana_home_from_env() {
+        temp_env::with_var("ANA_HOME", Some("/custom/ana/path"), || {
+            assert_eq!(ana_home(), PathBuf::from("/custom/ana/path"));
+        });
+    }
+
+    #[test]
+    fn test_tools_dir() {
+        temp_env::with_var("ANA_HOME", Some("/test/ana"), || {
+            assert_eq!(tools_dir(), PathBuf::from("/test/ana/tools"));
+        });
+    }
+
+    #[test]
+    fn test_tool_prefix() {
+        temp_env::with_var("ANA_HOME", Some("/test/ana"), || {
+            assert_eq!(
+                tool_prefix("some-tool"),
+                PathBuf::from("/test/ana/tools/some-tool")
+            );
+        });
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -32,6 +32,11 @@ fn tools_dir() -> PathBuf {
     ana_home().join("tools")
 }
 
+/// Returns the bin directory for shims (~/.ana/bin).
+pub fn bin_dir() -> PathBuf {
+    ana_home().join("bin")
+}
+
 /// Returns the prefix for a specific tool (~/.ana/tools/<name>).
 pub fn tool_prefix(name: &str) -> PathBuf {
     tools_dir().join(name)
@@ -75,6 +80,13 @@ mod tests {
     fn test_tools_dir() {
         temp_env::with_var("ANA_HOME", Some("/test/ana"), || {
             assert_eq!(tools_dir(), PathBuf::from("/test/ana/tools"));
+        });
+    }
+
+    #[test]
+    fn test_bin_dir() {
+        temp_env::with_var("ANA_HOME", Some("/test/ana"), || {
+            assert_eq!(bin_dir(), PathBuf::from("/test/ana/bin"));
         });
     }
 

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -1,0 +1,145 @@
+//! Package installation from lockfiles via rattler.
+
+use std::{path::Path, str::FromStr, time::Instant};
+
+use indicatif::{MultiProgress, ProgressDrawTarget};
+use miette::{Context, IntoDiagnostic};
+use rattler::{
+    default_cache_dir,
+    install::{IndicatifReporter, Installer},
+    package_cache::PackageCache,
+};
+use rattler_conda_types::{Platform, PrefixRecord};
+use rattler_lock::LockFile;
+
+use crate::paths;
+use super::lockfiles;
+
+/// Global progress bar for installation feedback.
+static MULTI_PROGRESS: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock::new(|| {
+    let mp = MultiProgress::new();
+    mp.set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
+    mp
+});
+
+/// Install a tool from its lockfile.
+pub async fn install_tool(name: &str) -> miette::Result<()> {
+    let prefix = paths::tool_prefix(name);
+
+    let lock_content = lockfiles::content(name)
+        .ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
+
+    eprintln!("Installing {} into {}", name, prefix.display());
+
+    install_from_lockfile(&prefix, &lock_content).await?;
+
+    Ok(())
+}
+
+/// Install packages from a lockfile string to a prefix.
+pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette::Result<()> {
+    let lock_file = LockFile::from_str(lock_content)
+        .into_diagnostic()
+        .context("failed to parse lockfile")?;
+
+    let env = lock_file
+        .default_environment()
+        .ok_or_else(|| miette::miette!("lockfile has no default environment"))?;
+
+    let platform = Platform::current();
+    let records = env
+        .conda_repodata_records(platform)
+        .into_diagnostic()
+        .context("failed to extract records from lockfile")?
+        .ok_or_else(|| miette::miette!("lockfile has no records for platform {}", platform))?;
+
+    eprintln!(
+        "   Lockfile contains {} packages for {}",
+        records.len(),
+        platform
+    );
+
+    // Ensure prefix directory exists
+    std::fs::create_dir_all(prefix)
+        .into_diagnostic()
+        .context("failed to create prefix directory")?;
+
+    // Check what's already installed
+    let installed = PrefixRecord::collect_from_prefix::<PrefixRecord>(prefix).into_diagnostic()?;
+
+    // Build HTTP client
+    let client = make_download_client();
+
+    // Ensure cache directory exists
+    // TODO(mattkram): Consider a custom cache dir
+    let cache_dir = default_cache_dir()
+        .map_err(|e| miette::miette!("could not determine cache directory: {}", e))?;
+    rattler_cache::ensure_cache_dir(&cache_dir)
+        .map_err(|e| miette::miette!("could not create cache directory: {}", e))?;
+
+    let package_cache = PackageCache::new(cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR));
+
+    // Run installation
+    let start = Instant::now();
+    let result = Installer::new()
+        .with_download_client(client)
+        .with_package_cache(package_cache)
+        .with_target_platform(platform)
+        .with_installed_packages(installed)
+        .with_execute_link_scripts(true)
+        .with_reporter(
+            IndicatifReporter::builder()
+                .with_multi_progress(MULTI_PROGRESS.clone())
+                .finish(),
+        )
+        .install(prefix, records)
+        .await
+        .into_diagnostic()
+        .context("failed to install packages")?;
+
+    if result.transaction.operations.is_empty() {
+        eprintln!("   ✓ Already up to date");
+    } else {
+        eprintln!(
+            "   Installed {} packages in {:.1}s",
+            result.transaction.operations.len(),
+            start.elapsed().as_secs_f64()
+        );
+    }
+
+    Ok(())
+}
+
+/// Create an HTTP client for downloading packages.
+fn make_download_client() -> reqwest_middleware::ClientWithMiddleware {
+    let client = reqwest::Client::builder()
+        .no_gzip()
+        .build()
+        .expect("failed to create HTTP client");
+
+    // TODO: Add AuthenticationMiddleware for private channel support
+    reqwest_middleware::ClientBuilder::new(client).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lockfile_parse_error() {
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(install_from_lockfile(
+                Path::new("/tmp/test"),
+                "invalid lockfile content",
+            ));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("parse"),
+            "error should mention parsing: {}",
+            err
+        );
+    }
+}

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -29,12 +29,14 @@ pub async fn install_tool(name: &str) -> miette::Result<()> {
     let lock_content = lockfiles::content(name)
         .ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
 
+    let binaries = lockfiles::binaries(name).unwrap_or(&[]);
+
     eprintln!("Installing {} into {}", name, prefix.display());
 
     install_from_lockfile(&prefix, &lock_content).await?;
 
-    // Create symlink in bin directory
-    create_bin_symlink(name, &prefix)?;
+    // Create symlinks in bin directory
+    create_bin_symlinks(&prefix, binaries)?;
 
     Ok(())
 }
@@ -113,23 +115,30 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
     Ok(())
 }
 
-/// Create a symlink for the tool's binary in ~/.ana/bin/
-fn create_bin_symlink(name: &str, prefix: &Path) -> miette::Result<()> {
+/// Create symlinks for the tool's binaries in ~/.ana/bin/
+fn create_bin_symlinks(prefix: &Path, binaries: &[&str]) -> miette::Result<()> {
     let bin_dir = paths::bin_dir();
     std::fs::create_dir_all(&bin_dir)
         .into_diagnostic()
         .context("failed to create bin directory")?;
 
-    // TODO(mattkram): The binary or binaries is not always the name. We need to either
-    // inspect the top level package, or expose via our own custom configuration.
-    let tool_bin = prefix.join("bin").join(name);
-    let symlink_path = bin_dir.join(name);
+    for binary in binaries {
+        create_bin_symlink(&bin_dir, prefix, binary)?;
+    }
+
+    Ok(())
+}
+
+/// Create a single symlink for a binary.
+fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Result<()> {
+    let tool_bin = prefix.join("bin").join(binary);
+    let symlink_path = bin_dir.join(binary);
 
     // Check if the tool binary exists
     if !tool_bin.exists() {
         eprintln!(
             "   Warning: binary '{}' not found in {}/bin/",
-            name,
+            binary,
             prefix.display()
         );
         return Ok(());

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -91,6 +91,7 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
         .with_package_cache(package_cache)
         .with_target_platform(platform)
         .with_installed_packages(installed)
+        // TODO(mattkram): Review whether we should execute link scripts by default or not
         .with_execute_link_scripts(true)
         .with_reporter(
             IndicatifReporter::builder()

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -33,6 +33,9 @@ pub async fn install_tool(name: &str) -> miette::Result<()> {
 
     install_from_lockfile(&prefix, &lock_content).await?;
 
+    // Create symlink in bin directory
+    create_bin_symlink(name, &prefix)?;
+
     Ok(())
 }
 
@@ -106,6 +109,58 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
             start.elapsed().as_secs_f64()
         );
     }
+
+    Ok(())
+}
+
+/// Create a symlink for the tool's binary in ~/.ana/bin/
+fn create_bin_symlink(name: &str, prefix: &Path) -> miette::Result<()> {
+    let bin_dir = paths::bin_dir();
+    std::fs::create_dir_all(&bin_dir)
+        .into_diagnostic()
+        .context("failed to create bin directory")?;
+
+    // TODO(mattkram): The binary or binaries is not always the name. We need to either
+    // inspect the top level package, or expose via our own custom configuration.
+    let tool_bin = prefix.join("bin").join(name);
+    let symlink_path = bin_dir.join(name);
+
+    // Check if the tool binary exists
+    if !tool_bin.exists() {
+        eprintln!(
+            "   Warning: binary '{}' not found in {}/bin/",
+            name,
+            prefix.display()
+        );
+        return Ok(());
+    }
+
+    // Remove existing symlink if present
+    if symlink_path.exists() || symlink_path.is_symlink() {
+        std::fs::remove_file(&symlink_path)
+            .into_diagnostic()
+            .context("failed to remove existing symlink")?;
+    }
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&tool_bin, &symlink_path)
+            .into_diagnostic()
+            .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
+    }
+
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(&tool_bin, &symlink_path)
+            .into_diagnostic()
+            .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
+    }
+
+    eprintln!(
+        "   Linked {} -> {}",
+        symlink_path.display(),
+        tool_bin.display()
+    );
 
     Ok(())
 }

--- a/src/tools/lockfiles.rs
+++ b/src/tools/lockfiles.rs
@@ -1,0 +1,53 @@
+//! Embedded lockfiles for tool installation.
+
+use std::path::PathBuf;
+
+/// Tool configuration.
+struct Tool {
+    name: &'static str,
+    lockfile: &'static str,
+}
+
+/// Embedded tool configurations.
+const TOOLS: &[Tool] = &[Tool {
+    name: "anaconda-cli",
+    lockfile: include_str!("../../lockfiles/anaconda-cli/pixi.lock"),
+}];
+
+fn find_tool(name: &str) -> Option<&'static Tool> {
+    TOOLS.iter().find(|t| t.name == name)
+}
+
+/// Returns the lockfile content for a tool.
+///
+/// If `ANA_LOCKFILES_DIR` is set, reads from that directory.
+/// Otherwise, returns the embedded lockfile compiled into the binary.
+pub fn content(name: &str) -> Option<String> {
+    if let Ok(dir) = std::env::var("ANA_LOCKFILES_DIR") {
+        let path = PathBuf::from(dir).join(name).join("pixi.lock");
+        std::fs::read_to_string(&path).ok()
+    } else {
+        find_tool(name).map(|t| t.lockfile.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_content_embedded() {
+        temp_env::with_var_unset("ANA_LOCKFILES_DIR", || {
+            let lockfile = content("uv");
+            assert!(lockfile.is_some());
+            assert!(lockfile.unwrap().contains("version: 6"));
+        });
+    }
+
+    #[test]
+    fn test_content_unknown_tool() {
+        temp_env::with_var_unset("ANA_LOCKFILES_DIR", || {
+            assert!(content("unknown-tool").is_none());
+        });
+    }
+}

--- a/src/tools/lockfiles.rs
+++ b/src/tools/lockfiles.rs
@@ -46,7 +46,7 @@ mod tests {
     #[test]
     fn test_content_embedded() {
         temp_env::with_var_unset("ANA_LOCKFILES_DIR", || {
-            let lockfile = content("uv");
+            let lockfile = content("anaconda-cli");
             assert!(lockfile.is_some());
             assert!(lockfile.unwrap().contains("version: 6"));
         });

--- a/src/tools/lockfiles.rs
+++ b/src/tools/lockfiles.rs
@@ -6,13 +6,16 @@ use std::path::PathBuf;
 struct Tool {
     name: &'static str,
     lockfile: &'static str,
+    binaries: &'static [&'static str],
 }
 
 /// Embedded tool configurations.
 const TOOLS: &[Tool] = &[Tool {
     name: "anaconda-cli",
     lockfile: include_str!("../../lockfiles/anaconda-cli/pixi.lock"),
-}];
+        binaries: &["anaconda"],
+    },
+];
 
 fn find_tool(name: &str) -> Option<&'static Tool> {
     TOOLS.iter().find(|t| t.name == name)
@@ -29,6 +32,11 @@ pub fn content(name: &str) -> Option<String> {
     } else {
         find_tool(name).map(|t| t.lockfile.to_string())
     }
+}
+
+/// Returns the binaries to symlink for a tool.
+pub fn binaries(name: &str) -> Option<&'static [&'static str]> {
+    find_tool(name).map(|t| t.binaries)
 }
 
 #[cfg(test)]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,0 +1,1 @@
+pub mod lockfiles;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,1 +1,2 @@
+pub mod install;
 pub mod lockfiles;


### PR DESCRIPTION
## Summary

This is a POC, heavily inspired by the approach used in https://github.com/jezdez/conda-express, to bootstrap a standalone environment containing the Anaconda CLI (implemented in Python). In order to do this, we statically embed a cross-platform lockfile and install using `rattler`. When the user runs the bootstrap command, they get our CLI packages, plus a Python runtime, isolated from all other system conda/python environments.

At this point, we are doing this for a few reasons:

* To better understand the underlying technology to understand edges and learn
* To prototype a method for rapidly shipping existing CLI functionality, all bootstrapped from `ana`, without having to do a full rewrite
* As a foundation for a **possible** general mechanism for tool installation

### How it works

* Adds a new subcommand `ana bootstrap`, which invokes the bootstrapping process
* There is a step included as well to do this in the `install.sh` script, after the `ana` binary is installed
* We store a rattler v6 lockfile, which is statically compiled into `ana` at build time. This could be extended in the future to fetch a package spec from a service for things like custom tools, etc.
* We use `rattler` to install a new environment inside `~/.ana/tools/anaconda-cli`
* We symlink the binary into `~/.ana/bin`. This is configurable per-tool, in cases where multiple entrypoints might need to be exposed (inside `lockfiles.rs`)
* The `~/.ana/bin` directory is also put onto `PATH` inside the `install.sh` script
* Adds a simple `ana org ...` wrapper, which runs `anaconda org ...` in a subprocess. This is just to demonstrate what a subprocess-level wrapper might look like

### Some design details

* The lockfile is configured specifically to use https://repo.anaconda.com (as opposed to conda-forge). We add `anaconda-cloud` channel on anaconda.org just because some of the packages are not in main yet
* One reason to pursue this approach is we can configure where the packages for the tool environments come from. In the future, with some backend services, we can potentially make this dynamic based on user/customer preferences
* We don't do any channel configuration yet

The binary size is now 15MB, compared to ~10MB of the current `main` branch build. Primary size increase is the one time addition of the rattler crates. Preliminary testing shows addition of more lockfiles has negligible effect on the binary size.

### Benchmarking

Preliminary benchmarking shows the bootstrapping process completing in <2s, with a cleared rattler cache: 
<img width="815" height="226" alt="image" src="https://github.com/user-attachments/assets/3ef21e72-b0d2-4c7b-9bd7-3a8426ad72a1" />

### Known issues

* On macOS, the first execution of `anaconda` is very slow. This is due to a combination of byte-compiling the Python code, but also most likely due to the Gatekeeper security feature of macOS, because it considers the entire folder as something that needs to be scanned.
* This does not (yet) do any shell activation, to the same extent that `pixi run` and `pixi shell` do. For `anaconda` CLI packages this should be fine, but this needs to be solved more generically if we decide to extend this feature more generally.

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-377](https://anaconda.atlassian.net/browse/CLI-377)


[CLI-377]: https://anaconda.atlassian.net/browse/CLI-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ