### PR TITLE
feat: Add Sentry integration under optional compile-time flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
   merge_group:
   workflow_call:
+    secrets:
+      PRIVATE_REPO_TOKEN:
+        description: Token for accessing private repositories
+        required: true
+      SENTRY_DSN:
+        description: Sentry DSN for error reporting (only for release builds)
+        required: false
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
           pixi run test
 
       - name: Build as standalone binary
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run build-release
 
@@ -70,6 +72,8 @@ jobs:
           pixi-version: v0.66.0
 
       - name: Build as conda package
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run build-conda
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,9 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yaml
-    secrets: inherit
+    secrets:
+      PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
   # Determine release info early so other jobs can use it
   release-info:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "reqwest-middleware",
  "self-replace",
  "semver",
+ "sentry",
  "serde",
  "serde_json",
  "temp-env",
@@ -349,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -682,6 +692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +741,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -846,6 +876,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "flate2"
@@ -1230,6 +1272,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1928,6 +1976,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +2065,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2106,6 +2288,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2310,7 +2508,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2400,11 +2598,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2421,12 +2630,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3163,6 +3391,114 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sentry"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016958f51b96861dead7c1e02290f138411d05e94fad175c8636a835dee6e51e"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57712c24e99252ef175b4b06c485294f10ad6bc5b5e1567ff3803ee7a0b7d3f"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba8754ec3b9279e00aa6d64916f211d44202370a1699afde1db2c16cbada089"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8b6dcd4fbae1e3e22b447f32670360b27e31b62ab040f7fb04e0f80c04d92"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8982a69133d3f5e4efdbfa0776937fca43c3a2e275a8fe184f50b1b0aa92e07c"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de296dae6f01e931b65071ee5fe28d66a27909857f744018f107ed15fd1f6b25"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f73c757ed7915d3e1e34625eae18cad498a95b4261603d4ce3f87b159a6f0"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ed3a389948a6a6d92b98e997a2723ca22f09660c5a7b7388ecd509a70a527"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -3946,6 +4282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,6 +4372,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,7 +4422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
  "rand 0.10.0",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2024"
 libc = "0.2"
 
 [features]
