### PR TITLE
feat: Add new local hook to format rust code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: cargo fmt --
+        language: system
+        types: [rust]
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help debug test test-integration
+.PHONY: help debug pre-commit test test-integration
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
 
 debug:  ## Build the debug binary
 	pixi run build-debug
+
+pre-commit:  ## Run pre-commit hooks on all files
+	pixi run pre-commit
 
 test:  ## Run all the unit tests
 	pixi run test

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@ fn main() {
     // Version is passed via PKG_VERSION environment variable.
     // This should be set by CI or locally via: PKG_VERSION=$(python scripts/get_version.py)
     // Falls back to CARGO_PKG_VERSION if not set.
-    let version = std::env::var("PKG_VERSION")
-        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    let version =
+        std::env::var("PKG_VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
 
     println!("cargo:rustc-env=PKG_VERSION={}", version);
 }

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -260,9 +260,18 @@ mod tests {
         save_api_key(&config_c, "key-for-c").unwrap();
 
         // Each config should only return its own key
-        assert_eq!(get_api_key(&config_a).unwrap(), Some("key-for-a".to_string()));
-        assert_eq!(get_api_key(&config_b).unwrap(), Some("key-for-b".to_string()));
-        assert_eq!(get_api_key(&config_c).unwrap(), Some("key-for-c".to_string()));
+        assert_eq!(
+            get_api_key(&config_a).unwrap(),
+            Some("key-for-a".to_string())
+        );
+        assert_eq!(
+            get_api_key(&config_b).unwrap(),
+            Some("key-for-b".to_string())
+        );
+        assert_eq!(
+            get_api_key(&config_c).unwrap(),
+            Some("key-for-c".to_string())
+        );
 
         // A domain with no key should return None
         let config_unknown = test_config_with_keyring(keyring_path.clone(), "unknown.com");

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,8 +141,7 @@ impl Config {
             .map(PathBuf::from)
             .unwrap_or_else(|_| default_keyring_path());
         let use_https = parse_bool_env("ANA_USE_HTTPS", DEFAULT_USE_HTTPS);
-        let include_prereleases =
-            parse_bool_env("ANA_PRERELEASES", DEFAULT_INCLUDE_PRERELEASES);
+        let include_prereleases = parse_bool_env("ANA_PRERELEASES", DEFAULT_INCLUDE_PRERELEASES);
 
         Self {
             domain,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -42,7 +42,6 @@ pub fn tool_prefix(name: &str) -> PathBuf {
     tools_dir().join(name)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -12,8 +12,8 @@ use rattler::{
 use rattler_conda_types::{Platform, PrefixRecord};
 use rattler_lock::LockFile;
 
-use crate::paths;
 use super::lockfiles;
+use crate::paths;
 
 /// Global progress bar for installation feedback.
 static MULTI_PROGRESS: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock::new(|| {
@@ -26,8 +26,8 @@ static MULTI_PROGRESS: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock:
 pub async fn install_tool(name: &str) -> miette::Result<()> {
     let prefix = paths::tool_prefix(name);
 
-    let lock_content = lockfiles::content(name)
-        .ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
+    let lock_content =
+        lockfiles::content(name).ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
 
     let binaries = lockfiles::binaries(name).unwrap_or(&[]);
 

--- a/src/tools/lockfiles.rs
+++ b/src/tools/lockfiles.rs
@@ -13,9 +13,8 @@ struct Tool {
 const TOOLS: &[Tool] = &[Tool {
     name: "anaconda-cli",
     lockfile: include_str!("../../lockfiles/anaconda-cli/pixi.lock"),
-        binaries: &["anaconda"],
-    },
-];
+    binaries: &["anaconda"],
+}];
 
 fn find_tool(name: &str) -> Option<&'static Tool> {
     TOOLS.iter().find(|t| t.name == name)

--- a/src/update.rs
+++ b/src/update.rs
@@ -232,7 +232,10 @@ pub fn apply_update(release: &Release) -> Result<(), Error> {
 pub fn check_for_update(current_version: &str) {
     match check_update(current_version) {
         Ok(UpdateCheck::Available(release)) => {
-            println!("Update available: {} -> {}", current_version, release.tag_name);
+            println!(
+                "Update available: {} -> {}",
+                current_version, release.tag_name
+            );
         }
         Ok(UpdateCheck::AlreadyUpToDate) => {
             println!("Already up to date ({})", current_version);
@@ -265,7 +268,10 @@ pub fn run_update(current_version: &str, force: bool) {
                 }
             }
             match apply_update(&release) {
-                Ok(()) => println!("Updated successfully: {} -> {}", current_version, release.tag_name),
+                Ok(()) => println!(
+                    "Updated successfully: {} -> {}",
+                    current_version, release.tag_name
+                ),
                 Err(e) => eprintln!("Failed to update: {}", e),
             }
         }
@@ -383,7 +389,9 @@ mod tests {
             make_release("v0.0.2.dev1", true),
         ];
         let result = find_update(releases, "0.0.1").unwrap();
-        assert!(matches!(result, UpdateCheck::Available(release) if release.tag_name == "v0.0.2.dev1"));
+        assert!(
+            matches!(result, UpdateCheck::Available(release) if release.tag_name == "v0.0.2.dev1")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new pre-commit hook to automatically format Rust code. This just runs as a local hook, which means developers just need to have `pixi` installed, which in turn will manage the `cargo` version etc.