### PR TITLE
ci: Split build into parallel jobs to improve performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ on:
   workflow_call:
 
 jobs:
-  build:
-    name: Build (${{ matrix.os }})
+  build-and-test:
+    name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,17 +40,6 @@ jobs:
         run: |
           pixi run test-integration
 
-      - name: Build as conda package
-        run: |
-          pixi run build-conda
-
-      - name: Upload conda package
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: conda-package-${{ matrix.os }}
-          path: output/
-          retention-days: 7
-
       - name: Upload binary
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -58,10 +47,43 @@ jobs:
           path: target/release/ana${{ matrix.os == 'windows-latest' && '.exe' || '' }}
           retention-days: 7
 
+  build-conda:
+    name: Build Conda (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git for private repos
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+        with:
+          pixi-version: v0.66.0
+
+      - name: Build as conda package
+        run: |
+          pixi run build-conda
+
+      - name: Upload conda package
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: conda-${{ matrix.os }}
+          path: output/
+          retention-days: 7
+
   check:
     name: Check
     if: always()
-    needs: [build]
+    needs: [build-and-test, build-conda]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether all jobs succeeded


### PR DESCRIPTION
## Summary

The builds are taking a while, especially on Windows. 

This PR splits the `build` job into two parallel jobs:

* `build-and-test`: Build and test the standalone binary
* `build-conda`: Build the conda package

We still aggregate them all together as artifacts for use by the release workflow, and also run each job across all three target platforms.

This should cut our CI time roughly in half (15-20 mins -> 6-7 mins), assuming we don't wait for workers longer.