### PR TITLE
ci: Ensure local 'latest' tag is deleted before creating 'latest' release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -176,6 +176,7 @@ jobs:
 
           # Update the 'latest' release to point to this version
           if gh release view latest &>/dev/null; then
+            echo "Removing existing 'latest' release, for replacement"
             gh release delete latest --yes
             git push origin :refs/tags/latest 2>/dev/null || true
           fi
@@ -190,6 +191,7 @@ jobs:
           EOF
           )
 
+          echo "Publishing release 'latest'"
           gh release create latest \
             --title "Latest Release" \
             --prerelease \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,9 @@ jobs:
             git push origin :refs/tags/latest 2>/dev/null || true
           fi
 
+          # Delete local tag if it exists (from fetch-depth: 0)
+          git tag -d latest 2>/dev/null || true
+
           NOTES=$(cat <<EOF
           This release always points to the most recent build.
 


### PR DESCRIPTION
## Summary

If the `latest` tag already exists, then we need to make sure it is deleted from the local clone before we re-create it with each subsequent re-generation of it.

This should resolve the failure that occurred in [this workflow](https://github.com/anaconda/ana-cli/actions/runs/23914944036).
