### PR TITLE
fix: Suppress telemetry logs to fail silently

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,9 +12,11 @@ use crate::config::{self, Config};
 use crate::update;
 
 pub fn execute() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    // Suppress telemetry logs by default to avoid leaking errors when telemetry fails
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::new("anaconda_otel_rs=off,opentelemetry=off,reqwest=off")
+    });
+    tracing_subscriber::fmt().with_env_filter(filter).init();
 
     config::setup_telemetry();
 


### PR DESCRIPTION
## Summary
- Suppress logs from `anaconda_otel_rs`, `opentelemetry`, and `reqwest` crates by default
- Telemetry errors now fail silently without leaking logs to users
- Users can still enable debug logs by setting `RUST_LOG` explicitly

## Test plan
- [ ] Run `ana` commands without telemetry configured and verify no error logs appear
- [ ] Verify `RUST_LOG=debug ana config` still shows debug logs when explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)