-default = []
+# TODO(mattkram): For the early project phase, we will enable diagnostics in our builds by
+#                 default. We will review this behavior before public release.
+default = ["diagnostics"]
 diagnostics = ["sentry"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2024"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[features]
+default = []
+diagnostics = ["sentry"]
+
 [dependencies]
 base64 = "0.22"
 futures-util = "0.3"
@@ -23,6 +27,7 @@ rattler_lock = { version = "0.27", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = "0.4"
 self-replace = "1.5"
+sentry = { version = "0.35", optional = true }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,21 @@
 fn main() {
-    // Re-run build.rs if PKG_VERSION changes
+    // Re-run build.rs if these env vars change
     println!("cargo:rerun-if-env-changed=PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
 
     // Version is passed via PKG_VERSION environment variable.
     // This should be set by CI or locally via: PKG_VERSION=$(python scripts/get_version.py)
     // Falls back to CARGO_PKG_VERSION if not set.
     let version =
         std::env::var("PKG_VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
-
     println!("cargo:rustc-env=PKG_VERSION={}", version);
+
+    // Sentry DSN is injected at build time. If not set, defaults to empty string
+    // which will disable Sentry at runtime.
+    let sentry_dsn = std::env::var("SENTRY_DSN").unwrap_or_default();
+    println!("cargo:rustc-env=SENTRY_DSN={}", sentry_dsn);
+
+    // Expose build target info for Sentry tags
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BUILD_TARGET={}", target);
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,55 @@
+//! Diagnostics and error reporting via Sentry.
+//!
+//! This module is conditionally compiled based on the `diagnostics` feature flag.
+//! When enabled, it initializes Sentry for error tracking. When disabled, all
+//! functions become no-ops.
+
+#[cfg(feature = "diagnostics")]
+mod inner {
+    use crate::VERSION;
+
+    const SENTRY_DSN: &str = env!("SENTRY_DSN");
+    const BUILD_TARGET: &str = env!("BUILD_TARGET");
+
+    /// Guard that must be held for the lifetime of the program.
+    pub type Guard = sentry::ClientInitGuard;
+
+    /// Initialize the diagnostics system.
+    ///
+    /// Returns a guard that must be held for the lifetime of the program.
+    /// The DSN is injected at build time; an empty string disables Sentry.
+    pub fn init() -> Guard {
+        let guard = sentry::init((
+            SENTRY_DSN,
+            sentry::ClientOptions {
+                release: Some(VERSION.into()),
+                environment: Some(
+                    std::env::var("ANA_ENV")
+                        .unwrap_or_else(|_| "production".to_string())
+                        .into(),
+                ),
+                send_default_pii: false,
+                attach_stacktrace: true,
+                ..Default::default()
+            },
+        ));
+
+        sentry::configure_scope(|scope| {
+            scope.set_tag("os", std::env::consts::OS);
+            scope.set_tag("arch", std::env::consts::ARCH);
+            scope.set_tag("target", BUILD_TARGET);
+        });
+
+        guard
+    }
+}
+
+#[cfg(not(feature = "diagnostics"))]
+mod inner {
+    /// Guard is a no-op when diagnostics is disabled.
+    pub type Guard = ();
+
+    pub fn init() -> Guard {}
+}
+
+pub use inner::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,26 @@ mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 
+#[cfg(feature = "diagnostics")]
+const SENTRY_DSN: &str = "https://c3c5f0c3bc1590e4a439af529d0bec39@o4506633492365312.ingest.us.sentry.io/4511137151385600";
+
 #[tokio::main]
 async fn main() {
+    // Initialize Sentry - guard must be held for the lifetime of the program
+    #[cfg(feature = "diagnostics")]
+    let _sentry_guard = sentry::init((
+        SENTRY_DSN,
+        sentry::ClientOptions {
+            release: Some(VERSION.into()),
+            environment: Some(
+                std::env::var("ANA_ENV")
+                    .unwrap_or_else(|_| "production".to_string())
+                    .into(),
+            ),
+            ..Default::default()
+        },
+    ));
+
     cli::execute().await;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,12 @@ mod update;
 pub const VERSION: &str = env!("PKG_VERSION");
 
 #[cfg(feature = "diagnostics")]
-const SENTRY_DSN: &str = "https://c3c5f0c3bc1590e4a439af529d0bec39@o4506633492365312.ingest.us.sentry.io/4511137151385600";
+const SENTRY_DSN: &str = env!("SENTRY_DSN");
 
 #[tokio::main]
 async fn main() {
     // Initialize Sentry - guard must be held for the lifetime of the program
+    // DSN is injected at build time; empty string disables Sentry
     #[cfg(feature = "diagnostics")]
     let _sentry_guard = sentry::init((
         SENTRY_DSN,
@@ -26,6 +27,8 @@ async fn main() {
                     .unwrap_or_else(|_| "production".to_string())
                     .into(),
             ),
+            send_default_pii: false,
+            attach_stacktrace: true,
             ..Default::default()
         },
     ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ pub const VERSION: &str = env!("PKG_VERSION");
 
 #[cfg(feature = "diagnostics")]
 const SENTRY_DSN: &str = env!("SENTRY_DSN");
+#[cfg(feature = "diagnostics")]
+const BUILD_TARGET: &str = env!("BUILD_TARGET");
 
 #[tokio::main]
 async fn main() {
@@ -32,6 +34,13 @@ async fn main() {
             ..Default::default()
         },
     ));
+
+    #[cfg(feature = "diagnostics")]
+    sentry::configure_scope(|scope| {
+        scope.set_tag("os", std::env::consts::OS);
+        scope.set_tag("arch", std::env::consts::ARCH);
+        scope.set_tag("target", BUILD_TARGET);
+    });
 
     cli::execute().await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod anaconda_cli;
 mod auth;
 mod cli;
 mod config;
+mod diagnostics;
 mod input;
 mod paths;
 mod qr;
@@ -10,38 +11,9 @@ mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 
-#[cfg(feature = "diagnostics")]
-const SENTRY_DSN: &str = env!("SENTRY_DSN");
-#[cfg(feature = "diagnostics")]
-const BUILD_TARGET: &str = env!("BUILD_TARGET");
-
 #[tokio::main]
 async fn main() {
-    // Initialize Sentry - guard must be held for the lifetime of the program
-    // DSN is injected at build time; empty string disables Sentry
-    #[cfg(feature = "diagnostics")]
-    let _sentry_guard = sentry::init((
-        SENTRY_DSN,
-        sentry::ClientOptions {
-            release: Some(VERSION.into()),
-            environment: Some(
-                std::env::var("ANA_ENV")
-                    .unwrap_or_else(|_| "production".to_string())
-                    .into(),
-            ),
-            send_default_pii: false,
-            attach_stacktrace: true,
-            ..Default::default()
-        },
-    ));
-
-    #[cfg(feature = "diagnostics")]
-    sentry::configure_scope(|scope| {
-        scope.set_tag("os", std::env::consts::OS);
-        scope.set_tag("arch", std::env::consts::ARCH);
-        scope.set_tag("target", BUILD_TARGET);
-    });
-
+    let _diagnostics_guard = diagnostics::init();
     cli::execute().await;
 }
 


### PR DESCRIPTION
## Summary

Adds Sentry integration, for monitoring of errors and panics. The integration is guarded by a compile-time feature flag called `diagnostics`. Currently, this is enabled by default. However, care is taken to make the behavior conditional, with the expectation that we may want to have builds without Sentry integration in the future for some users.

- Enable the `diagnostics` feature flag by default (Sentry error tracking)
- Inject `SENTRY_DSN` at build time via environment variable, allowing different DSNs per build environment
- Add build target tags (os, arch, target triple) to Sentry events for filtering
- Update CI workflow to pass `SENTRY_DSN` secret to build steps

## Details

The Sentry DSN is injected at build time rather than hardcoded. When `SENTRY_DSN` is not set (e.g., local dev or PR builds), it defaults to an empty string which disables Sentry at runtime.

Release builds will have Sentry enabled via the `SENTRY_DSN` repository secret passed through `secrets: inherit`.

**Sentry configuration:**
- `send_default_pii: false` - no usernames, IPs, etc.
- `attach_stacktrace: true` - stack traces for all events
- Tags: `os`, `arch`, `target` (build triple)
- Environment: controlled by `ANA_ENV` env var (defaults to "production")

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-365](https://anaconda.atlassian.net/browse/CLI-365)


[CLI-365]: https://anaconda.atlassian.net/browse/CLI-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