### PR TITLE
feat: Add lockfile updates to the pre-commit job

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,6 +33,10 @@ jobs:
         with:
           token: ${{ secrets.ANACONDA_BOT_TOKEN }}
 
+      - name: Configure git for private repos
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
@@ -43,31 +47,41 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ runner.arch }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Run pre-commit
+      - name: Run pre-commit and locks
+        id: updates
         run: |
-          pixi run pre-commit
-
-      ############################
-      # Checkout + commit + push when the previous pre-commit run step failed, as that indicates
-      # auto-fixes / formatting updates, but not outside pull-requests to avoid pushing commits without
-      # review to the main branch and also not for draft PRs to avoid pushing commits while the PR is
-      # still being worked on.
-      # Don't run pre-commit a second time after the commit, as that would mark the commit which triggered
-      # the workflow as green, which technically is not correct. A succeeding workflow run after commit + push
-      # will mark the PR as green, if everything is fine.
+          echo "::group::Rebuilding lockfiles and running pre-commit"
+          pixi lock
+          pixi run cargo-lock
+          pixi run pre-commit || :
+          echo "::endgroup::"
+          echo ""
+          if git status --porcelain | grep .; then
+            echo "::error::Changes detected:"
+            if git status --porcelain | grep Cargo.lock; then echo "- Cargo.lock"; fi
+            if git status --porcelain | grep pixi.lock; then echo "- pixi.lock"; fi
+            if git status --porcelain | grep -vE "(Cargo|pixi).lock"; then echo "- Pre-commit updates"; fi
+            echo "changed=1" >>$GITHUB_OUTPUT
+          else
+            echo "No changes detected!"
+          fi
 
       - name: Checkout the branch we're running on to enable a commit to it
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: steps.updates.outputs.changed == 1
         run: |
           git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
 
       - name: Commit linted files
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: steps.updates.outputs.changed == 1
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           message: 'chore(pre-commit): Linting'
           author_name: Anaconda Bot
           author_email: devops+anaconda-bot@anaconda.com
 
-      ############################
+      - name: Fail if changes occurred
+        if: steps.updates.outputs.changed == 1
+        run: |
+          echo "::error::Changes were committed. A new CI run will start."
+          exit 1

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,6 +16,10 @@ anaconda-client = ">=1.14.1,<2"
 cmd = "pre-commit run --verbose --show-diff-on-failure --color=always --all-files"
 description = "Run pre-commit hooks on all files"
 
+[tasks.cargo-lock]
+cmd = "cargo generate-lockfile"
+description = "Re-generate Cargo lockfile"
+
 [tasks.build-conda]
 cmd = "python scripts/with_version.py rattler-build build --recipe conda.recipe"
 description = "Build the conda package"

--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,8 @@
   ],
   "extends": [
     "local>anaconda/renovate-config"
+  ],
+  "gitIgnoredAuthors": [
+    "devops+anaconda-bot@anaconda.com"
   ]
 }


### PR DESCRIPTION
Here is a PR that I don't think will require as much thoughtful conversation :-) I noticed the building up renovate PRs, and in my experience, one problem with them is that they don't play nicely with pre-commit hooks, and they often fail to propagate package version updates to lockfiles properly. So this PR does two things:

- It adds Cargo.lock and pixi.lock regen to the same task that runs the pre-commit hooks
- Instructs renovate not to care if [devops+anaconda-bot@anaconda.com](mailto:devops+anaconda-bot@anaconda.com) adds a commit to their open PRs.

Hopefully with this fix in place it will be easier for y'all to accommodate the flood of renovate requests. Of course, in those cases where a renovate change breaks legitimate tests... well, that remains a manual issue.
