### PR TITLE
ci: Improve release and prerelease handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,13 +172,6 @@ jobs:
             # Publish as full release (remove draft/prerelease flags, mark as latest)
             echo "Publishing release $VERSION"
             gh release edit "$VERSION" --draft=false --prerelease=false --latest
-          else
-            echo "Creating new release $VERSION"
-            gh release create "$VERSION" \
-              --title "$VERSION" \
-              --generate-notes \
-              --latest \
-              release-assets/*
           fi
 
           # Update the 'latest' release to point to this version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,14 +169,15 @@ jobs:
             echo "Uploading assets to existing release $VERSION"
             gh release upload "$VERSION" release-assets/* --clobber
 
-            # Publish as full release (remove draft/prerelease flags)
+            # Publish as full release (remove draft/prerelease flags, mark as latest)
             echo "Publishing release $VERSION"
-            gh release edit "$VERSION" --draft=false --prerelease=false
+            gh release edit "$VERSION" --draft=false --prerelease=false --latest
           else
             echo "Creating new release $VERSION"
             gh release create "$VERSION" \
               --title "$VERSION" \
               --generate-notes \
+              --latest \
               release-assets/*
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,8 +124,40 @@ jobs:
             sha256sum "$file" > "${file}.sha256"
           done
 
-      # For releases: upload artifacts to existing draft release and publish it
-      - name: Publish release with artifacts
+      # For prereleases (main branch pushes): create automatic prerelease
+      - name: Create automatic prerelease
+        if: needs.release-info.outputs.is_release == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-info.outputs.version }}"
+
+          # Delete existing prerelease if it exists (prereleases are recreated each time)
+          if gh release view "$VERSION" &>/dev/null; then
+            gh release delete "$VERSION" --yes
+            git push origin ":refs/tags/$VERSION" 2>/dev/null || true
+          fi
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --prerelease \
+            --generate-notes \
+            release-assets/*
+
+          # Append footer to release notes
+          CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
+          NOTES=$(cat <<EOF
+          ${CURRENT_BODY}
+
+          ---
+          *Automated prerelease from main branch.*
+          EOF
+          )
+
+          gh release edit "$VERSION" --notes "$NOTES"
+
+      # For releases: upload artifacts to existing draft release, publish it, and update latest
+      - name: Publish release
         if: needs.release-info.outputs.is_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -151,33 +183,21 @@ jobs:
               release-assets/*
           fi
 
-      # For prereleases (main branch pushes): create automatic prerelease
-      - name: Create automatic prerelease
-        if: needs.release-info.outputs.is_release == 'false'
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          tag_name: ${{ needs.release-info.outputs.version }}
-          name: ${{ needs.release-info.outputs.version }}
-          prerelease: true
-          generate_release_notes: true
-          files: release-assets/*
-          append_body: true
-          body: |
-            ---
-            *Automated prerelease from main branch.*
+          # Update the 'latest' release to point to this version
+          if gh release view latest &>/dev/null; then
+            gh release delete latest --yes
+            git push origin :refs/tags/latest 2>/dev/null || true
+          fi
 
-      - name: Update latest release
-        if: needs.release-info.outputs.is_release == 'true'
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          tag_name: latest
-          name: Latest Release
-          # TODO(mattkram): Do we want it marked as a real release?
-          # Or use prerelease to "hide" it.
-          prerelease: true
-          make_latest: false
-          files: release-assets/*
-          body: |
-            This release always points to the most recent build.
+          NOTES=$(cat <<EOF
+          This release always points to the most recent build.
 
-            **Version:** ${{ needs.release-info.outputs.version }}
+          **Version:** ${VERSION}
+          EOF
+          )
+
+          gh release create latest \
+            --title "Latest Release" \
+            --prerelease \
+            --notes "$NOTES" \
+            release-assets/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,17 +164,14 @@ jobs:
         run: |
           VERSION="${{ needs.release-info.outputs.version }}"
 
-          # Check if release exists (draft or published)
+          # Check if release exists (draft, prerelease, or published)
           if gh release view "$VERSION" &>/dev/null; then
             echo "Uploading assets to existing release $VERSION"
             gh release upload "$VERSION" release-assets/* --clobber
 
-            # If it's a draft, publish it now
-            DRAFT_STATUS=$(gh release view "$VERSION" --json isDraft -q '.isDraft')
-            if [[ "$DRAFT_STATUS" == "true" ]]; then
-              echo "Publishing draft release $VERSION"
-              gh release edit "$VERSION" --draft=false
-            fi
+            # Publish as full release (remove draft/prerelease flags)
+            echo "Publishing release $VERSION"
+            gh release edit "$VERSION" --draft=false --prerelease=false
           else
             echo "Creating new release $VERSION"
             gh release create "$VERSION" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,8 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   ci:
@@ -18,10 +17,41 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
 
+  # Determine release info early so other jobs can use it
+  release-info:
+    name: Get Release Info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      is_release: ${{ steps.info.outputs.is_release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+        with:
+          pixi-version: v0.66.0
+
+      - name: Get release info
+        id: info
+        run: |
+          # is_release=true for manual version tags, false for main branch pushes (prereleases)
+          if [[ "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            VERSION=$(pixi run python scripts/with_version.py)
+            echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-to-anaconda-dot-org:
     name: Publish to Anaconda.org
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ci, release-info]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,8 +74,8 @@ jobs:
         env:
           TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
         run: |
-          # Default to dev label, use main only for full releases (not prereleases)
-          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" != "true" ]]; then
+          # Use main label for releases, dev label for prereleases
+          if [[ "${{ needs.release-info.outputs.is_release }}" == "true" ]]; then
             export LABEL="main"
           else
             export LABEL="dev"
@@ -65,7 +95,7 @@ jobs:
   create-github-release:
     name: Upload Binaries to GitHub Release
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ci, release-info]
     permissions:
       contents: write
     steps:
@@ -73,23 +103,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
-        with:
-          pixi-version: v0.66.0
-
-      - name: Get version
-        id: version
-        run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
-          else
-            VERSION=$(pixi run python scripts/with_version.py)
-            echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Download binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -111,19 +124,40 @@ jobs:
             sha256sum "$file" > "${file}.sha256"
           done
 
-      - name: Upload artifacts to manually tagged release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          files: release-assets/*
+      # For releases: upload artifacts to existing draft release and publish it
+      - name: Publish release with artifacts
+        if: needs.release-info.outputs.is_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-info.outputs.version }}"
 
+          # Check if release exists (draft or published)
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "Uploading assets to existing release $VERSION"
+            gh release upload "$VERSION" release-assets/* --clobber
+
+            # If it's a draft, publish it now
+            DRAFT_STATUS=$(gh release view "$VERSION" --json isDraft -q '.isDraft')
+            if [[ "$DRAFT_STATUS" == "true" ]]; then
+              echo "Publishing draft release $VERSION"
+              gh release edit "$VERSION" --draft=false
+            fi
+          else
+            echo "Creating new release $VERSION"
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --generate-notes \
+              release-assets/*
+          fi
+
+      # For prereleases (main branch pushes): create automatic prerelease
       - name: Create automatic prerelease
-        if: github.event_name == 'push'
+        if: needs.release-info.outputs.is_release == 'false'
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ needs.release-info.outputs.version }}
+          name: ${{ needs.release-info.outputs.version }}
           prerelease: true
           generate_release_notes: true
           files: release-assets/*
@@ -133,7 +167,7 @@ jobs:
             *Automated prerelease from main branch.*
 
       - name: Update latest release
-        if: steps.version.outputs.prerelease != 'true'
+        if: needs.release-info.outputs.is_release == 'true'
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: latest
@@ -146,4 +180,4 @@ jobs:
           body: |
             This release always points to the most recent build.
 
-            **Version:** ${{ steps.version.outputs.version }}
+            **Version:** ${{ needs.release-info.outputs.version }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,76 @@
+# Releasing
+
+This document describes the process for creating releases of the `ana` CLI.
+
+## Overview
+
+Releases are automated via GitHub Actions. The workflow is triggered by pushing a version tag (e.g., `v1.2.3`) and handles:
+
+- Building binaries for all platforms (Linux, macOS, Windows)
+- Generating checksums
+- Uploading binaries to the GitHub release
+- Publishing conda packages to Anaconda.org
+- Updating the `latest` release pointer
+
+## Creating a Release
+
+### 1. Create a Prerelease on GitHub
+
+1. Go to [Releases](https://github.com/anaconda/ana-cli/releases) and click **Draft a new release**
+2. Click **Choose a tag** and type your new version (e.g., `v1.2.3`)
+3. Select **Create new tag: v1.2.3 on publish**
+4. Write your release notes
+5. Check **Set as a pre-release**
+6. Click **Publish release**
+
+> [!IMPORTANT]
+> You must publish as a **prerelease** (not draft) to create the tag and trigger the workflow. The workflow will automatically convert it to a full release after uploading artifacts.
+
+### 2. Wait for the Workflow
+
+The release workflow will:
+
+1. Run CI builds (~20 minutes)
+2. Upload binaries and checksums to your release
+3. Convert the prerelease to a full release
+4. Update the `latest` release to point to this version
+5. Publish conda packages to Anaconda.org with the `main` label
+
+You can monitor progress at [Actions](https://github.com/anaconda/ana-cli/actions/workflows/release.yaml).
+
+### 3. Verify the Release
+
+Once the workflow completes:
+
+- Check that all 6 assets are attached (3 binaries + 3 checksums)
+- Verify the release is no longer marked as a prerelease
+- Confirm the `latest` release points to the new version
+
+## Version Format
+
+Tags must follow semantic versioning with a `v` prefix:
+
+- `v1.0.0` - stable release
+- `v1.0.0-alpha.1` - prerelease/alpha
+- `v1.0.0-rc.1` - release candidate
+
+## Automatic Prereleases
+
+Every push to `main` automatically creates a prerelease with a dev version (e.g., `v0.0.4.dev1`). These are published to Anaconda.org with the `dev` label.
+
+## Troubleshooting
+
+### Release stuck as prerelease
+
+If the workflow fails after creating the release but before converting it:
+
+```bash
+gh release edit v1.2.3 --prerelease=false
+```
+
+### Need to re-run the workflow
+
+If artifacts weren't uploaded correctly:
+
+1. Delete the release assets (not the release itself)
+2. Re-run the failed workflow job from the Actions tab


### PR DESCRIPTION
## Summary

There have been some issues with the release automation for manual releases the last two times. This PR refactors the release workflow logic for a more explicit differentiation between automated pre-releases, and manual "real" releases, which are intended to mimic future release process.

Specifically, we:

* Extract the version and release/pre-release logic into a shared step for consistency
* Remove the external GitHub actions dependency
* Replace that with explicit in-line scripts that leverage the `gh` CLI directly

Since these activities are small and relatively simple, the inline scripts are more clean and easy to understand, especially for such a critical workflow.

### New behavior

When we want to issue a prerelease:

* Triggered by pushes to `main` branch
* Still push conda package to anaconda.org channel with `dev` label
* We automatically generate a GitHub pre-release, with automated release notes generated

When we want to issue a release:

* Triggered by push of a semver tag: `v0.0.4` etc.
* Tag would be manually created by making a release via GitHub
* Pushes conda package to `main` label
* After build, push artifacts to the release and mark it as not a "prerelease"
* Similarly, we re-create the "latest" release with the artifacts and a generated reference to the semver-tagged release. This is for update tracking and installation.