### PR TITLE
feat: Add CycloneDX SBOM generation with cargo-audit integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,42 +97,6 @@ jobs:
           path: target/release/ana${{ matrix.os == 'windows-latest' && '.exe' || '' }}
           retention-days: 7
 
-  build-conda:
-    name: Build Conda (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    env:
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Configure git for private repos
-        run: |
-          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
-        with:
-          pixi-version: v0.66.0
-
-      - name: Build as conda package
-        run: |
-          pixi run build-conda
-
-      - name: Upload conda package
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: conda-${{ matrix.os }}
-          path: output/
-          retention-days: 7
-
-
   check:
     name: Check
     if: always()

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -66,7 +66,7 @@ jobs:
 
           git config user.name "Anaconda Bot"
           git config user.email "devops+anaconda-bot@anaconda.com"
-          git add -A
+          git add -u
           git commit -m "chore(pre-commit): Linting"
           git push
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -53,38 +53,22 @@ jobs:
       - name: Run pre-commit and locks
         id: updates
         run: |
-          echo "::group::Rebuilding lockfiles and running pre-commit"
-          pixi lock
-          pixi run cargo-lock
           pixi run pre-commit || :
-          echo "::endgroup::"
-          echo ""
-          if git status --porcelain | grep .; then
-            echo "::error::Changes detected:"
-            if git status --porcelain | grep Cargo.lock; then echo "- Cargo.lock"; fi
-            if git status --porcelain | grep pixi.lock; then echo "- pixi.lock"; fi
-            if git status --porcelain | grep -vE "(Cargo|pixi).lock"; then echo "- Pre-commit updates"; fi
+          if git status --porcelain | grep -q .; then
             echo "changed=1" >>$GITHUB_OUTPUT
-          else
-            echo "No changes detected!"
           fi
 
-      - name: Checkout the branch we're running on to enable a commit to it
+      - name: Commit and fail if changes occurred
         if: steps.updates.outputs.changed == 1
         run: |
           git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
 
-      - name: Commit linted files
-        if: steps.updates.outputs.changed == 1
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
-        with:
-          message: 'chore(pre-commit): Linting'
-          author_name: Anaconda Bot
-          author_email: devops+anaconda-bot@anaconda.com
+          git config user.name "Anaconda Bot"
+          git config user.email "devops+anaconda-bot@anaconda.com"
+          git add -A
+          git commit -m "chore(pre-commit): Linting"
+          git push
 
-      - name: Fail if changes occurred
-        if: steps.updates.outputs.changed == 1
-        run: |
           echo "::error::Changes were committed. A new CI run will start."
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,9 @@ bin/
 VERSION
 conda.recipe/variants.yaml
 
+# SBOM intermediate files
+*.cdx.json
+audit.raw.json
+
 # local dev config
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ conda.recipe/variants.yaml
 
 # SBOM intermediate files
 *.cdx.json
+ana-*.json
 audit.raw.json
 
 # local dev config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: pretty-format-json
         args: [--autofix]
+        exclude: ^SBOM\.json$
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
@@ -45,6 +46,12 @@ repos:
         language: system
         pass_filenames: false
         files: ^Cargo\.toml$
+      - id: sbom
+        name: SBOM freshness
+        entry: pixi run sbom
+        language: system
+        pass_filenames: false
+        files: ^Cargo\.(toml|lock)$
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         entry: pixi run sbom
         language: system
         pass_filenames: false
-        files: ^Cargo\.toml$
+        files: ^(Cargo\.(toml|lock)|scripts/(sbom-process\.py|update_lockfiles\.sh))$
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,18 +40,12 @@ repos:
         entry: cargo fmt --
         language: system
         types: [rust]
-      - id: cargo-lock
-        name: Cargo.lock freshness
-        entry: cargo generate-lockfile
-        language: system
-        pass_filenames: false
-        files: ^Cargo\.toml$
       - id: sbom
         name: SBOM freshness
         entry: pixi run sbom
         language: system
         pass_filenames: false
-        files: ^Cargo\.(toml|lock)$
+        files: ^Cargo\.toml$
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help version build debug release test test-release test-integration pre-commit conda cargo-lock lockfiles lockfiles-force
+.PHONY: help version build debug release test test-release test-integration pre-commit conda lockfiles lockfiles-force
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
@@ -28,9 +28,6 @@ pre-commit:  ## Run pre-commit hooks on all files
 
 conda:  ## Build the conda package
 	pixi run build-conda
-
-cargo-lock:  ## Regenerate Cargo lockfile
-	pixi run cargo-lock
 
 lockfiles:  ## Regenerate Cargo.lock (if needed) and update SBOM
 	pixi run lockfiles

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help version build debug release test test-release test-integration pre-commit conda lockfiles lockfiles-force
+.PHONY: help version build debug release test test-release test-integration pre-commit conda sbom sbom-force
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
@@ -29,8 +29,8 @@ pre-commit:  ## Run pre-commit hooks on all files
 conda:  ## Build the conda package
 	pixi run build-conda
 
-lockfiles:  ## Regenerate Cargo.lock (if needed) and update SBOM
-	pixi run lockfiles
+sbom:  ## Regenerate Cargo.lock (if needed) and update SBOM
+	pixi run sbom
 
-lockfiles-force:  ## Regenerate Cargo.lock and SBOM unconditionally
-	pixi run lockfiles-force
+sbom-force:  ## Regenerate Cargo.lock and SBOM unconditionally
+	pixi run sbom-force

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help version build debug release test test-release test-integration pre-commit conda sbom sbom-force
+.PHONY: help version build debug release test test-release test-integration pre-commit conda lockfiles sbom sbom-force
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
@@ -28,6 +28,9 @@ pre-commit:  ## Run pre-commit hooks on all files
 
 conda:  ## Build the conda package
 	pixi run build-conda
+
+lockfiles:  ## Regenerate embedded lockfiles
+	./lockfiles/lock-all.sh
 
 sbom:  ## Regenerate Cargo.lock (if needed) and update SBOM
 	pixi run sbom

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help version build debug release test test-release test-integration pre-commit conda cargo-lock lockfiles
+.PHONY: help version build debug release test test-release test-integration pre-commit conda cargo-lock lockfiles lockfiles-force
 
 help:  ## Display help on all Makefile targets
 	@@grep -h '^[a-zA-Z]' $(MAKEFILE_LIST) | awk -F ':.*?## ' 'NF==2 {printf "   %-20s%s\n", $$1, $$2}' | sort
@@ -31,3 +31,9 @@ conda:  ## Build the conda package
 
 cargo-lock:  ## Regenerate Cargo lockfile
 	pixi run cargo-lock
+
+lockfiles:  ## Regenerate Cargo.lock (if needed) and update SBOM
+	pixi run lockfiles
+
+lockfiles-force:  ## Regenerate Cargo.lock and SBOM unconditionally
+	pixi run lockfiles-force

--- a/SBOM.json
+++ b/SBOM.json
@@ -13,7 +13,7 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
       "name": "ana",
       "version": "0.0.0",
       "scope": "required",
@@ -21,7 +21,7 @@
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
+          "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0 bin-target-0",
           "name": "ana",
           "version": "0.0.0",
           "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
@@ -43,6 +43,238 @@
       "version": "0.1.0",
       "scope": "required",
       "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40f90811de7e83e34788694da50b3d3614b806d335"
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-codec",
+      "version": "0.5.2",
+      "description": "Codec utilities for working with framed protocols",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-codec@0.5.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-http",
+      "version": "3.12.0",
+      "description": "HTTP types and services for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f860ee6746d0c5b682147b2f7f8ef036d4f92fe518251a3a35ffa3650eafdf0e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-http@3.12.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-router",
+      "version": "0.5.4",
+      "description": "Resource path matching and router",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-router@0.5.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-rt",
+      "version": "2.11.0",
+      "description": "Tokio-based single-threaded async runtime for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-rt@2.11.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>",
+      "name": "actix-server",
+      "version": "2.6.0",
+      "description": "General purpose TCP server built for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-server@2.6.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net/tree/master/actix-server"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-service",
+      "version": "2.0.3",
+      "description": "Service trait and combinators for representing asynchronous request/response operations.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-service@2.0.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-utils",
+      "version": "3.0.1",
+      "description": "Various utilities used in the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-utils@3.0.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-web",
+      "version": "4.13.0",
+      "description": "Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-web@4.13.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
     },
     {
       "type": "library",
@@ -705,6 +937,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
+      "author": "RustCrypto Developers",
+      "name": "base64ct",
+      "version": "1.8.3",
+      "description": "Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of data-dependent branches/LUTs and thereby provides portable \"best effort\" constant-time operation and embedded-friendly no_std support ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/base64ct@1.8.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/base64ct"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/base64ct"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
       "author": "Ben Steadman <steadmanben1@gmail.com>",
       "name": "bisection",
@@ -988,6 +1255,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "bytestring",
+      "version": "1.5.0",
+      "description": "A UTF-8 encoded read-only string using `Bytes` as storage",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bytestring@1.5.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
       "name": "bzip2",
       "version": "0.6.1",
@@ -1017,6 +1315,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/trifectatechfoundation/bzip2-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
+      "author": "Tony Arcieri <bascule@gmail.com>",
+      "name": "cargo-lock",
+      "version": "11.0.1",
+      "description": "Self-contained Cargo.lock parser with optional dependency graph analysis",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/cargo-lock@11.0.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rustsec.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustsec/rustsec"
         }
       ]
     },
@@ -1472,6 +1801,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "author": "rutrum <dave@rutrum.net>",
+      "name": "convert_case",
+      "version": "0.10.0",
+      "description": "Convert strings into any case",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/convert_case@0.10.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rutrum/convert-case"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "author": "RustCrypto Developers",
       "name": "cpufeatures",
@@ -1833,6 +2189,72 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "debugid",
+      "version": "0.8.0",
+      "description": "Common reusable types for implementing the sentry.io protocol.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/debugid@0.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/debugid"
+        },
+        {
+          "type": "website",
+          "url": "https://sentry.io/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/rust-debugid"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+      "author": "RustCrypto Developers",
+      "name": "der",
+      "version": "0.8.0",
+      "description": "Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with full support for heapless `no_std`/`no_alloc` targets ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/der@0.8.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/der"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "author": "Jacob Pratt <jacob@jhpratt.dev>",
       "name": "deranged",
@@ -1855,6 +2277,68 @@
         {
           "type": "vcs",
           "url": "https://github.com/jhpratt/deranged"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more-impl",
+      "version": "2.1.1",
+      "description": "Internal implementation of `derive_more` crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more-impl@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more",
+      "version": "2.1.1",
+      "description": "Adds #[derive(x)] macros for more traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
         }
       ]
     },
@@ -2073,6 +2557,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+      "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
+      "name": "encoding_rs",
+      "version": "0.8.35",
+      "description": "A Gecko-oriented implementation of the Encoding Standard",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/encoding_rs@0.8.35",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/encoding_rs/"
+        },
+        {
+          "type": "website",
+          "url": "https://docs.rs/encoding_rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hsivonen/encoding_rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "author": "Anton Lazarev <https://antonok.com>",
       "name": "enum_dispatch",
@@ -2219,16 +2738,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
       "author": "Stjepan Glavina <stjepang@gmail.com>",
       "name": "fastrand",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "description": "A simple and fast random number generator",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+          "content": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
         }
       ],
       "licenses": [
@@ -2236,7 +2755,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/fastrand@2.4.0",
+      "purl": "pkg:cargo/fastrand@2.4.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -2338,6 +2857,36 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+      "name": "findshlibs",
+      "version": "0.10.2",
+      "description": "Find the set of shared libraries loaded in the current process with a cross platform API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/findshlibs@0.10.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/findshlibs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gimli-rs/findshlibs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
       "author": "Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>",
       "name": "flate2",
@@ -2430,6 +2979,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-fnv"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+      "author": "Orson Peters <orsonpeters@gmail.com>",
+      "name": "foldhash",
+      "version": "0.1.5",
+      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/foldhash@0.1.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/orlp/foldhash"
         }
       ]
     },
@@ -3410,6 +3986,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "http",
+      "version": "0.2.12",
+      "description": "A set of types for representing HTTP requests and responses. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/http@0.2.12",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/http"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/http"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http",
@@ -3467,6 +4074,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/seanmonstar/httparse"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+      "author": "Pyfisch <pyfisch@posteo.org>",
+      "name": "httpdate",
+      "version": "1.0.3",
+      "description": "HTTP date parsing and formatting",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/httpdate@1.0.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pyfisch/httpdate"
         }
       ]
     },
@@ -3982,6 +4616,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+      "author": "Rob Ede <robjtede@icloud.com>",
+      "name": "impl-more",
+      "version": "0.1.9",
+      "description": "Concise, declarative trait implementation macros",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/impl-more@0.1.9",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/robjtede/impl-more"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "name": "indexmap",
       "version": "1.9.3",
@@ -4346,6 +5007,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+      "author": "Pyfisch <pyfisch@gmail.com>, Tpt <thomas@pellissier-tanon.fr>",
+      "name": "language-tags",
+      "version": "0.3.2",
+      "description": "Language tags for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/language-tags@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pyfisch/rust-language-tags"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "author": "Canop <cano.petrole@gmail.com>",
       "name": "lazy-regex-proc_macros",
@@ -4576,6 +5264,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/LukasKalbertodt/litrs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "local-waker",
+      "version": "0.1.4",
+      "description": "A synchronization primitive for thread-local task wakeup",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/local-waker@0.1.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
         }
       ]
     },
@@ -5751,6 +6466,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+      "author": "RustCrypto Developers",
+      "name": "pem-rfc7468",
+      "version": "1.0.0",
+      "description": "PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a strict subset of the original Privacy-Enhanced Mail encoding intended specifically for use with cryptographic keys, certificates, and other messages. Provides a no_std-friendly, constant-time implementation suitable for use with cryptographic private keys. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/pem-rfc7468@1.0.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/pem-rfc7468"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
       "name": "pep440_rs",
       "version": "0.7.3",
@@ -6502,16 +7248,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler",
-      "version": "0.40.3",
+      "version": "0.40.4",
       "description": "Rust library to install conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "5ba7b9c2977ddc74fecb7e68dd6b3f40958416220b9643d94db5b7387fd0cbcd"
+          "content": "ef6a9b758727bf8da342d130a432ab0ea9d6038b5d45334b8da786b57af18c34"
         }
       ],
       "licenses": [
@@ -6519,7 +7265,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler@0.40.3",
+      "purl": "pkg:cargo/rattler@0.40.4",
       "externalReferences": [
         {
           "type": "website",
@@ -6533,15 +7279,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
       "name": "rattler_cache",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "description": "A crate to manage the caching of data in rattler",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f380851c13b9c14811d0281ce72ddd608b7dd98bc0a3e669247aa75dbac5e3b6"
+          "content": "a9fff3f818935d482ad9924c1a3bd6a67c1c8b8d52108cfad77ca1ae238093b3"
         }
       ],
       "licenses": [
@@ -6549,7 +7295,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_cache@0.6.18",
+      "purl": "pkg:cargo/rattler_cache@0.6.19",
       "externalReferences": [
         {
           "type": "website",
@@ -6563,16 +7309,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_conda_types",
-      "version": "0.44.3",
+      "version": "0.44.4",
       "description": "Rust data types for common types used within the Conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b8dc7eaa515b50a8ba80753d9902582bc2d62d8452ca61e6afd7bca866b54c85"
+          "content": "150d4876670a3950e8fb06afb43fbfb57bc720adb25f5d9b5d832474737e3b2f"
         }
       ],
       "licenses": [
@@ -6580,7 +7326,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_conda_types@0.44.3",
+      "purl": "pkg:cargo/rattler_conda_types@0.44.4",
       "externalReferences": [
         {
           "type": "website",
@@ -6625,16 +7371,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.27.4",
+      "version": "0.27.5",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "88f3b24c35849f7460d51b4b2016dfdab132e03d0a7d0f6d00d367cf16211fa2"
+          "content": "3ca5b4cf6588333d0c0085e54ad3585991484c110e6f6766048027ba57ea8d7b"
         }
       ],
       "licenses": [
@@ -6642,7 +7388,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.27.4",
+      "purl": "pkg:cargo/rattler_lock@0.27.5",
       "externalReferences": [
         {
           "type": "website",
@@ -6687,16 +7433,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_menuinst",
-      "version": "0.2.53",
+      "version": "0.2.54",
       "description": "Install menu entries for a Conda package",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0cb53fa7f10330b818ddfafd7c7d407254809ea249597bbc03073c2a3ad2854a"
+          "content": "bfa3a564e1defa136ffec1a0759e3677b98134b1645641e97e9b49bd3f5ff785"
         }
       ],
       "licenses": [
@@ -6704,7 +7450,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_menuinst@0.2.53",
+      "purl": "pkg:cargo/rattler_menuinst@0.2.54",
       "externalReferences": [
         {
           "type": "website",
@@ -6718,16 +7464,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_networking",
-      "version": "0.26.6",
+      "version": "0.26.7",
       "description": "Authenticated requests in the conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "67894637c820e2fbdf6ac44fc2b43d5ea38b7196439c4f7525b5c3dc2758e0b5"
+          "content": "ce99c6891e5a7b1945319c06fc34afa9dddb9c4b14890a997db5a47c1c8d5871"
         }
       ],
       "licenses": [
@@ -6735,7 +7481,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_networking@0.26.6",
+      "purl": "pkg:cargo/rattler_networking@0.26.7",
       "externalReferences": [
         {
           "type": "website",
@@ -6749,16 +7495,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_package_streaming",
-      "version": "0.24.6",
+      "version": "0.24.7",
       "description": "Extract and stream of Conda package archives",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "54da4bc16291b217181fa9ba07c0d5a796e1fa1e63591fef0f6e6e7e96e211d1"
+          "content": "079242c60d98e352409bae13227a1c587fa3c5d7fd6902f4ded924a6dbcf3b41"
         }
       ],
       "licenses": [
@@ -6766,7 +7512,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_package_streaming@0.24.6",
+      "purl": "pkg:cargo/rattler_package_streaming@0.24.7",
       "externalReferences": [
         {
           "type": "website",
@@ -6841,16 +7587,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_shell",
-      "version": "0.26.6",
+      "version": "0.26.7",
       "description": "A crate to help with activation and deactivation of a conda environment",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b0304b98dc745f816767dfd46c640c14b178c8327799c651dd10b6e25507cbae"
+          "content": "ccbe8db04cca2f2b159c536f688176391d4883f1068b221440d99d8c92c2654d"
         }
       ],
       "licenses": [
@@ -6858,7 +7604,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_shell@0.26.6",
+      "purl": "pkg:cargo/rattler_shell@0.26.7",
       "externalReferences": [
         {
           "type": "website",
@@ -6872,16 +7618,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "804311898940221962582b0fc0f48f122dfb1a85a0169c649121cce143a37f8f"
+          "content": "94c71d23b06b1b2fc3c98ccfd0b3110753509cf82fe3610f6a8e0c4439ef6016"
         }
       ],
       "licenses": [
@@ -6889,7 +7635,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@5.1.0",
+      "purl": "pkg:cargo/rattler_solve@5.2.0",
       "externalReferences": [
         {
           "type": "website",
@@ -7099,6 +7845,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+      "name": "regex-lite",
+      "version": "0.1.9",
+      "description": "A lightweight regex engine that optimizes for binary size and compilation time. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/regex-lite@0.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/regex-lite"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/regex/tree/master/regex-lite"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex-syntax",
@@ -7214,6 +7995,37 @@
         }
       ],
       "purl": "pkg:cargo/reqwest@0.12.28",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/reqwest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/reqwest"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "reqwest",
+      "version": "0.13.2",
+      "description": "higher level HTTP client library",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/reqwest@0.13.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7776,6 +8588,285 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-actix",
+      "version": "0.47.0",
+      "description": "Sentry integration for actix-web 4. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-actix@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-backtrace",
+      "version": "0.47.0",
+      "description": "Sentry integration and utilities for dealing with stacktraces. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-backtrace@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-contexts",
+      "version": "0.47.0",
+      "description": "Sentry integration for os, device, and rust contexts. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-contexts@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-core",
+      "version": "0.47.0",
+      "description": "Core Sentry library used for instrumentation and integration development. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-core@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-debug-images",
+      "version": "0.47.0",
+      "description": "Sentry integration that adds the list of loaded libraries to events. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-debug-images@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-panic",
+      "version": "0.47.0",
+      "description": "Sentry integration for capturing panics. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-panic@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-tracing",
+      "version": "0.47.0",
+      "description": "Sentry integration for the tracing and tracing-subscriber crates. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-tracing@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-types",
+      "version": "0.47.0",
+      "description": "Common reusable types for implementing the sentry.io protocol. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-types@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.47.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry",
+      "version": "0.47.0",
+      "description": "Sentry (sentry.io) client for Rust. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry@0.47.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "serde-untagged",
@@ -8031,6 +9122,32 @@
         {
           "type": "vcs",
           "url": "https://github.com/dtolnay/serde-repr"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
+      "name": "serde_spanned",
+      "version": "1.1.1",
+      "description": "Serde-compatible spanned Value",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_spanned@1.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/toml-rs/toml"
         }
       ]
     },
@@ -8491,6 +9608,41 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-smallvec"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+      "name": "socket2",
+      "version": "0.5.10",
+      "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/socket2@0.5.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/socket2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/socket2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/socket2"
         }
       ]
     },
@@ -9557,6 +10709,110 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
+      "name": "toml",
+      "version": "0.9.12+spec-1.1.0",
+      "description": "A native Rust encoder and decoder of TOML-formatted files and streams. Provides implementations of the standard Serialize/Deserialize traits for TOML data to facilitate deserializing and serializing Rust structures. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/toml@0.9.12+spec-1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/toml-rs/toml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
+      "name": "toml_datetime",
+      "version": "0.7.5+spec-1.1.0",
+      "description": "A TOML-compatible datetime type",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/toml_datetime@0.7.5+spec-1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/toml-rs/toml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+      "name": "toml_parser",
+      "version": "1.1.2+spec-1.1.0",
+      "description": "Yet another format-preserving TOML parser.",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/toml_parser@1.1.2+spec-1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/toml-rs/toml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.1+spec-1.1.0",
+      "name": "toml_writer",
+      "version": "1.1.1+spec-1.1.0",
+      "description": "A low-level interface for writing out TOML ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/toml_writer@1.1.1+spec-1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/toml-rs/toml"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
       "author": "Lucio Franco <luciofranco14@gmail.com>",
       "name": "tonic-prost",
@@ -10064,6 +11320,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
+      "author": "Ignacio Corderi <icorderi@msn.com>",
+      "name": "uname",
+      "version": "0.1.1",
+      "description": "Name and information about current kernel",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/uname@0.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://icorderi.github.io/rust-uname/index.html"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/icorderi/rust-uname"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/icorderi/rust-uname"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
       "name": "unarray",
       "version": "0.1.4",
@@ -10311,6 +11602,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+      "author": "erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-xid",
+      "version": "0.2.6",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-xid@0.2.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://unicode-rs.github.io/unicode-xid"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
       "name": "unit-prefix",
@@ -10427,6 +11753,60 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+      "author": "Martin Algesten <martin@algesten.se>",
+      "name": "ureq-proto",
+      "version": "0.6.0",
+      "description": "ureq support crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ureq-proto@0.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/ureq-proto"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
+      "author": "Martin Algesten <martin@algesten.se>, Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>",
+      "name": "ureq",
+      "version": "3.3.0",
+      "description": "Simple, safe HTTP client",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ureq@3.3.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/ureq"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
       "author": "The rust-url developers",
       "name": "url",
@@ -10484,6 +11864,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/kornelski/rust_urlencoding"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+      "author": "Simon Sapin <simon.sapin@exyr.org>, Martin Algesten <martin@algesten.se>",
+      "name": "utf8-zero",
+      "version": "0.8.1",
+      "description": "Zero-copy, incremental UTF-8 decoding with error handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/utf8-zero@0.8.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/utf8-zero"
         }
       ]
     },
@@ -10810,6 +12217,36 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.6",
+      "name": "webpki-root-certs",
+      "version": "1.0.6",
+      "description": "Mozilla trusted certificate authorities in self-signed X.509 format for use with crates other than webpki",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "CDLA-Permissive-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/webpki-root-certs@1.0.6",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/webpki-roots"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/webpki-roots"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
       "author": "Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>",
       "name": "which",
@@ -10836,6 +12273,58 @@
         {
           "type": "vcs",
           "url": "https://github.com/harryfei/which-rs.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15",
+      "name": "winnow",
+      "version": "0.7.15",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/winnow@0.7.15",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/winnow-rs/winnow"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.1",
+      "name": "winnow",
+      "version": "1.0.1",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/winnow@1.0.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/winnow-rs/winnow"
         }
       ]
     },
@@ -11150,16 +12639,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.1",
       "author": "Mathijs van de Nes <git@mathijs.vd-nes.nl>, Marli Frost <marli@frost.red>, Ryan Levick <ryan.levick@gmail.com>, Chris Hennick <hennickc@amazon.com>",
       "name": "zip",
-      "version": "8.5.0",
+      "version": "8.5.1",
       "description": "Library to support the reading and writing of zip files.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+          "content": "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
         }
       ],
       "licenses": [
@@ -11167,7 +12656,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/zip@8.5.0",
+      "purl": "pkg:cargo/zip@8.5.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -11717,6 +13206,41 @@
         {
           "type": "vcs",
           "url": "https://github.com/polyfill-rs/once_cell_polyfill"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
+      "author": "Jan Schulte <hello@unexpected-co.de>, Stanislav Tkach <stanislav.tkach@gmail.com>",
+      "name": "os_info",
+      "version": "3.14.0",
+      "description": "Detect the operating system type and version.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/os_info@3.14.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/os_info"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/stanislav-tkach/os_info"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/stanislav-tkach/os_info"
         }
       ]
     },
@@ -12565,33 +14089,162 @@
       ]
     },
     {
-      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry@0.47.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -12745,6 +14398,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0"
     },
     {
@@ -12781,9 +14437,24 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -12881,6 +14552,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17"
     },
     {
@@ -12961,10 +14638,41 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1"
       ]
     },
     {
@@ -13009,6 +14717,12 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -13042,7 +14756,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -13065,6 +14779,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -13080,6 +14801,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
@@ -13138,7 +14862,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
@@ -13292,6 +15016,14 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -13300,6 +15032,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0"
@@ -13451,6 +15186,9 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
@@ -13519,6 +15257,9 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -13552,6 +15293,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
@@ -13628,7 +15372,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
       ]
     },
     {
@@ -13829,6 +15574,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -13999,7 +15750,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
@@ -14017,13 +15768,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.7",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -14042,7 +15793,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
@@ -14054,10 +15805,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
@@ -14072,7 +15823,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
@@ -14126,7 +15877,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
@@ -14135,9 +15886,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
@@ -14156,7 +15907,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
@@ -14165,8 +15916,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
@@ -14179,7 +15930,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
@@ -14200,7 +15951,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
@@ -14214,9 +15965,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
@@ -14229,7 +15980,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3"
       ]
     },
@@ -14251,29 +16002,30 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -14324,6 +16076,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
       ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
@@ -14378,6 +16133,38 @@
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
@@ -14494,7 +16281,104 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.47.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.47.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
@@ -14551,6 +16435,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
         "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
     {
@@ -14661,6 +16551,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
@@ -14744,7 +16640,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
@@ -14891,6 +16787,33 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.1+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.1+spec-1.1.0"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -15005,6 +16928,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
@@ -15021,6 +16945,12 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4"
@@ -15050,6 +16980,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
     },
     {
@@ -15060,6 +16993,29 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+        "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.6"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
@@ -15075,6 +17031,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4"
     },
     {
@@ -15084,7 +17043,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
     {
@@ -15128,10 +17088,22 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.1"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3"
@@ -15205,7 +17177,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",

--- a/SBOM.json
+++ b/SBOM.json
@@ -1,0 +1,13926 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.3",
+  "version": 1,
+  "serialNumber": "urn:uuid:2f3eae5a-cd12-4060-bbd7-8ef90dcbef66",
+  "metadata": {
+    "timestamp": "2026-04-04T16:07:36.187336000Z",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "cargo-cyclonedx",
+        "version": "0.5.9"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "name": "ana",
+      "version": "0.0.0",
+      "scope": "required",
+      "purl": "pkg:cargo/ana@0.0.0?download_url=file://.",
+      "components": [
+        {
+          "type": "application",
+          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
+          "name": "ana",
+          "version": "0.0.0",
+          "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
+        }
+      ]
+    },
+    "properties": [
+      {
+        "name": "cdx:rustc:sbom:target:triple",
+        "value": "aarch64-apple-darwin"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
+      "name": "anaconda-otel-rs",
+      "version": "0.1.0",
+      "scope": "required",
+      "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40f90811de7e83e34788694da50b3d3614b806d335"
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
+      "name": "addr2line",
+      "version": "0.25.1",
+      "description": "A cross-platform symbolication library written in Rust, using `gimli`",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/addr2line@0.25.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/addr2line"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gimli-rs/addr2line"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1",
+      "author": "Jonas Schievink <jonasschievink@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>",
+      "name": "adler2",
+      "version": "2.0.1",
+      "description": "A simple clean-room implementation of the Adler-32 checksum",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "0BSD OR MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/adler2@2.0.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/adler2/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/oyvindln/adler2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+      "author": "Tom Kaitchuck <Tom.Kaitchuck@gmail.com>",
+      "name": "ahash",
+      "version": "0.8.12",
+      "description": "A non-cryptographic hash function using AES-NI for high performance",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ahash@0.8.12",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ahash"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tkaitchuck/ahash"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "aho-corasick",
+      "version": "1.1.4",
+      "description": "Fast multiple substring searching.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/aho-corasick@1.1.4",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/aho-corasick"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/aho-corasick"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21",
+      "author": "Zakarum <zaq.dev@icloud.com>",
+      "name": "allocator-api2",
+      "version": "0.2.21",
+      "description": "Mirror of Rust's allocator API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/allocator-api2@0.2.21",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/allocator-api2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/zakarumych/allocator-api2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zakarumych/allocator-api2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
+      "name": "anstream",
+      "version": "1.0.0",
+      "description": "IO stream adapters for writing colored text that will gracefully degrade according to your terminal's capabilities.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstream@1.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
+      "name": "anstyle-parse",
+      "version": "1.0.0",
+      "description": "Parse ANSI Style Escapes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstyle-parse@1.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+      "name": "anstyle-query",
+      "version": "1.1.5",
+      "description": "Look up colored console capabilities",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstyle-query@1.1.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+      "name": "anstyle",
+      "version": "1.0.14",
+      "description": "ANSI text styling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstyle@1.0.14",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "anyhow",
+      "version": "1.0.102",
+      "description": "Flexible concrete Error type built on std::error::Error",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anyhow@1.0.102",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/anyhow"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/anyhow"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>, dignifiedquire <me@dignifiequire.com>, Artem Vorotnikov <artem@vorotnikov.me>, Aiden McClelland <me@drbonez.dev>",
+      "name": "astral-tokio-tar",
+      "version": "0.6.0",
+      "description": "A Rust implementation of an async TAR file reader and writer. This library does not currently handle compression, but it is abstract over all I/O readers and writers. Additionally, great lengths are taken to ensure that the entire contents are never required to be entirely resident in memory all at once. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/astral-tokio-tar@0.6.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tokio-tar"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/astral-sh/tokio-tar"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/astral-sh/tokio-tar"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+      "author": "Harry [hello@majored.pw]",
+      "name": "astral_async_zip",
+      "version": "0.0.17",
+      "description": "An asynchronous ZIP archive reading/writing crate.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/astral_async_zip@0.0.17",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/async_zip/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/Majored/rs-async-zip"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Majored/rs-async-zip"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41",
+      "author": "Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>",
+      "name": "async-compression",
+      "version": "0.4.41",
+      "description": "Adaptors between compression crates and Rust's modern asynchronous IO types. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/async-compression@0.4.41",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Nullus157/async-compression"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
+      "author": "Daniel De Graaf <code@danieldg.net>",
+      "name": "async-once-cell",
+      "version": "0.5.4",
+      "description": "Async single assignment cells and lazy values.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/async-once-cell@0.5.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/async_once_cell"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/danieldg/async-once-cell"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
+      "name": "async-spooled-tempfile",
+      "version": "0.1.0",
+      "description": "Asynchronous spooled temporary file",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/async-spooled-tempfile@0.1.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/async-spooled-tempfile"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/AverageADF/async-spooled-tempfile"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "async-trait",
+      "version": "0.1.89",
+      "description": "Type erasure for async trait methods",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/async-trait@0.1.89",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/async-trait"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/async-trait"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async_http_range_reader@0.9.1",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "async_http_range_reader",
+      "version": "0.9.1",
+      "description": "A library for streaming reading of files over HTTP using range requests",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/async_http_range_reader@0.9.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/prefix-dev/async_http_range_reader"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
+      "author": "Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs",
+      "name": "atomic-waker",
+      "version": "1.1.2",
+      "description": "A synchronization primitive for task wakeup",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/atomic-waker@1.1.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/smol-rs/atomic-waker"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
+      "author": "Josh Stone <cuviper@gmail.com>",
+      "name": "autocfg",
+      "version": "1.5.0",
+      "description": "Automatic cfg for Rust compiler features",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/autocfg@1.5.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/autocfg/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/cuviper/autocfg"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#backtrace-ext@0.2.1",
+      "name": "backtrace-ext",
+      "version": "0.2.1",
+      "description": "minor conveniences on top of the backtrace crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/backtrace-ext@0.2.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/gankra/backtrace-ext"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
+      "author": "The Rust Project Developers",
+      "name": "backtrace",
+      "version": "0.3.76",
+      "description": "A library to acquire a stack trace (backtrace) at runtime in a Rust program. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/backtrace@0.3.76",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/backtrace"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/backtrace-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/backtrace-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+      "author": "Marshall Pierce <marshall@mpierce.org>",
+      "name": "base64",
+      "version": "0.22.1",
+      "description": "encodes and decodes base64 as bytes or utf8",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/base64@0.22.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/base64"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/marshallpierce/rust-base64"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
+      "author": "Ben Steadman <steadmanben1@gmail.com>",
+      "name": "bisection",
+      "version": "0.1.0",
+      "description": "Rust implementation of the Python bisect module",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/bisection@0.1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/SteadBytes/bisection"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/SteadBytes/bisection"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
+      "author": "Alexis Beingessner <a.beingessner@gmail.com>",
+      "name": "bit-set",
+      "version": "0.8.0",
+      "description": "A set of bits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/bit-set@0.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bit-set/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/contain-rs/bit-set"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/contain-rs/bit-set"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
+      "author": "Alexis Beingessner <a.beingessner@gmail.com>",
+      "name": "bit-vec",
+      "version": "0.8.0",
+      "description": "A vector of bits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/bit-vec@0.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bit-vec/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/contain-rs/bit-vec"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/contain-rs/bit-vec"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+      "author": "The Rust Project Developers",
+      "name": "bitflags",
+      "version": "2.11.0",
+      "description": "A macro to generate structures which behave like bitflags. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bitflags@2.11.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bitflags"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bitflags/bitflags"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bitflags/bitflags"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+      "author": "RustCrypto Developers",
+      "name": "blake2",
+      "version": "0.10.6",
+      "description": "BLAKE2 hash functions",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/blake2@0.10.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/blake2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/hashes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
+      "author": "RustCrypto Developers",
+      "name": "block-buffer",
+      "version": "0.10.4",
+      "description": "Buffer type for block processing of data",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/block-buffer@0.10.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/block-buffer"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14",
+      "author": "Ibraheem Ahmed <ibraheem@ibraheem.ca>",
+      "name": "boxcar",
+      "version": "0.2.14",
+      "description": "A concurrent, append-only vector",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/boxcar@0.2.14",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/ibraheemdev/boxcar"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
+      "author": "Nick Fitzgerald <fitzgen@gmail.com>",
+      "name": "bumpalo",
+      "version": "3.20.2",
+      "description": "A fast bump allocation arena for Rust.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bumpalo@3.20.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bumpalo"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/fitzgen/bumpalo"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+      "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "bytes",
+      "version": "1.11.1",
+      "description": "Types and traits for working with bytes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/bytes@1.11.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/bytes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
+      "name": "bzip2",
+      "version": "0.6.1",
+      "description": "Bindings to libbzip2 for bzip2 compression and decompression exposed as Reader/Writer streams. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bzip2@0.6.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bzip2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/trifectatechfoundation/bzip2-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/trifectatechfoundation/bzip2-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "cc",
+      "version": "1.2.59",
+      "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/cc@1.2.59",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/cc"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/cc-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/cc-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "cfg-if",
+      "version": "1.0.4",
+      "description": "A macro to ergonomically define an item depending on a large number of #[cfg] parameters. Structured like an if-else chain, the first matching branch is the item that gets emitted. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/cfg-if@1.0.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/cfg-if"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+      "author": "Zicklag <zicklag@katharostech.com>",
+      "name": "cfg_aliases",
+      "version": "0.2.1",
+      "description": "A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/cfg_aliases@0.2.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/cfg_aliases"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/katharostech/cfg_aliases"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/katharostech/cfg_aliases"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
+      "author": "RustCrypto Developers",
+      "name": "chacha20",
+      "version": "0.10.0",
+      "description": "The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2). Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/chacha20@0.10.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/chacha20"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/stream-ciphers"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+      "name": "chrono",
+      "version": "0.4.44",
+      "description": "Date and time library for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/chrono@0.4.44",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/chrono/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/chronotope/chrono"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/chronotope/chrono"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
+      "name": "clap",
+      "version": "4.6.0",
+      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/clap@4.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/clap-rs/clap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
+      "name": "clap_builder",
+      "version": "4.6.0",
+      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/clap_builder@4.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/clap-rs/clap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.0",
+      "name": "clap_derive",
+      "version": "4.6.0",
+      "description": "Parse command line argument by defining a struct, derive crate.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/clap_derive@4.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/clap-rs/clap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0",
+      "name": "clap_lex",
+      "version": "1.1.0",
+      "description": "Minimal, flexible command line parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/clap_lex@1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/clap-rs/clap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
+      "name": "colorchoice",
+      "version": "1.0.5",
+      "description": "Global override of color control",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/colorchoice@1.0.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
+      "author": "Arne Beer <contact@arne.beer>",
+      "name": "comfy-table",
+      "version": "7.2.2",
+      "description": "An easy to use library for building beautiful tables with automatic content wrapping",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/comfy-table@7.2.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/comfy-table/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/nukesor/comfy-table"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/nukesor/comfy-table"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37",
+      "author": "Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>",
+      "name": "compression-codecs",
+      "version": "0.4.37",
+      "description": "Adaptors for various compression algorithms. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/compression-codecs@0.4.37",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Nullus157/async-compression"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31",
+      "author": "Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>",
+      "name": "compression-core",
+      "version": "0.4.31",
+      "description": "Abstractions for compression algorithms. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/compression-core@0.4.31",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Nullus157/async-compression"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+      "name": "console",
+      "version": "0.16.3",
+      "description": "A terminal and console abstraction for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/console@0.16.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/console"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/console-rs/console"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/console-rs/console"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation-sys",
+      "version": "0.8.7",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation-sys@0.8.7",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/servo/core-foundation-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation",
+      "version": "0.10.1",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation@0.10.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+      "author": "RustCrypto Developers",
+      "name": "cpufeatures",
+      "version": "0.2.17",
+      "description": "Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets,  with no_std support and support for mobile targets including Android and iOS ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/cpufeatures@0.2.17",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/cpufeatures"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+      "author": "Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>",
+      "name": "crc32fast",
+      "version": "1.5.0",
+      "description": "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crc32fast@1.5.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/srijs/rust-crc32fast"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
+      "name": "crossbeam-deque",
+      "version": "0.8.6",
+      "description": "Concurrent work-stealing deque",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam-deque@0.8.6",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
+      "name": "crossbeam-epoch",
+      "version": "0.9.18",
+      "description": "Epoch-based garbage collection",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam-epoch@0.9.18",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+      "name": "crossbeam-utils",
+      "version": "0.8.21",
+      "description": "Utilities for concurrent programming",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam-utils@0.8.21",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
+      "author": "T. Post",
+      "name": "crossterm",
+      "version": "0.29.0",
+      "description": "A crossplatform terminal library for manipulating terminals.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/crossterm@0.29.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/crossterm/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossterm-rs/crossterm"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
+      "author": "RustCrypto Developers",
+      "name": "crypto-common",
+      "version": "0.1.7",
+      "description": "Common cryptographic traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crypto-common@0.1.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/crypto-common"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/traits"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
+      "author": "Ted Driggs <ted.driggs@outlook.com>",
+      "name": "darling",
+      "version": "0.23.0",
+      "description": "A proc-macro library for reading attributes into structs when implementing custom derives. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/darling@0.23.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/darling/0.23.0"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/TedDriggs/darling"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
+      "author": "Ted Driggs <ted.driggs@outlook.com>",
+      "name": "darling_core",
+      "version": "0.23.0",
+      "description": "Helper crate for proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/darling_core@0.23.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/TedDriggs/darling"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0",
+      "author": "Ted Driggs <ted.driggs@outlook.com>",
+      "name": "darling_macro",
+      "version": "0.23.0",
+      "description": "Internal support for a proc-macro library for reading attributes into structs when implementing custom derives. Use https://crates.io/crates/darling in your code. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/darling_macro@0.23.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/TedDriggs/darling"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+      "author": "Acrimon <joel.wejdenstal@gmail.com>",
+      "name": "dashmap",
+      "version": "6.1.0",
+      "description": "Blazing fast concurrent HashMap for Rust.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/dashmap@6.1.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/dashmap"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/xacrimon/dashmap"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/xacrimon/dashmap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
+      "author": "Jacob Pratt <jacob@jhpratt.dev>",
+      "name": "deranged",
+      "version": "0.5.8",
+      "description": "Ranged integers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/deranged@0.5.8",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/jhpratt/deranged"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+      "author": "RustCrypto Developers",
+      "name": "digest",
+      "version": "0.10.7",
+      "description": "Traits for cryptographic hash functions and message authentication codes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/digest@0.10.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/digest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/traits"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
+      "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+      "name": "dirs-sys",
+      "version": "0.5.0",
+      "description": "System-level helper functions for the dirs and directories crates.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/dirs-sys@0.5.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/dirs-dev/dirs-sys-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+      "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+      "name": "dirs",
+      "version": "6.0.0",
+      "description": "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/dirs@6.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/soc/dirs-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+      "author": "Jane Lusby <jlusby@yaah.dev>",
+      "name": "displaydoc",
+      "version": "0.2.5",
+      "description": "A derive macro for implementing the display Trait via a doc comment and string interpolation ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/displaydoc@0.2.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/displaydoc"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/yaahc/displaydoc"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/yaahc/displaydoc"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+      "author": "Slint Developers <info@slint.dev>",
+      "name": "document-features",
+      "version": "0.2.12",
+      "description": "Extract documentation for the feature flags from comments in Cargo.toml",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/document-features@0.2.12",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://slint.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/slint-ui/document-features"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "dyn-clone",
+      "version": "1.0.20",
+      "description": "Clone trait that is dyn-compatible",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/dyn-clone@1.0.20",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/dyn-clone"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/dyn-clone"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0",
+      "author": "bluss",
+      "name": "either",
+      "version": "1.15.0",
+      "description": "The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/either@1.15.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/either/1/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rayon-rs/either"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
+      "author": "Anton Lazarev <https://antonok.com>",
+      "name": "enum_dispatch",
+      "version": "0.3.13",
+      "description": "Near drop-in replacement for dynamic-dispatched method calls with up to 10x the speed",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/enum_dispatch@0.3.13",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://gitlab.com/antonok/enum_dispatch"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
+      "name": "equivalent",
+      "version": "1.0.2",
+      "description": "Traits for key comparison in maps.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/equivalent@1.0.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/indexmap-rs/equivalent"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "erased-serde",
+      "version": "0.4.10",
+      "description": "Type-erased Serialize and Serializer traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/erased-serde@0.4.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/erased-serde"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/erased-serde"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
+      "author": "Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>",
+      "name": "errno",
+      "version": "0.3.14",
+      "description": "Cross-platform interface to the `errno` variable.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/errno@0.3.14",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/errno"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/lambda-fairy/rust-errno"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+      "author": "Raph Levien <raph@google.com>, Robin Stocker <robin@nibor.org>, Keith Hall <keith.hall@available.systems>",
+      "name": "fancy-regex",
+      "version": "0.17.0",
+      "description": "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/fancy-regex@0.17.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/fancy-regex"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/fancy-regex/fancy-regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+      "author": "Stjepan Glavina <stjepang@gmail.com>",
+      "name": "fastrand",
+      "version": "2.3.0",
+      "description": "A simple and fast random number generator",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/fastrand@2.3.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/smol-rs/fastrand"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "file_url",
+      "version": "0.2.7",
+      "description": "Helper functions to work with file:// urls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "81d37aab514a05a249a5b15408dc74d716f5745a2c5daf22e40a245ffd38fa84"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/file_url@0.2.7",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "filetime",
+      "version": "0.2.27",
+      "description": "Platform-agnostic accessors of timestamps in File metadata ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/filetime@0.2.27",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/filetime"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/alexcrichton/filetime"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/alexcrichton/filetime"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
+      "name": "find-msvc-tools",
+      "version": "0.1.9",
+      "description": "Find windows-specific tools, read MSVC versions from the registry and from COM interfaces",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/find-msvc-tools@0.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/find-msvc-tools"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/cc-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>",
+      "name": "flate2",
+      "version": "1.1.9",
+      "description": "DEFLATE compression and decompression exposed as Read/BufRead/Write streams. Supports miniz_oxide and multiple zlib implementations. Supports zlib, gzip, and raw deflate streams. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/flate2@1.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/flate2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/flate2-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/flate2-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
+      "author": "Mike Dilger <mike@mikedilger.com>",
+      "name": "float-cmp",
+      "version": "0.10.0",
+      "description": "Floating point approximate comparison traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/float-cmp@0.10.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/float-cmp"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/mikedilger/float-cmp"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "fnv",
+      "version": "1.0.7",
+      "description": "Fowler\u2013Noll\u2013Vo hash function",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0  OR  MIT"
+        }
+      ],
+      "purl": "pkg:cargo/fnv@1.0.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://doc.servo.org/fnv/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-fnv"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0",
+      "author": "Orson Peters <orsonpeters@gmail.com>",
+      "name": "foldhash",
+      "version": "0.2.0",
+      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/foldhash@0.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/orlp/foldhash"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
+      "author": "The rust-url developers",
+      "name": "form_urlencoded",
+      "version": "1.2.2",
+      "description": "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/form_urlencoded@1.2.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-url"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+      "author": "Andrew Hickman <andrew.hickman1@sky.com>",
+      "name": "fs-err",
+      "version": "3.3.0",
+      "description": "A drop-in replacement for std::fs with more helpful error messages.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/fs-err@3.3.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/fs-err"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/andrewhickman/fs-err"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+      "author": "Dan Burkert <dan@danburkert.com>, Al Liu <scygliu1@gmail.com>",
+      "name": "fs4",
+      "version": "0.13.1",
+      "description": "No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/fs4@0.13.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/fs4"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/al8n/fs4-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+      "name": "futures-channel",
+      "version": "0.3.32",
+      "description": "Channels for asynchronous communication using futures-rs. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-channel@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+      "name": "futures-core",
+      "version": "0.3.32",
+      "description": "The core traits and types in for the `futures` library. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-core@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+      "name": "futures-executor",
+      "version": "0.3.32",
+      "description": "Executors for asynchronous tasks based on the futures-rs library. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-executor@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+      "name": "futures-io",
+      "version": "0.3.32",
+      "description": "The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-io@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
+      "author": "Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs",
+      "name": "futures-lite",
+      "version": "2.6.1",
+      "description": "Futures, streams, and async I/O combinators",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/futures-lite@2.6.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/futures-lite"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/smol-rs/futures-lite"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/smol-rs/futures-lite"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
+      "name": "futures-macro",
+      "version": "0.3.32",
+      "description": "The futures-rs procedural macro implementations. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-macro@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+      "name": "futures-sink",
+      "version": "0.3.32",
+      "description": "The asynchronous `Sink` trait for the futures-rs library. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-sink@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+      "name": "futures-task",
+      "version": "0.3.32",
+      "description": "Tools for working with tasks. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-task@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+      "name": "futures-util",
+      "version": "0.3.32",
+      "description": "Common utilities and extension traits for the futures-rs library. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures-util@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+      "name": "futures",
+      "version": "0.3.32",
+      "description": "An implementation of futures and streams featuring zero allocations, composability, and iterator-like interfaces. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/futures@0.3.32",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://rust-lang.github.io/futures-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/futures-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+      "author": "Bart\u0142omiej Kami\u0144ski <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>",
+      "name": "generic-array",
+      "version": "0.14.7",
+      "description": "Generic types implementing functionality of arrays",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/generic-array@0.14.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "http://fizyk20.github.io/generic-array/generic_array/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/fizyk20/generic-array.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+      "author": "The Rand Project Developers",
+      "name": "getrandom",
+      "version": "0.2.17",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/getrandom@0.2.17",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/getrandom"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/getrandom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
+      "author": "The Rand Project Developers",
+      "name": "getrandom",
+      "version": "0.3.4",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/getrandom@0.3.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/getrandom"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/getrandom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+      "author": "The Rand Project Developers",
+      "name": "getrandom",
+      "version": "0.4.2",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/getrandom@0.4.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/getrandom"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/getrandom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#gimli@0.32.3",
+      "name": "gimli",
+      "version": "0.32.3",
+      "description": "A library for reading and writing the DWARF debugging format.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/gimli@0.32.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/gimli"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gimli-rs/gimli"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+      "author": "The Rust Project Developers",
+      "name": "glob",
+      "version": "0.3.3",
+      "description": "Support for matching file paths against Unix shell style patterns. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/glob@0.3.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/glob"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/glob"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/glob"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
+      "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "h2",
+      "version": "0.4.13",
+      "description": "An HTTP/2 client and server",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/h2@0.4.13",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/h2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/h2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
+      "author": "Heinz N. Gies <heinz@licenser.net>",
+      "name": "halfbrown",
+      "version": "0.4.0",
+      "description": "Multi backend HashMap for higher performance on different key space sizes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/halfbrown@0.4.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Licenser/halfbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "hashbrown",
+      "version": "0.12.3",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hashbrown@0.12.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/hashbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "hashbrown",
+      "version": "0.14.5",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hashbrown@0.14.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/hashbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "hashbrown",
+      "version": "0.16.1",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hashbrown@0.16.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/hashbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+      "name": "heck",
+      "version": "0.5.0",
+      "description": "heck is a case conversion library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/heck@0.5.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/withoutboats/heck"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+      "author": "KokaKiwi <kokakiwi@kokakiwi.net>",
+      "name": "hex",
+      "version": "0.4.3",
+      "description": "Encoding and decoding data into/from hexadecimal representation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hex@0.4.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hex/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/KokaKiwi/rust-hex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
+      "name": "hostname",
+      "version": "0.4.2",
+      "description": "Cross-platform system's host name functions",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/hostname@0.4.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/djc/hostname"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+      "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "http-body-util",
+      "version": "0.1.3",
+      "description": "Combinators and adapters for HTTP request or response bodies. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/http-body-util@0.1.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/http-body-util"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/http-body"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+      "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "http-body",
+      "version": "1.0.1",
+      "description": "Trait representing an asynchronous, streaming, HTTP request or response body. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/http-body@1.0.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/http-body"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/http-body"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+      "author": "Yuri Astrakhan <YuriAstrakhan@gmail.com>",
+      "name": "http-content-range",
+      "version": "0.2.4",
+      "description": "HTTP Content Range response header parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/http-content-range@0.2.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/nyurik/http-content-range"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "http",
+      "version": "1.4.0",
+      "description": "A set of types for representing HTTP requests and responses. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/http@1.4.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/http"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/http"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "httparse",
+      "version": "1.10.1",
+      "description": "A tiny, safe, speedy, zero-copy HTTP/1.x parser.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/httparse@1.10.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/httparse"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/httparse"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+      "name": "humantime",
+      "version": "2.3.0",
+      "description": "A parser and formatter for std::time::{Duration, SystemTime}",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/humantime@2.3.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/humantime"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/chronotope/humantime"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/chronotope/humantime"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+      "name": "hyper-rustls",
+      "version": "0.27.7",
+      "description": "Rustls+hyper integration for pure rust HTTPS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR ISC OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/hyper-rustls@0.27.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hyper-rustls/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/hyper-rustls"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/hyper-rustls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "hyper-tls",
+      "version": "0.6.0",
+      "description": "Default TLS implementation for use with hyper",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hyper-tls@0.6.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hyper-tls"
+        },
+        {
+          "type": "website",
+          "url": "https://hyper.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/hyper-tls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "hyper-util",
+      "version": "0.1.20",
+      "description": "hyper utilities",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/hyper-util@0.1.20",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hyper-util"
+        },
+        {
+          "type": "website",
+          "url": "https://hyper.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/hyper-util"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "hyper",
+      "version": "1.9.0",
+      "description": "A protective and efficient HTTP library for all.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/hyper@1.9.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hyper"
+        },
+        {
+          "type": "website",
+          "url": "https://hyper.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/hyper"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+      "author": "Andrew Straw <strawman@astraw.com>, Ren\u00e9 Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
+      "name": "iana-time-zone",
+      "version": "0.1.65",
+      "description": "get the IANA time zone for the current system",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/iana-time-zone@0.1.65",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/strawlab/iana-time-zone"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_collections",
+      "version": "2.2.0",
+      "description": "Collection of API for use in ICU libraries.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_collections@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_locale_core",
+      "version": "2.2.0",
+      "description": "API for managing Unicode Language and Locale Identifiers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_locale_core@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_normalizer",
+      "version": "2.2.0",
+      "description": "API for normalizing text into Unicode Normalization Forms",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_normalizer@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_normalizer_data",
+      "version": "2.2.0",
+      "description": "Data for the icu_normalizer crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_normalizer_data@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_properties",
+      "version": "2.2.0",
+      "description": "Definitions for Unicode properties",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_properties@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties_data@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_properties_data",
+      "version": "2.2.0",
+      "description": "Data for the icu_properties crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_properties_data@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
+      "author": "The ICU4X Project Developers",
+      "name": "icu_provider",
+      "version": "2.2.0",
+      "description": "Trait and struct definitions for the ICU data provider",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/icu_provider@2.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
+      "author": "Ted Driggs <ted.driggs@outlook.com>",
+      "name": "ident_case",
+      "version": "1.0.1",
+      "description": "Utility for applying case rules to Rust identifiers.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ident_case@1.0.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ident_case/1.0.1"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/TedDriggs/ident_case"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
+      "author": "The rust-url developers",
+      "name": "idna",
+      "version": "1.1.0",
+      "description": "IDNA (Internationalizing Domain Names in Applications) and Punycode.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/idna@1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-url/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.1",
+      "author": "The rust-url developers",
+      "name": "idna_adapter",
+      "version": "1.2.1",
+      "description": "Back end adapter for idna",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/idna_adapter@1.2.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/idna_adapter/latest/idna_adapter/"
+        },
+        {
+          "type": "website",
+          "url": "https://docs.rs/crate/idna_adapter/latest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hsivonen/idna_adapter"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
+      "name": "indexmap",
+      "version": "1.9.3",
+      "description": "A hash table with consistent order and fast iteration.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/indexmap@1.9.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/indexmap/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bluss/indexmap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+      "name": "indexmap",
+      "version": "2.13.1",
+      "description": "A hash table with consistent order and fast iteration.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/indexmap@2.13.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/indexmap/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/indexmap-rs/indexmap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+      "name": "indicatif",
+      "version": "0.18.4",
+      "description": "A progress bar and cli reporting library for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/indicatif@0.18.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/indicatif"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/console-rs/indicatif"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "indoc",
+      "version": "2.0.7",
+      "description": "Indented document literals",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/indoc@2.0.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/indoc"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/indoc"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
+      "author": "Kris Price <kris@krisprice.nz>",
+      "name": "ipnet",
+      "version": "2.12.0",
+      "description": "Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ipnet@2.12.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ipnet"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/krisprice/ipnet"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.12",
+      "author": "YOSHIOKA Takuma <nop_thread@nops.red>",
+      "name": "iri-string",
+      "version": "0.7.12",
+      "description": "IRI as string types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/iri-string@0.7.12",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/lo48576/iri-string"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "is_ci",
+      "version": "1.2.0",
+      "description": "Super lightweight CI environment checker. Just tells you if you're in CI or not without much fuss.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "ISC"
+        }
+      ],
+      "purl": "pkg:cargo/is_ci@1.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/is_ci"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/is_ci"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
+      "name": "is_terminal_polyfill",
+      "version": "1.70.2",
+      "description": "Polyfill for `is_terminal` stdlib feature for use with older MSRVs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/is_terminal_polyfill@1.70.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/polyfill-rs/is_terminal_polyfill"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
+      "author": "bluss",
+      "name": "itertools",
+      "version": "0.13.0",
+      "description": "Extra iterator adaptors, iterator methods, free functions, and macros.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/itertools@0.13.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/itertools/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-itertools/itertools"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+      "author": "bluss",
+      "name": "itertools",
+      "version": "0.14.0",
+      "description": "Extra iterator adaptors, iterator methods, free functions, and macros.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/itertools@0.14.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/itertools/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-itertools/itertools"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "itoa",
+      "version": "1.0.18",
+      "description": "Fast integer primitive to string conversion",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/itoa@1.0.18",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/itoa"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/itoa"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "jobserver",
+      "version": "0.1.34",
+      "description": "An implementation of the GNU Make jobserver for Rust. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/jobserver@0.1.34",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jobserver"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/jobserver-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/jobserver-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
+      "author": "Canop <cano.petrole@gmail.com>",
+      "name": "lazy-regex-proc_macros",
+      "version": "3.6.0",
+      "description": "proc macros for the lazy_regex crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/lazy-regex-proc_macros@3.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/lazy-regex/tree/main/src/proc_macros"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+      "author": "Canop <cano.petrole@gmail.com>",
+      "name": "lazy-regex",
+      "version": "3.6.0",
+      "description": "lazy static regular expressions checked at compile time",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/lazy-regex@3.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/lazy-regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
+      "author": "Marvin L\u00f6bel <loebel.marvin@gmail.com>",
+      "name": "lazy_static",
+      "version": "1.5.0",
+      "description": "A macro for declaring lazily evaluated statics in Rust.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/lazy_static@1.5.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/lazy_static"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang-nursery/lazy-static.rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2",
+      "name": "libbz2-rs-sys",
+      "version": "0.2.2",
+      "description": "a drop-in compatible rust bzip2 implementation",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "bzip2-1.0.6"
+        }
+      ],
+      "purl": "pkg:cargo/libbz2-rs-sys@0.2.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/trifectatechfoundation/libbzip2-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/trifectatechfoundation/libbzip2-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+      "author": "The Rust Project Developers",
+      "name": "libc",
+      "version": "0.2.184",
+      "description": "Raw FFI bindings to platform libraries like libc.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/libc@0.2.184",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/libc"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2",
+      "author": "The ICU4X Project Developers",
+      "name": "litemap",
+      "version": "0.8.2",
+      "description": "A key-value Map implementation based on a flat, sorted Vec.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/litemap@0.8.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/litemap"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+      "author": "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>",
+      "name": "litrs",
+      "version": "1.0.0",
+      "description": "Parse and inspect Rust literals (i.e. tokens in the Rust programming language representing fixed values). Particularly useful for proc macros, but can also be used outside of a proc-macro context. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/litrs@1.0.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/litrs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/LukasKalbertodt/litrs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "lock_api",
+      "version": "0.4.14",
+      "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/lock_api@0.4.14",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Amanieu/parking_lot"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+      "author": "The Rust Project Developers",
+      "name": "log",
+      "version": "0.4.29",
+      "description": "A lightweight logging facade for Rust ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/log@0.4.29",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/log"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/log"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
+      "author": "Eliza Weisman <eliza@buoyant.io>",
+      "name": "matchers",
+      "version": "0.2.0",
+      "description": "Regex matching on character and byte streams. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/matchers@0.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/matchers/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/hawkw/matchers"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hawkw/matchers"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+      "author": "RustCrypto Developers",
+      "name": "md-5",
+      "version": "0.10.6",
+      "description": "MD5 hash function",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/md-5@0.10.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/md-5"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/hashes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+      "author": "Andrew Gallant <jamslam@gmail.com>, bluss",
+      "name": "memchr",
+      "version": "2.8.0",
+      "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/memchr@2.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/memchr/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/memchr"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/memchr"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+      "author": "Dan Burkert <dan@danburkert.com>, Yevhenii Reizner <razrfalcon@gmail.com>, The Contributors",
+      "name": "memmap2",
+      "version": "0.9.10",
+      "description": "Cross-platform Rust API for memory-mapped file IO",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/memmap2@0.9.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/memmap2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RazrFalcon/memmap2-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#miette-derive@7.6.0",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "miette-derive",
+      "version": "7.6.0",
+      "description": "Derive macros for miette. Like `thiserror` for Diagnostics.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/miette-derive@7.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/miette"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "miette",
+      "version": "7.6.0",
+      "description": "Fancy diagnostic reporting library and protocol for us mere mortals who aren't compiler hackers.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/miette@7.6.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/miette"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/miette"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "mime",
+      "version": "0.3.17",
+      "description": "Strongly Typed Mimes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/mime@0.3.17",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/mime"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/mime"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
+      "author": "Austin Bonander <austin.bonander@gmail.com>",
+      "name": "mime_guess",
+      "version": "2.0.5",
+      "description": "A simple crate for detection of a file's MIME type by its extension.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/mime_guess@2.0.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/mime_guess/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/abonander/mime_guess"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
+      "author": "Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com",
+      "name": "miniz_oxide",
+      "version": "0.8.9",
+      "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Zlib OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/miniz_oxide@0.8.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/miniz_oxide"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
+      "author": "Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>",
+      "name": "mio",
+      "version": "1.2.0",
+      "description": "Lightweight non-blocking I/O.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/mio@1.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/tokio-rs/mio"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/mio"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+      "author": "Steven Fackler <sfackler@gmail.com>",
+      "name": "native-tls",
+      "version": "0.2.18",
+      "description": "A wrapper over a platform's native TLS implementation",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/native-tls@0.2.18",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/native-tls"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-native-tls/rust-native-tls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
+      "author": "The nix-rust Project Developers",
+      "name": "nix",
+      "version": "0.30.1",
+      "description": "Rust friendly bindings to *nix APIs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/nix@0.30.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/nix-rust/nix"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+      "author": "contact@geoffroycouprie.com",
+      "name": "nom-language",
+      "version": "0.1.0",
+      "description": "Language parsing focused combinators for the nom parser library",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/nom-language@0.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-bakery/nom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
+      "author": "contact@geoffroycouprie.com",
+      "name": "nom",
+      "version": "8.0.0",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/nom@8.0.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/nom"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-bakery/nom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
+      "author": "ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers",
+      "name": "nu-ansi-term",
+      "version": "0.50.3",
+      "description": "Library for ANSI terminal colors and styles (bold, underline)",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/nu-ansi-term@0.50.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/nushell/nu-ansi-term"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
+      "author": "Jacob Pratt <jacob@jhpratt.dev>",
+      "name": "num-conv",
+      "version": "0.2.1",
+      "description": "`num_conv` is a crate to convert between integer types without using `as` casts. This provides better certainty when refactoring, makes the exact behavior of code more explicit, and allows using turbofish syntax. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/num-conv@0.2.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/jhpratt/num-conv"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
+      "author": "The Rust Project Developers",
+      "name": "num-traits",
+      "version": "0.2.19",
+      "description": "Numeric traits for generic mathematics",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/num-traits@0.2.19",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/num-traits"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-num/num-traits"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-num/num-traits"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "num_cpus",
+      "version": "1.17.0",
+      "description": "Get the number of CPUs on a machine.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/num_cpus@1.17.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/num_cpus"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/num_cpus"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
+      "name": "object",
+      "version": "0.37.3",
+      "description": "A unified interface for reading and writing object file formats.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/object@0.37.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/gimli-rs/object"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+      "author": "Aleksey Kladov <aleksey.kladov@gmail.com>",
+      "name": "once_cell",
+      "version": "1.21.4",
+      "description": "Single assignment cells and lazy values.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/once_cell@1.21.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/once_cell"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/matklad/once_cell"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
+      "name": "opentelemetry-http",
+      "version": "0.31.0",
+      "description": "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry-http@0.31.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
+      "name": "opentelemetry-otlp",
+      "version": "0.31.1",
+      "description": "Exporter for the OpenTelemetry Collector",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry-otlp@0.31.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.31.0",
+      "name": "opentelemetry-proto",
+      "version": "0.31.0",
+      "description": "Protobuf generated files and transformations.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry-proto@0.31.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-stdout@0.31.0",
+      "name": "opentelemetry-stdout",
+      "version": "0.31.0",
+      "description": "An OpenTelemetry exporter for stdout",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry-stdout@0.31.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+      "name": "opentelemetry",
+      "version": "0.31.0",
+      "description": "OpenTelemetry API for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry@0.31.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
+      "name": "opentelemetry_sdk",
+      "version": "0.31.0",
+      "description": "The SDK for the OpenTelemetry metrics collection and distributed tracing framework",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/opentelemetry_sdk@0.31.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
+      "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+      "name": "option-ext",
+      "version": "0.2.0",
+      "description": "Extends `Option` with additional operations",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MPL-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/option-ext@0.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/option-ext/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/soc/option-ext"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/soc/option-ext.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1",
+      "author": "Jonathan Reem <jonathan.reem@gmail.com>, Matt Brubeck <mbrubeck@limpet.net>",
+      "name": "ordered-float",
+      "version": "2.10.1",
+      "description": "Wrappers for total ordering on floats",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/ordered-float@2.10.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/reem/rust-ordered-float"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0",
+      "author": "jam1garner <8260240+jam1garner@users.noreply.github.com>",
+      "name": "owo-colors",
+      "version": "4.3.0",
+      "description": "Zero-allocation terminal colors that'll make people go owo",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/owo-colors@4.3.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/owo-colors"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/owo-colors/owo-colors"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
+      "author": "Stjepan Glavina <stjepang@gmail.com>, The Rust Project Developers",
+      "name": "parking",
+      "version": "2.2.1",
+      "description": "Thread parking and unparking",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/parking@2.2.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/parking"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/smol-rs/parking"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/smol-rs/parking"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "parking_lot",
+      "version": "0.12.5",
+      "description": "More compact and efficient implementations of the standard synchronization primitives.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/parking_lot@0.12.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Amanieu/parking_lot"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "parking_lot_core",
+      "version": "0.9.12",
+      "description": "An advanced API for creating custom synchronization primitives.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/parking_lot_core@0.9.12",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Amanieu/parking_lot"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.7",
+      "name": "path_resolver",
+      "version": "0.2.7",
+      "description": "Provides a trie-based data structure to track and resolve relative path ownership across multiple packages",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "59953de32542217edd1cc5fd52ac7ca2de57d7613a3a3e569370e5ea09231df3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/path_resolver@0.2.7",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
+      "name": "pep440_rs",
+      "version": "0.7.3",
+      "description": "A library for python version numbers and specifiers, implementing PEP 440",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR BSD-2-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/pep440_rs@0.7.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/konstin/pep440-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
+      "name": "pep508_rs",
+      "version": "0.9.2",
+      "description": "A library for python dependency specifiers, better known as PEP 508",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR BSD-2-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/pep508_rs@0.9.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/konstin/pep508_rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+      "author": "The rust-url developers",
+      "name": "percent-encoding",
+      "version": "2.3.2",
+      "description": "Percent encoding and decoding",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/percent-encoding@2.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-url/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-internal@1.1.11",
+      "name": "pin-project-internal",
+      "version": "1.1.11",
+      "description": "Implementation detail of the `pin-project` crate. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/pin-project-internal@1.1.11",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/taiki-e/pin-project"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+      "name": "pin-project-lite",
+      "version": "0.2.17",
+      "description": "A lightweight version of pin-project written with declarative macros. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/pin-project-lite@0.2.17",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/taiki-e/pin-project-lite"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
+      "name": "pin-project",
+      "version": "1.1.11",
+      "description": "A crate for safe and ergonomic pin-projection. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/pin-project@1.1.11",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/taiki-e/pin-project"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "pkg-config",
+      "version": "0.3.32",
+      "description": "A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/pkg-config@0.3.32",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/pkg-config"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/pkg-config-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "author": "Ed Barnard <eabarnard@gmail.com>",
+      "name": "plist",
+      "version": "1.8.0",
+      "description": "A rusty plist parser. Supports Serde serialization.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/plist@1.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/plist/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/ebarnard/rust-plist/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+      "name": "portable-atomic",
+      "version": "1.13.1",
+      "description": "Portable atomic types including support for 128-bit atomics, atomic float, etc. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/portable-atomic@1.13.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/taiki-e/portable-atomic"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
+      "author": "The ICU4X Project Developers",
+      "name": "potential_utf",
+      "version": "0.1.5",
+      "description": "Unvalidated string and character types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/potential_utf@0.1.5",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+      "author": "Jacob Pratt <jacob@jhpratt.dev>",
+      "name": "powerfmt",
+      "version": "0.2.0",
+      "description": "    `powerfmt` is a library that provides utilities for formatting values. This crate makes it     significantly easier to support filling to a minimum width with alignment, avoid heap     allocation, and avoid repetitive calculations. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/powerfmt@0.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/jhpratt/powerfmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
+      "author": "The CryptoCorrosion Contributors",
+      "name": "ppv-lite86",
+      "version": "0.2.21",
+      "description": "Cross-platform cryptography-oriented low-level SIMD library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ppv-lite86@0.2.21",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/cryptocorrosion/cryptocorrosion"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+      "author": "David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>",
+      "name": "proc-macro2",
+      "version": "1.0.106",
+      "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/proc-macro2@1.0.106",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/proc-macro2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/proc-macro2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
+      "author": "Jason Lingle",
+      "name": "proptest",
+      "version": "1.11.0",
+      "description": "Hypothesis-like property-based testing and shrinking. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/proptest@1.11.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/proptest/latest/proptest/"
+        },
+        {
+          "type": "website",
+          "url": "https://proptest-rs.github.io/proptest/proptest/index.html"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/proptest-rs/proptest"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3",
+      "author": "Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>",
+      "name": "prost-derive",
+      "version": "0.14.3",
+      "description": "Generate encoding and decoding implementations for Prost annotated types.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/prost-derive@0.14.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/prost"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
+      "author": "Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>",
+      "name": "prost",
+      "version": "0.14.3",
+      "description": "A Protocol Buffers implementation for the Rust Language.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/prost@0.14.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/prost"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
+      "name": "purl",
+      "version": "0.1.6",
+      "description": "A Package URL implementation with customizable package types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/purl@0.1.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/phylum-dev/purl/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3",
+      "author": "Paul Colomiets <paul@colomiets.name>, Colin Kiegel <kiegel@gmx.de>",
+      "name": "quick-error",
+      "version": "1.2.3",
+      "description": "    A macro which makes error types pleasant to write. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/quick-error@1.2.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "http://docs.rs/quick-error"
+        },
+        {
+          "type": "website",
+          "url": "http://github.com/tailhook/quick-error"
+        },
+        {
+          "type": "vcs",
+          "url": "http://github.com/tailhook/quick-error"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "name": "quick-xml",
+      "version": "0.38.4",
+      "description": "High performance xml reader and writer",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/quick-xml@0.38.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/quick-xml"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tafia/quick-xml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "quote",
+      "version": "1.0.45",
+      "description": "Quasi-quoting macro quote!(...)",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/quote@1.0.45",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/quote/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/quote"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+      "author": "The Rand Project Developers, The Rust Project Developers",
+      "name": "rand",
+      "version": "0.10.0",
+      "description": "Random number generators and other randomness functionality. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand@0.10.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rand"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+      "author": "The Rand Project Developers, The Rust Project Developers",
+      "name": "rand",
+      "version": "0.9.2",
+      "description": "Random number generators and other randomness functionality. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand@0.9.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rand"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
+      "author": "The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors",
+      "name": "rand_chacha",
+      "version": "0.9.0",
+      "description": "ChaCha random number generator ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand_chacha@0.9.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand_chacha"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rand"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
+      "author": "The Rand Project Developers",
+      "name": "rand_core",
+      "version": "0.10.0",
+      "description": "Core random number generation traits and tools for implementation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand_core@0.10.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand_core"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rand_core"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5",
+      "author": "The Rand Project Developers, The Rust Project Developers",
+      "name": "rand_core",
+      "version": "0.9.5",
+      "description": "Core random number generator traits and tools for implementation. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand_core@0.9.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand_core"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rand"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
+      "author": "The Rand Project Developers, The Rust Project Developers",
+      "name": "rand_xorshift",
+      "version": "0.4.0",
+      "description": "Xorshift random number generator ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rand_xorshift@0.4.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rand_xorshift"
+        },
+        {
+          "type": "website",
+          "url": "https://rust-random.github.io/book"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-random/rngs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler",
+      "version": "0.40.3",
+      "description": "Rust library to install conda environments",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ba7b9c2977ddc74fecb7e68dd6b3f40958416220b9643d94db5b7387fd0cbcd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler@0.40.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+      "name": "rattler_cache",
+      "version": "0.6.18",
+      "description": "A crate to manage the caching of data in rattler",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f380851c13b9c14811d0281ce72ddd608b7dd98bc0a3e669247aa75dbac5e3b6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_cache@0.6.18",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_conda_types",
+      "version": "0.44.3",
+      "description": "Rust data types for common types used within the Conda ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8dc7eaa515b50a8ba80753d9902582bc2d62d8452ca61e6afd7bca866b54c85"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_conda_types@0.44.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_digest",
+      "version": "1.2.3",
+      "description": "An simple crate used by rattler crates to compute different hashes from different sources",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_digest@1.2.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_lock",
+      "version": "0.27.4",
+      "description": "Rust data types for conda lock",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "88f3b24c35849f7460d51b4b2016dfdab132e03d0a7d0f6d00d367cf16211fa2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_lock@0.27.4",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.0.12",
+      "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
+      "name": "rattler_macros",
+      "version": "1.0.12",
+      "description": "A crate that provideds some procedural macros for the rattler project",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "18d0d45ce3ae00333421569d2fafa4b877708a901c3cb217f8d4acfab4328df0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_macros@1.0.12",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
+      "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
+      "name": "rattler_menuinst",
+      "version": "0.2.53",
+      "description": "Install menu entries for a Conda package",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0cb53fa7f10330b818ddfafd7c7d407254809ea249597bbc03073c2a3ad2854a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_menuinst@0.2.53",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+      "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
+      "name": "rattler_networking",
+      "version": "0.26.6",
+      "description": "Authenticated requests in the conda ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "67894637c820e2fbdf6ac44fc2b43d5ea38b7196439c4f7525b5c3dc2758e0b5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_networking@0.26.6",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_package_streaming",
+      "version": "0.24.6",
+      "description": "Extract and stream of Conda package archives",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "54da4bc16291b217181fa9ba07c0d5a796e1fa1e63591fef0f6e6e7e96e211d1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_package_streaming@0.24.6",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
+      "name": "rattler_pty",
+      "version": "0.2.9",
+      "description": "A crate to create pty",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ec435d69bcc064b5cb0f6a49d8cfc1dbed93f0ec233d4499156ae7c3bc7f90d7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_pty@0.2.9",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
+      "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
+      "name": "rattler_redaction",
+      "version": "0.1.13",
+      "description": "Redact sensitive information from URLs (ie. conda tokens)",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "961121cad9792daafc176a7f4caafc0fc889fb17507c23a4c86e1777a8b5e179"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_redaction@0.1.13",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+      "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
+      "name": "rattler_shell",
+      "version": "0.26.6",
+      "description": "A crate to help with activation and deactivation of a conda environment",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b0304b98dc745f816767dfd46c640c14b178c8327799c651dd10b6e25507cbae"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_shell@0.26.6",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_solve",
+      "version": "5.1.0",
+      "description": "A crate to solve conda environments",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "804311898940221962582b0fc0f48f122dfb1a85a0169c649121cce143a37f8f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_solve@5.1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0",
+      "name": "rayon-core",
+      "version": "1.13.0",
+      "description": "Core APIs for Rayon",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rayon-core@1.13.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rayon-core/"
+        },
+        {
+          "type": "other",
+          "url": "rayon-core"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rayon-rs/rayon"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+      "name": "rayon",
+      "version": "1.11.0",
+      "description": "Simple work-stealing parallelism for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rayon@1.11.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rayon/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rayon-rs/rayon"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "ref-cast-impl",
+      "version": "1.0.25",
+      "description": "Derive implementation for ref_cast::RefCast.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ref-cast-impl@1.0.25",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ref-cast"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/ref-cast"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "ref-cast",
+      "version": "1.0.25",
+      "description": "Safely cast &T to &U where the struct U contains a single field of type T.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ref-cast@1.0.25",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ref-cast"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/ref-cast"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
+      "author": "Jiahao XU <Jiahao_XU@outlook.com>",
+      "name": "reflink-copy",
+      "version": "0.1.29",
+      "description": "copy-on-write mechanism on supported file systems",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/reflink-copy@0.1.29",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/reflink-copy"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/cargo-bins/reflink-copy"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/cargo-bins/reflink-copy"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+      "name": "regex-automata",
+      "version": "0.4.14",
+      "description": "Automata construction and matching using regular expressions.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/regex-automata@0.4.14",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/regex-automata"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/regex/tree/master/regex-automata"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
+      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+      "name": "regex-syntax",
+      "version": "0.8.10",
+      "description": "A regular expression parser.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/regex-syntax@0.8.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/regex-syntax"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/regex/tree/master/regex-syntax"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+      "name": "regex",
+      "version": "1.12.3",
+      "description": "An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/regex@1.12.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/regex"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/regex"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+      "author": "Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>",
+      "name": "reqwest-middleware",
+      "version": "0.4.2",
+      "description": "Wrapper around reqwest to allow for client middleware chains.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/reqwest-middleware@0.4.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/TrueLayer/reqwest-middleware"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "reqwest",
+      "version": "0.12.28",
+      "description": "higher level HTTP client library",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/reqwest@0.12.28",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/reqwest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/reqwest"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "author": "Luca Palmieri <lpalmieri@truelayer.com>",
+      "name": "retry-policies",
+      "version": "0.5.1",
+      "description": "A collection of plug-and-play retry policies for Rust projects.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/retry-policies@0.5.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/TrueLayer/retry-policies"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
+      "name": "ring",
+      "version": "0.17.14",
+      "description": "An experiment.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND ISC"
+        }
+      ],
+      "purl": "pkg:cargo/ring@0.17.14",
+      "externalReferences": [
+        {
+          "type": "other",
+          "url": "ring_core_0_17_14_"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/briansmith/ring"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "rustc-demangle",
+      "version": "0.1.27",
+      "description": "Rust compiler symbol demangling. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rustc-demangle@0.1.27",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rustc-demangle"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/rustc-demangle"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/rustc-demangle"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+      "author": "The Rust Project Developers",
+      "name": "rustc-hash",
+      "version": "2.1.2",
+      "description": "A speedy, non-cryptographic hashing algorithm used by rustc",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/rustc-hash@2.1.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/rustc-hash"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+      "name": "rustc_version",
+      "version": "0.4.1",
+      "description": "A library for querying the version of a installed rustc compiler",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rustc_version@0.4.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rustc_version/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/djc/rustc-version-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc_version_runtime@0.3.0",
+      "author": "Sebastian Waisbrot <seppo0010@gmail.com>",
+      "name": "rustc_version_runtime",
+      "version": "0.3.0",
+      "description": "A library for querying the version of the rustc compiler used in runtime",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/rustc_version_runtime@0.3.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "http://seppo0010.github.io/rustc-version-runtime-rs/rustc_version_runtime/index.html"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seppo0010/rustc-version-runtime-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+      "author": "Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>",
+      "name": "rustix",
+      "version": "1.1.4",
+      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/rustix@1.1.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rustix"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/rustix"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+      "name": "rustls-pki-types",
+      "version": "1.14.0",
+      "description": "Shared types for the rustls PKI ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rustls-pki-types@1.14.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rustls-pki-types"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/pki-types"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/pki-types"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+      "name": "rustls-webpki",
+      "version": "0.103.10",
+      "description": "Web PKI X.509 Certificate Verification.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "ISC"
+        }
+      ],
+      "purl": "pkg:cargo/rustls-webpki@0.103.10",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/webpki"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+      "name": "rustls",
+      "version": "0.23.37",
+      "description": "Rustls is a modern TLS library written in Rust.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR ISC OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/rustls@0.23.37",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/rustls"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/rustls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "rustversion",
+      "version": "1.0.22",
+      "description": "Conditional compilation according to rustc compiler version",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rustversion@1.0.22",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rustversion"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/rustversion"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
+      "author": "Jason Lingle",
+      "name": "rusty-fork",
+      "version": "0.3.1",
+      "description": "Cross-platform library for running Rust tests in sub-processes using a fork-like interface. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/rusty-fork@0.3.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rusty-fork"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/altsysrq/rusty-fork"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "ryu",
+      "version": "1.0.23",
+      "description": "Fast floating point to string conversion",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR BSL-1.0"
+        }
+      ],
+      "purl": "pkg:cargo/ryu@1.0.23",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ryu"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/ryu"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
+      "author": "Graham Esau <gesau@hotmail.co.uk>",
+      "name": "schemars",
+      "version": "0.9.0",
+      "description": "Generate JSON Schemas from Rust code",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/schemars@0.9.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://graham.cool/schemars/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/GREsau/schemars"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+      "author": "Graham Esau <gesau@hotmail.co.uk>",
+      "name": "schemars",
+      "version": "1.2.1",
+      "description": "Generate JSON Schemas from Rust code",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/schemars@1.2.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://graham.cool/schemars/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/GREsau/schemars"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0",
+      "author": "bluss",
+      "name": "scopeguard",
+      "version": "1.2.0",
+      "description": "A RAII scope guard that will run a given closure when it goes out of scope, even if the code between panics (assuming unwinding panic).  Defines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as shorthands for guards with one of the implemented strategies. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/scopeguard@1.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/scopeguard/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bluss/scopeguard"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework-sys",
+      "version": "2.17.0",
+      "description": "Apple `Security.framework` low-level FFI bindings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework-sys@2.17.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security-framework-sys"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework",
+      "version": "3.7.0",
+      "description": "Security.framework bindings for macOS and iOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework@3.7.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/security_framework"
+        },
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security_framework"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
+      "author": "Armin Ronacher <armin.ronacher@active-4.com>",
+      "name": "self-replace",
+      "version": "1.5.0",
+      "description": "Utility crate that allows executables to replace or uninstall themselves",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/self-replace@1.5.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/mitsuhiko/self-replace"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/mitsuhiko/self-replace"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "semver",
+      "version": "1.0.28",
+      "description": "Parser and evaluator for Cargo's flavor of Semantic Versioning",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/semver@1.0.28",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/semver"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/semver"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "serde-untagged",
+      "version": "0.1.9",
+      "description": "Serde `Visitor` implementation for deserializing untagged enums",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde-untagged@0.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde-untagged"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/serde-untagged"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
+      "author": "arcnmx",
+      "name": "serde-value",
+      "version": "0.7.0",
+      "description": "Serialization value trees",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/serde-value@0.7.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde-value/*/serde_value/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/arcnmx/serde-value"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+      "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+      "name": "serde",
+      "version": "1.0.228",
+      "description": "A generic serialization/deserialization framework",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde@1.0.228",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde"
+        },
+        {
+          "type": "website",
+          "url": "https://serde.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/serde-rs/serde"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_bytes",
+      "version": "0.11.19",
+      "description": "Optimized handling of `&[u8]` and `Vec<u8>` for Serde",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_bytes@0.11.19",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_bytes"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/serde-rs/bytes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+      "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_core",
+      "version": "1.0.228",
+      "description": "Serde traits only, with no support for derive -- use the `serde` crate instead",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_core@1.0.228",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_core"
+        },
+        {
+          "type": "website",
+          "url": "https://serde.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/serde-rs/serde"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+      "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_derive",
+      "version": "1.0.228",
+      "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_derive@1.0.228",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://serde.rs/derive.html"
+        },
+        {
+          "type": "website",
+          "url": "https://serde.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/serde-rs/serde"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+      "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_json",
+      "version": "1.0.149",
+      "description": "A JSON serialization file format",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_json@1.0.149",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_json"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/serde-rs/json"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_repr",
+      "version": "0.1.20",
+      "description": "Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_repr@0.1.20",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_repr"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/serde-repr"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
+      "author": "Anthony Ramine <n.oxyde@gmail.com>",
+      "name": "serde_urlencoded",
+      "version": "0.7.1",
+      "description": "`x-www-form-urlencoded` meets Serde",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_urlencoded@0.7.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_urlencoded/0.7.1/serde_urlencoded/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/nox/serde_urlencoded"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
+      "author": "Jonas Bushart, Marcin Ka\u017amierczak",
+      "name": "serde_with",
+      "version": "3.18.0",
+      "description": "Custom de/serialization functions for Rust's serde",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_with@3.18.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_with/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/jonasbb/serde_with/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.18.0",
+      "author": "Jonas Bushart",
+      "name": "serde_with_macros",
+      "version": "3.18.0",
+      "description": "proc-macro library for serde_with",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_with_macros@3.18.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_with_macros/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/jonasbb/serde_with/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "serde_yaml",
+      "version": "0.9.34+deprecated",
+      "description": "YAML data format for Serde",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/serde_yaml@0.9.34+deprecated",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/serde_yaml/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/serde-yaml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+      "author": "RustCrypto Developers",
+      "name": "sha2",
+      "version": "0.10.9",
+      "description": "Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/sha2@0.10.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/sha2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/hashes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
+      "author": "Eliza Weisman <eliza@buoyant.io>",
+      "name": "sharded-slab",
+      "version": "0.1.7",
+      "description": "A lock-free concurrent slab. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sharded-slab@0.1.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/sharded-slab/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/hawkw/sharded-slab"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hawkw/sharded-slab"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+      "author": "comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>",
+      "name": "shlex",
+      "version": "1.3.0",
+      "description": "Split a string into shell words, like Python's shlex.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/shlex@1.3.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/comex/rust-shlex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
+      "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>",
+      "name": "signal-hook-registry",
+      "version": "1.4.8",
+      "description": "Backend crate for signal-hook",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/signal-hook-registry@1.4.8",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/signal-hook-registry"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/vorner/signal-hook"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>",
+      "name": "signal-hook",
+      "version": "0.3.18",
+      "description": "Unix signal handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/signal-hook@0.3.18",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/signal-hook"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/vorner/signal-hook"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9",
+      "author": "Marvin Countryman <me@maar.vin>",
+      "name": "simd-adler32",
+      "version": "0.3.9",
+      "description": "A SIMD-accelerated Adler-32 hash algorithm implementation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/simd-adler32@0.3.9",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/mcountryman/simd-adler32"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+      "author": "Heinz N. Gies <heinz@licenser.net>, Sunny Gleason",
+      "name": "simd-json",
+      "version": "0.17.0",
+      "description": "High performance JSON parser based on a port of simdjson",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/simd-json@0.17.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/simd-json"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/simd-lite/simd-json"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5",
+      "author": "Hans Kratz <hans@appfour.com>",
+      "name": "simdutf8",
+      "version": "0.1.5",
+      "description": "SIMD-accelerated UTF-8 validation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/simdutf8@0.1.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/simdutf8/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rusticstuff/simdutf8"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rusticstuff/simdutf8"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+      "name": "simple_spawn_blocking",
+      "version": "1.1.0",
+      "description": "A simple crate to make spawning blocking tasks more ergonomic",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/simple_spawn_blocking@1.1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
+      "author": "Carl Lerche <me@carllerche.com>",
+      "name": "slab",
+      "version": "0.4.12",
+      "description": "Pre-allocated storage for a uniform data type",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/slab@0.4.12",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/slab"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+      "author": "The Servo Project Developers",
+      "name": "smallvec",
+      "version": "1.15.1",
+      "description": "'Small vector' optimization: store up to a small number of items on the stack",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/smallvec@1.15.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/smallvec/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-smallvec"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+      "name": "socket2",
+      "version": "0.6.3",
+      "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/socket2@0.6.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/socket2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/socket2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/socket2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1",
+      "author": "Robert Grosse <n210241048576@gmail.com>",
+      "name": "stable_deref_trait",
+      "version": "1.2.1",
+      "description": "An unsafe marker trait for types like Box and Rc that dereference to a stable address even when moved, and hence can be used with libraries such as owning_ref and rental. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/stable_deref_trait@1.2.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/stable_deref_trait/1.2.1/stable_deref_trait"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/storyyeller/stable_deref_trait"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1",
+      "author": "Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>",
+      "name": "strsim",
+      "version": "0.11.1",
+      "description": "Implementations of string similarity metrics. Includes Hamming, Levenshtein, OSA, Damerau-Levenshtein, Jaro, Jaro-Winkler, and S\u00f8rensen-Dice. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/strsim@0.11.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/strsim/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rapidfuzz/strsim-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rapidfuzz/strsim-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
+      "author": "Peter Glotfelty <peter.glotfelty@microsoft.com>",
+      "name": "strum",
+      "version": "0.28.0",
+      "description": "Helpful macros for working with enums and strings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/strum@0.28.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/strum"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/Peternator7/strum"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Peternator7/strum"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0",
+      "author": "Peter Glotfelty <peter.glotfelty@microsoft.com>",
+      "name": "strum_macros",
+      "version": "0.28.0",
+      "description": "Helpful macros for working with enums and strings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/strum_macros@0.28.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/strum"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/Peternator7/strum"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Peternator7/strum"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
+      "author": "Isis Lovecruft <isis@patternsinthevoid.net>, Henry de Valence <hdevalence@hdevalence.ca>",
+      "name": "subtle",
+      "version": "2.6.1",
+      "description": "Pure-Rust traits and utilities for constant-time cryptographic implementations.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/subtle@2.6.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/subtle"
+        },
+        {
+          "type": "website",
+          "url": "https://dalek.rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dalek-cryptography/subtle"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#supports-color@3.0.2",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "supports-color",
+      "version": "3.0.2",
+      "description": "Detects whether a terminal supports color, and gives details about that support.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/supports-color@3.0.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/supports-color"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/supports-color"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#supports-hyperlinks@3.2.0",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "supports-hyperlinks",
+      "version": "3.2.0",
+      "description": "Detects whether a terminal supports rendering hyperlinks.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/supports-hyperlinks@3.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/supports-hyperlinks"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/supports-hyperlinks"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#supports-unicode@3.0.0",
+      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "name": "supports-unicode",
+      "version": "3.0.0",
+      "description": "Detects whether a terminal supports unicode.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/supports-unicode@3.0.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/supports-unicode"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zkat/supports-unicode"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "syn",
+      "version": "2.0.117",
+      "description": "Parser for Rust source code",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/syn@2.0.117",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/syn"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/syn"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+      "author": "Actyx AG <developer@actyx.io>",
+      "name": "sync_wrapper",
+      "version": "1.0.2",
+      "description": "A tool for enlisting the compiler's help in proving the absence of concurrency",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/sync_wrapper@1.0.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/sync_wrapper"
+        },
+        {
+          "type": "website",
+          "url": "https://docs.rs/sync_wrapper"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Actyx/sync_wrapper"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2",
+      "author": "Nika Layzell <nika@thelayzells.com>",
+      "name": "synstructure",
+      "version": "0.13.2",
+      "description": "Helper methods and macros for custom derives",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/synstructure@0.13.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/synstructure"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/mystor/synstructure"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
+      "author": "Guillaume Gomez <guillaume1.gomez@gmail.com>",
+      "name": "sysinfo",
+      "version": "0.30.13",
+      "description": "Library to get system information such as processes, CPUs, disks, components and networks",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sysinfo@0.30.13",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/GuillaumeGomez/sysinfo"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "tar",
+      "version": "0.4.45",
+      "description": "A Rust implementation of a TAR file reader and writer. This library does not currently handle compression, but it is abstract over all I/O readers and writers. Additionally, great lengths are taken to ensure that the entire contents are never required to be entirely resident in memory all at once. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/tar@0.4.45",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tar"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/alexcrichton/tar-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/alexcrichton/tar-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+      "author": "Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>",
+      "name": "tempfile",
+      "version": "3.27.0",
+      "description": "A library for managing temporary files and directories.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/tempfile@3.27.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tempfile"
+        },
+        {
+          "type": "website",
+          "url": "https://stebalien.com/projects/tempfile-rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Stebalien/tempfile"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
+      "author": "Andrew Chin <achin@eminence32.net>",
+      "name": "terminal_size",
+      "version": "0.4.4",
+      "description": "Gets the size of your Linux or Windows terminal",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/terminal_size@0.4.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/terminal_size"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/eminence/terminal-size"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.2",
+      "author": "Martin Geisler <martin@geisler.net>",
+      "name": "textwrap",
+      "version": "0.16.2",
+      "description": "Library for word wrapping, indenting, and dedenting strings. Has optional support for Unicode and emojis as well as machine hyphenation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/textwrap@0.16.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/textwrap/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/mgeisler/textwrap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "thiserror-impl",
+      "version": "1.0.69",
+      "description": "Implementation detail of the `thiserror` crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/thiserror-impl@1.0.69",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/thiserror"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "thiserror-impl",
+      "version": "2.0.18",
+      "description": "Implementation detail of the `thiserror` crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/thiserror-impl@2.0.18",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/thiserror"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "thiserror",
+      "version": "1.0.69",
+      "description": "derive(Error)",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/thiserror@1.0.69",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/thiserror"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/thiserror"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "thiserror",
+      "version": "2.0.18",
+      "description": "derive(Error)",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/thiserror@2.0.18",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/thiserror"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/thiserror"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "thread_local",
+      "version": "1.1.9",
+      "description": "Per-object thread-local storage",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/thread_local@1.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/thread_local/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Amanieu/thread_local-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
+      "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
+      "name": "time-core",
+      "version": "0.1.8",
+      "description": "This crate is an implementation detail and should not be relied upon directly.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/time-core@0.1.8",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/time-rs/time"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27",
+      "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
+      "name": "time-macros",
+      "version": "0.2.27",
+      "description": "    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/time-macros@0.2.27",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/time-rs/time"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+      "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
+      "name": "time",
+      "version": "0.3.47",
+      "description": "Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/time@0.3.47",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://time-rs.github.io"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/time-rs/time"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tinystr@0.8.3",
+      "author": "The ICU4X Project Developers",
+      "name": "tinystr",
+      "version": "0.8.3",
+      "description": "A small ASCII-only bounded length string representation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/tinystr@0.8.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0",
+      "author": "Lokathor <zefria@gmail.com>",
+      "name": "tinyvec",
+      "version": "1.11.0",
+      "description": "`tinyvec` provides 100% safe vec-like data structures.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tinyvec@1.11.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Lokathor/tinyvec"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1",
+      "author": "Soveu <marx.tomasz@gmail.com>",
+      "name": "tinyvec_macros",
+      "version": "0.1.1",
+      "description": "Some macros for tiny containers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0 OR Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/tinyvec_macros@0.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Soveu/tinyvec_macros"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tokio-macros",
+      "version": "2.7.0",
+      "description": "Tokio's proc macros. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tokio-macros@2.7.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tokio"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tokio-native-tls",
+      "version": "0.3.1",
+      "description": "An implementation of TLS/SSL streams for Tokio using native-tls giving an implementation of TLS for nonblocking I/O streams. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tokio-native-tls@0.3.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tokio-native-tls"
+        },
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
+      "name": "tokio-rustls",
+      "version": "0.26.4",
+      "description": "Asynchronous TLS/SSL streams for Tokio using Rustls.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/tokio-rustls@0.26.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tokio-rustls"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/tokio-rustls"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/tokio-rustls"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tokio-stream",
+      "version": "0.1.18",
+      "description": "Utilities to work with `Stream` and `tokio`. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tokio-stream@0.1.18",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tokio"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tokio-util",
+      "version": "0.7.18",
+      "description": "Additional utilities for working with Tokio. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tokio-util@0.7.18",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tokio"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tokio",
+      "version": "1.51.0",
+      "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tokio@1.51.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tokio"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
+      "author": "Lucio Franco <luciofranco14@gmail.com>",
+      "name": "tonic-prost",
+      "version": "0.14.5",
+      "description": "Prost codec implementation for tonic",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tonic-prost@0.14.5",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/hyperium/tonic"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/tonic"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5",
+      "author": "Lucio Franco <luciofranco14@gmail.com>",
+      "name": "tonic",
+      "version": "0.14.5",
+      "description": "A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tonic@0.14.5",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/hyperium/tonic"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/tonic"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
+      "author": "Tower Maintainers <team@tower-rs.com>",
+      "name": "tower-http",
+      "version": "0.6.8",
+      "description": "Tower middleware and utilities for HTTP clients and servers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tower-http@0.6.8",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/tower-rs/tower-http"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tower-rs/tower-http"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
+      "author": "Tower Maintainers <team@tower-rs.com>",
+      "name": "tower-layer",
+      "version": "0.3.3",
+      "description": "Decorates a `Service` to allow easy composition between `Service`s. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tower-layer@0.3.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tower-layer/0.3.3"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/tower-rs/tower"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tower-rs/tower"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+      "author": "Tower Maintainers <team@tower-rs.com>",
+      "name": "tower-service",
+      "version": "0.3.3",
+      "description": "Trait representing an asynchronous, request / response based, client or server. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tower-service@0.3.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/tower-service/0.3.3"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/tower-rs/tower"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tower-rs/tower"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+      "author": "Tower Maintainers <team@tower-rs.com>",
+      "name": "tower",
+      "version": "0.5.3",
+      "description": "Tower is a library of modular and reusable components for building robust clients and servers. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tower@0.5.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/tower-rs/tower"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tower-rs/tower"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
+      "author": "Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>",
+      "name": "tracing-attributes",
+      "version": "0.1.31",
+      "description": "Procedural macro attributes for automatically instrumenting functions. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing-attributes@0.1.31",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tracing-core",
+      "version": "0.1.36",
+      "description": "Core primitives for application-level tracing. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing-core@0.1.36",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
+      "author": "Tokio Contributors <team@tokio.rs>",
+      "name": "tracing-log",
+      "version": "0.2.0",
+      "description": "Provides compatibility between `tracing` and the `log` crate. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing-log@0.2.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
+      "name": "tracing-opentelemetry",
+      "version": "0.32.1",
+      "description": "OpenTelemetry integration for tracing",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing-opentelemetry@0.32.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/tokio-rs/tracing-opentelemetry"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing-opentelemetry"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+      "author": "Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>",
+      "name": "tracing-subscriber",
+      "version": "0.3.23",
+      "description": "Utilities for implementing and composing `tracing` subscribers. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing-subscriber@0.3.23",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+      "author": "Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>",
+      "name": "tracing",
+      "version": "0.1.44",
+      "description": "Application-level tracing for Rust. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/tracing@0.1.44",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://tokio.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/tracing"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "try-lock",
+      "version": "0.2.5",
+      "description": "A lightweight atomic lock.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/try-lock@0.2.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/try-lock"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/seanmonstar/try-lock"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/try-lock"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+      "author": "Chip Senkbeil <chip@senkbeil.org>",
+      "name": "typed-path",
+      "version": "0.12.3",
+      "description": "Provides typed variants of Path and PathBuf for Unix and Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/typed-path@0.12.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/chipsenkbeil/typed-path"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/chipsenkbeil/typed-path"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "typeid",
+      "version": "1.0.3",
+      "description": "Const TypeId and non-'static TypeId",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/typeid@1.0.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/typeid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/typeid"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0",
+      "author": "Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>",
+      "name": "typenum",
+      "version": "1.19.0",
+      "description": "Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/typenum@1.19.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/typenum"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/paholg/typenum"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
+      "name": "unarray",
+      "version": "0.1.4",
+      "description": "Utilities for working with uninitialized arrays",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unarray@0.1.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/cameron1024/unarray"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "unicase",
+      "version": "2.9.0",
+      "description": "A case-insensitive wrapper around strings.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicase@2.9.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/unicase"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/unicase"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "unicode-ident",
+      "version": "1.0.24",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "(MIT OR Apache-2.0) AND Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-ident@1.0.24",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/unicode-ident"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/unicode-ident"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5",
+      "author": "Axel Forsman <axelsfor@gmail.com>",
+      "name": "unicode-linebreak",
+      "version": "0.1.5",
+      "description": "Implementation of the Unicode Line Breaking Algorithm",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-linebreak@0.1.5",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/axelf4/unicode-linebreak"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/axelf4/unicode-linebreak"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
+      "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-normalization",
+      "version": "0.1.25",
+      "description": "This crate provides functions for normalization of Unicode strings, including Canonical and Compatible Decomposition and Recomposition, as described in Unicode Standard Annex #15. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-normalization@0.1.25",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/unicode-normalization/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-normalization"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-normalization"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
+      "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-segmentation",
+      "version": "1.13.2",
+      "description": "This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-segmentation@1.13.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-segmentation"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-segmentation"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14",
+      "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-width",
+      "version": "0.1.14",
+      "description": "Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-width@0.1.14",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-width"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-width"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+      "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-width",
+      "version": "0.2.2",
+      "description": "Determine displayed width of `char` and `str` types according to Unicode Standard Annex #11 rules. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-width@0.2.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-width"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-width"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
+      "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
+      "name": "unit-prefix",
+      "version": "0.5.2",
+      "description": "Format numbers with metric and binary unit prefixes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/unit-prefix@0.5.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://codeberg.org/commons-rs/unit-prefix"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "unsafe-libyaml",
+      "version": "0.2.11",
+      "description": "libyaml transpiled to rust by c2rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/unsafe-libyaml@0.2.11",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/unsafe-libyaml"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/unsafe-libyaml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0",
+      "author": "Laurenz <laurmaedje@gmail.com>",
+      "name": "unscanny",
+      "version": "0.1.0",
+      "description": "Painless string scanning.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unscanny@0.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/typst/unscanny"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0",
+      "author": "Brian Smith <brian@briansmith.org>",
+      "name": "untrusted",
+      "version": "0.9.0",
+      "description": "Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "ISC"
+        }
+      ],
+      "purl": "pkg:cargo/untrusted@0.9.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://briansmith.org/rustdoc/untrusted/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/briansmith/untrusted"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+      "author": "The rust-url developers",
+      "name": "url",
+      "version": "2.5.8",
+      "description": "URL library for Rust, based on the WHATWG URL Standard",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/url@2.5.8",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/url"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/rust-url"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
+      "author": "Kornel <kornel@geekhood.net>, Bertram Truong <b@bertramtruong.com>",
+      "name": "urlencoding",
+      "version": "2.1.3",
+      "description": "A Rust library for doing URL percentage encoding.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/urlencoding@2.1.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://lib.rs/urlencoding"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust_urlencoding"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
+      "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
+      "name": "utf8_iter",
+      "version": "1.0.4",
+      "description": "Iterator by char over potentially-invalid UTF-8 in &[u8]",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/utf8_iter@1.0.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/utf8_iter/"
+        },
+        {
+          "type": "website",
+          "url": "https://docs.rs/utf8_iter/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hsivonen/utf8_iter"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2",
+      "author": "Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>",
+      "name": "utf8parse",
+      "version": "0.2.2",
+      "description": "Table-driven UTF-8 parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/utf8parse@0.2.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/utf8parse/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/alacritty/vte"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0",
+      "author": "Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>",
+      "name": "uuid",
+      "version": "1.23.0",
+      "description": "A library to generate and parse UUIDs.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/uuid@1.23.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/uuid"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/uuid-rs/uuid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/uuid-rs/uuid"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
+      "author": "Heinz N. Gies <heinz@licenser.net>",
+      "name": "value-trait",
+      "version": "0.12.1",
+      "description": "Traits to deal with JSONesque values",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/value-trait@0.12.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/value-trait"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/simd-lite/value-trait"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
+      "name": "version-ranges",
+      "version": "0.1.2",
+      "description": "Performance-optimized type for generic version ranges and operations on them.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MPL-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/version-ranges@0.1.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pubgrub-rs/pubgrub"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
+      "author": "Sergio Benitez <sb@sergio.bz>",
+      "name": "version_check",
+      "version": "0.9.5",
+      "description": "Tiny crate to check the version of the installed/running rustc.",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/version_check@0.9.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/version_check/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/SergioBenitez/version_check"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wait-timeout",
+      "version": "0.2.1",
+      "description": "A crate to wait on a child process with a timeout specified across Unix and Windows platforms. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wait-timeout@0.2.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wait-timeout"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/alexcrichton/wait-timeout"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/alexcrichton/wait-timeout"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "want",
+      "version": "0.3.1",
+      "description": "Detect when another Future wants a result.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/want@0.3.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/want"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/want"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
+      "author": "Amod Malviya @amodm",
+      "name": "webbrowser",
+      "version": "1.2.0",
+      "description": "Open URLs in web browsers available on a platform",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/webbrowser@1.2.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/webbrowser"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/amodm/webbrowser-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/amodm/webbrowser-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
+      "author": "Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>",
+      "name": "which",
+      "version": "8.0.2",
+      "description": "A Rust equivalent of Unix command \"which\". Locate installed executable in cross platforms.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/which@8.0.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/which/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/harryfei/which-rs.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
+      "author": "The ICU4X Project Developers",
+      "name": "writeable",
+      "version": "0.6.3",
+      "description": "A more efficient alternative to fmt::Display",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/writeable@0.6.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
+      "author": "Steven Allen <steven@stebalien.com>",
+      "name": "xattr",
+      "version": "1.6.1",
+      "description": "unix extended filesystem attributes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/xattr@1.6.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/xattr"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Stebalien/xattr"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "yoke-derive",
+      "version": "0.8.2",
+      "description": "Custom derive for the yoke crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/yoke-derive@0.8.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "yoke",
+      "version": "0.8.2",
+      "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/yoke@0.8.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
+      "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
+      "name": "zerocopy",
+      "version": "0.8.48",
+      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zerocopy@0.8.48",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/google/zerocopy"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerofrom-derive",
+      "version": "0.1.7",
+      "description": "Custom derive for the zerofrom crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerofrom-derive@0.1.7",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerofrom",
+      "version": "0.1.7",
+      "description": "ZeroFrom trait for constructing",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerofrom@0.1.7",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
+      "author": "The RustCrypto Project Developers",
+      "name": "zeroize",
+      "version": "1.8.2",
+      "description": "Securely clear secrets from memory with a simple trait built on stable Rust primitives which guarantee memory is zeroed using an operation will not be 'optimized away' by the compiler. Uses a portable pure Rust implementation that works everywhere, even WASM! ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zeroize@1.8.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/utils/tree/master/zeroize"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
+      "author": "The ICU4X Project Developers",
+      "name": "zerotrie",
+      "version": "0.2.4",
+      "description": "A data structure that efficiently maps strings to integers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerotrie@0.2.4",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerovec-derive",
+      "version": "0.11.3",
+      "description": "Custom derive for the zerovec crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerovec-derive@0.11.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6",
+      "author": "The ICU4X Project Developers",
+      "name": "zerovec",
+      "version": "0.11.6",
+      "description": "Zero-copy vector backed by a byte array",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerovec@0.11.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+      "author": "Mathijs van de Nes <git@mathijs.vd-nes.nl>, Marli Frost <marli@frost.red>, Ryan Levick <ryan.levick@gmail.com>, Chris Hennick <hennickc@amazon.com>",
+      "name": "zip",
+      "version": "8.5.0",
+      "description": "Library to support the reading and writing of zip files.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zip@8.5.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/zip-rs/zip2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
+      "name": "zlib-rs",
+      "version": "0.6.3",
+      "description": "A memory-safe zlib implementation written in rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/zlib-rs@0.6.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/trifectatechfoundation/zlib-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/trifectatechfoundation/zlib-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "zmij",
+      "version": "1.0.21",
+      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zmij@1.0.21",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/zmij"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/zmij"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3",
+      "name": "zopfli",
+      "version": "0.8.3",
+      "description": "A Rust implementation of the Zopfli compression algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/zopfli@0.8.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/zopfli-rs/zopfli"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zopfli-rs/zopfli"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd-safe",
+      "version": "7.2.4",
+      "description": "Safe low-level bindings for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/zstd-safe@7.2.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd-sys",
+      "version": "2.0.16+zstd.1.5.7",
+      "description": "Low-level bindings for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/zstd-sys@2.0.16+zstd.1.5.7",
+      "externalReferences": [
+        {
+          "type": "other",
+          "url": "zstd"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd",
+      "version": "0.13.3",
+      "description": "Binding for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zstd@0.13.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/zstd"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-stdout@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version_runtime@0.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "dependsOn": [
+        "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+        "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#gimli@0.32.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
+        "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
+        "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41",
+        "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37",
+        "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async_http_range_reader@0.9.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#backtrace-ext@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
+        "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+        "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+        "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.37",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31",
+        "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
+        "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
+        "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5",
+        "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
+        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
+        "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0",
+        "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#gimli@0.32.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21",
+        "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tinystr@0.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_properties_data@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties_data@2.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer@2.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#miette-derive@7.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace-ext@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#miette-derive@7.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#supports-color@3.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#supports-hyperlinks@3.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#supports-unicode@3.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
+        "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.2",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+        "registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.31.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5",
+        "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-stdout@0.31.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-internal@1.1.11",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-internal@1.1.11"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
+        "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.0.12",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
+        "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.0.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+        "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41",
+        "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#async_http_range_reader@0.9.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc_version_runtime@0.3.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+        "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.18.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-color@3.0.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-hyperlinks@3.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-unicode@3.0.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
+        "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinystr@0.8.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
+        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.41",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.12",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
+        "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4"
+      ]
+    }
+  ]
+}

--- a/SBOM.json
+++ b/SBOM.json
@@ -30,8 +30,8 @@
     },
     "properties": [
       {
-        "name": "cdx:rustc:sbom:target:all_targets",
-        "value": "true"
+        "name": "cdx:rustc:sbom:target:triple",
+        "value": "x86_64-unknown-linux-gnu"
       }
     ]
   },
@@ -204,41 +204,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
-      "author": "Nicolas Silva <nical@fastmail.com>",
-      "name": "android_system_properties",
-      "version": "0.1.5",
-      "description": "Minimal Android system properties wrapper",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/android_system_properties@0.1.5",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/android_system_properties"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/nical/android_system_properties"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/nical/android_system_properties"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
       "name": "anstream",
       "version": "1.0.0",
@@ -308,32 +273,6 @@
         }
       ],
       "purl": "pkg:cargo/anstyle-query@1.1.5",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/rust-cli/anstyle.git"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
-      "name": "anstyle-wincon",
-      "version": "3.0.11",
-      "description": "Styling legacy Windows terminals",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/anstyle-wincon@3.0.11",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1375,37 +1314,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
-      "author": "Markus Westerlind <marwes91@gmail.com>",
-      "name": "combine",
-      "version": "4.6.7",
-      "description": "Fast parser combinators on arbitrary streams with zero-copy support.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/combine@4.6.7",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/combine"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/Marwes/combine"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
       "author": "Arne Beer <contact@arne.beer>",
       "name": "comfy-table",
@@ -1559,64 +1467,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/console-rs/console"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-      "author": "The Servo Project Developers",
-      "name": "core-foundation-sys",
-      "version": "0.8.7",
-      "description": "Bindings to Core Foundation for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/core-foundation-sys@0.8.7",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/servo/core-foundation-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/servo/core-foundation-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-      "author": "The Servo Project Developers",
-      "name": "core-foundation",
-      "version": "0.10.1",
-      "description": "Bindings to Core Foundation for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/core-foundation@0.10.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/servo/core-foundation-rs"
         }
       ]
     },
@@ -1827,37 +1677,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/crossterm-rs/crossterm"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
-      "author": "T. Post",
-      "name": "crossterm_winapi",
-      "version": "0.9.1",
-      "description": "WinAPI wrapper that provides some basic simple abstractions around common WinAPI calls",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/crossterm_winapi@0.9.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/crossterm_winapi/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/crossterm-rs/crossterm-winapi"
         }
       ]
     },
@@ -2254,37 +2073,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
-      "author": "Torbj\u00f8rn Birch Moltu <t.b.moltu@lyse.net>",
-      "name": "encode_unicode",
-      "version": "1.0.0",
-      "description": "UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/encode_unicode@1.0.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/encode_unicode/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/tormol/encode_unicode"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "author": "Anton Lazarev <https://antonok.com>",
       "name": "enum_dispatch",
@@ -2642,33 +2430,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-fnv"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
-      "author": "Orson Peters <orsonpeters@gmail.com>",
-      "name": "foldhash",
-      "version": "0.1.5",
-      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Zlib"
-        }
-      ],
-      "purl": "pkg:cargo/foldhash@0.1.5",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/orlp/foldhash"
         }
       ]
     },
@@ -3450,33 +3211,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
-      "author": "Amanieu d'Antras <amanieu@gmail.com>",
-      "name": "hashbrown",
-      "version": "0.15.5",
-      "description": "A Rust port of Google's SwissTable hash map",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/hashbrown@0.15.5",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/rust-lang/hashbrown"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
       "author": "Amanieu d'Antras <amanieu@gmail.com>",
       "name": "hashbrown",
@@ -3525,33 +3259,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/withoutboats/heck"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2",
-      "author": "Stefan Lankes",
-      "name": "hermit-abi",
-      "version": "0.5.2",
-      "description": "Hermit system calls definitions.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/hermit-abi@0.5.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/hermit-os/hermit-rs"
         }
       ]
     },
@@ -3938,33 +3645,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
-      "author": "Ren\u00e9 Kijewski <crates.io@k6i.de>",
-      "name": "iana-time-zone-haiku",
-      "version": "0.1.2",
-      "description": "iana-time-zone support crate for Haiku OS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/iana-time-zone-haiku@0.1.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/strawlab/iana-time-zone"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
       "author": "Andrew Straw <strawman@astraw.com>, Ren\u00e9 Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
       "name": "iana-time-zone",
@@ -4204,37 +3884,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0",
-      "author": "Nick Fitzgerald <fitzgen@gmail.com>, Aleksey Kladov <aleksey.kladov@gmail.com>",
-      "name": "id-arena",
-      "version": "2.3.0",
-      "description": "A simple, id-based arena.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/id-arena@2.3.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/id-arena"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/fitzgen/id-arena"
         }
       ]
     },
@@ -4662,125 +4311,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
-      "name": "jni-macros",
-      "version": "0.22.4",
-      "description": "Procedural macros for the jni crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/jni-macros@0.22.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/jni-rs/jni-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1",
-      "author": "Robert Bragg <robert@sixbynine.org>",
-      "name": "jni-sys-macros",
-      "version": "0.4.1",
-      "description": "Macros for jni-sys crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/jni-sys-macros@0.4.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/jni-sys-macros"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/jni-rs/jni-sys"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
-      "author": "Steven Fackler <sfackler@gmail.com>, Robert Bragg <robert@sixbynine.org>",
-      "name": "jni-sys",
-      "version": "0.4.1",
-      "description": "Rust definitions corresponding to jni.h",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/jni-sys@0.4.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/jni-sys"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/jni-rs/jni-sys"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
-      "author": "jni team",
-      "name": "jni",
-      "version": "0.22.4",
-      "description": "Rust bindings to the JNI",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/jni@0.22.4",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/jni"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/jni-rs/jni-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "jobserver",
@@ -4811,76 +4341,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-lang/jobserver-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-      "author": "The wasm-bindgen Developers",
-      "name": "js-sys",
-      "version": "0.3.94",
-      "description": "Bindings for all JS global objects and functions in all JS environments like Node.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/js-sys@0.3.94",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/js-sys"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
-      "author": "Ryan Lopopolo <rjl@hyperbo.la>",
-      "name": "known-folders",
-      "version": "1.4.2",
-      "description": "A safe wrapper around the Known Folders API on Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/known-folders@1.4.2",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/known-folders"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/artichoke/known-folders-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/artichoke/known-folders-rs"
         }
       ]
     },
@@ -4971,37 +4431,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0",
-      "author": "Bryant Luk <code@bryantluk.com>",
-      "name": "leb128fmt",
-      "version": "0.1.0",
-      "description": "A library to encode and decode LEB128 compressed integers.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/leb128fmt@0.1.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/leb128fmt"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bluk/leb128fmt"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2",
       "name": "libbz2-rs-sys",
       "version": "0.2.2",
@@ -5054,33 +4483,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-lang/libc"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
-      "author": "4lDO2 <4lDO2@protonmail.com>",
-      "name": "libredox",
-      "version": "0.1.15",
-      "description": "Redox stable ABI",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/libredox@0.1.15",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://gitlab.redox-os.org/redox-os/libredox.git"
         }
       ]
     },
@@ -5586,41 +4988,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1",
-      "author": "The Rust Windowing contributors",
-      "name": "ndk-context",
-      "version": "0.1.1",
-      "description": "Handles for accessing Android APIs",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/ndk-context@0.1.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/ndk-context"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/rust-windowing/android-ndk-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/rust-windowing/android-ndk-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
       "author": "The nix-rust Project Developers",
       "name": "nix",
@@ -5701,37 +5068,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-bakery/nom"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
-      "author": "MSxDOS <melcodos@gmail.com>",
-      "name": "ntapi",
-      "version": "0.4.3",
-      "description": "FFI bindings for Native API",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/ntapi@0.4.3",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/ntapi/*/x86_64-pc-windows-msvc/ntapi/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/MSxDOS/ntapi"
         }
       ]
     },
@@ -5857,86 +5193,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0",
-      "author": "Mads Marquart <mads@marquart.dk>",
-      "name": "objc2-encode",
-      "version": "4.1.0",
-      "description": "Objective-C type-encoding representation and parsing",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/objc2-encode@4.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/madsmtm/objc2"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
-      "name": "objc2-foundation",
-      "version": "0.3.2",
-      "description": "Bindings to the Foundation framework",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/objc2-foundation@0.3.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/madsmtm/objc2"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
-      "author": "Mads Marquart <mads@marquart.dk>",
-      "name": "objc2",
-      "version": "0.6.4",
-      "description": "Objective-C interface and runtime bindings",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/objc2@0.6.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/madsmtm/objc2"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
       "name": "object",
       "version": "0.37.3",
@@ -5989,32 +5245,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/matklad/once_cell"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
-      "name": "once_cell_polyfill",
-      "version": "1.70.2",
-      "description": "Polyfill for `OnceCell` stdlib feature for use with older MSRVs",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/once_cell_polyfill@1.70.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/polyfill-rs/once_cell_polyfill"
         }
       ]
     },
@@ -6709,72 +5939,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3",
-      "author": "jzr",
-      "name": "plain",
-      "version": "0.2.3",
-      "description": "A small Rust library that allows users to reinterpret data of certain types safely.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/plain@0.2.3",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/plain"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/randomites/plain"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/randomites/plain"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
-      "author": "Ed Barnard <eabarnard@gmail.com>",
-      "name": "plist",
-      "version": "1.8.0",
-      "description": "A rusty plist parser. Supports Serde serialization.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/plist@1.8.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/plist/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ebarnard/rust-plist/"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
       "name": "portable-atomic",
       "version": "1.13.1",
@@ -6881,41 +6045,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/cryptocorrosion/cryptocorrosion"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
-      "author": "David Tolnay <dtolnay@gmail.com>",
-      "name": "prettyplease",
-      "version": "0.2.37",
-      "description": "A minimal `syn` syntax tree pretty-printer",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/prettyplease@0.2.37",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/prettyplease"
-        },
-        {
-          "type": "other",
-          "url": "prettyplease02"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/dtolnay/prettyplease"
         }
       ]
     },
@@ -7132,36 +6261,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
-      "name": "quick-xml",
-      "version": "0.38.4",
-      "description": "High performance xml reader and writer",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/quick-xml@0.38.4",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/quick-xml"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/tafia/quick-xml"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "quote",
@@ -7188,66 +6287,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/dtolnay/quote"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0",
-      "name": "r-efi",
-      "version": "5.3.0",
-      "description": "UEFI Reference Specification Protocol Constants and Definitions",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
-        }
-      ],
-      "purl": "pkg:cargo/r-efi@5.3.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/r-efi/r-efi/wiki"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/r-efi/r-efi"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0",
-      "name": "r-efi",
-      "version": "6.0.0",
-      "description": "UEFI Reference Specification Protocol Constants and Definitions",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
-        }
-      ],
-      "purl": "pkg:cargo/r-efi@6.0.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/r-efi/r-efi/wiki"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/r-efi/r-efi"
         }
       ]
     },
@@ -7928,99 +6967,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
-      "author": "Jeremy Soller <jackpot51@gmail.com>",
-      "name": "redox_syscall",
-      "version": "0.5.18",
-      "description": "A Rust library to access raw Redox system calls",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/redox_syscall@0.5.18",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/redox_syscall"
-        },
-        {
-          "type": "vcs",
-          "url": "https://gitlab.redox-os.org/redox-os/syscall"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3",
-      "author": "Jeremy Soller <jackpot51@gmail.com>",
-      "name": "redox_syscall",
-      "version": "0.7.3",
-      "description": "A Rust library to access raw Redox system calls",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/redox_syscall@0.7.3",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/redox_syscall"
-        },
-        {
-          "type": "vcs",
-          "url": "https://gitlab.redox-os.org/redox-os/syscall"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
-      "author": "Jose Narvaez <goyox86@gmail.com>, Wesley Hershberger <mggmugginsmc@gmail.com>",
-      "name": "redox_users",
-      "version": "0.5.2",
-      "description": "A Rust library to access Redox users and groups functionality",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/redox_users@0.5.2",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/redox_users"
-        },
-        {
-          "type": "vcs",
-          "url": "https://gitlab.redox-os.org/redox-os/users"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "ref-cast-impl",
@@ -8675,72 +7621,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
-      "author": "Andrew Gallant <jamslam@gmail.com>",
-      "name": "same-file",
-      "version": "1.0.6",
-      "description": "A simple crate for determining whether two file paths point to the same file. ",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unlicense OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/same-file@1.0.6",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/same-file"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/BurntSushi/same-file"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/BurntSushi/same-file"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
-      "author": "Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>",
-      "name": "schannel",
-      "version": "0.1.29",
-      "description": "Schannel bindings for rust, allowing SSL/TLS (e.g. https) without openssl",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/schannel@0.1.29",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/schannel/0.1.19/schannel/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/steffengy/schannel-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
       "author": "Graham Esau <gesau@hotmail.co.uk>",
       "name": "schemars",
@@ -8829,72 +7709,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/bluss/scopeguard"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
-      "name": "security-framework-sys",
-      "version": "2.17.0",
-      "description": "Apple `Security.framework` low-level FFI bindings",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/security-framework-sys@2.17.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://lib.rs/crates/security-framework-sys"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/kornelski/rust-security-framework"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
-      "name": "security-framework",
-      "version": "3.7.0",
-      "description": "Security.framework bindings for macOS and iOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/security-framework@3.7.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/security_framework"
-        },
-        {
-          "type": "website",
-          "url": "https://lib.rs/crates/security_framework"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/kornelski/rust-security-framework"
         }
       ]
     },
@@ -9554,37 +8368,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/simd-lite/simd-json"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
-      "author": "Sean C. Roach <me@seancroach.dev>",
-      "name": "simd_cesu8",
-      "version": "1.1.1",
-      "description": "An extremely fast, SIMD accelerated, encoding and decoding library for CESU-8 and Modified UTF-8.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/simd_cesu8@1.1.1",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/seancroach/simd_cesu8"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/seancroach/simd_cesu8"
         }
       ]
     },
@@ -11528,41 +10311,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
-      "author": "erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "unicode-xid",
-      "version": "0.2.6",
-      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/unicode-xid@0.2.6",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://unicode-rs.github.io/unicode-xid"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/unicode-rs/unicode-xid"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-rs/unicode-xid"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
       "name": "unit-prefix",
@@ -11842,32 +10590,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1",
-      "name": "valuable",
-      "version": "0.1.1",
-      "description": "Object-safe value inspection, used to pass un-typed structured data across trait-object boundaries. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/valuable@0.1.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/tokio-rs/valuable"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
       "author": "Heinz N. Gies <heinz@licenser.net>",
       "name": "value-trait",
@@ -12022,41 +10744,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
-      "author": "Andrew Gallant <jamslam@gmail.com>",
-      "name": "walkdir",
-      "version": "2.5.0",
-      "description": "Recursively walk a directory.",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unlicense OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/walkdir@2.5.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/walkdir/"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/BurntSushi/walkdir"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/BurntSushi/walkdir"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
       "author": "Sean McArthur <sean@seanmonstar.com>",
       "name": "want",
@@ -12083,456 +10770,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/seanmonstar/want"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
-      "author": "The Cranelift Project Developers",
-      "name": "wasi",
-      "version": "0.11.1+wasi-snapshot-preview1",
-      "description": "Experimental WASI API bindings for Rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasi@0.11.1+wasi-snapshot-preview1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasi"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasi"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
-      "name": "wasip2",
-      "version": "1.0.2+wasi-0.2.9",
-      "description": "WASIp2 API bindings for Rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasip2@1.0.2+wasi-0.2.9",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasip2"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasi-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
-      "name": "wasip3",
-      "version": "0.4.0+wasi-0.3.0-rc-2026-01-06",
-      "description": "WASIp3 API bindings for Rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasip3"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasi-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
-      "author": "The wasm-bindgen Developers",
-      "name": "wasm-bindgen-futures",
-      "version": "0.4.67",
-      "description": "Bridging the gap between Rust Futures and JavaScript Promises",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-bindgen-futures@0.4.67",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-bindgen-futures"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117",
-      "author": "The wasm-bindgen Developers",
-      "name": "wasm-bindgen-macro-support",
-      "version": "0.2.117",
-      "description": "Implementation APIs for the `#[wasm_bindgen]` attribute",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-bindgen-macro-support@0.2.117",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-bindgen"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
-      "author": "The wasm-bindgen Developers",
-      "name": "wasm-bindgen-macro",
-      "version": "0.2.117",
-      "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-bindgen-macro@0.2.117",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-bindgen"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117",
-      "author": "The wasm-bindgen Developers",
-      "name": "wasm-bindgen-shared",
-      "version": "0.2.117",
-      "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal dependency. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-bindgen-shared@0.2.117",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-bindgen-shared"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
-        },
-        {
-          "type": "other",
-          "url": "wasm_bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-      "author": "The wasm-bindgen Developers",
-      "name": "wasm-bindgen",
-      "version": "0.2.117",
-      "description": "Easy support for interacting between JS and Rust. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-bindgen@0.2.117",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-bindgen"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
-      "author": "Nick Fitzgerald <fitzgen@gmail.com>",
-      "name": "wasm-encoder",
-      "version": "0.244.0",
-      "description": "A low-level WebAssembly encoder. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-encoder@0.244.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wasm-encoder"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
-      "name": "wasm-metadata",
-      "version": "0.244.0",
-      "description": "Read and manipulate WebAssembly metadata",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-metadata@0.244.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
-      "author": "Mattias Buelens <mattias@buelens.com>",
-      "name": "wasm-streams",
-      "version": "0.4.2",
-      "description": "Bridging between web streams and Rust streams using WebAssembly ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/wasm-streams@0.4.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/MattiasBuelens/wasm-streams/"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
-      "author": "Yury Delendik <ydelendik@mozilla.com>",
-      "name": "wasmparser",
-      "version": "0.244.0",
-      "description": "A simple event-driven library for parsing WebAssembly binary files. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wasmparser@0.244.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94",
-      "author": "The wasm-bindgen Developers",
-      "name": "web-sys",
-      "version": "0.3.94",
-      "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/web-sys@0.3.94",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/api/web_sys/"
-        },
-        {
-          "type": "website",
-          "url": "https://wasm-bindgen.github.io/wasm-bindgen/web-sys/index.html"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0",
-      "name": "web-time",
-      "version": "1.1.0",
-      "description": "Drop-in replacement for std::time for Wasm in browsers",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/web-time@1.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/daxpedda/web-time"
         }
       ]
     },
@@ -12604,16 +10841,43 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
-      "author": "Peter Atashian <retep998@gmail.com>",
-      "name": "winapi-i686-pc-windows-gnu",
-      "version": "0.4.0",
-      "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
+      "author": "The ICU4X Project Developers",
+      "name": "writeable",
+      "version": "0.6.3",
+      "description": "A more efficient alternative to fmt::Display",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+          "content": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/writeable@0.6.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
+      "author": "Steven Allen <steven@stebalien.com>",
+      "name": "xattr",
+      "version": "1.6.1",
+      "description": "unix extended filesystem attributes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
         }
       ],
       "licenses": [
@@ -12621,61 +10885,399 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/retep998/winapi-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11",
-      "author": "Andrew Gallant <jamslam@gmail.com>",
-      "name": "winapi-util",
-      "version": "0.1.11",
-      "description": "A dumping ground for high level safe wrappers over windows-sys.",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unlicense OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/winapi-util@0.1.11",
+      "purl": "pkg:cargo/xattr@1.6.1",
       "externalReferences": [
         {
           "type": "documentation",
-          "url": "https://docs.rs/winapi-util"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/BurntSushi/winapi-util"
+          "url": "https://docs.rs/xattr"
         },
         {
           "type": "vcs",
-          "url": "https://github.com/BurntSushi/winapi-util"
+          "url": "https://github.com/Stebalien/xattr"
         }
       ]
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
-      "author": "Peter Atashian <retep998@gmail.com>",
-      "name": "winapi-x86_64-pc-windows-gnu",
-      "version": "0.4.0",
-      "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "yoke-derive",
+      "version": "0.8.2",
+      "description": "Custom derive for the yoke crate",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+          "content": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/yoke-derive@0.8.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "yoke",
+      "version": "0.8.2",
+      "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/yoke@0.8.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
+      "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
+      "name": "zerocopy",
+      "version": "0.8.48",
+      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zerocopy@0.8.48",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/google/zerocopy"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerofrom-derive",
+      "version": "0.1.7",
+      "description": "Custom derive for the zerofrom crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerofrom-derive@0.1.7",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerofrom",
+      "version": "0.1.7",
+      "description": "ZeroFrom trait for constructing",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerofrom@0.1.7",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
+      "author": "The RustCrypto Project Developers",
+      "name": "zeroize",
+      "version": "1.8.2",
+      "description": "Securely clear secrets from memory with a simple trait built on stable Rust primitives which guarantee memory is zeroed using an operation will not be 'optimized away' by the compiler. Uses a portable pure Rust implementation that works everywhere, even WASM! ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zeroize@1.8.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/utils/tree/master/zeroize"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
+      "author": "The ICU4X Project Developers",
+      "name": "zerotrie",
+      "version": "0.2.4",
+      "description": "A data structure that efficiently maps strings to integers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerotrie@0.2.4",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://icu4x.unicode.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3",
+      "author": "Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "zerovec-derive",
+      "version": "0.11.3",
+      "description": "Custom derive for the zerovec crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerovec-derive@0.11.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6",
+      "author": "The ICU4X Project Developers",
+      "name": "zerovec",
+      "version": "0.11.6",
+      "description": "Zero-copy vector backed by a byte array",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unicode-3.0"
+        }
+      ],
+      "purl": "pkg:cargo/zerovec@0.11.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
+      "author": "Mathijs van de Nes <git@mathijs.vd-nes.nl>, Marli Frost <marli@frost.red>, Ryan Levick <ryan.levick@gmail.com>, Chris Hennick <hennickc@amazon.com>",
+      "name": "zip",
+      "version": "8.5.0",
+      "description": "Library to support the reading and writing of zip files.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zip@8.5.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/zip-rs/zip2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
+      "name": "zlib-rs",
+      "version": "0.6.3",
+      "description": "A memory-safe zlib implementation written in rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/zlib-rs@0.6.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/trifectatechfoundation/zlib-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/trifectatechfoundation/zlib-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "zmij",
+      "version": "1.0.21",
+      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zmij@1.0.21",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/zmij"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/zmij"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3",
+      "name": "zopfli",
+      "version": "0.8.3",
+      "description": "A Rust implementation of the Zopfli compression algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/zopfli@0.8.3",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/zopfli-rs/zopfli"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/zopfli-rs/zopfli"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd-safe",
+      "version": "7.2.4",
+      "description": "Safe low-level bindings for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
         }
       ],
       "licenses": [
@@ -12683,11 +11285,469 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0",
+      "purl": "pkg:cargo/zstd-safe@7.2.4",
       "externalReferences": [
         {
           "type": "vcs",
-          "url": "https://github.com/retep998/winapi-rs"
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd-sys",
+      "version": "2.0.16+zstd.1.5.7",
+      "description": "Low-level bindings for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/zstd-sys@2.0.16+zstd.1.5.7",
+      "externalReferences": [
+        {
+          "type": "other",
+          "url": "zstd"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
+      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
+      "name": "zstd",
+      "version": "0.13.3",
+      "description": "Binding for the zstd compression library.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zstd@0.13.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/zstd"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gyscos/zstd-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation-sys",
+      "version": "0.8.7",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation-sys@0.8.7",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/servo/core-foundation-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation",
+      "version": "0.10.1",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation@0.10.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "author": "Ed Barnard <eabarnard@gmail.com>",
+      "name": "plist",
+      "version": "1.8.0",
+      "description": "A rusty plist parser. Supports Serde serialization.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/plist@1.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/plist/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/ebarnard/rust-plist/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "name": "quick-xml",
+      "version": "0.38.4",
+      "description": "High performance xml reader and writer",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/quick-xml@0.38.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/quick-xml"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tafia/quick-xml"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework-sys",
+      "version": "2.17.0",
+      "description": "Apple `Security.framework` low-level FFI bindings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework-sys@2.17.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security-framework-sys"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework",
+      "version": "3.7.0",
+      "description": "Security.framework bindings for macOS and iOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework@3.7.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/security_framework"
+        },
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security_framework"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
+      "name": "anstyle-wincon",
+      "version": "3.0.11",
+      "description": "Styling legacy Windows terminals",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstyle-wincon@3.0.11",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
+      "author": "T. Post",
+      "name": "crossterm_winapi",
+      "version": "0.9.1",
+      "description": "WinAPI wrapper that provides some basic simple abstractions around common WinAPI calls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/crossterm_winapi@0.9.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/crossterm_winapi/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossterm-rs/crossterm-winapi"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
+      "author": "Torbj\u00f8rn Birch Moltu <t.b.moltu@lyse.net>",
+      "name": "encode_unicode",
+      "version": "1.0.0",
+      "description": "UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/encode_unicode@1.0.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/encode_unicode/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tormol/encode_unicode"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
+      "author": "Ryan Lopopolo <rjl@hyperbo.la>",
+      "name": "known-folders",
+      "version": "1.4.2",
+      "description": "A safe wrapper around the Known Folders API on Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/known-folders@1.4.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/known-folders"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/artichoke/known-folders-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/artichoke/known-folders-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
+      "author": "MSxDOS <melcodos@gmail.com>",
+      "name": "ntapi",
+      "version": "0.4.3",
+      "description": "FFI bindings for Native API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/ntapi@0.4.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ntapi/*/x86_64-pc-windows-msvc/ntapi/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/MSxDOS/ntapi"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
+      "name": "once_cell_polyfill",
+      "version": "1.70.2",
+      "description": "Polyfill for `OnceCell` stdlib feature for use with older MSRVs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/once_cell_polyfill@1.70.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/polyfill-rs/once_cell_polyfill"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+      "author": "Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>",
+      "name": "schannel",
+      "version": "0.1.29",
+      "description": "Schannel bindings for rust, allowing SSL/TLS (e.g. https) without openssl",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/schannel@0.1.29",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/schannel/0.1.19/schannel/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/steffengy/schannel-rs"
         }
       ]
     },
@@ -13450,195 +12510,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_aarch64_gnullvm",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_aarch64_gnullvm@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_aarch64_msvc",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_aarch64_msvc@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_i686_gnu",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_i686_gnu@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_i686_gnullvm",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_i686_gnullvm@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_i686_msvc",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_i686_msvc@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_x86_64_gnu",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_x86_64_gnu@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6",
-      "author": "Microsoft",
-      "name": "windows_x86_64_gnullvm",
-      "version": "0.52.6",
-      "description": "Import lib for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows_x86_64_gnullvm@0.52.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "author": "Microsoft",
       "name": "windows_x86_64_msvc",
@@ -13661,743 +12532,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
-      "author": "Alex Crichton <alex@alexcrichton.com>",
-      "name": "wit-bindgen-core",
-      "version": "0.51.0",
-      "description": "Low-level support for bindings generation based on WIT files for use with `wit-bindgen-cli` and other languages. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-bindgen-core@0.51.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0",
-      "author": "Alex Crichton <alex@alexcrichton.com>",
-      "name": "wit-bindgen-rust-macro",
-      "version": "0.51.0",
-      "description": "Procedural macro paired with the `wit-bindgen` crate. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-bindgen-rust-macro@0.51.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0",
-      "author": "Alex Crichton <alex@alexcrichton.com>",
-      "name": "wit-bindgen-rust",
-      "version": "0.51.0",
-      "description": "Rust bindings generator for WIT and the component model, typically used through the `wit-bindgen` crate's `generate!` macro. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-bindgen-rust@0.51.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0",
-      "author": "Alex Crichton <alex@alexcrichton.com>",
-      "name": "wit-bindgen",
-      "version": "0.51.0",
-      "description": "Rust bindings generator and runtime support for WIT and the component model. Used when compiling Rust programs to the component model. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-bindgen@0.51.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wit-bindgen"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0",
-      "author": "Peter Huene <peter@huene.dev>",
-      "name": "wit-component",
-      "version": "0.244.0",
-      "description": "Tooling for working with `*.wit` and component files together. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-component@0.244.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wit-component"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0",
-      "author": "Alex Crichton <alex@alexcrichton.com>",
-      "name": "wit-parser",
-      "version": "0.244.0",
-      "description": "Tooling for parsing `*.wit` files and working with their contents. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/wit-parser@0.244.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/wit-parser"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
-      "author": "The ICU4X Project Developers",
-      "name": "writeable",
-      "version": "0.6.3",
-      "description": "A more efficient alternative to fmt::Display",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/writeable@0.6.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
-      "author": "Steven Allen <steven@stebalien.com>",
-      "name": "xattr",
-      "version": "1.6.1",
-      "description": "unix extended filesystem attributes",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/xattr@1.6.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/xattr"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/Stebalien/xattr"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
-      "author": "Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "yoke-derive",
-      "version": "0.8.2",
-      "description": "Custom derive for the yoke crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/yoke-derive@0.8.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
-      "author": "Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "yoke",
-      "version": "0.8.2",
-      "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/yoke@0.8.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48",
-      "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
-      "name": "zerocopy-derive",
-      "version": "0.8.48",
-      "description": "Custom derive for traits from the zerocopy crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zerocopy-derive@0.8.48",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/google/zerocopy"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
-      "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
-      "name": "zerocopy",
-      "version": "0.8.48",
-      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zerocopy@0.8.48",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/google/zerocopy"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
-      "author": "Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "zerofrom-derive",
-      "version": "0.1.7",
-      "description": "Custom derive for the zerofrom crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/zerofrom-derive@0.1.7",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.7",
-      "author": "Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "zerofrom",
-      "version": "0.1.7",
-      "description": "ZeroFrom trait for constructing",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/zerofrom@0.1.7",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
-      "author": "The RustCrypto Project Developers",
-      "name": "zeroize",
-      "version": "1.8.2",
-      "description": "Securely clear secrets from memory with a simple trait built on stable Rust primitives which guarantee memory is zeroed using an operation will not be 'optimized away' by the compiler. Uses a portable pure Rust implementation that works everywhere, even WASM! ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zeroize@1.8.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/utils/tree/master/zeroize"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/utils"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
-      "author": "The ICU4X Project Developers",
-      "name": "zerotrie",
-      "version": "0.2.4",
-      "description": "A data structure that efficiently maps strings to integers",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/zerotrie@0.2.4",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://icu4x.unicode.org"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3",
-      "author": "Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "zerovec-derive",
-      "version": "0.11.3",
-      "description": "Custom derive for the zerovec crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/zerovec-derive@0.11.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6",
-      "author": "The ICU4X Project Developers",
-      "name": "zerovec",
-      "version": "0.11.6",
-      "description": "Zero-copy vector backed by a byte array",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unicode-3.0"
-        }
-      ],
-      "purl": "pkg:cargo/zerovec@0.11.6",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-org/icu4x"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.0",
-      "author": "Mathijs van de Nes <git@mathijs.vd-nes.nl>, Marli Frost <marli@frost.red>, Ryan Levick <ryan.levick@gmail.com>, Chris Hennick <hennickc@amazon.com>",
-      "name": "zip",
-      "version": "8.5.0",
-      "description": "Library to support the reading and writing of zip files.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zip@8.5.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/zip-rs/zip2"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
-      "name": "zlib-rs",
-      "version": "0.6.3",
-      "description": "A memory-safe zlib implementation written in rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Zlib"
-        }
-      ],
-      "purl": "pkg:cargo/zlib-rs@0.6.3",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/trifectatechfoundation/zlib-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/trifectatechfoundation/zlib-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
-      "author": "David Tolnay <dtolnay@gmail.com>",
-      "name": "zmij",
-      "version": "1.0.21",
-      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zmij@1.0.21",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/zmij"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/dtolnay/zmij"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3",
-      "name": "zopfli",
-      "version": "0.8.3",
-      "description": "A Rust implementation of the Zopfli compression algorithm.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/zopfli@0.8.3",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/zopfli-rs/zopfli"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/zopfli-rs/zopfli"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
-      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
-      "name": "zstd-safe",
-      "version": "7.2.4",
-      "description": "Safe low-level bindings for the zstd compression library.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/zstd-safe@7.2.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/gyscos/zstd-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
-      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
-      "name": "zstd-sys",
-      "version": "2.0.16+zstd.1.5.7",
-      "description": "Low-level bindings for the zstd compression library.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/zstd-sys@2.0.16+zstd.1.5.7",
-      "externalReferences": [
-        {
-          "type": "other",
-          "url": "zstd"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/gyscos/zstd-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
-      "author": "Alexandre Bury <alexandre.bury@gmail.com>",
-      "name": "zstd",
-      "version": "0.13.3",
-      "description": "Binding for the zstd compression library.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/zstd@0.13.3",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/zstd"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/gyscos/zstd-rs"
         }
       ]
     }
@@ -14489,18 +12623,11 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
-        "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
         "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
         "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
@@ -14513,18 +12640,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14"
@@ -14622,8 +12738,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
       ]
     },
     {
@@ -14698,11 +12813,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
       ]
     },
     {
@@ -14737,13 +12849,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
@@ -14771,33 +12876,15 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -14825,17 +12912,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
     {
@@ -14900,9 +12979,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
       ]
     },
     {
@@ -14932,9 +13009,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -14949,7 +13023,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
@@ -14957,8 +13030,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
@@ -14986,8 +13058,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
@@ -15009,9 +13080,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
@@ -15043,8 +13111,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
       ]
     },
     {
@@ -15130,32 +13197,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
-        "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
       ]
     },
     {
@@ -15194,12 +13251,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21",
@@ -15211,17 +13262,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
@@ -15322,22 +13369,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
@@ -15401,9 +13433,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
     },
     {
@@ -15434,7 +13463,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -15444,8 +13472,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
-        "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0"
+        "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
       ]
     },
     {
@@ -15486,62 +13513,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
-        "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
-        "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15565,22 +13539,10 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
@@ -15666,27 +13628,17 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
-        "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
       ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
@@ -15710,16 +13662,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1"
@@ -15733,24 +13676,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0"
       ]
     },
     {
@@ -15761,9 +13687,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
@@ -15844,7 +13767,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -15891,9 +13813,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
       ]
     },
     {
@@ -15961,19 +13881,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1"
     },
     {
@@ -15989,13 +13896,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16056,22 +13956,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106"
       ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
@@ -16188,7 +14076,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -16276,24 +14163,19 @@
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
-        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3"
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2"
       ]
     },
     {
@@ -16304,7 +14186,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
@@ -16331,8 +14212,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
@@ -16417,26 +14296,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -16455,8 +14314,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
     {
@@ -16507,7 +14365,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
@@ -16524,11 +14381,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -16543,9 +14396,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
+        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
     {
@@ -16573,8 +14424,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
       ]
     },
     {
@@ -16617,18 +14467,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
@@ -16650,28 +14488,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
       ]
     },
     {
@@ -16681,7 +14500,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
@@ -16703,15 +14521,11 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
@@ -16727,7 +14541,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
       ]
@@ -16830,13 +14643,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
     },
     {
@@ -16857,8 +14663,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
@@ -16923,12 +14728,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0"
       ]
     },
     {
@@ -16945,15 +14747,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
     {
@@ -17012,7 +14812,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
@@ -17088,8 +14887,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0"
       ]
     },
     {
@@ -17167,8 +14965,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1"
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
       ]
     },
     {
@@ -17182,14 +14979,12 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
-        "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
       ]
     },
     {
@@ -17255,9 +15050,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
     },
     {
@@ -17296,9 +15088,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1"
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
@@ -17326,133 +15115,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
-        "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
-        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
-        "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -17462,316 +15134,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6",
-        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
-        "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
-        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
@@ -17793,18 +15160,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",

--- a/SBOM.json
+++ b/SBOM.json
@@ -1,6 +1,6 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.3",
+  "specVersion": "1.4",
   "version": 1,
   "metadata": {
     "timestamp": "1970-01-01T00:00:00.000000000Z",
@@ -13,15 +13,15 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
+      "bom-ref": "ana@0.0.0",
       "name": "ana",
       "version": "0.0.0",
       "scope": "required",
-      "purl": "pkg:cargo/ana@0.0.0?download_url=file://.",
+      "purl": "pkg:cargo/ana@0.0.0?download_url=",
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0 bin-target-0",
+          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
           "name": "ana",
           "version": "0.0.0",
           "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
@@ -31,7 +31,7 @@
     "properties": [
       {
         "name": "cdx:rustc:sbom:target:triple",
-        "value": "x86_64-unknown-linux-gnu"
+        "value": "aarch64-apple-darwin,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu"
       }
     ]
   },
@@ -303,6 +303,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/gimli-rs/addr2line"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -1763,6 +1769,12 @@
           "type": "vcs",
           "url": "https://github.com/QEDK/configparser-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
       ]
     },
     {
@@ -1885,6 +1897,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/RustCrypto/utils"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,windows"
         }
       ]
     },
@@ -2703,6 +2721,12 @@
           "type": "vcs",
           "url": "https://github.com/lambda-fairy/rust-errno"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -3061,6 +3085,12 @@
           "type": "vcs",
           "url": "https://github.com/sfackler/foreign-types"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
       ]
     },
     {
@@ -3087,6 +3117,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/sfackler/foreign-types"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
         }
       ]
     },
@@ -3635,6 +3671,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/gimli-rs/gimli"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -4301,6 +4343,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/strawlab/iana-time-zone"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -5203,6 +5251,12 @@
           "type": "vcs",
           "url": "https://github.com/sunfishcode/linux-raw-sys"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
       ]
     },
     {
@@ -5726,6 +5780,12 @@
           "type": "vcs",
           "url": "https://github.com/nix-rust/nix"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -5930,6 +5990,12 @@
           "type": "vcs",
           "url": "https://github.com/gimli-rs/object"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -5981,7 +6047,13 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/openssl-macros@0.1.1"
+      "purl": "pkg:cargo/openssl-macros@0.1.1",
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
+      ]
     },
     {
       "type": "library",
@@ -6011,6 +6083,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/rustls/openssl-probe"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
         }
       ]
     },
@@ -6043,6 +6121,12 @@
           "type": "vcs",
           "url": "https://github.com/rust-openssl/rust-openssl"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
       ]
     },
     {
@@ -6069,6 +6153,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-openssl/rust-openssl"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
         }
       ]
     },
@@ -7002,6 +7092,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/tafia/quick-xml"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
         }
       ]
     },
@@ -8246,6 +8342,12 @@
           "type": "vcs",
           "url": "https://github.com/bytecodealliance/rustix"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -9397,6 +9499,12 @@
           "type": "vcs",
           "url": "https://github.com/vorner/signal-hook"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -9427,6 +9535,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/vorner/signal-hook"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -11351,6 +11465,12 @@
           "type": "vcs",
           "url": "https://github.com/icorderi/rust-uname"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
       ]
     },
     {
@@ -12055,6 +12175,12 @@
           "type": "vcs",
           "url": "https://github.com/mcgoo/vcpkg-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux"
+        }
       ]
     },
     {
@@ -12383,6 +12509,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/Stebalien/xattr"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -12873,6 +13005,12 @@
           "type": "vcs",
           "url": "https://github.com/servo/core-foundation-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
+        }
       ]
     },
     {
@@ -12899,6 +13037,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
         }
       ]
     },
@@ -12931,6 +13075,12 @@
           "type": "vcs",
           "url": "https://github.com/ebarnard/rust-plist/"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
+        }
       ]
     },
     {
@@ -12960,6 +13110,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/tafia/quick-xml"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
         }
       ]
     },
@@ -12991,6 +13147,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
         }
       ]
     },
@@ -13027,6 +13189,12 @@
           "type": "vcs",
           "url": "https://github.com/kornelski/rust-security-framework"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "macos"
+        }
       ]
     },
     {
@@ -13052,6 +13220,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13084,6 +13258,12 @@
           "type": "vcs",
           "url": "https://github.com/crossterm-rs/crossterm-winapi"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13114,6 +13294,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/tormol/encode_unicode"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13150,6 +13336,12 @@
           "type": "vcs",
           "url": "https://github.com/artichoke/known-folders-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13181,6 +13373,12 @@
           "type": "vcs",
           "url": "https://github.com/MSxDOS/ntapi"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13206,6 +13404,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/polyfill-rs/once_cell_polyfill"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13242,6 +13446,12 @@
           "type": "vcs",
           "url": "https://github.com/stanislav-tkach/os_info"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13272,6 +13482,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/steffengy/schannel-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13304,6 +13520,12 @@
           "type": "vcs",
           "url": "https://github.com/retep998/winapi-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13330,6 +13552,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13355,6 +13583,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13383,6 +13617,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13410,6 +13650,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13435,6 +13681,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13462,6 +13714,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13487,6 +13745,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13514,6 +13778,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13539,6 +13809,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13567,6 +13843,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13592,6 +13874,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13619,6 +13907,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13644,6 +13938,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13672,6 +13972,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13699,6 +14005,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13724,6 +14036,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13752,6 +14070,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13777,6 +14101,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13805,6 +14135,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13832,6 +14168,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13857,6 +14199,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13885,6 +14233,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13912,6 +14266,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -13937,6 +14297,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
         }
       ]
     },
@@ -13969,6 +14335,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -14000,6 +14372,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -14030,6 +14408,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     },
     {
@@ -14057,6 +14441,12 @@
           "type": "vcs",
           "url": "https://github.com/microsoft/windows-rs"
         }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
       ]
     }
   ],
@@ -14069,9 +14459,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-stdout@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -14082,14 +14472,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
+      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
@@ -14108,8 +14498,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
         "registry+https://github.com/rust-lang/crates.io-index#sentry@0.47.0",
@@ -14117,8 +14507,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0"
       ]
@@ -14132,8 +14522,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -14160,8 +14550,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -14254,7 +14644,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
@@ -14273,14 +14664,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
         "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
         "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
@@ -14293,13 +14686,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
@@ -14309,8 +14707,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
     },
@@ -14322,8 +14720,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
       ]
     },
     {
@@ -14337,7 +14735,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
@@ -14362,20 +14761,22 @@
         "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#backtrace-ext@0.2.1",
@@ -14391,17 +14792,21 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
@@ -14410,10 +14815,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
@@ -14428,13 +14835,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.0",
@@ -14467,10 +14877,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
@@ -14485,7 +14897,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -14514,10 +14927,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
@@ -14534,21 +14949,25 @@
         "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3",
-        "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4"
+        "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
+        "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -14558,10 +14977,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -14583,15 +15006,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
       ]
     },
     {
@@ -14687,7 +15113,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
+        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -14711,10 +15138,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
@@ -14732,7 +15161,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
@@ -14756,7 +15186,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -14776,13 +15207,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
       ]
     },
     {
@@ -14800,16 +15234,20 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
@@ -14835,7 +15273,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -14846,7 +15285,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
@@ -14857,7 +15297,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
@@ -14878,10 +15319,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
@@ -14940,10 +15383,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#gimli@0.32.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#gimli@0.32.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
@@ -14956,8 +15401,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -14969,10 +15414,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
@@ -14983,16 +15430,19 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -15000,8 +15450,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
       ]
     },
@@ -15013,7 +15463,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
@@ -15031,24 +15482,27 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
@@ -15057,11 +15511,11 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
@@ -15072,8 +15526,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
@@ -15093,8 +15547,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
@@ -15104,7 +15558,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
@@ -15139,7 +15596,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0",
@@ -15153,7 +15611,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties_data@2.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_properties_data@2.2.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
@@ -15168,7 +15627,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
@@ -15186,7 +15646,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
@@ -15220,7 +15681,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.12",
@@ -15230,10 +15692,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
@@ -15248,16 +15712,19 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
@@ -15277,25 +15744,32 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
@@ -15304,7 +15778,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
@@ -15320,7 +15795,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
@@ -15339,8 +15815,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
         "registry+https://github.com/rust-lang/crates.io-index#backtrace-ext@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#miette-derive@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0",
@@ -15353,7 +15829,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
@@ -15373,16 +15850,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+        "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
       ]
     },
     {
@@ -15407,10 +15890,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
@@ -15431,7 +15918,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
@@ -15442,7 +15930,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
@@ -15479,9 +15968,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.31.0",
+        "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
@@ -15495,8 +15984,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5",
-        "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5"
+        "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
+        "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.5"
       ]
     },
     {
@@ -15527,12 +16016,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1",
@@ -15541,10 +16031,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
@@ -15558,7 +16050,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -15609,7 +16102,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-internal@1.1.11",
@@ -15620,7 +16114,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
@@ -15629,10 +16124,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
@@ -15641,7 +16138,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
@@ -15698,7 +16196,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
@@ -15735,7 +16234,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5",
@@ -15778,8 +16278,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
@@ -15811,8 +16311,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -15827,6 +16327,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -15837,15 +16338,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
-        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.0.12",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
@@ -15889,8 +16390,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.18.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
@@ -15914,19 +16415,24 @@
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
-        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3"
       ]
     },
     {
@@ -15939,8 +16445,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
@@ -15961,23 +16467,23 @@
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#zip@8.5.1",
@@ -15996,8 +16502,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
@@ -16066,7 +16572,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
     },
     {
@@ -16078,10 +16585,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -16113,13 +16622,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
@@ -16130,12 +16639,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
@@ -16148,13 +16657,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.13",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
@@ -16163,11 +16672,11 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
@@ -16183,14 +16692,17 @@
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
@@ -16239,7 +16751,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
@@ -16251,7 +16764,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
@@ -16272,12 +16786,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
@@ -16309,6 +16826,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
         "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1"
@@ -16409,7 +16927,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
@@ -16502,7 +17021,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
@@ -16519,7 +17039,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
@@ -16533,7 +17054,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
@@ -16542,7 +17064,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
@@ -16553,20 +17076,24 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
@@ -16584,7 +17111,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-color@3.0.2",
@@ -16593,10 +17121,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-hyperlinks@3.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-hyperlinks@3.2.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-unicode@3.0.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#supports-unicode@3.0.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
@@ -16624,9 +17154,12 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0"
       ]
     },
     {
@@ -16643,13 +17176,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -16694,7 +17229,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27",
@@ -16729,7 +17265,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
@@ -16758,8 +17295,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
       ]
     },
     {
@@ -16783,7 +17320,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -16811,7 +17349,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.1+spec-1.1.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.1+spec-1.1.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.5",
@@ -16827,9 +17366,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
@@ -16847,23 +17386,25 @@
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#iri-string@0.7.12",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
@@ -16904,10 +17445,10 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
@@ -16920,9 +17461,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
@@ -16935,16 +17476,20 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.19.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
@@ -16953,16 +17498,20 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicase@2.9.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
@@ -16971,28 +17520,36 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
@@ -17028,16 +17585,20 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0",
@@ -17057,7 +17618,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
@@ -17066,7 +17628,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
@@ -17083,6 +17646,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
@@ -17100,13 +17664,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.1"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.1",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
@@ -17132,7 +17699,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
@@ -17150,7 +17718,8 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
@@ -17189,10 +17758,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
+      "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3",
@@ -17221,6 +17792,292 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4"
       ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
+      "dependsOn": []
     }
   ]
 }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,8 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
   "version": 1,
-  "serialNumber": "urn:uuid:d08bc80e-ff8e-4881-abe5-2a0c942accde",
   "metadata": {
-    "timestamp": "2026-04-04T16:27:41.090242755Z",
+    "timestamp": "1970-01-01T00:00:00.000000000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,7 +13,7 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
+      "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
       "name": "ana",
       "version": "0.0.0",
       "scope": "required",
@@ -22,7 +21,7 @@
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0 bin-target-0",
+          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
           "name": "ana",
           "version": "0.0.0",
           "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
@@ -31,8 +30,8 @@
     },
     "properties": [
       {
-        "name": "cdx:rustc:sbom:target:triple",
-        "value": "x86_64-unknown-linux-gnu"
+        "name": "cdx:rustc:sbom:target:all_targets",
+        "value": "true"
       }
     ]
   },
@@ -205,6 +204,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+      "author": "Nicolas Silva <nical@fastmail.com>",
+      "name": "android_system_properties",
+      "version": "0.1.5",
+      "description": "Minimal Android system properties wrapper",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/android_system_properties@0.1.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/android_system_properties"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/nical/android_system_properties"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/nical/android_system_properties"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
       "name": "anstream",
       "version": "1.0.0",
@@ -274,6 +308,32 @@
         }
       ],
       "purl": "pkg:cargo/anstyle-query@1.1.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-cli/anstyle.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
+      "name": "anstyle-wincon",
+      "version": "3.0.11",
+      "description": "Styling legacy Windows terminals",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/anstyle-wincon@3.0.11",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1315,6 +1375,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
+      "author": "Markus Westerlind <marwes91@gmail.com>",
+      "name": "combine",
+      "version": "4.6.7",
+      "description": "Fast parser combinators on arbitrary streams with zero-copy support.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/combine@4.6.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/combine"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Marwes/combine"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
       "author": "Arne Beer <contact@arne.beer>",
       "name": "comfy-table",
@@ -1468,6 +1559,64 @@
         {
           "type": "vcs",
           "url": "https://github.com/console-rs/console"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation-sys",
+      "version": "0.8.7",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation-sys@0.8.7",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/servo/core-foundation-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "author": "The Servo Project Developers",
+      "name": "core-foundation",
+      "version": "0.10.1",
+      "description": "Bindings to Core Foundation for macOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/core-foundation@0.10.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/servo/core-foundation-rs"
         }
       ]
     },
@@ -1678,6 +1827,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/crossterm-rs/crossterm"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
+      "author": "T. Post",
+      "name": "crossterm_winapi",
+      "version": "0.9.1",
+      "description": "WinAPI wrapper that provides some basic simple abstractions around common WinAPI calls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/crossterm_winapi@0.9.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/crossterm_winapi/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossterm-rs/crossterm-winapi"
         }
       ]
     },
@@ -2074,6 +2254,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
+      "author": "Torbj\u00f8rn Birch Moltu <t.b.moltu@lyse.net>",
+      "name": "encode_unicode",
+      "version": "1.0.0",
+      "description": "UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/encode_unicode@1.0.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/encode_unicode/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tormol/encode_unicode"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "author": "Anton Lazarev <https://antonok.com>",
       "name": "enum_dispatch",
@@ -2431,6 +2642,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-fnv"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+      "author": "Orson Peters <orsonpeters@gmail.com>",
+      "name": "foldhash",
+      "version": "0.1.5",
+      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/foldhash@0.1.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/orlp/foldhash"
         }
       ]
     },
@@ -3212,6 +3450,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "hashbrown",
+      "version": "0.15.5",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hashbrown@0.15.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/hashbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
       "author": "Amanieu d'Antras <amanieu@gmail.com>",
       "name": "hashbrown",
@@ -3260,6 +3525,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/withoutboats/heck"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2",
+      "author": "Stefan Lankes",
+      "name": "hermit-abi",
+      "version": "0.5.2",
+      "description": "Hermit system calls definitions.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hermit-abi@0.5.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/hermit-os/hermit-rs"
         }
       ]
     },
@@ -3646,6 +3938,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
+      "author": "Ren\u00e9 Kijewski <crates.io@k6i.de>",
+      "name": "iana-time-zone-haiku",
+      "version": "0.1.2",
+      "description": "iana-time-zone support crate for Haiku OS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/iana-time-zone-haiku@0.1.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/strawlab/iana-time-zone"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
       "author": "Andrew Straw <strawman@astraw.com>, Ren\u00e9 Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
       "name": "iana-time-zone",
@@ -3885,6 +4204,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0",
+      "author": "Nick Fitzgerald <fitzgen@gmail.com>, Aleksey Kladov <aleksey.kladov@gmail.com>",
+      "name": "id-arena",
+      "version": "2.3.0",
+      "description": "A simple, id-based arena.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/id-arena@2.3.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/id-arena"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/fitzgen/id-arena"
         }
       ]
     },
@@ -4312,6 +4662,125 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
+      "name": "jni-macros",
+      "version": "0.22.4",
+      "description": "Procedural macros for the jni crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/jni-macros@0.22.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/jni-rs/jni-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1",
+      "author": "Robert Bragg <robert@sixbynine.org>",
+      "name": "jni-sys-macros",
+      "version": "0.4.1",
+      "description": "Macros for jni-sys crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/jni-sys-macros@0.4.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jni-sys-macros"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/jni-rs/jni-sys"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
+      "author": "Steven Fackler <sfackler@gmail.com>, Robert Bragg <robert@sixbynine.org>",
+      "name": "jni-sys",
+      "version": "0.4.1",
+      "description": "Rust definitions corresponding to jni.h",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/jni-sys@0.4.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jni-sys"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/jni-rs/jni-sys"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
+      "author": "jni team",
+      "name": "jni",
+      "version": "0.22.4",
+      "description": "Rust bindings to the JNI",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/jni@0.22.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jni"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/jni-rs/jni-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "jobserver",
@@ -4342,6 +4811,76 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-lang/jobserver-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+      "author": "The wasm-bindgen Developers",
+      "name": "js-sys",
+      "version": "0.3.94",
+      "description": "Bindings for all JS global objects and functions in all JS environments like Node.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/js-sys@0.3.94",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/js-sys"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
+      "author": "Ryan Lopopolo <rjl@hyperbo.la>",
+      "name": "known-folders",
+      "version": "1.4.2",
+      "description": "A safe wrapper around the Known Folders API on Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/known-folders@1.4.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/known-folders"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/artichoke/known-folders-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/artichoke/known-folders-rs"
         }
       ]
     },
@@ -4432,6 +4971,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0",
+      "author": "Bryant Luk <code@bryantluk.com>",
+      "name": "leb128fmt",
+      "version": "0.1.0",
+      "description": "A library to encode and decode LEB128 compressed integers.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/leb128fmt@0.1.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/leb128fmt"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bluk/leb128fmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2",
       "name": "libbz2-rs-sys",
       "version": "0.2.2",
@@ -4484,6 +5054,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-lang/libc"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
+      "author": "4lDO2 <4lDO2@protonmail.com>",
+      "name": "libredox",
+      "version": "0.1.15",
+      "description": "Redox stable ABI",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/libredox@0.1.15",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://gitlab.redox-os.org/redox-os/libredox.git"
         }
       ]
     },
@@ -4989,6 +5586,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1",
+      "author": "The Rust Windowing contributors",
+      "name": "ndk-context",
+      "version": "0.1.1",
+      "description": "Handles for accessing Android APIs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ndk-context@0.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ndk-context"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-windowing/android-ndk-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-windowing/android-ndk-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
       "author": "The nix-rust Project Developers",
       "name": "nix",
@@ -5069,6 +5701,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-bakery/nom"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
+      "author": "MSxDOS <melcodos@gmail.com>",
+      "name": "ntapi",
+      "version": "0.4.3",
+      "description": "FFI bindings for Native API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/ntapi@0.4.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/ntapi/*/x86_64-pc-windows-msvc/ntapi/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/MSxDOS/ntapi"
         }
       ]
     },
@@ -5194,6 +5857,86 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0",
+      "author": "Mads Marquart <mads@marquart.dk>",
+      "name": "objc2-encode",
+      "version": "4.1.0",
+      "description": "Objective-C type-encoding representation and parsing",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/objc2-encode@4.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/madsmtm/objc2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
+      "name": "objc2-foundation",
+      "version": "0.3.2",
+      "description": "Bindings to the Foundation framework",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/objc2-foundation@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/madsmtm/objc2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
+      "author": "Mads Marquart <mads@marquart.dk>",
+      "name": "objc2",
+      "version": "0.6.4",
+      "description": "Objective-C interface and runtime bindings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/objc2@0.6.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/madsmtm/objc2"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
       "name": "object",
       "version": "0.37.3",
@@ -5246,6 +5989,32 @@
         {
           "type": "vcs",
           "url": "https://github.com/matklad/once_cell"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
+      "name": "once_cell_polyfill",
+      "version": "1.70.2",
+      "description": "Polyfill for `OnceCell` stdlib feature for use with older MSRVs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/once_cell_polyfill@1.70.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/polyfill-rs/once_cell_polyfill"
         }
       ]
     },
@@ -5940,6 +6709,72 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3",
+      "author": "jzr",
+      "name": "plain",
+      "version": "0.2.3",
+      "description": "A small Rust library that allows users to reinterpret data of certain types safely.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/plain@0.2.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/plain"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/randomites/plain"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/randomites/plain"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "author": "Ed Barnard <eabarnard@gmail.com>",
+      "name": "plist",
+      "version": "1.8.0",
+      "description": "A rusty plist parser. Supports Serde serialization.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/plist@1.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/plist/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/ebarnard/rust-plist/"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
       "name": "portable-atomic",
       "version": "1.13.1",
@@ -6046,6 +6881,41 @@
         {
           "type": "vcs",
           "url": "https://github.com/cryptocorrosion/cryptocorrosion"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "prettyplease",
+      "version": "0.2.37",
+      "description": "A minimal `syn` syntax tree pretty-printer",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/prettyplease@0.2.37",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/prettyplease"
+        },
+        {
+          "type": "other",
+          "url": "prettyplease02"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/prettyplease"
         }
       ]
     },
@@ -6262,6 +7132,36 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "name": "quick-xml",
+      "version": "0.38.4",
+      "description": "High performance xml reader and writer",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/quick-xml@0.38.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/quick-xml"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/tafia/quick-xml"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "quote",
@@ -6288,6 +7188,66 @@
         {
           "type": "vcs",
           "url": "https://github.com/dtolnay/quote"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0",
+      "name": "r-efi",
+      "version": "5.3.0",
+      "description": "UEFI Reference Specification Protocol Constants and Definitions",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
+        }
+      ],
+      "purl": "pkg:cargo/r-efi@5.3.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/r-efi/r-efi/wiki"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/r-efi/r-efi"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0",
+      "name": "r-efi",
+      "version": "6.0.0",
+      "description": "UEFI Reference Specification Protocol Constants and Definitions",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
+        }
+      ],
+      "purl": "pkg:cargo/r-efi@6.0.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/r-efi/r-efi/wiki"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/r-efi/r-efi"
         }
       ]
     },
@@ -6968,6 +7928,99 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
+      "author": "Jeremy Soller <jackpot51@gmail.com>",
+      "name": "redox_syscall",
+      "version": "0.5.18",
+      "description": "A Rust library to access raw Redox system calls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/redox_syscall@0.5.18",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/redox_syscall"
+        },
+        {
+          "type": "vcs",
+          "url": "https://gitlab.redox-os.org/redox-os/syscall"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3",
+      "author": "Jeremy Soller <jackpot51@gmail.com>",
+      "name": "redox_syscall",
+      "version": "0.7.3",
+      "description": "A Rust library to access raw Redox system calls",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/redox_syscall@0.7.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/redox_syscall"
+        },
+        {
+          "type": "vcs",
+          "url": "https://gitlab.redox-os.org/redox-os/syscall"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
+      "author": "Jose Narvaez <goyox86@gmail.com>, Wesley Hershberger <mggmugginsmc@gmail.com>",
+      "name": "redox_users",
+      "version": "0.5.2",
+      "description": "A Rust library to access Redox users and groups functionality",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/redox_users@0.5.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/redox_users"
+        },
+        {
+          "type": "vcs",
+          "url": "https://gitlab.redox-os.org/redox-os/users"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "ref-cast-impl",
@@ -7622,6 +8675,72 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "same-file",
+      "version": "1.0.6",
+      "description": "A simple crate for determining whether two file paths point to the same file. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/same-file@1.0.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/same-file"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/same-file"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/same-file"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+      "author": "Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>",
+      "name": "schannel",
+      "version": "0.1.29",
+      "description": "Schannel bindings for rust, allowing SSL/TLS (e.g. https) without openssl",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/schannel@0.1.29",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/schannel/0.1.19/schannel/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/steffengy/schannel-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
       "author": "Graham Esau <gesau@hotmail.co.uk>",
       "name": "schemars",
@@ -7710,6 +8829,72 @@
         {
           "type": "vcs",
           "url": "https://github.com/bluss/scopeguard"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework-sys",
+      "version": "2.17.0",
+      "description": "Apple `Security.framework` low-level FFI bindings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework-sys@2.17.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security-framework-sys"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+      "name": "security-framework",
+      "version": "3.7.0",
+      "description": "Security.framework bindings for macOS and iOS",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/security-framework@3.7.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/security_framework"
+        },
+        {
+          "type": "website",
+          "url": "https://lib.rs/crates/security_framework"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/kornelski/rust-security-framework"
         }
       ]
     },
@@ -8369,6 +9554,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/simd-lite/simd-json"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
+      "author": "Sean C. Roach <me@seancroach.dev>",
+      "name": "simd_cesu8",
+      "version": "1.1.1",
+      "description": "An extremely fast, SIMD accelerated, encoding and decoding library for CESU-8 and Modified UTF-8.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/simd_cesu8@1.1.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/seancroach/simd_cesu8"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seancroach/simd_cesu8"
         }
       ]
     },
@@ -10312,6 +11528,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+      "author": "erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-xid",
+      "version": "0.2.6",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-xid@0.2.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://unicode-rs.github.io/unicode-xid"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
       "name": "unit-prefix",
@@ -10591,6 +11842,32 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1",
+      "name": "valuable",
+      "version": "0.1.1",
+      "description": "Object-safe value inspection, used to pass un-typed structured data across trait-object boundaries. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/valuable@0.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/tokio-rs/valuable"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
       "author": "Heinz N. Gies <heinz@licenser.net>",
       "name": "value-trait",
@@ -10745,6 +12022,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "walkdir",
+      "version": "2.5.0",
+      "description": "Recursively walk a directory.",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/walkdir@2.5.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/walkdir/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/walkdir"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/walkdir"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
       "author": "Sean McArthur <sean@seanmonstar.com>",
       "name": "want",
@@ -10771,6 +12083,456 @@
         {
           "type": "vcs",
           "url": "https://github.com/seanmonstar/want"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
+      "author": "The Cranelift Project Developers",
+      "name": "wasi",
+      "version": "0.11.1+wasi-snapshot-preview1",
+      "description": "Experimental WASI API bindings for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasi@0.11.1+wasi-snapshot-preview1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasi"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasi"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
+      "name": "wasip2",
+      "version": "1.0.2+wasi-0.2.9",
+      "description": "WASIp2 API bindings for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasip2@1.0.2+wasi-0.2.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasip2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasi-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
+      "name": "wasip3",
+      "version": "0.4.0+wasi-0.3.0-rc-2026-01-06",
+      "description": "WASIp3 API bindings for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasip3"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasi-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
+      "author": "The wasm-bindgen Developers",
+      "name": "wasm-bindgen-futures",
+      "version": "0.4.67",
+      "description": "Bridging the gap between Rust Futures and JavaScript Promises",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-bindgen-futures@0.4.67",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-bindgen-futures"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117",
+      "author": "The wasm-bindgen Developers",
+      "name": "wasm-bindgen-macro-support",
+      "version": "0.2.117",
+      "description": "Implementation APIs for the `#[wasm_bindgen]` attribute",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-bindgen-macro-support@0.2.117",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-bindgen"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
+      "author": "The wasm-bindgen Developers",
+      "name": "wasm-bindgen-macro",
+      "version": "0.2.117",
+      "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-bindgen-macro@0.2.117",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-bindgen"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117",
+      "author": "The wasm-bindgen Developers",
+      "name": "wasm-bindgen-shared",
+      "version": "0.2.117",
+      "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal dependency. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-bindgen-shared@0.2.117",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-bindgen-shared"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/"
+        },
+        {
+          "type": "other",
+          "url": "wasm_bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+      "author": "The wasm-bindgen Developers",
+      "name": "wasm-bindgen",
+      "version": "0.2.117",
+      "description": "Easy support for interacting between JS and Rust. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-bindgen@0.2.117",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-bindgen"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
+      "author": "Nick Fitzgerald <fitzgen@gmail.com>",
+      "name": "wasm-encoder",
+      "version": "0.244.0",
+      "description": "A low-level WebAssembly encoder. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-encoder@0.244.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wasm-encoder"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
+      "name": "wasm-metadata",
+      "version": "0.244.0",
+      "description": "Read and manipulate WebAssembly metadata",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-metadata@0.244.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
+      "author": "Mattias Buelens <mattias@buelens.com>",
+      "name": "wasm-streams",
+      "version": "0.4.2",
+      "description": "Bridging between web streams and Rust streams using WebAssembly ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/wasm-streams@0.4.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/MattiasBuelens/wasm-streams/"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
+      "author": "Yury Delendik <ydelendik@mozilla.com>",
+      "name": "wasmparser",
+      "version": "0.244.0",
+      "description": "A simple event-driven library for parsing WebAssembly binary files. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wasmparser@0.244.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94",
+      "author": "The wasm-bindgen Developers",
+      "name": "web-sys",
+      "version": "0.3.94",
+      "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/web-sys@0.3.94",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/api/web_sys/"
+        },
+        {
+          "type": "website",
+          "url": "https://wasm-bindgen.github.io/wasm-bindgen/web-sys/index.html"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0",
+      "name": "web-time",
+      "version": "1.1.0",
+      "description": "Drop-in replacement for std::time for Wasm in browsers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/web-time@1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/daxpedda/web-time"
         }
       ]
     },
@@ -10837,6 +12599,1262 @@
         {
           "type": "vcs",
           "url": "https://github.com/harryfei/which-rs.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+      "author": "Peter Atashian <retep998@gmail.com>",
+      "name": "winapi-i686-pc-windows-gnu",
+      "version": "0.4.0",
+      "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/retep998/winapi-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "winapi-util",
+      "version": "0.1.11",
+      "description": "A dumping ground for high level safe wrappers over windows-sys.",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/winapi-util@0.1.11",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/winapi-util"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/winapi-util"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/winapi-util"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
+      "author": "Peter Atashian <retep998@gmail.com>",
+      "name": "winapi-x86_64-pc-windows-gnu",
+      "version": "0.4.0",
+      "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/retep998/winapi-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
+      "author": "Peter Atashian <retep998@gmail.com>",
+      "name": "winapi",
+      "version": "0.3.9",
+      "description": "Raw FFI bindings for all of Windows API.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/winapi@0.3.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/winapi/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/retep998/winapi-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
+      "name": "windows-collections",
+      "version": "0.2.0",
+      "description": "Windows collection types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-collections@0.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
+      "name": "windows-collections",
+      "version": "0.3.2",
+      "description": "Windows collection types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-collections@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
+      "author": "Microsoft",
+      "name": "windows-core",
+      "version": "0.52.0",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-core@0.52.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+      "author": "Microsoft",
+      "name": "windows-core",
+      "version": "0.61.2",
+      "description": "Core type support for COM and Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-core@0.61.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+      "name": "windows-core",
+      "version": "0.62.2",
+      "description": "Core type support for COM and Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-core@0.62.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
+      "name": "windows-future",
+      "version": "0.2.1",
+      "description": "Windows async types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-future@0.2.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
+      "name": "windows-future",
+      "version": "0.3.2",
+      "description": "Windows async types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-future@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+      "name": "windows-implement",
+      "version": "0.60.2",
+      "description": "The implement macro for the Windows crates",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-implement@0.60.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+      "name": "windows-interface",
+      "version": "0.59.3",
+      "description": "The interface macro for the Windows crates",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-interface@0.59.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+      "author": "Microsoft",
+      "name": "windows-link",
+      "version": "0.1.3",
+      "description": "Linking for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-link@0.1.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+      "name": "windows-link",
+      "version": "0.2.1",
+      "description": "Linking for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-link@0.2.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
+      "name": "windows-numerics",
+      "version": "0.2.0",
+      "description": "Windows numeric types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-numerics@0.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1",
+      "name": "windows-numerics",
+      "version": "0.3.1",
+      "description": "Windows numeric types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-numerics@0.3.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
+      "author": "Microsoft",
+      "name": "windows-registry",
+      "version": "0.5.3",
+      "description": "Windows registry",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-registry@0.5.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+      "author": "Microsoft",
+      "name": "windows-result",
+      "version": "0.3.4",
+      "description": "Windows error handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-result@0.3.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+      "name": "windows-result",
+      "version": "0.4.1",
+      "description": "Windows error handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-result@0.4.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
+      "author": "Microsoft",
+      "name": "windows-strings",
+      "version": "0.4.2",
+      "description": "Windows string types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-strings@0.4.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1",
+      "name": "windows-strings",
+      "version": "0.5.1",
+      "description": "Windows string types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-strings@0.5.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0",
+      "author": "Microsoft",
+      "name": "windows-sys",
+      "version": "0.52.0",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-sys@0.52.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0",
+      "author": "Microsoft",
+      "name": "windows-sys",
+      "version": "0.59.0",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-sys@0.59.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2",
+      "name": "windows-sys",
+      "version": "0.61.2",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-sys@0.61.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6",
+      "author": "Microsoft",
+      "name": "windows-targets",
+      "version": "0.52.6",
+      "description": "Import libs for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-targets@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
+      "author": "Microsoft",
+      "name": "windows-threading",
+      "version": "0.1.0",
+      "description": "Windows threading",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-threading@0.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
+      "name": "windows-threading",
+      "version": "0.2.1",
+      "description": "Windows threading",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-threading@0.2.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0",
+      "author": "Microsoft",
+      "name": "windows",
+      "version": "0.52.0",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows@0.52.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://microsoft.github.io/windows-docs-rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
+      "author": "Microsoft",
+      "name": "windows",
+      "version": "0.61.3",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows@0.61.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://microsoft.github.io/windows-docs-rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2",
+      "name": "windows",
+      "version": "0.62.2",
+      "description": "Rust for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows@0.62.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://microsoft.github.io/windows-docs-rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_aarch64_gnullvm@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_aarch64_msvc",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_aarch64_msvc@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_i686_gnu",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_i686_gnu@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_i686_gnullvm",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_i686_gnullvm@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_i686_msvc",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_i686_msvc@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_x86_64_gnu",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_x86_64_gnu@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_x86_64_gnullvm@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
+      "author": "Microsoft",
+      "name": "windows_x86_64_msvc",
+      "version": "0.52.6",
+      "description": "Import lib for Windows",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows_x86_64_msvc@0.52.6",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wit-bindgen-core",
+      "version": "0.51.0",
+      "description": "Low-level support for bindings generation based on WIT files for use with `wit-bindgen-cli` and other languages. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-bindgen-core@0.51.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wit-bindgen-rust-macro",
+      "version": "0.51.0",
+      "description": "Procedural macro paired with the `wit-bindgen` crate. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-bindgen-rust-macro@0.51.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wit-bindgen-rust",
+      "version": "0.51.0",
+      "description": "Rust bindings generator for WIT and the component model, typically used through the `wit-bindgen` crate's `generate!` macro. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-bindgen-rust@0.51.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wit-bindgen",
+      "version": "0.51.0",
+      "description": "Rust bindings generator and runtime support for WIT and the component model. Used when compiling Rust programs to the component model. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-bindgen@0.51.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wit-bindgen"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0",
+      "author": "Peter Huene <peter@huene.dev>",
+      "name": "wit-component",
+      "version": "0.244.0",
+      "description": "Tooling for working with `*.wit` and component files together. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-component@0.244.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wit-component"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "wit-parser",
+      "version": "0.244.0",
+      "description": "Tooling for parsing `*.wit` files and working with their contents. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/wit-parser@0.244.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/wit-parser"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser"
         }
       ]
     },
@@ -10949,6 +13967,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/unicode-org/icu4x"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48",
+      "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
+      "name": "zerocopy-derive",
+      "version": "0.8.48",
+      "description": "Custom derive for traits from the zerocopy crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/zerocopy-derive@0.8.48",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/google/zerocopy"
         }
       ]
     },
@@ -11386,7 +14431,7 @@
       ]
     },
     {
-      "ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
+      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
@@ -11444,11 +14489,18 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-parse@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
         "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.2",
         "registry+https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2"
@@ -11461,7 +14513,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.11",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14"
@@ -11559,7 +14622,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27"
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -11634,8 +14698,11 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -11670,6 +14737,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
@@ -11697,15 +14771,33 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -11733,9 +14825,17 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
       ]
     },
     {
@@ -11800,7 +14900,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0"
+        "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -11830,6 +14932,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -11844,6 +14949,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
@@ -11851,7 +14957,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -11879,7 +14986,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15"
       ]
     },
     {
@@ -11901,6 +15009,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
@@ -11932,7 +15043,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -12018,22 +15130,32 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+        "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
+        "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
       ]
     },
     {
@@ -12072,6 +15194,12 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21",
@@ -12083,13 +15211,17 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -12190,7 +15322,22 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
@@ -12254,6 +15401,9 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
     },
     {
@@ -12284,6 +15434,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -12293,7 +15444,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
+        "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0"
       ]
     },
     {
@@ -12334,9 +15486,62 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#jni-sys-macros@0.4.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#combine@4.6.7",
+        "registry+https://github.com/rust-lang/crates.io-index#jni-macros@0.22.4",
+        "registry+https://github.com/rust-lang/crates.io-index#jni-sys@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -12360,10 +15565,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#libbz2-rs-sys@0.2.2"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3",
+        "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
@@ -12449,17 +15666,27 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+        "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
       ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
@@ -12483,7 +15710,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1"
@@ -12497,7 +15733,24 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0"
       ]
     },
     {
@@ -12508,6 +15761,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
@@ -12588,6 +15844,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -12634,7 +15891,9 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
+        "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
@@ -12702,6 +15961,19 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#plain@0.2.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1"
     },
     {
@@ -12717,6 +15989,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -12777,10 +16056,22 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106"
       ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@5.3.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#r-efi@6.0.0"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
@@ -12897,6 +16188,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -12984,19 +16276,24 @@
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
-        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3"
       ]
     },
     {
@@ -13007,6 +16304,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
@@ -13033,6 +16331,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
@@ -13117,6 +16417,26 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.7.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#redox_users@0.5.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#libredox@0.1.15",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -13135,7 +16455,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
     },
     {
@@ -13186,6 +16507,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
@@ -13202,7 +16524,11 @@
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.8",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
       ]
     },
     {
@@ -13217,7 +16543,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
@@ -13245,7 +16573,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
+        "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -13288,6 +16617,18 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
@@ -13309,9 +16650,28 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
@@ -13321,6 +16681,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
@@ -13342,11 +16703,15 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
@@ -13362,6 +16727,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
       ]
@@ -13464,6 +16830,13 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd_cesu8@1.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5"
     },
     {
@@ -13484,7 +16857,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -13549,9 +16923,12 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0"
       ]
     },
     {
@@ -13568,13 +16945,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -13633,6 +17012,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
@@ -13708,7 +17088,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -13786,7 +17167,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1"
       ]
     },
     {
@@ -13800,12 +17182,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
+        "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0"
       ]
     },
     {
@@ -13871,6 +17255,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
     },
     {
@@ -13909,6 +17296,9 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#valuable@0.1.1"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
@@ -13936,16 +17326,133 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.5.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#try-lock@0.2.5"
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasip2@1.0.2+wasi-0.2.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#leb128fmt@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.67",
+        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#web-time@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.94",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.117"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#jni@0.22.4",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+        "registry+https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#objc2@0.6.4",
+        "registry+https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.94"
       ]
     },
     {
@@ -13955,11 +17462,316 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.11",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6",
+        "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.52.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust@0.51.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#prettyplease@0.2.37",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-core@0.51.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen@0.51.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#wit-bindgen-rust-macro@0.51.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-component@0.244.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-encoder@0.244.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasm-metadata@0.244.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0",
+        "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#wit-parser@0.244.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#id-arena@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#wasmparser@0.244.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
@@ -13981,7 +17793,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.48",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.48"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
   "version": 1,
-  "serialNumber": "urn:uuid:2f3eae5a-cd12-4060-bbd7-8ef90dcbef66",
+  "serialNumber": "urn:uuid:d08bc80e-ff8e-4881-abe5-2a0c942accde",
   "metadata": {
-    "timestamp": "2026-04-04T16:07:36.187336000Z",
+    "timestamp": "2026-04-04T16:27:41.090242755Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,7 +14,7 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
       "name": "ana",
       "version": "0.0.0",
       "scope": "required",
@@ -22,7 +22,7 @@
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
+          "bom-ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0 bin-target-0",
           "name": "ana",
           "version": "0.0.0",
           "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
@@ -32,7 +32,7 @@
     "properties": [
       {
         "name": "cdx:rustc:sbom:target:triple",
-        "value": "aarch64-apple-darwin"
+        "value": "x86_64-unknown-linux-gnu"
       }
     ]
   },
@@ -1404,6 +1404,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
+      "author": "QEDK <qedk.en@gmail.com>",
+      "name": "configparser",
+      "version": "3.1.0",
+      "description": "A simple configuration parsing utility with no dependencies that allows you to parse INI and ini-style syntax. You can use this to write Rust programs which can be customized by end users easily.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR LGPL-3.0-or-later"
+        }
+      ],
+      "purl": "pkg:cargo/configparser@3.1.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/configparser"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/QEDK/configparser-rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/QEDK/configparser-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "name": "console",
       "version": "0.16.3",
@@ -1438,64 +1473,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-      "author": "The Servo Project Developers",
-      "name": "core-foundation-sys",
-      "version": "0.8.7",
-      "description": "Bindings to Core Foundation for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/core-foundation-sys@0.8.7",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/servo/core-foundation-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/servo/core-foundation-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-      "author": "The Servo Project Developers",
-      "name": "core-foundation",
-      "version": "0.10.1",
-      "description": "Bindings to Core Foundation for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/core-foundation@0.10.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/servo/core-foundation-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "author": "RustCrypto Developers",
       "name": "cpufeatures",
@@ -1514,6 +1491,37 @@
         }
       ],
       "purl": "pkg:cargo/cpufeatures@0.2.17",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/cpufeatures"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
+      "author": "RustCrypto Developers",
+      "name": "cpufeatures",
+      "version": "0.3.0",
+      "description": "Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, with no_std support and support for mobile targets including Android and iOS ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/cpufeatures@0.3.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2450,6 +2458,60 @@
         {
           "type": "vcs",
           "url": "https://github.com/orlp/foldhash"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1",
+      "author": "Steven Fackler <sfackler@gmail.com>",
+      "name": "foreign-types-shared",
+      "version": "0.1.1",
+      "description": "An internal crate used by foreign-types",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/foreign-types-shared@0.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/sfackler/foreign-types"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+      "author": "Steven Fackler <sfackler@gmail.com>",
+      "name": "foreign-types",
+      "version": "0.3.2",
+      "description": "A framework for Rust wrappers over C APIs",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/foreign-types@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/sfackler/foreign-types"
         }
       ]
     },
@@ -4427,6 +4489,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1",
+      "author": "Dan Gohman <dev@sunfishcode.online>",
+      "name": "linux-raw-sys",
+      "version": "0.12.1",
+      "description": "Generated bindings for Linux's userspace API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/linux-raw-sys@0.12.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/linux-raw-sys"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/sunfishcode/linux-raw-sys"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2",
       "author": "The ICU4X Project Developers",
       "name": "litemap",
@@ -5158,6 +5251,115 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
+      "name": "openssl-macros",
+      "version": "0.1.1",
+      "description": "Internal macros used by the openssl crate.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/openssl-macros@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
+      "author": "Alex Crichton <alex@alexcrichton.com>",
+      "name": "openssl-probe",
+      "version": "0.2.1",
+      "description": "A library for helping to find system-wide trust anchor (\"root\") certificate locations based on paths typically used by `openssl`. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/openssl-probe@0.2.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/openssl-probe"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/openssl-probe"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>",
+      "name": "openssl-sys",
+      "version": "0.9.112",
+      "description": "FFI bindings to OpenSSL",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/openssl-sys@0.9.112",
+      "externalReferences": [
+        {
+          "type": "other",
+          "url": "openssl"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-openssl/rust-openssl"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+      "author": "Steven Fackler <sfackler@gmail.com>",
+      "name": "openssl",
+      "version": "0.10.76",
+      "description": "OpenSSL bindings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/openssl@0.10.76",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-openssl/rust-openssl"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
       "name": "opentelemetry-http",
       "version": "0.31.0",
@@ -5738,37 +5940,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
-      "author": "Ed Barnard <eabarnard@gmail.com>",
-      "name": "plist",
-      "version": "1.8.0",
-      "description": "A rusty plist parser. Supports Serde serialization.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/plist@1.8.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/plist/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ebarnard/rust-plist/"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
       "name": "portable-atomic",
       "version": "1.13.1",
@@ -6061,15 +6232,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
       "name": "quick-xml",
-      "version": "0.38.4",
+      "version": "0.37.5",
       "description": "High performance xml reader and writer",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+          "content": "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
         }
       ],
       "licenses": [
@@ -6077,7 +6248,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/quick-xml@0.38.4",
+      "purl": "pkg:cargo/quick-xml@0.37.5",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7539,72 +7710,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/bluss/scopeguard"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
-      "name": "security-framework-sys",
-      "version": "2.17.0",
-      "description": "Apple `Security.framework` low-level FFI bindings",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/security-framework-sys@2.17.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://lib.rs/crates/security-framework-sys"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/kornelski/rust-security-framework"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-      "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
-      "name": "security-framework",
-      "version": "3.7.0",
-      "description": "Security.framework bindings for macOS and iOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/security-framework@3.7.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/security_framework"
-        },
-        {
-          "type": "website",
-          "url": "https://lib.rs/crates/security_framework"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/kornelski/rust-security-framework"
         }
       ]
     },
@@ -10517,6 +10622,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15",
+      "author": "Jim McGrath <jimmc2@gmail.com>",
+      "name": "vcpkg",
+      "version": "0.2.15",
+      "description": "A library to find native dependencies in a vcpkg tree at build time in order to be used in Cargo build scripts. ",
+      "scope": "excluded",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/vcpkg@0.2.15",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/vcpkg"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/mcgoo/vcpkg-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
       "name": "version-ranges",
       "version": "0.1.2",
@@ -11250,7 +11386,7 @@
       ]
     },
     {
-      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "ref": "path+file:///home/runner/work/ana-cli/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
@@ -11490,6 +11626,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
       ]
     },
@@ -11555,6 +11692,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.31"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
@@ -11562,20 +11702,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -11774,6 +11904,15 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.2.0"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
@@ -12051,10 +12190,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7"
-      ]
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
@@ -12230,6 +12366,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2"
     },
     {
@@ -12316,10 +12455,10 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0"
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
       ]
     },
     {
@@ -12369,6 +12508,38 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1"
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
@@ -12531,16 +12702,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1"
     },
     {
@@ -12610,7 +12771,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-error@1.2.3"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
       ]
@@ -12736,7 +12897,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -12820,17 +12980,18 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.53",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.6",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -12972,7 +13133,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"
       ]
     },
     {
@@ -13054,7 +13217,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
@@ -13082,7 +13244,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
       ]
     },
     {
@@ -13144,23 +13307,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0"
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
@@ -13310,6 +13456,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5",
@@ -13402,8 +13549,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0"
       ]
     },
@@ -13771,6 +13918,9 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
@@ -13794,7 +13944,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]

--- a/SBOM.json
+++ b/SBOM.json
@@ -2219,16 +2219,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
       "author": "Stjepan Glavina <stjepang@gmail.com>",
       "name": "fastrand",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "description": "A simple and fast random number generator",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+          "content": "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
         }
       ],
       "licenses": [
@@ -2236,7 +2236,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/fastrand@2.3.0",
+      "purl": "pkg:cargo/fastrand@2.4.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -13042,7 +13042,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0"
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
@@ -13138,7 +13138,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
@@ -14744,7 +14744,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4"

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-04T16:07:36.187336000Z<br>
+Generated: 2026-04-04T16:27:41.090242755Z<br>
 Format: CycloneDX 1.3<br>
-Packages: 367
+Packages: 372
 <br>**Security advisories: 0 found at this time**
 
 ## Packages
@@ -55,10 +55,10 @@ Packages: 367
 | [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |
 | [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.37 | MIT OR Apache-2.0 |  |
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |
+| [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |
-| [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 |  |
-| [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |
 | [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |
 | [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |
@@ -90,6 +90,8 @@ Packages: 367
 | [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |
 | [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |
 | [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |
+| [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 |  |
+| [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 |  |
 | [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |
 | [fs-err](https://crates.io/crates/fs-err) | 3.3.0 | MIT OR Apache-2.0 |  |
 | [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |
@@ -155,6 +157,7 @@ Packages: 367
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |
 | [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |
 | [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |
+| [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |
 | [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |
@@ -179,6 +182,10 @@ Packages: 367
 | [num\_cpus](https://crates.io/crates/num_cpus) | 1.17.0 | MIT OR Apache-2.0 |  |
 | [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT |  |
 | [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |
+| [openssl](https://crates.io/crates/openssl) | 0.10.76 | Apache-2.0 |  |
+| [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 |  |
+| [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.112 | MIT |  |
 | [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |
 | [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |
 | [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |
@@ -199,7 +206,6 @@ Packages: 367
 | [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |
 | [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |
 | [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [plist](https://crates.io/crates/plist) | 1.8.0 | MIT |  |
 | [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |
 | [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |
 | [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |
@@ -210,7 +216,7 @@ Packages: 367
 | [prost-derive](https://crates.io/crates/prost-derive) | 0.14.3 | Apache-2.0 |  |
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |
 | [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |
 | [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |
@@ -257,8 +263,6 @@ Packages: 367
 | [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |
 | [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |
 | [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |
-| [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 |  |
-| [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |
@@ -352,6 +356,7 @@ Packages: 367
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |
 | [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |
 | [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |
+| [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 |  |
 | [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |
 | [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |
@@ -381,15 +386,16 @@ Packages: 367
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 187 |
+| MIT OR Apache-2.0 | 189 |
 | MIT | 76 |
 | Apache-2.0 OR MIT | 27 |
+| Apache-2.0 | 18 |
 | Unicode-3.0 | 18 |
-| Apache-2.0 | 17 |
 | BSD-3-Clause | 17 |
 | ISC | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
+| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
 | Unlicense OR MIT | 2 |
 | Zlib | 2 |
@@ -398,9 +404,9 @@ Packages: 367
 | Apache-2.0  OR  MIT | 1 |
 | Apache-2.0 AND ISC | 1 |
 | Apache-2.0 OR BSL-1.0 | 1 |
-| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 1 |
 | BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
+| MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |
 | NOASSERTION | 1 |
 | Zlib OR Apache-2.0 OR MIT | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-04T16:27:41.090242755Z<br>
+Generated: 1970-01-01T00:00:00.000000000Z<br>
 Format: CycloneDX 1.3<br>
-Packages: 372
+Packages: 475
 <br>**Security advisories: 0 found at this time**
 
 ## Packages
@@ -15,10 +15,12 @@ Packages: 372
 | [aho-corasick](https://crates.io/crates/aho-corasick) | 1.1.4 | Unlicense OR MIT |  |
 | [allocator-api2](https://crates.io/crates/allocator-api2) | 0.2.21 | MIT OR Apache-2.0 |  |
 | [anaconda-otel-rs](https://crates.io/crates/anaconda-otel-rs) | 0.1.0 | NOASSERTION |  |
+| [android\_system\_properties](https://crates.io/crates/android_system_properties) | 0.1.5 | MIT OR Apache-2.0 |  |
 | [anstream](https://crates.io/crates/anstream) | 1.0.0 | MIT OR Apache-2.0 |  |
 | [anstyle](https://crates.io/crates/anstyle) | 1.0.14 | MIT OR Apache-2.0 |  |
 | [anstyle-parse](https://crates.io/crates/anstyle-parse) | 1.0.0 | MIT OR Apache-2.0 |  |
 | [anstyle-query](https://crates.io/crates/anstyle-query) | 1.1.5 | MIT OR Apache-2.0 |  |
+| [anstyle-wincon](https://crates.io/crates/anstyle-wincon) | 3.0.11 | MIT OR Apache-2.0 |  |
 | [anyhow](https://crates.io/crates/anyhow) | 1.0.102 | MIT OR Apache-2.0 |  |
 | [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.0 | MIT OR Apache-2.0 |  |
 | [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |
@@ -52,11 +54,14 @@ Packages: 372
 | [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.0 | MIT OR Apache-2.0 |  |
 | [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |
 | [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |
+| [combine](https://crates.io/crates/combine) | 4.6.7 | MIT |  |
 | [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |
 | [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.37 | MIT OR Apache-2.0 |  |
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |
 | [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |
+| [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 |  |
+| [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |
@@ -64,6 +69,7 @@ Packages: 372
 | [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |
 | [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.21 | MIT OR Apache-2.0 |  |
 | [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |
+| [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT |  |
 | [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |
 | [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |
@@ -77,6 +83,7 @@ Packages: 372
 | [document-features](https://crates.io/crates/document-features) | 0.2.12 | MIT OR Apache-2.0 |  |
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |
 | [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |
+| [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |
@@ -89,6 +96,7 @@ Packages: 372
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |
 | [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |
 | [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |
+| [foldhash](https://crates.io/crates/foldhash) | 0.1.5 | Zlib |  |
 | [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |
 | [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 |  |
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 |  |
@@ -115,8 +123,10 @@ Packages: 372
 | [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.15.5 | MIT OR Apache-2.0 |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |
+| [hermit-abi](https://crates.io/crates/hermit-abi) | 0.5.2 | MIT OR Apache-2.0 |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |
 | [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |
@@ -130,6 +140,7 @@ Packages: 372
 | [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |
 | [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |
 | [iana-time-zone](https://crates.io/crates/iana-time-zone) | 0.1.65 | MIT OR Apache-2.0 |  |
+| [iana-time-zone-haiku](https://crates.io/crates/iana-time-zone-haiku) | 0.1.2 | MIT OR Apache-2.0 |  |
 | [icu\_collections](https://crates.io/crates/icu_collections) | 2.2.0 | Unicode-3.0 |  |
 | [icu\_locale\_core](https://crates.io/crates/icu_locale_core) | 2.2.0 | Unicode-3.0 |  |
 | [icu\_normalizer](https://crates.io/crates/icu_normalizer) | 2.2.0 | Unicode-3.0 |  |
@@ -137,6 +148,7 @@ Packages: 372
 | [icu\_properties](https://crates.io/crates/icu_properties) | 2.2.0 | Unicode-3.0 |  |
 | [icu\_properties\_data](https://crates.io/crates/icu_properties_data) | 2.2.0 | Unicode-3.0 |  |
 | [icu\_provider](https://crates.io/crates/icu_provider) | 2.2.0 | Unicode-3.0 |  |
+| [id-arena](https://crates.io/crates/id-arena) | 2.3.0 | MIT OR Apache-2.0 |  |
 | [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |
 | [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |
@@ -151,12 +163,20 @@ Packages: 372
 | [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |
+| [jni](https://crates.io/crates/jni) | 0.22.4 | MIT OR Apache-2.0 |  |
+| [jni-macros](https://crates.io/crates/jni-macros) | 0.22.4 | MIT OR Apache-2.0 |  |
+| [jni-sys](https://crates.io/crates/jni-sys) | 0.4.1 | MIT OR Apache-2.0 |  |
+| [jni-sys-macros](https://crates.io/crates/jni-sys-macros) | 0.4.1 | MIT OR Apache-2.0 |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |
+| [js-sys](https://crates.io/crates/js-sys) | 0.3.94 | MIT OR Apache-2.0 |  |
+| [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |
+| [leb128fmt](https://crates.io/crates/leb128fmt) | 0.1.0 | MIT OR Apache-2.0 |  |
 | [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |
 | [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |
+| [libredox](https://crates.io/crates/libredox) | 0.1.15 | MIT |  |
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |
@@ -173,15 +193,21 @@ Packages: 372
 | [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |
 | [mio](https://crates.io/crates/mio) | 1.2.0 | MIT |  |
 | [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |
+| [ndk-context](https://crates.io/crates/ndk-context) | 0.1.1 | MIT OR Apache-2.0 |  |
 | [nix](https://crates.io/crates/nix) | 0.30.1 | MIT |  |
 | [nom](https://crates.io/crates/nom) | 8.0.0 | MIT |  |
 | [nom-language](https://crates.io/crates/nom-language) | 0.1.0 | MIT |  |
+| [ntapi](https://crates.io/crates/ntapi) | 0.4.3 | Apache-2.0 OR MIT |  |
 | [nu-ansi-term](https://crates.io/crates/nu-ansi-term) | 0.50.3 | MIT |  |
 | [num-conv](https://crates.io/crates/num-conv) | 0.2.1 | MIT OR Apache-2.0 |  |
 | [num-traits](https://crates.io/crates/num-traits) | 0.2.19 | MIT OR Apache-2.0 |  |
 | [num\_cpus](https://crates.io/crates/num_cpus) | 1.17.0 | MIT OR Apache-2.0 |  |
+| [objc2](https://crates.io/crates/objc2) | 0.6.4 | MIT |  |
+| [objc2-encode](https://crates.io/crates/objc2-encode) | 4.1.0 | MIT |  |
+| [objc2-foundation](https://crates.io/crates/objc2-foundation) | 0.3.2 | MIT |  |
 | [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT |  |
 | [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |
+| [once\_cell\_polyfill](https://crates.io/crates/once_cell_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |
 | [openssl](https://crates.io/crates/openssl) | 0.10.76 | Apache-2.0 |  |
 | [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 |  |
 | [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 |  |
@@ -206,10 +232,13 @@ Packages: 372
 | [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |
 | [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |
 | [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [plain](https://crates.io/crates/plain) | 0.2.3 | MIT OR Apache-2.0 |  |
+| [plist](https://crates.io/crates/plist) | 1.8.0 | MIT |  |
 | [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |
 | [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |
 | [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |
 | [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |
+| [prettyplease](https://crates.io/crates/prettyplease) | 0.2.37 | MIT OR Apache-2.0 |  |
 | [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |
 | [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |
 | [prost](https://crates.io/crates/prost) | 0.14.3 | Apache-2.0 |  |
@@ -217,7 +246,10 @@ Packages: 372
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |
+| [r-efi](https://crates.io/crates/r-efi) | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later |  |
+| [r-efi](https://crates.io/crates/r-efi) | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later |  |
 | [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |
 | [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |
 | [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |
@@ -239,6 +271,9 @@ Packages: 372
 | [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.1.0 | BSD-3-Clause |  |
 | [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |
+| [redox\_syscall](https://crates.io/crates/redox_syscall) | 0.5.18 | MIT |  |
+| [redox\_syscall](https://crates.io/crates/redox_syscall) | 0.7.3 | MIT |  |
+| [redox\_users](https://crates.io/crates/redox_users) | 0.5.2 | MIT |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |
 | [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |
 | [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |
@@ -260,9 +295,13 @@ Packages: 372
 | [rustversion](https://crates.io/crates/rustversion) | 1.0.22 | MIT OR Apache-2.0 |  |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |
+| [same-file](https://crates.io/crates/same-file) | 1.0.6 | Unlicense OR MIT |  |
+| [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT |  |
 | [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |
 | [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |
 | [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |
+| [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 |  |
+| [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |
@@ -284,6 +323,7 @@ Packages: 372
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 |  |
 | [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |
 | [simd-json](https://crates.io/crates/simd-json) | 0.17.0 | Apache-2.0 OR MIT |  |
+| [simd\_cesu8](https://crates.io/crates/simd_cesu8) | 1.1.1 | Apache-2.0 OR MIT |  |
 | [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |
@@ -346,6 +386,7 @@ Packages: 372
 | [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |
+| [unicode-xid](https://crates.io/crates/unicode-xid) | 0.2.6 | MIT OR Apache-2.0 |  |
 | [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |
 | [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |
 | [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |
@@ -355,19 +396,81 @@ Packages: 372
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |
 | [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |
+| [valuable](https://crates.io/crates/valuable) | 0.1.1 | MIT |  |
 | [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |
 | [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 |  |
 | [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |
 | [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [walkdir](https://crates.io/crates/walkdir) | 2.5.0 | Unlicense OR MIT |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |
+| [wasi](https://crates.io/crates/wasi) | 0.11.1+wasi-snapshot-preview1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wasip2](https://crates.io/crates/wasip2) | 1.0.2+wasi-0.2.9 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wasip3](https://crates.io/crates/wasip3) | 0.4.0+wasi-0.3.0-rc-2026-01-06 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wasm-bindgen](https://crates.io/crates/wasm-bindgen) | 0.2.117 | MIT OR Apache-2.0 |  |
+| [wasm-bindgen-futures](https://crates.io/crates/wasm-bindgen-futures) | 0.4.67 | MIT OR Apache-2.0 |  |
+| [wasm-bindgen-macro](https://crates.io/crates/wasm-bindgen-macro) | 0.2.117 | MIT OR Apache-2.0 |  |
+| [wasm-bindgen-macro-support](https://crates.io/crates/wasm-bindgen-macro-support) | 0.2.117 | MIT OR Apache-2.0 |  |
+| [wasm-bindgen-shared](https://crates.io/crates/wasm-bindgen-shared) | 0.2.117 | MIT OR Apache-2.0 |  |
+| [wasm-encoder](https://crates.io/crates/wasm-encoder) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wasm-metadata](https://crates.io/crates/wasm-metadata) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wasm-streams](https://crates.io/crates/wasm-streams) | 0.4.2 | MIT OR Apache-2.0 |  |
+| [wasmparser](https://crates.io/crates/wasmparser) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [web-sys](https://crates.io/crates/web-sys) | 0.3.94 | MIT OR Apache-2.0 |  |
+| [web-time](https://crates.io/crates/web-time) | 1.1.0 | MIT OR Apache-2.0 |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.0 | MIT OR Apache-2.0 |  |
 | [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |
+| [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 |  |
+| [winapi-i686-pc-windows-gnu](https://crates.io/crates/winapi-i686-pc-windows-gnu) | 0.4.0 | MIT OR Apache-2.0 |  |
+| [winapi-util](https://crates.io/crates/winapi-util) | 0.1.11 | Unlicense OR MIT |  |
+| [winapi-x86\_64-pc-windows-gnu](https://crates.io/crates/winapi-x86_64-pc-windows-gnu) | 0.4.0 | MIT OR Apache-2.0 |  |
+| [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 |  |
+| [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 |  |
+| [windows](https://crates.io/crates/windows) | 0.62.2 | MIT OR Apache-2.0 |  |
+| [windows-collections](https://crates.io/crates/windows-collections) | 0.2.0 | MIT OR Apache-2.0 |  |
+| [windows-collections](https://crates.io/crates/windows-collections) | 0.3.2 | MIT OR Apache-2.0 |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.52.0 | MIT OR Apache-2.0 |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.61.2 | MIT OR Apache-2.0 |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.62.2 | MIT OR Apache-2.0 |  |
+| [windows-future](https://crates.io/crates/windows-future) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [windows-future](https://crates.io/crates/windows-future) | 0.3.2 | MIT OR Apache-2.0 |  |
+| [windows-implement](https://crates.io/crates/windows-implement) | 0.60.2 | MIT OR Apache-2.0 |  |
+| [windows-interface](https://crates.io/crates/windows-interface) | 0.59.3 | MIT OR Apache-2.0 |  |
+| [windows-link](https://crates.io/crates/windows-link) | 0.1.3 | MIT OR Apache-2.0 |  |
+| [windows-link](https://crates.io/crates/windows-link) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 |  |
+| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 |  |
+| [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 |  |
+| [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 |  |
+| [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 |  |
+| [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 |  |
+| [windows-strings](https://crates.io/crates/windows-strings) | 0.5.1 | MIT OR Apache-2.0 |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.52.0 | MIT OR Apache-2.0 |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.59.0 | MIT OR Apache-2.0 |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.61.2 | MIT OR Apache-2.0 |  |
+| [windows-targets](https://crates.io/crates/windows-targets) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows-threading](https://crates.io/crates/windows-threading) | 0.1.0 | MIT OR Apache-2.0 |  |
+| [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [windows\_aarch64\_gnullvm](https://crates.io/crates/windows_aarch64_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_aarch64\_msvc](https://crates.io/crates/windows_aarch64_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_i686\_gnu](https://crates.io/crates/windows_i686_gnu) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_i686\_gnullvm](https://crates.io/crates/windows_i686_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_i686\_msvc](https://crates.io/crates/windows_i686_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_x86\_64\_gnu](https://crates.io/crates/windows_x86_64_gnu) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_x86\_64\_gnullvm](https://crates.io/crates/windows_x86_64_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
+| [wit-bindgen](https://crates.io/crates/wit-bindgen) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wit-bindgen-core](https://crates.io/crates/wit-bindgen-core) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wit-bindgen-rust](https://crates.io/crates/wit-bindgen-rust) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wit-bindgen-rust-macro](https://crates.io/crates/wit-bindgen-rust-macro) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wit-component](https://crates.io/crates/wit-component) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [wit-parser](https://crates.io/crates/wit-parser) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
 | [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |
 | [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 |  |
 | [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |
 | [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |
 | [zerocopy](https://crates.io/crates/zerocopy) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |
+| [zerocopy-derive](https://crates.io/crates/zerocopy-derive) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |
 | [zerofrom](https://crates.io/crates/zerofrom) | 0.1.7 | Unicode-3.0 |  |
 | [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |
 | [zeroize](https://crates.io/crates/zeroize) | 1.8.2 | Apache-2.0 OR MIT |  |
@@ -386,25 +489,26 @@ Packages: 372
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 189 |
-| MIT | 76 |
-| Apache-2.0 OR MIT | 27 |
+| MIT OR Apache-2.0 | 256 |
+| MIT | 89 |
+| Apache-2.0 OR MIT | 31 |
 | Apache-2.0 | 18 |
 | Unicode-3.0 | 18 |
 | BSD-3-Clause | 17 |
+| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 14 |
+| Unlicense OR MIT | 5 |
 | ISC | 3 |
+| Zlib | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
-| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
+| BSD-2-Clause OR Apache-2.0 OR MIT | 2 |
+| MIT OR Apache-2.0 OR LGPL-2.1-or-later | 2 |
 | MPL-2.0 | 2 |
-| Unlicense OR MIT | 2 |
-| Zlib | 2 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |
 | Apache-2.0 AND ISC | 1 |
 | Apache-2.0 OR BSL-1.0 | 1 |
-| BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
 | MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -88,7 +88,7 @@ Platforms: linux, macos, windows
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
 | [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
-| [fastrand](https://crates.io/crates/fastrand) | 2.3.0 | Apache-2.0 OR MIT |  |  |
+| [fastrand](https://crates.io/crates/fastrand) | 2.4.0 | Apache-2.0 OR MIT |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.2.7 | BSD-3-Clause |  |  |
 | [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |

--- a/SBOM.md
+++ b/SBOM.md
@@ -2,513 +2,452 @@
 
 Generated: 1970-01-01T00:00:00.000000000Z<br>
 Format: CycloneDX 1.3<br>
-Packages: 475
+Packages: 414 (64 platform-specific)<br>
+Platforms: linux, macos, windows
 <br>**Security advisories: 0 found at this time**
 
 ## Packages
 
-| Package | Version | License | CVEs |
-| --- | --- | --- | ---: |
-| [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT |  |
-| [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |
-| [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |
-| [aho-corasick](https://crates.io/crates/aho-corasick) | 1.1.4 | Unlicense OR MIT |  |
-| [allocator-api2](https://crates.io/crates/allocator-api2) | 0.2.21 | MIT OR Apache-2.0 |  |
-| [anaconda-otel-rs](https://crates.io/crates/anaconda-otel-rs) | 0.1.0 | NOASSERTION |  |
-| [android\_system\_properties](https://crates.io/crates/android_system_properties) | 0.1.5 | MIT OR Apache-2.0 |  |
-| [anstream](https://crates.io/crates/anstream) | 1.0.0 | MIT OR Apache-2.0 |  |
-| [anstyle](https://crates.io/crates/anstyle) | 1.0.14 | MIT OR Apache-2.0 |  |
-| [anstyle-parse](https://crates.io/crates/anstyle-parse) | 1.0.0 | MIT OR Apache-2.0 |  |
-| [anstyle-query](https://crates.io/crates/anstyle-query) | 1.1.5 | MIT OR Apache-2.0 |  |
-| [anstyle-wincon](https://crates.io/crates/anstyle-wincon) | 3.0.11 | MIT OR Apache-2.0 |  |
-| [anyhow](https://crates.io/crates/anyhow) | 1.0.102 | MIT OR Apache-2.0 |  |
-| [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.0 | MIT OR Apache-2.0 |  |
-| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |
-| [async-compression](https://crates.io/crates/async-compression) | 0.4.41 | MIT OR Apache-2.0 |  |
-| [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |
-| [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |
-| [async-trait](https://crates.io/crates/async-trait) | 0.1.89 | MIT OR Apache-2.0 |  |
-| [async\_http\_range\_reader](https://crates.io/crates/async_http_range_reader) | 0.9.1 | MIT |  |
-| [atomic-waker](https://crates.io/crates/atomic-waker) | 1.1.2 | Apache-2.0 OR MIT |  |
-| [autocfg](https://crates.io/crates/autocfg) | 1.5.0 | Apache-2.0 OR MIT |  |
-| [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |
-| [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |
-| [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |
-| [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |
-| [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |
-| [bitflags](https://crates.io/crates/bitflags) | 2.11.0 | MIT OR Apache-2.0 |  |
-| [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |
-| [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |
-| [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |
-| [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |
-| [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |
-| [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |
-| [cc](https://crates.io/crates/cc) | 1.2.59 | MIT OR Apache-2.0 |  |
-| [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |
-| [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |
-| [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |
-| [clap](https://crates.io/crates/clap) | 4.6.0 | MIT OR Apache-2.0 |  |
-| [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |
-| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.0 | MIT OR Apache-2.0 |  |
-| [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |
-| [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |
-| [combine](https://crates.io/crates/combine) | 4.6.7 | MIT |  |
-| [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |
-| [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.37 | MIT OR Apache-2.0 |  |
-| [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |
-| [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later |  |
-| [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |
-| [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 |  |
-| [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 |  |
-| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |
-| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |
-| [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |
-| [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |
-| [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |
-| [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.21 | MIT OR Apache-2.0 |  |
-| [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |
-| [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT |  |
-| [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |
-| [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |
-| [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |
-| [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |
-| [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |
-| [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |
-| [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |
-| [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |
-| [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |
-| [displaydoc](https://crates.io/crates/displaydoc) | 0.2.5 | MIT OR Apache-2.0 |  |
-| [document-features](https://crates.io/crates/document-features) | 0.2.12 | MIT OR Apache-2.0 |  |
-| [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |
-| [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |
-| [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT |  |
-| [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |
-| [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |
-| [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |
-| [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 |  |
-| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |
-| [fastrand](https://crates.io/crates/fastrand) | 2.3.0 | Apache-2.0 OR MIT |  |
-| [file\_url](https://crates.io/crates/file_url) | 0.2.7 | BSD-3-Clause |  |
-| [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |
-| [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |
-| [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |
-| [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |
-| [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |
-| [foldhash](https://crates.io/crates/foldhash) | 0.1.5 | Zlib |  |
-| [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |
-| [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 |  |
-| [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 |  |
-| [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |
-| [fs-err](https://crates.io/crates/fs-err) | 3.3.0 | MIT OR Apache-2.0 |  |
-| [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |
-| [futures](https://crates.io/crates/futures) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-channel](https://crates.io/crates/futures-channel) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-core](https://crates.io/crates/futures-core) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-executor](https://crates.io/crates/futures-executor) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-io](https://crates.io/crates/futures-io) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-lite](https://crates.io/crates/futures-lite) | 2.6.1 | Apache-2.0 OR MIT |  |
-| [futures-macro](https://crates.io/crates/futures-macro) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-sink](https://crates.io/crates/futures-sink) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-task](https://crates.io/crates/futures-task) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [futures-util](https://crates.io/crates/futures-util) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [generic-array](https://crates.io/crates/generic-array) | 0.14.7 | MIT |  |
-| [getrandom](https://crates.io/crates/getrandom) | 0.2.17 | MIT OR Apache-2.0 |  |
-| [getrandom](https://crates.io/crates/getrandom) | 0.3.4 | MIT OR Apache-2.0 |  |
-| [getrandom](https://crates.io/crates/getrandom) | 0.4.2 | MIT OR Apache-2.0 |  |
-| [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 |  |
-| [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |
-| [h2](https://crates.io/crates/h2) | 0.4.13 | MIT |  |
-| [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.15.5 | MIT OR Apache-2.0 |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |
-| [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |
-| [hermit-abi](https://crates.io/crates/hermit-abi) | 0.5.2 | MIT OR Apache-2.0 |  |
-| [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |
-| [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |
-| [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |
-| [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |
-| [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |
-| [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |
-| [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |
-| [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |
-| [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |
-| [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.7 | Apache-2.0 OR ISC OR MIT |  |
-| [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |
-| [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |
-| [iana-time-zone](https://crates.io/crates/iana-time-zone) | 0.1.65 | MIT OR Apache-2.0 |  |
-| [iana-time-zone-haiku](https://crates.io/crates/iana-time-zone-haiku) | 0.1.2 | MIT OR Apache-2.0 |  |
-| [icu\_collections](https://crates.io/crates/icu_collections) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_locale\_core](https://crates.io/crates/icu_locale_core) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_normalizer](https://crates.io/crates/icu_normalizer) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_normalizer\_data](https://crates.io/crates/icu_normalizer_data) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_properties](https://crates.io/crates/icu_properties) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_properties\_data](https://crates.io/crates/icu_properties_data) | 2.2.0 | Unicode-3.0 |  |
-| [icu\_provider](https://crates.io/crates/icu_provider) | 2.2.0 | Unicode-3.0 |  |
-| [id-arena](https://crates.io/crates/id-arena) | 2.3.0 | MIT OR Apache-2.0 |  |
-| [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |
-| [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |
-| [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |
-| [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |
-| [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |
-| [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |
-| [indoc](https://crates.io/crates/indoc) | 2.0.7 | MIT OR Apache-2.0 |  |
-| [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |
-| [iri-string](https://crates.io/crates/iri-string) | 0.7.12 | MIT OR Apache-2.0 |  |
-| [is\_ci](https://crates.io/crates/is_ci) | 1.2.0 | ISC |  |
-| [is\_terminal\_polyfill](https://crates.io/crates/is_terminal_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |
-| [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |
-| [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |
-| [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |
-| [jni](https://crates.io/crates/jni) | 0.22.4 | MIT OR Apache-2.0 |  |
-| [jni-macros](https://crates.io/crates/jni-macros) | 0.22.4 | MIT OR Apache-2.0 |  |
-| [jni-sys](https://crates.io/crates/jni-sys) | 0.4.1 | MIT OR Apache-2.0 |  |
-| [jni-sys-macros](https://crates.io/crates/jni-sys-macros) | 0.4.1 | MIT OR Apache-2.0 |  |
-| [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |
-| [js-sys](https://crates.io/crates/js-sys) | 0.3.94 | MIT OR Apache-2.0 |  |
-| [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT |  |
-| [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |
-| [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |
-| [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |
-| [leb128fmt](https://crates.io/crates/leb128fmt) | 0.1.0 | MIT OR Apache-2.0 |  |
-| [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |
-| [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |
-| [libredox](https://crates.io/crates/libredox) | 0.1.15 | MIT |  |
-| [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |
-| [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |
-| [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |
-| [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |
-| [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |
-| [md-5](https://crates.io/crates/md-5) | 0.10.6 | MIT OR Apache-2.0 |  |
-| [memchr](https://crates.io/crates/memchr) | 2.8.0 | Unlicense OR MIT |  |
-| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  |
-| [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |
-| [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |
-| [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |
-| [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |
-| [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |
-| [mio](https://crates.io/crates/mio) | 1.2.0 | MIT |  |
-| [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |
-| [ndk-context](https://crates.io/crates/ndk-context) | 0.1.1 | MIT OR Apache-2.0 |  |
-| [nix](https://crates.io/crates/nix) | 0.30.1 | MIT |  |
-| [nom](https://crates.io/crates/nom) | 8.0.0 | MIT |  |
-| [nom-language](https://crates.io/crates/nom-language) | 0.1.0 | MIT |  |
-| [ntapi](https://crates.io/crates/ntapi) | 0.4.3 | Apache-2.0 OR MIT |  |
-| [nu-ansi-term](https://crates.io/crates/nu-ansi-term) | 0.50.3 | MIT |  |
-| [num-conv](https://crates.io/crates/num-conv) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [num-traits](https://crates.io/crates/num-traits) | 0.2.19 | MIT OR Apache-2.0 |  |
-| [num\_cpus](https://crates.io/crates/num_cpus) | 1.17.0 | MIT OR Apache-2.0 |  |
-| [objc2](https://crates.io/crates/objc2) | 0.6.4 | MIT |  |
-| [objc2-encode](https://crates.io/crates/objc2-encode) | 4.1.0 | MIT |  |
-| [objc2-foundation](https://crates.io/crates/objc2-foundation) | 0.3.2 | MIT |  |
-| [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT |  |
-| [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |
-| [once\_cell\_polyfill](https://crates.io/crates/once_cell_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |
-| [openssl](https://crates.io/crates/openssl) | 0.10.76 | Apache-2.0 |  |
-| [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 |  |
-| [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.112 | MIT |  |
-| [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |
-| [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |
-| [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |
-| [opentelemetry-proto](https://crates.io/crates/opentelemetry-proto) | 0.31.0 | Apache-2.0 |  |
-| [opentelemetry-stdout](https://crates.io/crates/opentelemetry-stdout) | 0.31.0 | Apache-2.0 |  |
-| [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |
-| [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |
-| [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |
-| [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |
-| [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |
-| [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |
-| [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |
-| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.7 | BSD-3-Clause |  |
-| [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |
-| [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |
-| [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |
-| [pin-project](https://crates.io/crates/pin-project) | 1.1.11 | Apache-2.0 OR MIT |  |
-| [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |
-| [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |
-| [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |
-| [plain](https://crates.io/crates/plain) | 0.2.3 | MIT OR Apache-2.0 |  |
-| [plist](https://crates.io/crates/plist) | 1.8.0 | MIT |  |
-| [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |
-| [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |
-| [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |
-| [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |
-| [prettyplease](https://crates.io/crates/prettyplease) | 0.2.37 | MIT OR Apache-2.0 |  |
-| [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |
-| [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |
-| [prost](https://crates.io/crates/prost) | 0.14.3 | Apache-2.0 |  |
-| [prost-derive](https://crates.io/crates/prost-derive) | 0.14.3 | Apache-2.0 |  |
-| [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |
-| [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT |  |
-| [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |
-| [r-efi](https://crates.io/crates/r-efi) | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later |  |
-| [r-efi](https://crates.io/crates/r-efi) | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later |  |
-| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |
-| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |
-| [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |
-| [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |
-| [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |
-| [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |
-| [rattler](https://crates.io/crates/rattler) | 0.40.3 | BSD-3-Clause |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.18 | BSD-3-Clause |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.3 | BSD-3-Clause |  |
-| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.2.3 | BSD-3-Clause |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.4 | BSD-3-Clause |  |
-| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.0.12 | BSD-3-Clause |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.53 | BSD-3-Clause |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.6 | BSD-3-Clause |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.6 | BSD-3-Clause |  |
-| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.9 | BSD-3-Clause |  |
-| [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.1.13 | BSD-3-Clause |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.6 | BSD-3-Clause |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.1.0 | BSD-3-Clause |  |
-| [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |
-| [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |
-| [redox\_syscall](https://crates.io/crates/redox_syscall) | 0.5.18 | MIT |  |
-| [redox\_syscall](https://crates.io/crates/redox_syscall) | 0.7.3 | MIT |  |
-| [redox\_users](https://crates.io/crates/redox_users) | 0.5.2 | MIT |  |
-| [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |
-| [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |
-| [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |
-| [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |
-| [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |
-| [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |
-| [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |
-| [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |
-| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |
-| [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |
-| [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |
-| [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.2 | Apache-2.0 OR MIT |  |
-| [rustc\_version](https://crates.io/crates/rustc_version) | 0.4.1 | MIT OR Apache-2.0 |  |
-| [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |
-| [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [rustls](https://crates.io/crates/rustls) | 0.23.37 | Apache-2.0 OR ISC OR MIT |  |
-| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |
-| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.10 | ISC |  |
-| [rustversion](https://crates.io/crates/rustversion) | 1.0.22 | MIT OR Apache-2.0 |  |
-| [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |
-| [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |
-| [same-file](https://crates.io/crates/same-file) | 1.0.6 | Unlicense OR MIT |  |
-| [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT |  |
-| [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |
-| [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |
-| [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |
-| [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 |  |
-| [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 |  |
-| [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |
-| [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |
-| [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |
-| [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |
-| [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |
-| [serde\_bytes](https://crates.io/crates/serde_bytes) | 0.11.19 | MIT OR Apache-2.0 |  |
-| [serde\_core](https://crates.io/crates/serde_core) | 1.0.228 | MIT OR Apache-2.0 |  |
-| [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.228 | MIT OR Apache-2.0 |  |
-| [serde\_json](https://crates.io/crates/serde_json) | 1.0.149 | MIT OR Apache-2.0 |  |
-| [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |
-| [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |
-| [serde\_with](https://crates.io/crates/serde_with) | 3.18.0 | MIT OR Apache-2.0 |  |
-| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.18.0 | MIT OR Apache-2.0 |  |
-| [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |
-| [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |
-| [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |
-| [shlex](https://crates.io/crates/shlex) | 1.3.0 | MIT OR Apache-2.0 |  |
-| [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT |  |
-| [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 |  |
-| [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |
-| [simd-json](https://crates.io/crates/simd-json) | 0.17.0 | Apache-2.0 OR MIT |  |
-| [simd\_cesu8](https://crates.io/crates/simd_cesu8) | 1.1.1 | Apache-2.0 OR MIT |  |
-| [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |
-| [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |
-| [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |
-| [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |
-| [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |
-| [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |
-| [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |
-| [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |
-| [strum\_macros](https://crates.io/crates/strum_macros) | 0.28.0 | MIT |  |
-| [subtle](https://crates.io/crates/subtle) | 2.6.1 | BSD-3-Clause |  |
-| [supports-color](https://crates.io/crates/supports-color) | 3.0.2 | Apache-2.0 |  |
-| [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |
-| [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |
-| [syn](https://crates.io/crates/syn) | 2.0.117 | MIT OR Apache-2.0 |  |
-| [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |
-| [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |
-| [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |
-| [tar](https://crates.io/crates/tar) | 0.4.45 | MIT OR Apache-2.0 |  |
-| [tempfile](https://crates.io/crates/tempfile) | 3.27.0 | MIT OR Apache-2.0 |  |
-| [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |
-| [textwrap](https://crates.io/crates/textwrap) | 0.16.2 | MIT |  |
-| [thiserror](https://crates.io/crates/thiserror) | 1.0.69 | MIT OR Apache-2.0 |  |
-| [thiserror](https://crates.io/crates/thiserror) | 2.0.18 | MIT OR Apache-2.0 |  |
-| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 1.0.69 | MIT OR Apache-2.0 |  |
-| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.18 | MIT OR Apache-2.0 |  |
-| [thread\_local](https://crates.io/crates/thread_local) | 1.1.9 | MIT OR Apache-2.0 |  |
-| [time](https://crates.io/crates/time) | 0.3.47 | MIT OR Apache-2.0 |  |
-| [time-core](https://crates.io/crates/time-core) | 0.1.8 | MIT OR Apache-2.0 |  |
-| [time-macros](https://crates.io/crates/time-macros) | 0.2.27 | MIT OR Apache-2.0 |  |
-| [tinystr](https://crates.io/crates/tinystr) | 0.8.3 | Unicode-3.0 |  |
-| [tinyvec](https://crates.io/crates/tinyvec) | 1.11.0 | Zlib OR Apache-2.0 OR MIT |  |
-| [tinyvec\_macros](https://crates.io/crates/tinyvec_macros) | 0.1.1 | MIT OR Apache-2.0 OR Zlib |  |
-| [tokio](https://crates.io/crates/tokio) | 1.51.0 | MIT |  |
-| [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.0 | MIT |  |
-| [tokio-native-tls](https://crates.io/crates/tokio-native-tls) | 0.3.1 | MIT |  |
-| [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |
-| [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |
-| [tokio-util](https://crates.io/crates/tokio-util) | 0.7.18 | MIT |  |
-| [tonic](https://crates.io/crates/tonic) | 0.14.5 | MIT |  |
-| [tonic-prost](https://crates.io/crates/tonic-prost) | 0.14.5 | MIT |  |
-| [tower](https://crates.io/crates/tower) | 0.5.3 | MIT |  |
-| [tower-http](https://crates.io/crates/tower-http) | 0.6.8 | MIT |  |
-| [tower-layer](https://crates.io/crates/tower-layer) | 0.3.3 | MIT |  |
-| [tower-service](https://crates.io/crates/tower-service) | 0.3.3 | MIT |  |
-| [tracing](https://crates.io/crates/tracing) | 0.1.44 | MIT |  |
-| [tracing-attributes](https://crates.io/crates/tracing-attributes) | 0.1.31 | MIT |  |
-| [tracing-core](https://crates.io/crates/tracing-core) | 0.1.36 | MIT |  |
-| [tracing-log](https://crates.io/crates/tracing-log) | 0.2.0 | MIT |  |
-| [tracing-opentelemetry](https://crates.io/crates/tracing-opentelemetry) | 0.32.1 | MIT |  |
-| [tracing-subscriber](https://crates.io/crates/tracing-subscriber) | 0.3.23 | MIT |  |
-| [try-lock](https://crates.io/crates/try-lock) | 0.2.5 | MIT |  |
-| [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |
-| [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |
-| [typenum](https://crates.io/crates/typenum) | 1.19.0 | MIT OR Apache-2.0 |  |
-| [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |
-| [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |
-| [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |
-| [unicode-linebreak](https://crates.io/crates/unicode-linebreak) | 0.1.5 | Apache-2.0 |  |
-| [unicode-normalization](https://crates.io/crates/unicode-normalization) | 0.1.25 | MIT OR Apache-2.0 |  |
-| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |
-| [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |
-| [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |
-| [unicode-xid](https://crates.io/crates/unicode-xid) | 0.2.6 | MIT OR Apache-2.0 |  |
-| [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |
-| [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |
-| [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |
-| [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |
-| [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |
-| [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |
-| [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |
-| [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |
-| [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |
-| [valuable](https://crates.io/crates/valuable) | 0.1.1 | MIT |  |
-| [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |
-| [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 |  |
-| [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |
-| [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |
-| [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [walkdir](https://crates.io/crates/walkdir) | 2.5.0 | Unlicense OR MIT |  |
-| [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |
-| [wasi](https://crates.io/crates/wasi) | 0.11.1+wasi-snapshot-preview1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wasip2](https://crates.io/crates/wasip2) | 1.0.2+wasi-0.2.9 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wasip3](https://crates.io/crates/wasip3) | 0.4.0+wasi-0.3.0-rc-2026-01-06 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wasm-bindgen](https://crates.io/crates/wasm-bindgen) | 0.2.117 | MIT OR Apache-2.0 |  |
-| [wasm-bindgen-futures](https://crates.io/crates/wasm-bindgen-futures) | 0.4.67 | MIT OR Apache-2.0 |  |
-| [wasm-bindgen-macro](https://crates.io/crates/wasm-bindgen-macro) | 0.2.117 | MIT OR Apache-2.0 |  |
-| [wasm-bindgen-macro-support](https://crates.io/crates/wasm-bindgen-macro-support) | 0.2.117 | MIT OR Apache-2.0 |  |
-| [wasm-bindgen-shared](https://crates.io/crates/wasm-bindgen-shared) | 0.2.117 | MIT OR Apache-2.0 |  |
-| [wasm-encoder](https://crates.io/crates/wasm-encoder) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wasm-metadata](https://crates.io/crates/wasm-metadata) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wasm-streams](https://crates.io/crates/wasm-streams) | 0.4.2 | MIT OR Apache-2.0 |  |
-| [wasmparser](https://crates.io/crates/wasmparser) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [web-sys](https://crates.io/crates/web-sys) | 0.3.94 | MIT OR Apache-2.0 |  |
-| [web-time](https://crates.io/crates/web-time) | 1.1.0 | MIT OR Apache-2.0 |  |
-| [webbrowser](https://crates.io/crates/webbrowser) | 1.2.0 | MIT OR Apache-2.0 |  |
-| [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |
-| [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 |  |
-| [winapi-i686-pc-windows-gnu](https://crates.io/crates/winapi-i686-pc-windows-gnu) | 0.4.0 | MIT OR Apache-2.0 |  |
-| [winapi-util](https://crates.io/crates/winapi-util) | 0.1.11 | Unlicense OR MIT |  |
-| [winapi-x86\_64-pc-windows-gnu](https://crates.io/crates/winapi-x86_64-pc-windows-gnu) | 0.4.0 | MIT OR Apache-2.0 |  |
-| [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 |  |
-| [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 |  |
-| [windows](https://crates.io/crates/windows) | 0.62.2 | MIT OR Apache-2.0 |  |
-| [windows-collections](https://crates.io/crates/windows-collections) | 0.2.0 | MIT OR Apache-2.0 |  |
-| [windows-collections](https://crates.io/crates/windows-collections) | 0.3.2 | MIT OR Apache-2.0 |  |
-| [windows-core](https://crates.io/crates/windows-core) | 0.52.0 | MIT OR Apache-2.0 |  |
-| [windows-core](https://crates.io/crates/windows-core) | 0.61.2 | MIT OR Apache-2.0 |  |
-| [windows-core](https://crates.io/crates/windows-core) | 0.62.2 | MIT OR Apache-2.0 |  |
-| [windows-future](https://crates.io/crates/windows-future) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [windows-future](https://crates.io/crates/windows-future) | 0.3.2 | MIT OR Apache-2.0 |  |
-| [windows-implement](https://crates.io/crates/windows-implement) | 0.60.2 | MIT OR Apache-2.0 |  |
-| [windows-interface](https://crates.io/crates/windows-interface) | 0.59.3 | MIT OR Apache-2.0 |  |
-| [windows-link](https://crates.io/crates/windows-link) | 0.1.3 | MIT OR Apache-2.0 |  |
-| [windows-link](https://crates.io/crates/windows-link) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 |  |
-| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 |  |
-| [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 |  |
-| [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 |  |
-| [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 |  |
-| [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 |  |
-| [windows-strings](https://crates.io/crates/windows-strings) | 0.5.1 | MIT OR Apache-2.0 |  |
-| [windows-sys](https://crates.io/crates/windows-sys) | 0.52.0 | MIT OR Apache-2.0 |  |
-| [windows-sys](https://crates.io/crates/windows-sys) | 0.59.0 | MIT OR Apache-2.0 |  |
-| [windows-sys](https://crates.io/crates/windows-sys) | 0.61.2 | MIT OR Apache-2.0 |  |
-| [windows-targets](https://crates.io/crates/windows-targets) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows-threading](https://crates.io/crates/windows-threading) | 0.1.0 | MIT OR Apache-2.0 |  |
-| [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 |  |
-| [windows\_aarch64\_gnullvm](https://crates.io/crates/windows_aarch64_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_aarch64\_msvc](https://crates.io/crates/windows_aarch64_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_i686\_gnu](https://crates.io/crates/windows_i686_gnu) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_i686\_gnullvm](https://crates.io/crates/windows_i686_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_i686\_msvc](https://crates.io/crates/windows_i686_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_x86\_64\_gnu](https://crates.io/crates/windows_x86_64_gnu) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_x86\_64\_gnullvm](https://crates.io/crates/windows_x86_64_gnullvm) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 |  |
-| [wit-bindgen](https://crates.io/crates/wit-bindgen) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wit-bindgen-core](https://crates.io/crates/wit-bindgen-core) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wit-bindgen-rust](https://crates.io/crates/wit-bindgen-rust) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wit-bindgen-rust-macro](https://crates.io/crates/wit-bindgen-rust-macro) | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wit-component](https://crates.io/crates/wit-component) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [wit-parser](https://crates.io/crates/wit-parser) | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
-| [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |
-| [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 |  |
-| [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |
-| [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |
-| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |
-| [zerocopy-derive](https://crates.io/crates/zerocopy-derive) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |
-| [zerofrom](https://crates.io/crates/zerofrom) | 0.1.7 | Unicode-3.0 |  |
-| [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |
-| [zeroize](https://crates.io/crates/zeroize) | 1.8.2 | Apache-2.0 OR MIT |  |
-| [zerotrie](https://crates.io/crates/zerotrie) | 0.2.4 | Unicode-3.0 |  |
-| [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |
-| [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |
-| [zip](https://crates.io/crates/zip) | 8.5.0 | MIT |  |
-| [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.3 | Zlib |  |
-| [zmij](https://crates.io/crates/zmij) | 1.0.21 | MIT |  |
-| [zopfli](https://crates.io/crates/zopfli) | 0.8.3 | Apache-2.0 |  |
-| [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |
-| [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |
-| [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |
+| Package | Version | License | Platforms | CVEs |
+| --- | --- | --- | --- | ---: |
+| [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT | linux, macos |  |
+| [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |  |
+| [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |  |
+| [aho-corasick](https://crates.io/crates/aho-corasick) | 1.1.4 | Unlicense OR MIT |  |  |
+| [allocator-api2](https://crates.io/crates/allocator-api2) | 0.2.21 | MIT OR Apache-2.0 |  |  |
+| [anaconda-otel-rs](https://crates.io/crates/anaconda-otel-rs) | 0.1.0 | NOASSERTION |  |  |
+| [anstream](https://crates.io/crates/anstream) | 1.0.0 | MIT OR Apache-2.0 |  |  |
+| [anstyle](https://crates.io/crates/anstyle) | 1.0.14 | MIT OR Apache-2.0 |  |  |
+| [anstyle-parse](https://crates.io/crates/anstyle-parse) | 1.0.0 | MIT OR Apache-2.0 |  |  |
+| [anstyle-query](https://crates.io/crates/anstyle-query) | 1.1.5 | MIT OR Apache-2.0 |  |  |
+| [anstyle-wincon](https://crates.io/crates/anstyle-wincon) | 3.0.11 | MIT OR Apache-2.0 | windows |  |
+| [anyhow](https://crates.io/crates/anyhow) | 1.0.102 | MIT OR Apache-2.0 |  |  |
+| [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.0 | MIT OR Apache-2.0 |  |  |
+| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |  |
+| [async-compression](https://crates.io/crates/async-compression) | 0.4.41 | MIT OR Apache-2.0 |  |  |
+| [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |  |
+| [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |  |
+| [async-trait](https://crates.io/crates/async-trait) | 0.1.89 | MIT OR Apache-2.0 |  |  |
+| [async\_http\_range\_reader](https://crates.io/crates/async_http_range_reader) | 0.9.1 | MIT |  |  |
+| [atomic-waker](https://crates.io/crates/atomic-waker) | 1.1.2 | Apache-2.0 OR MIT |  |  |
+| [autocfg](https://crates.io/crates/autocfg) | 1.5.0 | Apache-2.0 OR MIT |  |  |
+| [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |  |
+| [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |  |
+| [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
+| [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |  |
+| [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
+| [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
+| [bitflags](https://crates.io/crates/bitflags) | 2.11.0 | MIT OR Apache-2.0 |  |  |
+| [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |  |
+| [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
+| [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
+| [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |  |
+| [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
+| [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.2.59 | MIT OR Apache-2.0 |  |  |
+| [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
+| [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
+| [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
+| [clap](https://crates.io/crates/clap) | 4.6.0 | MIT OR Apache-2.0 |  |  |
+| [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |  |
+| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.0 | MIT OR Apache-2.0 |  |  |
+| [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |  |
+| [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |  |
+| [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |  |
+| [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.37 | MIT OR Apache-2.0 |  |  |
+| [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |  |
+| [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
+| [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
+| [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
+| [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 | linux, windows |  |
+| [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.21 | MIT OR Apache-2.0 |  |  |
+| [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |  |
+| [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT | windows |  |
+| [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |  |
+| [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |  |
+| [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
+| [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
+| [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |  |
+| [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
+| [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
+| [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
+| [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
+| [displaydoc](https://crates.io/crates/displaydoc) | 0.2.5 | MIT OR Apache-2.0 |  |  |
+| [document-features](https://crates.io/crates/document-features) | 0.2.12 | MIT OR Apache-2.0 |  |  |
+| [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
+| [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |  |
+| [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
+| [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
+| [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
+| [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
+| [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
+| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
+| [fastrand](https://crates.io/crates/fastrand) | 2.3.0 | Apache-2.0 OR MIT |  |  |
+| [file\_url](https://crates.io/crates/file_url) | 0.2.7 | BSD-3-Clause |  |  |
+| [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |  |
+| [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
+| [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
+| [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |  |
+| [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |  |
+| [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |  |
+| [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 | linux |  |
+| [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
+| [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |  |
+| [fs-err](https://crates.io/crates/fs-err) | 3.3.0 | MIT OR Apache-2.0 |  |  |
+| [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |  |
+| [futures](https://crates.io/crates/futures) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-channel](https://crates.io/crates/futures-channel) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-core](https://crates.io/crates/futures-core) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-executor](https://crates.io/crates/futures-executor) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-io](https://crates.io/crates/futures-io) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-lite](https://crates.io/crates/futures-lite) | 2.6.1 | Apache-2.0 OR MIT |  |  |
+| [futures-macro](https://crates.io/crates/futures-macro) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-sink](https://crates.io/crates/futures-sink) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-task](https://crates.io/crates/futures-task) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-util](https://crates.io/crates/futures-util) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [generic-array](https://crates.io/crates/generic-array) | 0.14.7 | MIT |  |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.2.17 | MIT OR Apache-2.0 |  |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.3.4 | MIT OR Apache-2.0 |  |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.4.2 | MIT OR Apache-2.0 |  |  |
+| [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 | linux, macos |  |
+| [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |  |
+| [h2](https://crates.io/crates/h2) | 0.4.13 | MIT |  |  |
+| [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |  |
+| [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
+| [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
+| [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
+| [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |  |
+| [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
+| [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
+| [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
+| [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
+| [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
+| [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |  |
+| [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.7 | Apache-2.0 OR ISC OR MIT |  |  |
+| [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |  |
+| [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |  |
+| [iana-time-zone](https://crates.io/crates/iana-time-zone) | 0.1.65 | MIT OR Apache-2.0 | linux, macos |  |
+| [icu\_collections](https://crates.io/crates/icu_collections) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_locale\_core](https://crates.io/crates/icu_locale_core) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_normalizer](https://crates.io/crates/icu_normalizer) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_normalizer\_data](https://crates.io/crates/icu_normalizer_data) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_properties](https://crates.io/crates/icu_properties) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_properties\_data](https://crates.io/crates/icu_properties_data) | 2.2.0 | Unicode-3.0 |  |  |
+| [icu\_provider](https://crates.io/crates/icu_provider) | 2.2.0 | Unicode-3.0 |  |  |
+| [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |  |
+| [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |  |
+| [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |  |
+| [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
+| [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |  |
+| [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
+| [indoc](https://crates.io/crates/indoc) | 2.0.7 | MIT OR Apache-2.0 |  |  |
+| [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |  |
+| [iri-string](https://crates.io/crates/iri-string) | 0.7.12 | MIT OR Apache-2.0 |  |  |
+| [is\_ci](https://crates.io/crates/is_ci) | 1.2.0 | ISC |  |  |
+| [is\_terminal\_polyfill](https://crates.io/crates/is_terminal_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |  |
+| [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |  |
+| [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
+| [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
+| [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
+| [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
+| [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
+| [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
+| [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
+| [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |  |
+| [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |  |
+| [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
+| [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
+| [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
+| [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |  |
+| [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |  |
+| [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |  |
+| [md-5](https://crates.io/crates/md-5) | 0.10.6 | MIT OR Apache-2.0 |  |  |
+| [memchr](https://crates.io/crates/memchr) | 2.8.0 | Unlicense OR MIT |  |  |
+| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  |  |
+| [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |  |
+| [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |  |
+| [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |  |
+| [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |  |
+| [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |  |
+| [mio](https://crates.io/crates/mio) | 1.2.0 | MIT |  |  |
+| [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |  |
+| [nix](https://crates.io/crates/nix) | 0.30.1 | MIT | linux, macos |  |
+| [nom](https://crates.io/crates/nom) | 8.0.0 | MIT |  |  |
+| [nom-language](https://crates.io/crates/nom-language) | 0.1.0 | MIT |  |  |
+| [ntapi](https://crates.io/crates/ntapi) | 0.4.3 | Apache-2.0 OR MIT | windows |  |
+| [nu-ansi-term](https://crates.io/crates/nu-ansi-term) | 0.50.3 | MIT |  |  |
+| [num-conv](https://crates.io/crates/num-conv) | 0.2.1 | MIT OR Apache-2.0 |  |  |
+| [num-traits](https://crates.io/crates/num-traits) | 0.2.19 | MIT OR Apache-2.0 |  |  |
+| [num\_cpus](https://crates.io/crates/num_cpus) | 1.17.0 | MIT OR Apache-2.0 |  |  |
+| [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT | linux, macos |  |
+| [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |  |
+| [once\_cell\_polyfill](https://crates.io/crates/once_cell_polyfill) | 1.70.2 | MIT OR Apache-2.0 | windows |  |
+| [openssl](https://crates.io/crates/openssl) | 0.10.76 | Apache-2.0 | linux |  |
+| [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
+| [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 | linux |  |
+| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.112 | MIT | linux |  |
+| [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |  |
+| [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |  |
+| [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |  |
+| [opentelemetry-proto](https://crates.io/crates/opentelemetry-proto) | 0.31.0 | Apache-2.0 |  |  |
+| [opentelemetry-stdout](https://crates.io/crates/opentelemetry-stdout) | 0.31.0 | Apache-2.0 |  |  |
+| [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |  |
+| [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |  |
+| [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |  |
+| [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |  |
+| [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
+| [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
+| [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
+| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.7 | BSD-3-Clause |  |  |
+| [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
+| [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |  |
+| [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |  |
+| [pin-project](https://crates.io/crates/pin-project) | 1.1.11 | Apache-2.0 OR MIT |  |  |
+| [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |  |
+| [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |  |
+| [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [plist](https://crates.io/crates/plist) | 1.8.0 | MIT | macos |  |
+| [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |  |
+| [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |  |
+| [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |  |
+| [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |  |
+| [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |  |
+| [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |  |
+| [prost](https://crates.io/crates/prost) | 0.14.3 | Apache-2.0 |  |  |
+| [prost-derive](https://crates.io/crates/prost-derive) | 0.14.3 | Apache-2.0 |  |  |
+| [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
+| [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT | macos |  |
+| [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |  |
+| [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |  |
+| [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |  |
+| [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
+| [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.40.3 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.18 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.3 | BSD-3-Clause |  |  |
+| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.2.3 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.4 | BSD-3-Clause |  |  |
+| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.0.12 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.53 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.6 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.6 | BSD-3-Clause |  |  |
+| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.9 | BSD-3-Clause |  |  |
+| [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.1.13 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.6 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.1.0 | BSD-3-Clause |  |  |
+| [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |  |
+| [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
+| [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |
+| [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |  |
+| [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
+| [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |  |
+| [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
+| [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |  |
+| [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
+| [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
+| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |  |
+| [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
+| [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |  |
+| [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.2 | Apache-2.0 OR MIT |  |  |
+| [rustc\_version](https://crates.io/crates/rustc_version) | 0.4.1 | MIT OR Apache-2.0 |  |  |
+| [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |  |
+| [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux, macos |  |
+| [rustls](https://crates.io/crates/rustls) | 0.23.37 | Apache-2.0 OR ISC OR MIT |  |  |
+| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |  |
+| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.10 | ISC |  |  |
+| [rustversion](https://crates.io/crates/rustversion) | 1.0.22 | MIT OR Apache-2.0 |  |  |
+| [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
+| [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
+| [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT | windows |  |
+| [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |  |
+| [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |  |
+| [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |  |
+| [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 | macos |  |
+| [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
+| [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
+| [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
+| [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
+| [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
+| [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
+| [serde\_bytes](https://crates.io/crates/serde_bytes) | 0.11.19 | MIT OR Apache-2.0 |  |  |
+| [serde\_core](https://crates.io/crates/serde_core) | 1.0.228 | MIT OR Apache-2.0 |  |  |
+| [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.228 | MIT OR Apache-2.0 |  |  |
+| [serde\_json](https://crates.io/crates/serde_json) | 1.0.149 | MIT OR Apache-2.0 |  |  |
+| [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
+| [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
+| [serde\_with](https://crates.io/crates/serde_with) | 3.18.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.18.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |  |
+| [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |  |
+| [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
+| [shlex](https://crates.io/crates/shlex) | 1.3.0 | MIT OR Apache-2.0 |  |  |
+| [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
+| [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
+| [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |  |
+| [simd-json](https://crates.io/crates/simd-json) | 0.17.0 | Apache-2.0 OR MIT |  |  |
+| [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |  |
+| [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
+| [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
+| [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |  |
+| [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
+| [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
+| [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |  |
+| [strum\_macros](https://crates.io/crates/strum_macros) | 0.28.0 | MIT |  |  |
+| [subtle](https://crates.io/crates/subtle) | 2.6.1 | BSD-3-Clause |  |  |
+| [supports-color](https://crates.io/crates/supports-color) | 3.0.2 | Apache-2.0 |  |  |
+| [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |  |
+| [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |  |
+| [syn](https://crates.io/crates/syn) | 2.0.117 | MIT OR Apache-2.0 |  |  |
+| [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |  |
+| [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |  |
+| [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |  |
+| [tar](https://crates.io/crates/tar) | 0.4.45 | MIT OR Apache-2.0 |  |  |
+| [tempfile](https://crates.io/crates/tempfile) | 3.27.0 | MIT OR Apache-2.0 |  |  |
+| [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |  |
+| [textwrap](https://crates.io/crates/textwrap) | 0.16.2 | MIT |  |  |
+| [thiserror](https://crates.io/crates/thiserror) | 1.0.69 | MIT OR Apache-2.0 |  |  |
+| [thiserror](https://crates.io/crates/thiserror) | 2.0.18 | MIT OR Apache-2.0 |  |  |
+| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 1.0.69 | MIT OR Apache-2.0 |  |  |
+| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.18 | MIT OR Apache-2.0 |  |  |
+| [thread\_local](https://crates.io/crates/thread_local) | 1.1.9 | MIT OR Apache-2.0 |  |  |
+| [time](https://crates.io/crates/time) | 0.3.47 | MIT OR Apache-2.0 |  |  |
+| [time-core](https://crates.io/crates/time-core) | 0.1.8 | MIT OR Apache-2.0 |  |  |
+| [time-macros](https://crates.io/crates/time-macros) | 0.2.27 | MIT OR Apache-2.0 |  |  |
+| [tinystr](https://crates.io/crates/tinystr) | 0.8.3 | Unicode-3.0 |  |  |
+| [tinyvec](https://crates.io/crates/tinyvec) | 1.11.0 | Zlib OR Apache-2.0 OR MIT |  |  |
+| [tinyvec\_macros](https://crates.io/crates/tinyvec_macros) | 0.1.1 | MIT OR Apache-2.0 OR Zlib |  |  |
+| [tokio](https://crates.io/crates/tokio) | 1.51.0 | MIT |  |  |
+| [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.0 | MIT |  |  |
+| [tokio-native-tls](https://crates.io/crates/tokio-native-tls) | 0.3.1 | MIT |  |  |
+| [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |  |
+| [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |  |
+| [tokio-util](https://crates.io/crates/tokio-util) | 0.7.18 | MIT |  |  |
+| [tonic](https://crates.io/crates/tonic) | 0.14.5 | MIT |  |  |
+| [tonic-prost](https://crates.io/crates/tonic-prost) | 0.14.5 | MIT |  |  |
+| [tower](https://crates.io/crates/tower) | 0.5.3 | MIT |  |  |
+| [tower-http](https://crates.io/crates/tower-http) | 0.6.8 | MIT |  |  |
+| [tower-layer](https://crates.io/crates/tower-layer) | 0.3.3 | MIT |  |  |
+| [tower-service](https://crates.io/crates/tower-service) | 0.3.3 | MIT |  |  |
+| [tracing](https://crates.io/crates/tracing) | 0.1.44 | MIT |  |  |
+| [tracing-attributes](https://crates.io/crates/tracing-attributes) | 0.1.31 | MIT |  |  |
+| [tracing-core](https://crates.io/crates/tracing-core) | 0.1.36 | MIT |  |  |
+| [tracing-log](https://crates.io/crates/tracing-log) | 0.2.0 | MIT |  |  |
+| [tracing-opentelemetry](https://crates.io/crates/tracing-opentelemetry) | 0.32.1 | MIT |  |  |
+| [tracing-subscriber](https://crates.io/crates/tracing-subscriber) | 0.3.23 | MIT |  |  |
+| [try-lock](https://crates.io/crates/try-lock) | 0.2.5 | MIT |  |  |
+| [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |  |
+| [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |  |
+| [typenum](https://crates.io/crates/typenum) | 1.19.0 | MIT OR Apache-2.0 |  |  |
+| [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |  |
+| [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |  |
+| [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |  |
+| [unicode-linebreak](https://crates.io/crates/unicode-linebreak) | 0.1.5 | Apache-2.0 |  |  |
+| [unicode-normalization](https://crates.io/crates/unicode-normalization) | 0.1.25 | MIT OR Apache-2.0 |  |  |
+| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |  |
+| [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |  |
+| [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |  |
+| [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |  |
+| [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |  |
+| [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |  |
+| [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |  |
+| [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |  |
+| [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
+| [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
+| [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
+| [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |  |
+| [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |  |
+| [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 | linux |  |
+| [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |  |
+| [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |  |
+| [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
+| [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
+| [webbrowser](https://crates.io/crates/webbrowser) | 1.2.0 | MIT OR Apache-2.0 |  |  |
+| [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |  |
+| [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
+| [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
+| [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 | windows |  |
+| [windows](https://crates.io/crates/windows) | 0.62.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-collections](https://crates.io/crates/windows-collections) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-collections](https://crates.io/crates/windows-collections) | 0.3.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.61.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-core](https://crates.io/crates/windows-core) | 0.62.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-future](https://crates.io/crates/windows-future) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
+| [windows-future](https://crates.io/crates/windows-future) | 0.3.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-implement](https://crates.io/crates/windows-implement) | 0.60.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-interface](https://crates.io/crates/windows-interface) | 0.59.3 | MIT OR Apache-2.0 | windows |  |
+| [windows-link](https://crates.io/crates/windows-link) | 0.1.3 | MIT OR Apache-2.0 | windows |  |
+| [windows-link](https://crates.io/crates/windows-link) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
+| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 | windows |  |
+| [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 | windows |  |
+| [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 | windows |  |
+| [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 | windows |  |
+| [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-strings](https://crates.io/crates/windows-strings) | 0.5.1 | MIT OR Apache-2.0 | windows |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.59.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-sys](https://crates.io/crates/windows-sys) | 0.61.2 | MIT OR Apache-2.0 | windows |  |
+| [windows-targets](https://crates.io/crates/windows-targets) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
+| [windows-threading](https://crates.io/crates/windows-threading) | 0.1.0 | MIT OR Apache-2.0 | windows |  |
+| [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
+| [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
+| [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |  |
+| [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 | linux, macos |  |
+| [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |  |
+| [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |  |
+| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |  |
+| [zerofrom](https://crates.io/crates/zerofrom) | 0.1.7 | Unicode-3.0 |  |  |
+| [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |  |
+| [zeroize](https://crates.io/crates/zeroize) | 1.8.2 | Apache-2.0 OR MIT |  |  |
+| [zerotrie](https://crates.io/crates/zerotrie) | 0.2.4 | Unicode-3.0 |  |  |
+| [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |  |
+| [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |  |
+| [zip](https://crates.io/crates/zip) | 8.5.0 | MIT |  |  |
+| [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.3 | Zlib |  |  |
+| [zmij](https://crates.io/crates/zmij) | 1.0.21 | MIT |  |  |
+| [zopfli](https://crates.io/crates/zopfli) | 0.8.3 | Apache-2.0 |  |  |
+| [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |  |
+| [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
+| [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
 
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 256 |
-| MIT | 89 |
-| Apache-2.0 OR MIT | 31 |
+| MIT OR Apache-2.0 | 224 |
+| MIT | 80 |
+| Apache-2.0 OR MIT | 30 |
 | Apache-2.0 | 18 |
 | Unicode-3.0 | 18 |
 | BSD-3-Clause | 17 |
-| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 14 |
-| Unlicense OR MIT | 5 |
 | ISC | 3 |
-| Zlib | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
-| BSD-2-Clause OR Apache-2.0 OR MIT | 2 |
-| MIT OR Apache-2.0 OR LGPL-2.1-or-later | 2 |
+| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
+| Unlicense OR MIT | 2 |
+| Zlib | 2 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |
 | Apache-2.0 AND ISC | 1 |
 | Apache-2.0 OR BSL-1.0 | 1 |
+| BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
 | MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -2,7 +2,7 @@
 
 Generated: 1970-01-01T00:00:00.000000000Z<br>
 Format: CycloneDX 1.3<br>
-Packages: 414 (64 platform-specific)<br>
+Packages: 465 (65 platform-specific)<br>
 Platforms: linux, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -10,6 +10,14 @@ Platforms: linux, macos, windows
 
 | Package | Version | License | Platforms | CVEs |
 | --- | --- | --- | --- | ---: |
+| [actix-codec](https://crates.io/crates/actix-codec) | 0.5.2 | MIT OR Apache-2.0 |  |  |
+| [actix-http](https://crates.io/crates/actix-http) | 3.12.0 | MIT OR Apache-2.0 |  |  |
+| [actix-router](https://crates.io/crates/actix-router) | 0.5.4 | MIT OR Apache-2.0 |  |  |
+| [actix-rt](https://crates.io/crates/actix-rt) | 2.11.0 | MIT OR Apache-2.0 |  |  |
+| [actix-server](https://crates.io/crates/actix-server) | 2.6.0 | MIT OR Apache-2.0 |  |  |
+| [actix-service](https://crates.io/crates/actix-service) | 2.0.3 | MIT OR Apache-2.0 |  |  |
+| [actix-utils](https://crates.io/crates/actix-utils) | 3.0.1 | MIT OR Apache-2.0 |  |  |
+| [actix-web](https://crates.io/crates/actix-web) | 4.13.0 | MIT OR Apache-2.0 |  |  |
 | [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT | linux, macos |  |
 | [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |  |
 | [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |  |
@@ -34,6 +42,7 @@ Platforms: linux, macos, windows
 | [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |  |
 | [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
+| [base64ct](https://crates.io/crates/base64ct) | 1.8.3 | Apache-2.0 OR MIT |  |  |
 | [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
@@ -43,10 +52,12 @@ Platforms: linux, macos, windows
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
+| [bytestring](https://crates.io/crates/bytestring) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
+| [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
 | [cc](https://crates.io/crates/cc) | 1.2.59 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
 | [clap](https://crates.io/crates/clap) | 4.6.0 | MIT OR Apache-2.0 |  |  |
@@ -59,6 +70,7 @@ Platforms: linux, macos, windows
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |  |
 | [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
+| [convert\_case](https://crates.io/crates/convert_case) | 0.10.0 | MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
@@ -74,7 +86,11 @@ Platforms: linux, macos, windows
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |  |
+| [debugid](https://crates.io/crates/debugid) | 0.8.0 | Apache-2.0 |  |  |
+| [der](https://crates.io/crates/der) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
+| [derive\_more](https://crates.io/crates/derive_more) | 2.1.1 | MIT |  |  |
+| [derive\_more-impl](https://crates.io/crates/derive_more-impl) | 2.1.1 | MIT |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
@@ -83,18 +99,21 @@ Platforms: linux, macos, windows
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
 | [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |  |
 | [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
+| [encoding\_rs](https://crates.io/crates/encoding_rs) | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause |  |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
 | [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
-| [fastrand](https://crates.io/crates/fastrand) | 2.4.0 | Apache-2.0 OR MIT |  |  |
+| [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.2.7 | BSD-3-Clause |  |  |
 | [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
+| [findshlibs](https://crates.io/crates/findshlibs) | 0.10.2 | MIT OR Apache-2.0 |  |  |
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
 | [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |  |
 | [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |  |
+| [foldhash](https://crates.io/crates/foldhash) | 0.1.5 | Zlib |  |  |
 | [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |  |
 | [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 | linux |  |
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
@@ -125,11 +144,13 @@ Platforms: linux, macos, windows
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
+| [http](https://crates.io/crates/http) | 0.2.12 | MIT OR Apache-2.0 |  |  |
 | [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |  |
 | [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
 | [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
 | [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
+| [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
 | [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.7 | Apache-2.0 OR ISC OR MIT |  |  |
@@ -146,6 +167,7 @@ Platforms: linux, macos, windows
 | [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |  |
 | [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |  |
+| [impl-more](https://crates.io/crates/impl-more) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |  |
 | [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
@@ -159,6 +181,7 @@ Platforms: linux, macos, windows
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
+| [language-tags](https://crates.io/crates/language-tags) | 0.3.2 | MIT OR Apache-2.0 |  |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
@@ -167,6 +190,7 @@ Platforms: linux, macos, windows
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
+| [local-waker](https://crates.io/crates/local-waker) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |  |
 | [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |  |
 | [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |  |
@@ -203,11 +227,13 @@ Platforms: linux, macos, windows
 | [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |  |
 | [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |  |
 | [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |  |
+| [os\_info](https://crates.io/crates/os_info) | 3.14.0 | MIT | windows |  |
 | [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |  |
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
 | [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.7 | BSD-3-Clause |  |  |
+| [pem-rfc7468](https://crates.io/crates/pem-rfc7468) | 1.0.0 | Apache-2.0 OR MIT |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |  |
@@ -235,19 +261,19 @@ Platforms: linux, macos, windows
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
-| [rattler](https://crates.io/crates/rattler) | 0.40.3 | BSD-3-Clause |  |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.18 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.3 | BSD-3-Clause |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.40.4 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.19 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.4 | BSD-3-Clause |  |  |
 | [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.2.3 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.4 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.5 | BSD-3-Clause |  |  |
 | [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.0.12 | BSD-3-Clause |  |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.53 | BSD-3-Clause |  |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.6 | BSD-3-Clause |  |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.6 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.54 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.7 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.7 | BSD-3-Clause |  |  |
 | [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.9 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.1.13 | BSD-3-Clause |  |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.6 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.1.0 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.7 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.2.0 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |
@@ -255,8 +281,10 @@ Platforms: linux, macos, windows
 | [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
 | [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |  |
 | [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
+| [regex-lite](https://crates.io/crates/regex-lite) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
+| [reqwest](https://crates.io/crates/reqwest) | 0.13.2 | MIT OR Apache-2.0 |  |  |
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
 | [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
@@ -279,6 +307,15 @@ Platforms: linux, macos, windows
 | [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
+| [sentry](https://crates.io/crates/sentry) | 0.47.0 | MIT |  |  |
+| [sentry-actix](https://crates.io/crates/sentry-actix) | 0.47.0 | MIT |  |  |
+| [sentry-backtrace](https://crates.io/crates/sentry-backtrace) | 0.47.0 | MIT |  |  |
+| [sentry-contexts](https://crates.io/crates/sentry-contexts) | 0.47.0 | MIT |  |  |
+| [sentry-core](https://crates.io/crates/sentry-core) | 0.47.0 | MIT |  |  |
+| [sentry-debug-images](https://crates.io/crates/sentry-debug-images) | 0.47.0 | MIT |  |  |
+| [sentry-panic](https://crates.io/crates/sentry-panic) | 0.47.0 | MIT |  |  |
+| [sentry-tracing](https://crates.io/crates/sentry-tracing) | 0.47.0 | MIT |  |  |
+| [sentry-types](https://crates.io/crates/sentry-types) | 0.47.0 | MIT |  |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
 | [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
@@ -287,6 +324,7 @@ Platforms: linux, macos, windows
 | [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.228 | MIT OR Apache-2.0 |  |  |
 | [serde\_json](https://crates.io/crates/serde_json) | 1.0.149 | MIT OR Apache-2.0 |  |  |
 | [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
+| [serde\_spanned](https://crates.io/crates/serde_spanned) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_with](https://crates.io/crates/serde_with) | 3.18.0 | MIT OR Apache-2.0 |  |  |
 | [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.18.0 | MIT OR Apache-2.0 |  |  |
@@ -302,6 +340,7 @@ Platforms: linux, macos, windows
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.5.10 | MIT OR Apache-2.0 |  |  |
 | [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
@@ -336,6 +375,10 @@ Platforms: linux, macos, windows
 | [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |  |
 | [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |  |
 | [tokio-util](https://crates.io/crates/tokio-util) | 0.7.18 | MIT |  |  |
+| [toml](https://crates.io/crates/toml) | 0.9.12+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
+| [toml\_datetime](https://crates.io/crates/toml_datetime) | 0.7.5+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
+| [toml\_parser](https://crates.io/crates/toml_parser) | 1.1.2+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
+| [toml\_writer](https://crates.io/crates/toml_writer) | 1.1.1+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [tonic](https://crates.io/crates/tonic) | 0.14.5 | MIT |  |  |
 | [tonic-prost](https://crates.io/crates/tonic-prost) | 0.14.5 | MIT |  |  |
 | [tower](https://crates.io/crates/tower) | 0.5.3 | MIT |  |  |
@@ -352,6 +395,7 @@ Platforms: linux, macos, windows
 | [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [typenum](https://crates.io/crates/typenum) | 1.19.0 | MIT OR Apache-2.0 |  |  |
+| [uname](https://crates.io/crates/uname) | 0.1.1 | MIT OR Apache-2.0 | linux, macos |  |
 | [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |  |
 | [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |  |
@@ -360,12 +404,16 @@ Platforms: linux, macos, windows
 | [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |  |
+| [unicode-xid](https://crates.io/crates/unicode-xid) | 0.2.6 | MIT OR Apache-2.0 |  |  |
 | [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |  |
 | [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |  |
 | [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |  |
 | [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |  |
+| [ureq](https://crates.io/crates/ureq) | 3.3.0 | MIT OR Apache-2.0 |  |  |
+| [ureq-proto](https://crates.io/crates/ureq-proto) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |  |
 | [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
+| [utf8-zero](https://crates.io/crates/utf8-zero) | 0.8.1 | MIT OR Apache-2.0 |  |  |
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
 | [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |  |
@@ -376,6 +424,7 @@ Platforms: linux, macos, windows
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.0 | MIT OR Apache-2.0 |  |  |
+| [webpki-root-certs](https://crates.io/crates/webpki-root-certs) | 1.0.6 | CDLA-Permissive-2.0 |  |  |
 | [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
@@ -406,6 +455,8 @@ Platforms: linux, macos, windows
 | [windows-threading](https://crates.io/crates/windows-threading) | 0.1.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
 | [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
+| [winnow](https://crates.io/crates/winnow) | 0.7.15 | MIT |  |  |
+| [winnow](https://crates.io/crates/winnow) | 1.0.1 | MIT |  |  |
 | [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |  |
 | [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 | linux, macos |  |
 | [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |  |
@@ -417,7 +468,7 @@ Platforms: linux, macos, windows
 | [zerotrie](https://crates.io/crates/zerotrie) | 0.2.4 | Unicode-3.0 |  |  |
 | [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |  |
 | [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |  |
-| [zip](https://crates.io/crates/zip) | 8.5.0 | MIT |  |  |
+| [zip](https://crates.io/crates/zip) | 8.5.1 | MIT |  |  |
 | [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.3 | Zlib |  |  |
 | [zmij](https://crates.io/crates/zmij) | 1.0.21 | MIT |  |  |
 | [zopfli](https://crates.io/crates/zopfli) | 0.8.3 | Apache-2.0 |  |  |
@@ -429,25 +480,27 @@ Platforms: linux, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 224 |
-| MIT | 80 |
-| Apache-2.0 OR MIT | 30 |
-| Apache-2.0 | 18 |
+| MIT OR Apache-2.0 | 252 |
+| MIT | 95 |
+| Apache-2.0 OR MIT | 34 |
+| Apache-2.0 | 19 |
 | Unicode-3.0 | 18 |
 | BSD-3-Clause | 17 |
 | ISC | 3 |
+| Zlib | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
 | Unlicense OR MIT | 2 |
-| Zlib | 2 |
+| (Apache-2.0 OR MIT) AND BSD-3-Clause | 1 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |
 | Apache-2.0 AND ISC | 1 |
 | Apache-2.0 OR BSL-1.0 | 1 |
 | BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
+| CDLA-Permissive-2.0 | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
 | MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,7 +1,7 @@
 # Software Bill of Materials (SBOM)
 
 Generated: 1970-01-01T00:00:00.000000000Z<br>
-Format: CycloneDX 1.3<br>
+Format: CycloneDX 1.4<br>
 Packages: 465 (65 platform-specific)<br>
 Platforms: linux, macos, windows
 <br>**Security advisories: 0 found at this time**

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,0 +1,407 @@
+# Software Bill of Materials (SBOM)
+
+Generated: 2026-04-04T16:07:36.187336000Z<br>
+Format: CycloneDX 1.3<br>
+Packages: 367
+<br>**Security advisories: 0 found at this time**
+
+## Packages
+
+| Package | Version | License | CVEs |
+| --- | --- | --- | ---: |
+| [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT |  |
+| [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |
+| [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |
+| [aho-corasick](https://crates.io/crates/aho-corasick) | 1.1.4 | Unlicense OR MIT |  |
+| [allocator-api2](https://crates.io/crates/allocator-api2) | 0.2.21 | MIT OR Apache-2.0 |  |
+| [anaconda-otel-rs](https://crates.io/crates/anaconda-otel-rs) | 0.1.0 | NOASSERTION |  |
+| [anstream](https://crates.io/crates/anstream) | 1.0.0 | MIT OR Apache-2.0 |  |
+| [anstyle](https://crates.io/crates/anstyle) | 1.0.14 | MIT OR Apache-2.0 |  |
+| [anstyle-parse](https://crates.io/crates/anstyle-parse) | 1.0.0 | MIT OR Apache-2.0 |  |
+| [anstyle-query](https://crates.io/crates/anstyle-query) | 1.1.5 | MIT OR Apache-2.0 |  |
+| [anyhow](https://crates.io/crates/anyhow) | 1.0.102 | MIT OR Apache-2.0 |  |
+| [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.0 | MIT OR Apache-2.0 |  |
+| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |
+| [async-compression](https://crates.io/crates/async-compression) | 0.4.41 | MIT OR Apache-2.0 |  |
+| [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |
+| [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |
+| [async-trait](https://crates.io/crates/async-trait) | 0.1.89 | MIT OR Apache-2.0 |  |
+| [async\_http\_range\_reader](https://crates.io/crates/async_http_range_reader) | 0.9.1 | MIT |  |
+| [atomic-waker](https://crates.io/crates/atomic-waker) | 1.1.2 | Apache-2.0 OR MIT |  |
+| [autocfg](https://crates.io/crates/autocfg) | 1.5.0 | Apache-2.0 OR MIT |  |
+| [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |
+| [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |
+| [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |
+| [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |
+| [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |
+| [bitflags](https://crates.io/crates/bitflags) | 2.11.0 | MIT OR Apache-2.0 |  |
+| [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |
+| [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |
+| [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |
+| [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |
+| [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |
+| [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |
+| [cc](https://crates.io/crates/cc) | 1.2.59 | MIT OR Apache-2.0 |  |
+| [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |
+| [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |
+| [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |
+| [clap](https://crates.io/crates/clap) | 4.6.0 | MIT OR Apache-2.0 |  |
+| [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |
+| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.0 | MIT OR Apache-2.0 |  |
+| [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |
+| [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |
+| [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |
+| [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.37 | MIT OR Apache-2.0 |  |
+| [compression-core](https://crates.io/crates/compression-core) | 0.4.31 | MIT OR Apache-2.0 |  |
+| [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |
+| [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 |  |
+| [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |
+| [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |
+| [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |
+| [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |
+| [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.21 | MIT OR Apache-2.0 |  |
+| [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |
+| [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |
+| [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |
+| [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |
+| [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |
+| [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |
+| [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |
+| [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |
+| [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |
+| [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |
+| [displaydoc](https://crates.io/crates/displaydoc) | 0.2.5 | MIT OR Apache-2.0 |  |
+| [document-features](https://crates.io/crates/document-features) | 0.2.12 | MIT OR Apache-2.0 |  |
+| [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |
+| [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |
+| [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |
+| [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |
+| [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |
+| [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 |  |
+| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |
+| [fastrand](https://crates.io/crates/fastrand) | 2.3.0 | Apache-2.0 OR MIT |  |
+| [file\_url](https://crates.io/crates/file_url) | 0.2.7 | BSD-3-Clause |  |
+| [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |
+| [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |
+| [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |
+| [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |
+| [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |
+| [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |
+| [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |
+| [fs-err](https://crates.io/crates/fs-err) | 3.3.0 | MIT OR Apache-2.0 |  |
+| [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |
+| [futures](https://crates.io/crates/futures) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-channel](https://crates.io/crates/futures-channel) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-core](https://crates.io/crates/futures-core) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-executor](https://crates.io/crates/futures-executor) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-io](https://crates.io/crates/futures-io) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-lite](https://crates.io/crates/futures-lite) | 2.6.1 | Apache-2.0 OR MIT |  |
+| [futures-macro](https://crates.io/crates/futures-macro) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-sink](https://crates.io/crates/futures-sink) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-task](https://crates.io/crates/futures-task) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [futures-util](https://crates.io/crates/futures-util) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [generic-array](https://crates.io/crates/generic-array) | 0.14.7 | MIT |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.2.17 | MIT OR Apache-2.0 |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.3.4 | MIT OR Apache-2.0 |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.4.2 | MIT OR Apache-2.0 |  |
+| [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 |  |
+| [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |
+| [h2](https://crates.io/crates/h2) | 0.4.13 | MIT |  |
+| [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |
+| [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |
+| [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |
+| [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |
+| [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |
+| [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |
+| [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |
+| [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |
+| [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |
+| [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |
+| [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |
+| [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.7 | Apache-2.0 OR ISC OR MIT |  |
+| [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |
+| [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |
+| [iana-time-zone](https://crates.io/crates/iana-time-zone) | 0.1.65 | MIT OR Apache-2.0 |  |
+| [icu\_collections](https://crates.io/crates/icu_collections) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_locale\_core](https://crates.io/crates/icu_locale_core) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_normalizer](https://crates.io/crates/icu_normalizer) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_normalizer\_data](https://crates.io/crates/icu_normalizer_data) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_properties](https://crates.io/crates/icu_properties) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_properties\_data](https://crates.io/crates/icu_properties_data) | 2.2.0 | Unicode-3.0 |  |
+| [icu\_provider](https://crates.io/crates/icu_provider) | 2.2.0 | Unicode-3.0 |  |
+| [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |
+| [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |
+| [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |
+| [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |
+| [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |
+| [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |
+| [indoc](https://crates.io/crates/indoc) | 2.0.7 | MIT OR Apache-2.0 |  |
+| [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |
+| [iri-string](https://crates.io/crates/iri-string) | 0.7.12 | MIT OR Apache-2.0 |  |
+| [is\_ci](https://crates.io/crates/is_ci) | 1.2.0 | ISC |  |
+| [is\_terminal\_polyfill](https://crates.io/crates/is_terminal_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |
+| [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |
+| [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |
+| [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |
+| [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |
+| [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |
+| [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |
+| [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |
+| [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |
+| [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |
+| [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |
+| [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |
+| [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |
+| [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |
+| [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |
+| [md-5](https://crates.io/crates/md-5) | 0.10.6 | MIT OR Apache-2.0 |  |
+| [memchr](https://crates.io/crates/memchr) | 2.8.0 | Unlicense OR MIT |  |
+| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  |
+| [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |
+| [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |
+| [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |
+| [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |
+| [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |
+| [mio](https://crates.io/crates/mio) | 1.2.0 | MIT |  |
+| [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |
+| [nix](https://crates.io/crates/nix) | 0.30.1 | MIT |  |
+| [nom](https://crates.io/crates/nom) | 8.0.0 | MIT |  |
+| [nom-language](https://crates.io/crates/nom-language) | 0.1.0 | MIT |  |
+| [nu-ansi-term](https://crates.io/crates/nu-ansi-term) | 0.50.3 | MIT |  |
+| [num-conv](https://crates.io/crates/num-conv) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [num-traits](https://crates.io/crates/num-traits) | 0.2.19 | MIT OR Apache-2.0 |  |
+| [num\_cpus](https://crates.io/crates/num_cpus) | 1.17.0 | MIT OR Apache-2.0 |  |
+| [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT |  |
+| [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |
+| [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |
+| [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |
+| [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |
+| [opentelemetry-proto](https://crates.io/crates/opentelemetry-proto) | 0.31.0 | Apache-2.0 |  |
+| [opentelemetry-stdout](https://crates.io/crates/opentelemetry-stdout) | 0.31.0 | Apache-2.0 |  |
+| [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |
+| [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |
+| [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |
+| [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |
+| [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |
+| [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |
+| [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |
+| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.7 | BSD-3-Clause |  |
+| [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |
+| [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |
+| [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |
+| [pin-project](https://crates.io/crates/pin-project) | 1.1.11 | Apache-2.0 OR MIT |  |
+| [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |
+| [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |
+| [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |
+| [plist](https://crates.io/crates/plist) | 1.8.0 | MIT |  |
+| [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |
+| [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |
+| [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |
+| [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |
+| [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |
+| [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |
+| [prost](https://crates.io/crates/prost) | 0.14.3 | Apache-2.0 |  |
+| [prost-derive](https://crates.io/crates/prost-derive) | 0.14.3 | Apache-2.0 |  |
+| [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |
+| [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT |  |
+| [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |
+| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |
+| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |
+| [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |
+| [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |
+| [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |
+| [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |
+| [rattler](https://crates.io/crates/rattler) | 0.40.3 | BSD-3-Clause |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.18 | BSD-3-Clause |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.3 | BSD-3-Clause |  |
+| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.2.3 | BSD-3-Clause |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.4 | BSD-3-Clause |  |
+| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.0.12 | BSD-3-Clause |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.53 | BSD-3-Clause |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.6 | BSD-3-Clause |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.6 | BSD-3-Clause |  |
+| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.9 | BSD-3-Clause |  |
+| [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.1.13 | BSD-3-Clause |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.6 | BSD-3-Clause |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.1.0 | BSD-3-Clause |  |
+| [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |
+| [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |
+| [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |
+| [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |
+| [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |
+| [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |
+| [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |
+| [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |
+| [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |
+| [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |
+| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |
+| [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |
+| [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |
+| [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.2 | Apache-2.0 OR MIT |  |
+| [rustc\_version](https://crates.io/crates/rustc_version) | 0.4.1 | MIT OR Apache-2.0 |  |
+| [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |
+| [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |  |
+| [rustls](https://crates.io/crates/rustls) | 0.23.37 | Apache-2.0 OR ISC OR MIT |  |
+| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |
+| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.10 | ISC |  |
+| [rustversion](https://crates.io/crates/rustversion) | 1.0.22 | MIT OR Apache-2.0 |  |
+| [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |
+| [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |
+| [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |
+| [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |
+| [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |
+| [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 |  |
+| [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 |  |
+| [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |
+| [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |
+| [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |
+| [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |
+| [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |
+| [serde\_bytes](https://crates.io/crates/serde_bytes) | 0.11.19 | MIT OR Apache-2.0 |  |
+| [serde\_core](https://crates.io/crates/serde_core) | 1.0.228 | MIT OR Apache-2.0 |  |
+| [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.228 | MIT OR Apache-2.0 |  |
+| [serde\_json](https://crates.io/crates/serde_json) | 1.0.149 | MIT OR Apache-2.0 |  |
+| [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |
+| [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |
+| [serde\_with](https://crates.io/crates/serde_with) | 3.18.0 | MIT OR Apache-2.0 |  |
+| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.18.0 | MIT OR Apache-2.0 |  |
+| [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |
+| [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |
+| [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |
+| [shlex](https://crates.io/crates/shlex) | 1.3.0 | MIT OR Apache-2.0 |  |
+| [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT |  |
+| [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 |  |
+| [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |
+| [simd-json](https://crates.io/crates/simd-json) | 0.17.0 | Apache-2.0 OR MIT |  |
+| [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |
+| [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |
+| [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |
+| [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |
+| [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |
+| [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |
+| [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |
+| [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |
+| [strum\_macros](https://crates.io/crates/strum_macros) | 0.28.0 | MIT |  |
+| [subtle](https://crates.io/crates/subtle) | 2.6.1 | BSD-3-Clause |  |
+| [supports-color](https://crates.io/crates/supports-color) | 3.0.2 | Apache-2.0 |  |
+| [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |
+| [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |
+| [syn](https://crates.io/crates/syn) | 2.0.117 | MIT OR Apache-2.0 |  |
+| [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |
+| [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |
+| [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |
+| [tar](https://crates.io/crates/tar) | 0.4.45 | MIT OR Apache-2.0 |  |
+| [tempfile](https://crates.io/crates/tempfile) | 3.27.0 | MIT OR Apache-2.0 |  |
+| [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |
+| [textwrap](https://crates.io/crates/textwrap) | 0.16.2 | MIT |  |
+| [thiserror](https://crates.io/crates/thiserror) | 1.0.69 | MIT OR Apache-2.0 |  |
+| [thiserror](https://crates.io/crates/thiserror) | 2.0.18 | MIT OR Apache-2.0 |  |
+| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 1.0.69 | MIT OR Apache-2.0 |  |
+| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.18 | MIT OR Apache-2.0 |  |
+| [thread\_local](https://crates.io/crates/thread_local) | 1.1.9 | MIT OR Apache-2.0 |  |
+| [time](https://crates.io/crates/time) | 0.3.47 | MIT OR Apache-2.0 |  |
+| [time-core](https://crates.io/crates/time-core) | 0.1.8 | MIT OR Apache-2.0 |  |
+| [time-macros](https://crates.io/crates/time-macros) | 0.2.27 | MIT OR Apache-2.0 |  |
+| [tinystr](https://crates.io/crates/tinystr) | 0.8.3 | Unicode-3.0 |  |
+| [tinyvec](https://crates.io/crates/tinyvec) | 1.11.0 | Zlib OR Apache-2.0 OR MIT |  |
+| [tinyvec\_macros](https://crates.io/crates/tinyvec_macros) | 0.1.1 | MIT OR Apache-2.0 OR Zlib |  |
+| [tokio](https://crates.io/crates/tokio) | 1.51.0 | MIT |  |
+| [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.0 | MIT |  |
+| [tokio-native-tls](https://crates.io/crates/tokio-native-tls) | 0.3.1 | MIT |  |
+| [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |
+| [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |
+| [tokio-util](https://crates.io/crates/tokio-util) | 0.7.18 | MIT |  |
+| [tonic](https://crates.io/crates/tonic) | 0.14.5 | MIT |  |
+| [tonic-prost](https://crates.io/crates/tonic-prost) | 0.14.5 | MIT |  |
+| [tower](https://crates.io/crates/tower) | 0.5.3 | MIT |  |
+| [tower-http](https://crates.io/crates/tower-http) | 0.6.8 | MIT |  |
+| [tower-layer](https://crates.io/crates/tower-layer) | 0.3.3 | MIT |  |
+| [tower-service](https://crates.io/crates/tower-service) | 0.3.3 | MIT |  |
+| [tracing](https://crates.io/crates/tracing) | 0.1.44 | MIT |  |
+| [tracing-attributes](https://crates.io/crates/tracing-attributes) | 0.1.31 | MIT |  |
+| [tracing-core](https://crates.io/crates/tracing-core) | 0.1.36 | MIT |  |
+| [tracing-log](https://crates.io/crates/tracing-log) | 0.2.0 | MIT |  |
+| [tracing-opentelemetry](https://crates.io/crates/tracing-opentelemetry) | 0.32.1 | MIT |  |
+| [tracing-subscriber](https://crates.io/crates/tracing-subscriber) | 0.3.23 | MIT |  |
+| [try-lock](https://crates.io/crates/try-lock) | 0.2.5 | MIT |  |
+| [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |
+| [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |
+| [typenum](https://crates.io/crates/typenum) | 1.19.0 | MIT OR Apache-2.0 |  |
+| [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |
+| [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |
+| [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |
+| [unicode-linebreak](https://crates.io/crates/unicode-linebreak) | 0.1.5 | Apache-2.0 |  |
+| [unicode-normalization](https://crates.io/crates/unicode-normalization) | 0.1.25 | MIT OR Apache-2.0 |  |
+| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |
+| [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |
+| [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |
+| [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |
+| [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |
+| [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |
+| [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |
+| [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |
+| [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |
+| [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |
+| [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |
+| [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |
+| [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |
+| [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |
+| [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |
+| [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |
+| [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |
+| [webbrowser](https://crates.io/crates/webbrowser) | 1.2.0 | MIT OR Apache-2.0 |  |
+| [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |
+| [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |
+| [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 |  |
+| [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |
+| [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |
+| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT |  |
+| [zerofrom](https://crates.io/crates/zerofrom) | 0.1.7 | Unicode-3.0 |  |
+| [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |
+| [zeroize](https://crates.io/crates/zeroize) | 1.8.2 | Apache-2.0 OR MIT |  |
+| [zerotrie](https://crates.io/crates/zerotrie) | 0.2.4 | Unicode-3.0 |  |
+| [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |
+| [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |
+| [zip](https://crates.io/crates/zip) | 8.5.0 | MIT |  |
+| [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.3 | Zlib |  |
+| [zmij](https://crates.io/crates/zmij) | 1.0.21 | MIT |  |
+| [zopfli](https://crates.io/crates/zopfli) | 0.8.3 | Apache-2.0 |  |
+| [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |
+| [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |
+| [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |
+
+## License Summary
+
+| License | Count |
+| --- | ---: |
+| MIT OR Apache-2.0 | 187 |
+| MIT | 76 |
+| Apache-2.0 OR MIT | 27 |
+| Unicode-3.0 | 18 |
+| Apache-2.0 | 17 |
+| BSD-3-Clause | 17 |
+| ISC | 3 |
+| Apache-2.0 OR BSD-2-Clause | 2 |
+| Apache-2.0 OR ISC OR MIT | 2 |
+| MPL-2.0 | 2 |
+| Unlicense OR MIT | 2 |
+| Zlib | 2 |
+| (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
+| 0BSD OR MIT OR Apache-2.0 | 1 |
+| Apache-2.0  OR  MIT | 1 |
+| Apache-2.0 AND ISC | 1 |
+| Apache-2.0 OR BSL-1.0 | 1 |
+| Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 1 |
+| BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
+| MIT OR Apache-2.0 OR Zlib | 1 |
+| MIT OR Zlib OR Apache-2.0 | 1 |
+| NOASSERTION | 1 |
+| Zlib OR Apache-2.0 OR MIT | 1 |
+| bzip2-1.0.6 | 1 |

--- a/pixi.lock
+++ b/pixi.lock
@@ -22,6 +22,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-audit-0.22.1-hb17b654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-auditable-0.7.4-hb17b654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-cyclonedx-0.5.9-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -171,6 +174,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-audit-0.22.1-h6fdd925_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-auditable-0.7.4-h6fdd925_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-cyclonedx-0.5.9-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -302,6 +308,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py314he701e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-audit-0.22.1-h18a1a76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-auditable-0.7.4-h18a1a76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-cyclonedx-0.5.9-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -702,6 +711,102 @@ packages:
   license: ISC
   size: 147413
   timestamp: 1772006283803
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-audit-0.22.1-hb17b654_0.conda
+  sha256: dc0d51012c6ef6b1f5e2e41ab38700692493113e37591b71b69c0536e44492a5
+  md5: 2619739164c9edb4a6cbd41a4455eb6b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  size: 5318095
+  timestamp: 1771402755844
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-audit-0.22.1-h6fdd925_0.conda
+  sha256: 178a64dbb0f823a1a38567cdacf1f553d043327b6db70e83920f5738ba8c2970
+  md5: cc4f31dded0b6ecceddaef7eafc8e55a
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  size: 4911337
+  timestamp: 1771402802055
+- conda: https://conda.anaconda.org/conda-forge/win-64/cargo-audit-0.22.1-h18a1a76_0.conda
+  sha256: 287a3335266ae5d687b92f5783b8ce32796a4c182d1cf216d46e990891f85d6c
+  md5: e4f0dae1a78d917899e2b1c325630935
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0 OR MIT
+  size: 5445585
+  timestamp: 1771402801201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-auditable-0.7.4-hb17b654_0.conda
+  sha256: 6a41d5bb99fd0136f206d2265f73bbcf59b6d5466c2bbc33295341d50fba4b3b
+  md5: 230c04d739589b61d246b2f1a30e1cff
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  size: 457733
+  timestamp: 1772711188336
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-auditable-0.7.4-h6fdd925_0.conda
+  sha256: 1d788d608425f83b138753d6e923b39539070d892228fcef7157d32a527e56ce
+  md5: de9ce33ddc38d99e02d2dcd28f16eb21
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  size: 397906
+  timestamp: 1772711222138
+- conda: https://conda.anaconda.org/conda-forge/win-64/cargo-auditable-0.7.4-h18a1a76_0.conda
+  sha256: 662cb9e09894cec7fb5f2d970ae05c1935b04a3f59f20295e3b4464b63ad63ee
+  md5: efe9e9a3b67a971c57efdc22afccc58b
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0 OR MIT
+  size: 392556
+  timestamp: 1772711207588
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-cyclonedx-0.5.9-hb17b654_0.conda
+  sha256: 10f265c84f60efe618a40ea10501a1a2117a6b5bd4e98d10a473dd50c12b5c1a
+  md5: bd20734fa98408865007f2e4b631c808
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1752768
+  timestamp: 1773925873889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-cyclonedx-0.5.9-h6fdd925_0.conda
+  sha256: 9318ad3efb8af7270adf87096eed2af9e20a69db1e304905dd61679db6689111
+  md5: b3034c73245abacb135a6759834b041d
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1586351
+  timestamp: 1773925972401
+- conda: https://conda.anaconda.org/conda-forge/win-64/cargo-cyclonedx-0.5.9-h18a1a76_0.conda
+  sha256: 60a1f3110c2395761f3da41956b3e87b12affd5fbe7a397507a5ba03f6be625f
+  md5: 996e62c9fc42876cb71bc69e81e8e125
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1762783
+  timestamp: 1773925839207
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
   sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
   md5: 765c4d97e877cdbbb88ff33152b86125

--- a/pixi.toml
+++ b/pixi.toml
@@ -47,10 +47,10 @@ cmd = "pytest tests -v"
 depends-on = ["build-release"]
 description = "Run integration tests"
 
-[tasks.lockfiles]
+[tasks.sbom]
 cmd = "./scripts/update_lockfiles.sh"
 description = "Regenerate Cargo.lock (if needed) and update SBOM"
 
-[tasks.lockfiles-force]
+[tasks.sbom-force]
 cmd = "./scripts/update_lockfiles.sh --force"
 description = "Regenerate Cargo.lock and SBOM unconditionally"

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,9 +19,6 @@ cargo-cyclonedx = ">=0.5,<1"
 cmd = "pre-commit run --verbose --show-diff-on-failure --color=always --all-files"
 description = "Run pre-commit hooks on all files"
 
-[tasks.cargo-lock]
-cmd = "cargo generate-lockfile"
-description = "Re-generate Cargo lockfile"
 
 [tasks.build-conda]
 cmd = "python scripts/with_version.py rattler-build build --recipe conda.recipe"

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,9 @@ rattler-build = ">=0.61.1,<0.62"
 rust = "*"
 setuptools-scm = ">=8"
 anaconda-client = ">=1.14.1,<2"
+cargo-auditable = ">=0.7,<1"
+cargo-audit = ">=0.22,<1"
+cargo-cyclonedx = ">=0.5,<1"
 
 [tasks.pre-commit]
 cmd = "pre-commit run --verbose --show-diff-on-failure --color=always --all-files"
@@ -26,11 +29,11 @@ depends-on = ["build-release"]
 description = "Build the conda package"
 
 [tasks.build-debug]
-cmd = "python scripts/with_version.py cargo build"
+cmd = "python scripts/with_version.py cargo auditable build"
 description = "Build the standalone Rust binary in debug mode"
 
 [tasks.build-release]
-cmd = "python scripts/with_version.py cargo build --release"
+cmd = "python scripts/with_version.py cargo auditable build --release"
 description = "Build the standalone Rust binary in release mode"
 
 [tasks.test]
@@ -46,3 +49,11 @@ description = "Run the unit tests in release mode"
 cmd = "pytest tests -v"
 depends-on = ["build-release"]
 description = "Run integration tests"
+
+[tasks.lockfiles]
+cmd = "./scripts/update_lockfiles.sh"
+description = "Regenerate Cargo.lock (if needed) and update SBOM"
+
+[tasks.lockfiles-force]
+cmd = "./scripts/update_lockfiles.sh --force"
+description = "Regenerate Cargo.lock and SBOM unconditionally"

--- a/scripts/sbom-process.py
+++ b/scripts/sbom-process.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Process cargo-cyclonedx and cargo-audit output into SBOM.json and SBOM.md.
+
+Usage: sbom-process.py [--force] <sbom-raw.json> <audit.json> <SBOM.json> <SBOM.md>
+
+Reads the raw CycloneDX SBOM from cargo-cyclonedx and vulnerability data from
+cargo-audit, merges them, and produces a clean SBOM.json and human-readable
+SBOM.md with packages, security advisories, and license summary tables.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import unquote
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def md_escape(text: str) -> str:
+    """Escape underscores for Markdown table cells."""
+    return text.replace("_", r"\_")
+
+
+def purl_to_url(purl: str) -> str:
+    """Best-effort conversion of a package URL to a browsable registry link."""
+    if purl.startswith("pkg:cargo/"):
+        name = unquote(purl[len("pkg:cargo/") :].rsplit("@", 1)[0])
+        return f"https://crates.io/crates/{name}"
+    if purl.startswith("pkg:npm/"):
+        rest = purl[len("pkg:npm/") :]
+        name = unquote(
+            rest.split("@")[-2] if rest.startswith("%40") else rest.rsplit("@", 1)[0]
+        )
+        if not name.startswith("@"):
+            name = unquote(rest.rsplit("@", 1)[0])
+        return f"https://www.npmjs.com/package/{name}"
+    if purl.startswith("pkg:golang/"):
+        module = unquote(purl[len("pkg:golang/") :].rsplit("@", 1)[0])
+        return f"https://pkg.go.dev/{module}"
+    if purl.startswith("pkg:pypi/"):
+        name = unquote(purl[len("pkg:pypi/") :].rsplit("@", 1)[0])
+        return f"https://pypi.org/project/{name}/"
+    return ""
+
+
+def get_license(comp: dict) -> str:
+    """Extract a license string from a CycloneDX component."""
+    licenses = comp.get("licenses", [])
+    if not licenses:
+        return "NOASSERTION"
+    parts = []
+    for entry in licenses:
+        # cargo-cyclonedx uses {"expression": "MIT OR Apache-2.0"} format
+        if "expression" in entry:
+            parts.append(entry["expression"])
+        else:
+            lic = entry.get("license", {})
+            parts.append(lic.get("id", lic.get("name", "NOASSERTION")))
+    return " AND ".join(parts) if parts else "NOASSERTION"
+
+
+# ---------------------------------------------------------------------------
+# Audit merging
+# ---------------------------------------------------------------------------
+
+
+def merge_audit(sbom: dict, audit: dict) -> None:
+    """Merge cargo-audit findings into the CycloneDX SBOM as vulnerabilities."""
+    vuln_list = audit.get("vulnerabilities", {}).get("list", [])
+    warnings = audit.get("warnings", {})
+
+    if not vuln_list and not warnings:
+        return
+
+    # Build name+version -> component bom-ref lookup
+    comp_refs: dict[tuple[str, str], str] = {}
+    for comp in sbom.get("components", []):
+        key = (comp["name"], comp.get("version", ""))
+        comp_refs[key] = comp.get("bom-ref", "")
+
+    vulnerabilities = sbom.setdefault("vulnerabilities", [])
+
+    for entry in vuln_list:
+        advisory = entry.get("advisory", {})
+        versions = entry.get("versions", {})
+        package = entry.get("package", {})
+
+        vuln_id = advisory.get("id", "")
+        aliases = advisory.get("aliases", [])
+        # Prefer CVE ID if available
+        cve_id = next((a for a in aliases if a.startswith("CVE-")), vuln_id)
+
+        # Build affects list
+        affects = []
+        pkg_name = package.get("name", "")
+        pkg_version = package.get("version", "")
+        ref = comp_refs.get((pkg_name, pkg_version), "")
+        if ref:
+            affects.append({"ref": ref})
+
+        # Build ratings from CVSS if available
+        ratings = []
+        cvss = advisory.get("cvss")
+        if cvss:
+            score = cvss.get("score")
+            if score is not None:
+                severity = _cvss_to_severity(float(score))
+                ratings.append(
+                    {
+                        "score": score,
+                        "severity": severity.lower(),
+                        "method": "CVSSv31",
+                    }
+                )
+
+        vuln = {
+            "id": cve_id,
+            "description": advisory.get("description", advisory.get("title", "")),
+            "source": {
+                "name": "RustSec",
+                "url": f"https://rustsec.org/advisories/{vuln_id}.html",
+            },
+            "ratings": ratings,
+            "affects": affects,
+        }
+        # Add RUSTSEC ID as reference if we used CVE as primary
+        if cve_id != vuln_id:
+            vuln["references"] = [
+                {
+                    "id": vuln_id,
+                    "source": {
+                        "name": "RustSec",
+                        "url": f"https://rustsec.org/advisories/{vuln_id}.html",
+                    },
+                }
+            ]
+
+        vulnerabilities.append(vuln)
+
+    # Add warnings (unmaintained, unsound, etc.) as informational entries
+    for warn_type, warn_list in warnings.items():
+        for warn_entry in warn_list:
+            advisory = warn_entry.get("advisory", {})
+            package = warn_entry.get("package", {})
+            vuln_id = advisory.get("id", "")
+
+            affects = []
+            pkg_name = package.get("name", "")
+            pkg_version = package.get("version", "")
+            ref = comp_refs.get((pkg_name, pkg_version), "")
+            if ref:
+                affects.append({"ref": ref})
+
+            vulnerabilities.append(
+                {
+                    "id": vuln_id,
+                    "description": f"[{warn_type}] {advisory.get('title', '')}",
+                    "source": {
+                        "name": "RustSec",
+                        "url": f"https://rustsec.org/advisories/{vuln_id}.html",
+                    },
+                    "ratings": [{"severity": "info", "method": "other"}],
+                    "affects": affects,
+                }
+            )
+
+
+def _cvss_to_severity(score: float) -> str:
+    """Convert a CVSS v3 score to a severity string."""
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0.0:
+        return "LOW"
+    return "NONE"
+
+
+# ---------------------------------------------------------------------------
+# Markdown generation
+# ---------------------------------------------------------------------------
+
+
+def extract_scores(vuln: dict) -> tuple[str, str, str]:
+    """Extract (cvss_v2, cvss_v3, severity) from a CycloneDX vulnerability."""
+    v2 = ""
+    v3 = ""
+    severity = ""
+    for rating in vuln.get("ratings", []):
+        method = rating.get("method", "")
+        score = rating.get("score")
+        sev = rating.get("severity", "")
+        if method == "CVSSv2" and score is not None:
+            v2 = str(score)
+        elif method in ("CVSSv30", "CVSSv31", "CVSSv40") and score is not None:
+            v3 = str(score)
+            if sev:
+                severity = sev.upper()
+        elif method == "other" and sev:
+            severity = sev.upper()
+    if not severity:
+        for rating in vuln.get("ratings", []):
+            if rating.get("severity"):
+                severity = rating["severity"].upper()
+                break
+    return v2, v3, severity
+
+
+def generate_markdown(data: dict) -> str:
+    """Generate SBOM.md from a CycloneDX BOM."""
+    components = data.get("components", [])
+    vulnerabilities = data.get("vulnerabilities", [])
+    created = data.get("metadata", {}).get("timestamp", "unknown")
+    spec_version = data.get("specVersion", "unknown")
+
+    # Build bom-ref -> component lookup
+    ref_to_comp: dict[str, dict] = {}
+    for comp in components:
+        ref = comp.get("bom-ref", "")
+        if ref:
+            ref_to_comp[ref] = comp
+
+    # Map (name_lower, version) -> list of vulns
+    comp_vulns: dict[tuple[str, str], list[dict]] = {}
+    for vuln in vulnerabilities:
+        for affect in vuln.get("affects", []):
+            comp = ref_to_comp.get(affect.get("ref", ""))
+            if comp:
+                key = (comp["name"].lower(), comp.get("version", ""))
+                comp_vulns.setdefault(key, []).append(vuln)
+
+    components_sorted = sorted(components, key=lambda c: c.get("name", "").lower())
+
+    # License summary
+    license_counts: dict[str, int] = {}
+    for comp in components_sorted:
+        lic = get_license(comp)
+        license_counts[lic] = license_counts.get(lic, 0) + 1
+
+    # Advisory rows (deduplicated by name+version+id)
+    advisory_rows: list[tuple[str, str, str, str, str, str]] = []
+    seen_advisories: set[str] = set()
+    for comp in components_sorted:
+        name = comp.get("name", "")
+        version = comp.get("version", "")
+        for vuln in comp_vulns.get((name.lower(), version), []):
+            vuln_id = vuln.get("id", "")
+            dedup_key = f"{name.lower()}@{version}:{vuln_id}"
+            if dedup_key in seen_advisories:
+                continue
+            seen_advisories.add(dedup_key)
+            v2, v3, severity = extract_scores(vuln)
+            advisory_rows.append((name, version, vuln_id, v2, v3, severity))
+
+    affected_pkgs = set(f"{r[0]}@{r[1]}" for r in advisory_rows)
+
+    # --- Render ---
+    lines: list[str] = []
+    lines.append("# Software Bill of Materials (SBOM)")
+    lines.append("")
+    lines.append(f"Generated: {created}<br>")
+    lines.append(f"Format: CycloneDX {spec_version}<br>")
+    lines.append(f"Packages: {len(components)}")
+    if not advisory_rows:
+        lines.append("<br>**Security advisories: 0 found at this time**")
+    else:
+        sev_counts: dict[str, int] = {}
+        for _, _, _, _, _, sev in advisory_rows:
+            if sev:
+                sev_counts[sev] = sev_counts.get(sev, 0) + 1
+        sev_parts = []
+        for level in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
+            if level in sev_counts:
+                sev_parts.append(f"{sev_counts[level]} {level}")
+        sev_summary = f" ({', '.join(sev_parts)})" if sev_parts else ""
+        pkg_word = "package" if len(affected_pkgs) == 1 else "packages"
+        lines.append(
+            f"<br>**[Security advisories](#security-advisories):"
+            f" {len(advisory_rows)}{sev_summary}"
+            f" across {len(affected_pkgs)} {pkg_word}**"
+        )
+    lines.append("")
+
+    # Package table
+    lines.append("## Packages")
+    lines.append("")
+    lines.append("| Package | Version | License | CVEs |")
+    lines.append("| --- | --- | --- | ---: |")
+    for comp in components_sorted:
+        name = comp.get("name", "")
+        version = comp.get("version", "")
+        license_val = get_license(comp)
+
+        purl = comp.get("purl", "")
+        link = purl_to_url(purl)
+        escaped_name = md_escape(name)
+        display_name = f"[{escaped_name}]({link})" if link else escaped_name
+
+        cve_count = sum(
+            1
+            for r in advisory_rows
+            if r[0].lower() == name.lower() and r[1] == version
+        )
+        cve_display = str(cve_count) if cve_count else ""
+
+        lines.append(
+            f"| {display_name} | {version} | {license_val} | {cve_display} |"
+        )
+    lines.append("")
+
+    # Security advisories table
+    if advisory_rows:
+        lines.append("## Security Advisories")
+        lines.append("")
+        lines.append("| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |")
+        lines.append("| --- | --- | --- | :---: | :---: | --- |")
+
+        def _sort_key(row):
+            _, _, _, v2, v3, sev = row
+            v2_f = float(v2) if v2 else 0.0
+            v3_f = float(v3) if v3 else 0.0
+            # Info-level warnings sort last
+            info_penalty = 100 if sev == "INFO" else 0
+            return (info_penalty, -max(v3_f, v2_f), -v3_f, -v2_f, row[0].lower())
+
+        for pkg_name, version, vuln_id, v2, v3, severity in sorted(
+            advisory_rows, key=_sort_key
+        ):
+            if vuln_id.startswith("CVE-"):
+                url = f"https://nvd.nist.gov/vuln/detail/{vuln_id}"
+            elif vuln_id.startswith("RUSTSEC-"):
+                url = f"https://rustsec.org/advisories/{vuln_id}.html"
+            else:
+                url = ""
+            id_display = f"[{vuln_id}]({url})" if url else vuln_id
+            lines.append(
+                f"| {md_escape(pkg_name)} | {version} | {id_display}"
+                f" | {v2} | {v3} | {severity} |"
+            )
+        lines.append("")
+
+    # License summary
+    lines.append("## License Summary")
+    lines.append("")
+    lines.append("| License | Count |")
+    lines.append("| --- | ---: |")
+    for lic, count in sorted(license_counts.items(), key=lambda x: (-x[1], x[0])):
+        lines.append(f"| {lic} | {count} |")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _strip_volatile(comp: dict) -> dict:
+    """Return a copy of a component with run-specific fields removed."""
+    return {k: v for k, v in comp.items() if k != "bom-ref"}
+
+
+def material_content(data: dict) -> tuple[list, list]:
+    """Extract the material (non-metadata) content for comparison.
+
+    Strips bom-ref fields since they may change between runs.
+    """
+    comps = [_strip_volatile(c) for c in data.get("components", [])]
+    vulns = data.get("vulnerabilities", [])
+    return (comps, vulns)
+
+
+def main() -> None:
+    force = "--force" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--force"]
+
+    if len(args) != 4:
+        print(
+            f"Usage: {sys.argv[0]} [--force] <sbom-raw.json> <audit.json>"
+            f" <SBOM.json> <SBOM.md>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    raw_path, audit_path, json_path, md_path = args
+
+    with open(raw_path) as f:
+        sbom = json.load(f)
+
+    with open(audit_path) as f:
+        audit = json.load(f)
+
+    # Merge audit findings into the SBOM
+    merge_audit(sbom, audit)
+
+    comp_count = len(sbom.get("components", []))
+    vuln_count = len(sbom.get("vulnerabilities", []))
+    print(f"==> {comp_count} components, {vuln_count} vulnerabilities")
+
+    # Compare material content against existing SBOM.json
+    if not force and os.path.exists(json_path):
+        with open(json_path) as f:
+            existing = json.load(f)
+        if material_content(sbom) == material_content(existing):
+            print("==> No material changes — SBOM.json and SBOM.md unchanged")
+            return
+
+    # Write clean JSON
+    with open(json_path, "w") as f:
+        json.dump(sbom, f, indent=2)
+        f.write("\n")
+    print(f"==> Wrote {json_path}")
+
+    # Generate and write markdown
+    md = generate_markdown(sbom)
+    with open(md_path, "w") as f:
+        f.write(md)
+    print(f"==> Wrote {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sbom-process.py
+++ b/scripts/sbom-process.py
@@ -84,7 +84,6 @@ def merge_audit(sbom: dict, audit: dict) -> None:
 
     for entry in vuln_list:
         advisory = entry.get("advisory", {})
-        versions = entry.get("versions", {})
         package = entry.get("package", {})
 
         vuln_id = advisory.get("id", "")
@@ -301,15 +300,11 @@ def generate_markdown(data: dict) -> str:
         display_name = f"[{escaped_name}]({link})" if link else escaped_name
 
         cve_count = sum(
-            1
-            for r in advisory_rows
-            if r[0].lower() == name.lower() and r[1] == version
+            1 for r in advisory_rows if r[0].lower() == name.lower() and r[1] == version
         )
         cve_display = str(cve_count) if cve_count else ""
 
-        lines.append(
-            f"| {display_name} | {version} | {license_val} | {cve_display} |"
-        )
+        lines.append(f"| {display_name} | {version} | {license_val} | {cve_display} |")
     lines.append("")
 
     # Security advisories table

--- a/scripts/sbom-process.py
+++ b/scripts/sbom-process.py
@@ -1,17 +1,28 @@
 #!/usr/bin/env python3
-"""Process cargo-cyclonedx and cargo-audit output into SBOM.json and SBOM.md.
+"""Process per-target cargo-cyclonedx and cargo-audit output into SBOM.json and SBOM.md.
 
-Usage: sbom-process.py [--force] <sbom-raw.json> <audit.json> <SBOM.json> <SBOM.md>
+Usage:
+    sbom-process.py [--force] --audit <audit.json>
+        --output-json <SBOM.json> --output-md <SBOM.md>
+        <target-sbom-1.json> [<target-sbom-2.json> ...]
 
-Reads the raw CycloneDX SBOM from cargo-cyclonedx and vulnerability data from
-cargo-audit, merges them, and produces a clean SBOM.json and human-readable
-SBOM.md with packages, security advisories, and license summary tables.
+Merges per-target CycloneDX SBOMs into a single combined SBOM with platform
+annotations, integrates cargo-audit vulnerability data, and produces a clean
+SBOM.json and human-readable SBOM.md.
 """
 
+import argparse
 import json
 import os
-import sys
+import re
 from urllib.parse import unquote
+
+# Mapping from Rust target triples to short platform labels
+TARGET_LABELS: dict[str, str] = {
+    "x86_64-unknown-linux-gnu": "linux",
+    "aarch64-apple-darwin": "macos",
+    "x86_64-pc-windows-msvc": "windows",
+}
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -52,13 +63,61 @@ def get_license(comp: dict) -> str:
         return "NOASSERTION"
     parts = []
     for entry in licenses:
-        # cargo-cyclonedx uses {"expression": "MIT OR Apache-2.0"} format
         if "expression" in entry:
             parts.append(entry["expression"])
         else:
             lic = entry.get("license", {})
             parts.append(lic.get("id", lic.get("name", "NOASSERTION")))
     return " AND ".join(parts) if parts else "NOASSERTION"
+
+
+def label_from_filename(filename: str) -> str:
+    """Extract a platform label from a per-target SBOM filename.
+
+    E.g. 'ana-x86_64-unknown-linux-gnu.json' -> 'linux'
+    """
+    base = os.path.basename(filename)
+    for triple, label in TARGET_LABELS.items():
+        if triple in base:
+            return label
+    # Fallback: strip ana- prefix and .json suffix
+    return re.sub(r"^ana-|\.json$", "", base)
+
+
+# ---------------------------------------------------------------------------
+# Merging per-target SBOMs
+# ---------------------------------------------------------------------------
+
+
+def merge_target_sboms(
+    target_files: list[str],
+) -> tuple[dict, dict[tuple[str, str], set[str]]]:
+    """Merge multiple per-target CycloneDX SBOMs into a single combined SBOM.
+
+    Returns (combined_sbom, platform_map) where platform_map maps
+    (name, version) -> set of platform labels.
+    """
+    platform_map: dict[tuple[str, str], set[str]] = {}
+    # Use the first target as the base SBOM (for metadata, etc.)
+    combined: dict = {}
+    seen_components: dict[tuple[str, str], dict] = {}
+
+    for filepath in target_files:
+        label = label_from_filename(filepath)
+        with open(filepath) as f:
+            data = json.load(f)
+
+        if not combined:
+            combined = data
+        for comp in data.get("components", []):
+            key = (comp["name"], comp.get("version", ""))
+            platform_map.setdefault(key, set()).add(label)
+            if key not in seen_components:
+                seen_components[key] = comp
+
+    # Replace components with the merged set
+    combined["components"] = list(seen_components.values())
+    return combined, platform_map
 
 
 # ---------------------------------------------------------------------------
@@ -88,10 +147,8 @@ def merge_audit(sbom: dict, audit: dict) -> None:
 
         vuln_id = advisory.get("id", "")
         aliases = advisory.get("aliases", [])
-        # Prefer CVE ID if available
         cve_id = next((a for a in aliases if a.startswith("CVE-")), vuln_id)
 
-        # Build affects list
         affects = []
         pkg_name = package.get("name", "")
         pkg_version = package.get("version", "")
@@ -99,7 +156,6 @@ def merge_audit(sbom: dict, audit: dict) -> None:
         if ref:
             affects.append({"ref": ref})
 
-        # Build ratings from CVSS if available
         ratings = []
         cvss = advisory.get("cvss")
         if cvss:
@@ -124,7 +180,6 @@ def merge_audit(sbom: dict, audit: dict) -> None:
             "ratings": ratings,
             "affects": affects,
         }
-        # Add RUSTSEC ID as reference if we used CVE as primary
         if cve_id != vuln_id:
             vuln["references"] = [
                 {
@@ -138,7 +193,6 @@ def merge_audit(sbom: dict, audit: dict) -> None:
 
         vulnerabilities.append(vuln)
 
-    # Add warnings (unmaintained, unsound, etc.) as informational entries
     for warn_type, warn_list in warnings.items():
         for warn_entry in warn_list:
             advisory = warn_entry.get("advisory", {})
@@ -209,12 +263,30 @@ def extract_scores(vuln: dict) -> tuple[str, str, str]:
     return v2, v3, severity
 
 
-def generate_markdown(data: dict) -> str:
-    """Generate SBOM.md from a CycloneDX BOM."""
+def platform_display(platforms: set[str], all_labels: set[str]) -> str:
+    """Return a display string for platform annotations.
+
+    Returns empty string if the dep is on all platforms (no annotation needed).
+    """
+    if platforms >= all_labels:
+        return ""
+    return ", ".join(sorted(platforms))
+
+
+def generate_markdown(
+    data: dict,
+    platform_map: dict[tuple[str, str], set[str]] | None = None,
+) -> str:
+    """Generate SBOM.md from a CycloneDX BOM with optional platform annotations."""
     components = data.get("components", [])
     vulnerabilities = data.get("vulnerabilities", [])
     created = data.get("metadata", {}).get("timestamp", "unknown")
     spec_version = data.get("specVersion", "unknown")
+
+    all_labels = set()
+    if platform_map:
+        for platforms in platform_map.values():
+            all_labels |= platforms
 
     # Build bom-ref -> component lookup
     ref_to_comp: dict[str, dict] = {}
@@ -257,13 +329,29 @@ def generate_markdown(data: dict) -> str:
 
     affected_pkgs = set(f"{r[0]}@{r[1]}" for r in advisory_rows)
 
+    # Count platform-specific deps
+    platform_specific_count = 0
+    if platform_map and all_labels:
+        for comp in components:
+            key = (comp["name"], comp.get("version", ""))
+            platforms = platform_map.get(key, all_labels)
+            if platforms < all_labels:
+                platform_specific_count += 1
+
     # --- Render ---
     lines: list[str] = []
     lines.append("# Software Bill of Materials (SBOM)")
     lines.append("")
     lines.append(f"Generated: {created}<br>")
     lines.append(f"Format: CycloneDX {spec_version}<br>")
-    lines.append(f"Packages: {len(components)}")
+    if platform_specific_count:
+        lines.append(
+            f"Packages: {len(components)}"
+            f" ({platform_specific_count} platform-specific)<br>"
+        )
+        lines.append(f"Platforms: {', '.join(sorted(all_labels))}")
+    else:
+        lines.append(f"Packages: {len(components)}")
     if not advisory_rows:
         lines.append("<br>**Security advisories: 0 found at this time**")
     else:
@@ -285,10 +373,15 @@ def generate_markdown(data: dict) -> str:
     lines.append("")
 
     # Package table
+    has_platforms = platform_map is not None and all_labels
     lines.append("## Packages")
     lines.append("")
-    lines.append("| Package | Version | License | CVEs |")
-    lines.append("| --- | --- | --- | ---: |")
+    if has_platforms:
+        lines.append("| Package | Version | License | Platforms | CVEs |")
+        lines.append("| --- | --- | --- | --- | ---: |")
+    else:
+        lines.append("| Package | Version | License | CVEs |")
+        lines.append("| --- | --- | --- | ---: |")
     for comp in components_sorted:
         name = comp.get("name", "")
         version = comp.get("version", "")
@@ -304,7 +397,18 @@ def generate_markdown(data: dict) -> str:
         )
         cve_display = str(cve_count) if cve_count else ""
 
-        lines.append(f"| {display_name} | {version} | {license_val} | {cve_display} |")
+        if has_platforms:
+            key = (name, version)
+            platforms = platform_map.get(key, all_labels)
+            plat_display = platform_display(platforms, all_labels)
+            lines.append(
+                f"| {display_name} | {version} | {license_val}"
+                f" | {plat_display} | {cve_display} |"
+            )
+        else:
+            lines.append(
+                f"| {display_name} | {version} | {license_val} | {cve_display} |"
+            )
     lines.append("")
 
     # Security advisories table
@@ -318,7 +422,6 @@ def generate_markdown(data: dict) -> str:
             _, _, _, v2, v3, sev = row
             v2_f = float(v2) if v2 else 0.0
             v3_f = float(v3) if v3 else 0.0
-            # Info-level warnings sort last
             info_penalty = 100 if sev == "INFO" else 0
             return (info_penalty, -max(v3_f, v2_f), -v3_f, -v2_f, row[0].lower())
 
@@ -371,23 +474,22 @@ def material_content(data: dict) -> tuple[list, list]:
 
 
 def main() -> None:
-    force = "--force" in sys.argv
-    args = [a for a in sys.argv[1:] if a != "--force"]
+    parser = argparse.ArgumentParser(
+        description="Merge per-target CycloneDX SBOMs with cargo-audit data"
+    )
+    parser.add_argument("--force", action="store_true", help="Force regeneration")
+    parser.add_argument("--audit", required=True, help="cargo-audit JSON output")
+    parser.add_argument("--output-json", required=True, help="Output SBOM.json path")
+    parser.add_argument("--output-md", required=True, help="Output SBOM.md path")
+    parser.add_argument(
+        "target_sboms", nargs="+", help="Per-target CycloneDX SBOM JSON files"
+    )
+    args = parser.parse_args()
 
-    if len(args) != 4:
-        print(
-            f"Usage: {sys.argv[0]} [--force] <sbom-raw.json> <audit.json>"
-            f" <SBOM.json> <SBOM.md>",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    # Merge per-target SBOMs
+    sbom, platform_map = merge_target_sboms(args.target_sboms)
 
-    raw_path, audit_path, json_path, md_path = args
-
-    with open(raw_path) as f:
-        sbom = json.load(f)
-
-    with open(audit_path) as f:
+    with open(args.audit) as f:
         audit = json.load(f)
 
     # Merge audit findings into the SBOM
@@ -395,27 +497,35 @@ def main() -> None:
 
     comp_count = len(sbom.get("components", []))
     vuln_count = len(sbom.get("vulnerabilities", []))
-    print(f"==> {comp_count} components, {vuln_count} vulnerabilities")
+    platform_specific = sum(
+        1
+        for platforms in platform_map.values()
+        if platforms < set(TARGET_LABELS.values())
+    )
+    print(
+        f"==> {comp_count} components ({platform_specific} platform-specific),"
+        f" {vuln_count} vulnerabilities"
+    )
 
     # Compare material content against existing SBOM.json
-    if not force and os.path.exists(json_path):
-        with open(json_path) as f:
+    if not args.force and os.path.exists(args.output_json):
+        with open(args.output_json) as f:
             existing = json.load(f)
         if material_content(sbom) == material_content(existing):
             print("==> No material changes — SBOM.json and SBOM.md unchanged")
             return
 
     # Write clean JSON
-    with open(json_path, "w") as f:
+    with open(args.output_json, "w") as f:
         json.dump(sbom, f, indent=2)
         f.write("\n")
-    print(f"==> Wrote {json_path}")
+    print(f"==> Wrote {args.output_json}")
 
     # Generate and write markdown
-    md = generate_markdown(sbom)
-    with open(md_path, "w") as f:
+    md = generate_markdown(sbom, platform_map)
+    with open(args.output_md, "w") as f:
         f.write(md)
-    print(f"==> Wrote {md_path}")
+    print(f"==> Wrote {args.output_md}")
 
 
 if __name__ == "__main__":

--- a/scripts/sbom-process.py
+++ b/scripts/sbom-process.py
@@ -101,6 +101,8 @@ def merge_target_sboms(
     # Use the first target as the base SBOM (for metadata, etc.)
     combined: dict = {}
     seen_components: dict[tuple[str, str], dict] = {}
+    # Union dependency graph edges across all targets
+    seen_deps: dict[str, set[str]] = {}
 
     for filepath in target_files:
         label = label_from_filename(filepath)
@@ -114,9 +116,50 @@ def merge_target_sboms(
             platform_map.setdefault(key, set()).add(label)
             if key not in seen_components:
                 seen_components[key] = comp
+        for dep in data.get("dependencies", []):
+            ref = dep["ref"]
+            seen_deps.setdefault(ref, set()).update(dep.get("dependsOn", []))
 
-    # Replace components with the merged set
+    # Replace components and dependencies with the merged sets
     combined["components"] = list(seen_components.values())
+    combined["dependencies"] = [
+        {"ref": ref, "dependsOn": sorted(deps)} for ref, deps in seen_deps.items()
+    ]
+
+    all_labels = set(TARGET_LABELS.values())
+
+    # Write platform annotations as CycloneDX component properties so that
+    # downstream consumers of SBOM.json can see which platforms need each dep.
+    for comp in combined["components"]:
+        key = (comp["name"], comp.get("version", ""))
+        platforms = platform_map.get(key, set())
+        if platforms and platforms < all_labels:
+            comp.setdefault("properties", []).append(
+                {"name": "cdx:ana:platforms", "value": ",".join(sorted(platforms))}
+            )
+
+    # Sanitize local filesystem paths from metadata (cargo-cyclonedx embeds
+    # the developer's absolute path in bom-ref and purl).
+    meta_comp = combined.get("metadata", {}).get("component", {})
+    for field in ("bom-ref", "purl"):
+        val = meta_comp.get(field, "")
+        if "file:///" in val:
+            # Keep only the fragment after '#' (e.g. "ana@0.0.0")
+            meta_comp[field] = val.split("#")[-1] if "#" in val else val
+        elif "file://." in val:
+            meta_comp[field] = val.replace("file://.", "")
+
+    # Update metadata properties to reflect all merged target triples
+    all_triples = sorted(TARGET_LABELS.keys())
+    props = combined.get("metadata", {}).get("properties", [])
+    for prop in props:
+        if prop.get("name") == "cdx:rustc:sbom:target:triple":
+            prop["value"] = ",".join(all_triples)
+            break
+
+    # Bump specVersion to 1.4 since we use the vulnerabilities field (added in 1.4)
+    combined["specVersion"] = "1.4"
+
     return combined, platform_map
 
 

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -16,8 +16,8 @@ if [ ! -f Cargo.lock ] || [ Cargo.toml -nt Cargo.lock ]; then
     cargo generate-lockfile
 fi
 
-# Generate raw CycloneDX SBOM
-cargo cyclonedx --format json
+# Generate raw CycloneDX SBOM (all targets, reproducible timestamp)
+SOURCE_DATE_EPOCH=0 cargo cyclonedx --format json --target all
 
 # Run cargo-audit (allow non-zero exit for found vulnerabilities)
 cargo audit --json > audit.raw.json 2>/dev/null || true

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -23,5 +23,5 @@ cargo cyclonedx --format json
 cargo audit --json > audit.raw.json 2>/dev/null || true
 
 # Process into SBOM.json and SBOM.md
-python3 scripts/sbom-process.py $FORCE_FLAG \
+python3 scripts/sbom-process.py ${FORCE_FLAG:+"$FORCE_FLAG"} \
     ana.cdx.json audit.raw.json SBOM.json SBOM.md

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -28,8 +28,16 @@ for target in "${TARGETS[@]}"; do
     TARGET_FILES+=("ana-${target}.json")
 done
 
-# Run cargo-audit (allow non-zero exit for found vulnerabilities)
-cargo audit --json > audit.raw.json 2>/dev/null || true
+# Run cargo-audit: exit code 1 means "vulnerabilities found" (expected),
+# but any other non-zero exit indicates an actual failure (missing binary,
+# corrupted advisory DB, etc.) that should not be silently swallowed.
+cargo audit --json > audit.raw.json 2>audit.stderr.log || {
+    rc=$?
+    if [ $rc -ne 1 ]; then
+        cat audit.stderr.log >&2
+        exit $rc
+    fi
+}
 
 # Process into SBOM.json and SBOM.md (merge per-target SBOMs + audit)
 python3 scripts/sbom-process.py ${FORCE_FLAG:+"$FORCE_FLAG"} \
@@ -39,4 +47,4 @@ python3 scripts/sbom-process.py ${FORCE_FLAG:+"$FORCE_FLAG"} \
     "${TARGET_FILES[@]}"
 
 # Clean up intermediate files
-rm -f audit.raw.json ana.cdx.json "${TARGET_FILES[@]}"
+rm -f audit.raw.json audit.stderr.log ana.cdx.json "${TARGET_FILES[@]}"

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -37,3 +37,6 @@ python3 scripts/sbom-process.py ${FORCE_FLAG:+"$FORCE_FLAG"} \
     --output-json SBOM.json \
     --output-md SBOM.md \
     "${TARGET_FILES[@]}"
+
+# Clean up intermediate files
+rm -f audit.raw.json ana.cdx.json "${TARGET_FILES[@]}"

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -16,12 +16,24 @@ if [ ! -f Cargo.lock ] || [ Cargo.toml -nt Cargo.lock ]; then
     cargo generate-lockfile
 fi
 
-# Generate raw CycloneDX SBOM (all targets, reproducible timestamp)
-SOURCE_DATE_EPOCH=0 cargo cyclonedx --format json --target all
+# Target triples for per-platform SBOM generation
+TARGETS=(x86_64-unknown-linux-gnu aarch64-apple-darwin x86_64-pc-windows-msvc)
+
+# Generate per-target CycloneDX SBOMs (reproducible timestamp)
+TARGET_FILES=()
+for target in "${TARGETS[@]}"; do
+    echo "==> Generating SBOM for $target"
+    SOURCE_DATE_EPOCH=0 cargo cyclonedx --format json --target "$target" \
+        --override-filename "ana-${target}"
+    TARGET_FILES+=("ana-${target}.json")
+done
 
 # Run cargo-audit (allow non-zero exit for found vulnerabilities)
 cargo audit --json > audit.raw.json 2>/dev/null || true
 
-# Process into SBOM.json and SBOM.md
+# Process into SBOM.json and SBOM.md (merge per-target SBOMs + audit)
 python3 scripts/sbom-process.py ${FORCE_FLAG:+"$FORCE_FLAG"} \
-    ana.cdx.json audit.raw.json SBOM.json SBOM.md
+    --audit audit.raw.json \
+    --output-json SBOM.json \
+    --output-md SBOM.md \
+    "${TARGET_FILES[@]}"

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Regenerate Cargo.lock (if Cargo.toml changed) and update the SBOM.
+# Used as a pre-commit hook and in CI.
+# Usage: update_lockfiles.sh [--force]
+set -euo pipefail
+
+FORCE_FLAG="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Regenerate Cargo.lock if Cargo.toml is newer or lock is missing
+if [ ! -f Cargo.lock ] || [ Cargo.toml -nt Cargo.lock ]; then
+    echo "==> Regenerating Cargo.lock"
+    cargo generate-lockfile
+fi
+
+# Generate raw CycloneDX SBOM
+cargo cyclonedx --format json
+
+# Run cargo-audit (allow non-zero exit for found vulnerabilities)
+cargo audit --json > audit.raw.json 2>/dev/null || true
+
+# Process into SBOM.json and SBOM.md
+python3 scripts/sbom-process.py $FORCE_FLAG \
+    ana.cdx.json audit.raw.json SBOM.json SBOM.md


### PR DESCRIPTION
> **⚠️ This PR is based on `ci/caching-and-versioning` (#82) and must be rebased once that PR is merged or if we decide to target `main` directly. The SBOM output and pre-commit behavior should be re-verified after rebasing.**
>
> **[View rendered SBOM.md](https://github.com/anaconda/ana-cli/blob/1edb70d50677877046736414c6f22b6ff11c6c2f/SBOM.md)**

## Summary

Adds automated CycloneDX SBOM generation with vulnerability scanning, supporting our NIST SSDF compliance requirements (dependencies, 3rd-party, vulns, sbom). See the [SSDF product dashboard](https://anaconda.atlassian.net/wiki/x/MQB6OgE) for tracking.

Inspired by the SBOM patterns in [gated-registration-cli](https://github.com/anaconda/gated-registration-cli) and [ip-bouncer-worker](https://github.com/anaconda/ip-bouncer-worker), adapted for a Rust-native toolchain (cargo-cyclonedx + cargo-audit instead of Trivy).

- **cargo-cyclonedx**: Generates per-target CycloneDX 1.3 SBOMs for linux, macos, and windows, merged into a single combined SBOM (414 components, 64 platform-specific)
- **cargo-audit**: Scans dependencies against the RustSec Advisory Database, findings merged into the SBOM
- **cargo-auditable**: Embeds dependency info in compiled binaries so they can be audited standalone
- **sbom-process.py**: Merges per-target SBOMs + audit output into clean `SBOM.json` and human-readable `SBOM.md` with packages, platform annotations, security advisories, and license summary tables
- **Pre-commit hook**: `sbom` hook triggered by `Cargo.toml` or `Cargo.lock` changes keeps SBOM in sync automatically
- **Simplified pre-commit CI**: Reduced to `pixi run pre-commit || :` — all lockfile and SBOM work handled by hooks

### Platform annotations

Dependencies that are only needed on specific platforms are annotated in the SBOM.md Packages table. Per-target SBOMs are generated for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc`, then merged into a true union. This corrects `cargo-cyclonedx --target all` which only produced host-platform deps despite the flag name.

### New files
- `SBOM.json` — CycloneDX SBOM (committed, machine-readable)
- `SBOM.md` — Human-readable SBOM report with platform annotations
- `scripts/sbom-process.py` — Per-target SBOM merge, audit integration, and Markdown generation
- `scripts/update_lockfiles.sh` — Cargo.lock regen + per-target SBOM pipeline (cleans up intermediate files)

### Developer workflow
- `make sbom` / `pixi run sbom` — regenerate SBOM (skips if unchanged)
- `make sbom-force` / `pixi run sbom-force` — unconditional regeneration
- Pre-commit hook runs automatically when `Cargo.toml` or `Cargo.lock` changes

## Test plan

- [ ] Pre-commit hook triggers on `Cargo.lock` changes and regenerates SBOM
- [ ] `make sbom` is idempotent (no-op when nothing changed)
- [ ] `make sbom-force` regenerates unconditionally
- [ ] `cargo audit bin target/release/ana` confirms auditable binary
- [ ] CI pre-commit workflow passes without auto-committing changes
- [ ] Re-verify after rebasing onto merged #82 or `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
