### PR TITLE
feat: Add logging middleware to ApiClient and improve CLI verbosity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "webbrowser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
+tracing = "0.1"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros"] }
 webbrowser = "1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use reqwest::blocking::RequestBuilder;
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
@@ -58,6 +58,11 @@ impl ApiClient {
         })
     }
 
+    /// Get the config.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
     /// Check if the client has valid credentials.
     pub fn is_authenticated(&self) -> bool {
         self.api_key.is_some()
@@ -91,7 +96,7 @@ impl ApiClient {
         if status.is_success() {
             info!(%method, %url, %status, duration_ms = %duration.as_millis(), "request completed");
         } else {
-            warn!(%method, %url, %status, duration_ms = %duration.as_millis(), "request failed");
+            tracing::error!(%method, %url, %status, duration_ms = %duration.as_millis(), "request failed");
         }
 
         Ok(response)
@@ -110,27 +115,41 @@ impl ApiClient {
     }
 
     /// Create a PUT request builder.
+    #[allow(dead_code)]
     pub fn put_builder(&self, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.config.base_url(), path);
         self.client.put(&url)
     }
 
     /// Create a PATCH request builder.
+    #[allow(dead_code)]
     pub fn patch_builder(&self, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.config.base_url(), path);
         self.client.patch(&url)
     }
 
     /// Create a DELETE request builder.
+    #[allow(dead_code)]
     pub fn delete_builder(&self, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.config.base_url(), path);
         self.client.delete(&url)
     }
 
     /// Create a request builder for any HTTP method.
+    #[allow(dead_code)]
     pub fn request_builder(&self, method: reqwest::Method, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.config.base_url(), path);
         self.client.request(method, &url)
+    }
+
+    /// Create a GET request builder for a full URL (not relative to base_url).
+    pub fn get_url(&self, url: &str) -> RequestBuilder {
+        self.client.get(url)
+    }
+
+    /// Create a POST request builder for a full URL (not relative to base_url).
+    pub fn post_url(&self, url: &str) -> RequestBuilder {
+        self.client.post(url)
     }
 }
 
@@ -167,18 +186,14 @@ struct TokenErrorResponse {
 
 /// Perform the device authorization flow.
 pub fn login() -> Result<(), AuthError> {
-    // We use a new, unauthenticated client instead of ApiClient, since
-    // login by definition happens first. It ends up being simpler to do
-    // this, at least for now, because the auth flow needs to follow direct
-    // URLs from openid-configuration etc.
-    let config = Config::load();
-    let client = reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
+    let client = ApiClient::new()?;
+    let config = client.config();
 
     // TODO(mattkram): Better handling for common exceptions like SSL cert, etc.
     // Fetch OpenID configuration
-    let openid_config: OpenIdConfig = client.get(&config.well_known_url()).send()?.json()?;
+    let openid_config: OpenIdConfig = client
+        .send(client.get_url(&config.well_known_url()))?
+        .json()?;
 
     let device_auth_endpoint = openid_config
         .device_authorization_endpoint
@@ -186,12 +201,12 @@ pub fn login() -> Result<(), AuthError> {
 
     // Request device authorization
     let device_response: DeviceAuthResponse = client
-        .post(&device_auth_endpoint)
-        .form(&[
-            ("client_id", config.client_id.as_str()),
-            ("scope", "openid profile email"),
-        ])
-        .send()?
+        .send(
+            client.post_url(&device_auth_endpoint).form(&[
+                ("client_id", config.client_id.as_str()),
+                ("scope", "openid profile email"),
+            ]),
+        )?
         .json()?;
 
     // Display instructions to user
@@ -264,6 +279,7 @@ pub fn login() -> Result<(), AuthError> {
 
     loop {
         if start.elapsed() > timeout {
+            tracing::error!("authentication timed out waiting for user");
             return Err(AuthError::Timeout);
         }
 
@@ -285,14 +301,13 @@ pub fn login() -> Result<(), AuthError> {
             thread::sleep(Duration::from_millis(100));
         }
 
-        let response = client
-            .post(&openid_config.token_endpoint)
-            .form(&[
+        let response = client.send(
+            client.post_url(&openid_config.token_endpoint).form(&[
                 ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
                 ("device_code", &device_response.device_code),
                 ("client_id", &config.client_id),
-            ])
-            .send()?;
+            ]),
+        )?;
 
         if response.status().is_success() {
             let token: TokenResponse = response.json()?;
@@ -301,14 +316,15 @@ pub fn login() -> Result<(), AuthError> {
 
             // Create API key
             println!("Creating API key...");
-            let api_key = create_api_key(&client, &config, &token.access_token)?;
+            let api_key = create_api_key(&client, &token.access_token)?;
 
             // Save to keyring
-            save_api_key(&config, &api_key)?;
-            println!("API key saved to {}", config.keyring_path.display());
+            save_api_key(client.config(), &api_key)?;
+            println!("API key saved to {}", client.config().keyring_path.display());
             return Ok(());
         }
 
+        // Parse error response to check for expected polling states
         let error: TokenErrorResponse = response.json()?;
         match error.error.as_str() {
             "authorization_pending" => continue,
@@ -316,18 +332,22 @@ pub fn login() -> Result<(), AuthError> {
                 thread::sleep(Duration::from_secs(5));
                 continue;
             }
-            "expired_token" => return Err(AuthError::Timeout),
+            "expired_token" => {
+                tracing::error!("token expired during authentication");
+                return Err(AuthError::Timeout);
+            }
             "access_denied" => {
+                tracing::error!("user denied access");
                 return Err(AuthError::Authorization(
                     "Access denied by user".to_string(),
                 ));
             }
             _ => {
-                return Err(AuthError::Authorization(
-                    error
-                        .error_description
-                        .unwrap_or_else(|| error.error.clone()),
-                ));
+                let desc = error
+                    .error_description
+                    .unwrap_or_else(|| error.error.clone());
+                tracing::error!(error = %error.error, description = %desc, "token request failed");
+                return Err(AuthError::Authorization(desc));
             }
         }
     }
@@ -371,10 +391,8 @@ pub fn whoami() -> Result<(), AuthError> {
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().unwrap_or_default();
-        return Err(AuthError::Authorization(format!(
-            "Failed to get account info: {} - {}",
-            status, body
-        )));
+        tracing::error!(%status, %body, "failed to get account info");
+        return Err(AuthError::Authorization("Failed to get account info".into()));
     }
 
     let data: serde_json::Value = response.json()?;

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -2,8 +2,8 @@
 
 use std::time::{Duration, Instant};
 
-use reqwest::header::{self, HeaderMap, HeaderValue};
 use reqwest::RequestBuilder;
+use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
 use tokio::time::sleep;
 use tracing::{debug, info};
@@ -75,10 +75,7 @@ impl ApiClient {
 
     /// Send a request with logging middleware.
     /// Logs the request method/URL before sending and status/duration after.
-    pub async fn send(
-        &self,
-        request: RequestBuilder,
-    ) -> Result<reqwest::Response, AuthError> {
+    pub async fn send(&self, request: RequestBuilder) -> Result<reqwest::Response, AuthError> {
         // Build the request to inspect it before sending
         let request = request.build()?;
         let method = request.method().clone();
@@ -202,12 +199,10 @@ pub async fn login() -> Result<(), AuthError> {
 
     // Request device authorization
     let device_response: DeviceAuthResponse = client
-        .send(
-            client.post_url(&device_auth_endpoint).form(&[
-                ("client_id", config.client_id.as_str()),
-                ("scope", "openid profile email"),
-            ]),
-        )
+        .send(client.post_url(&device_auth_endpoint).form(&[
+            ("client_id", config.client_id.as_str()),
+            ("scope", "openid profile email"),
+        ]))
         .await?
         .json()
         .await?;
@@ -303,13 +298,11 @@ pub async fn login() -> Result<(), AuthError> {
         }
 
         let response = client
-            .send(
-                client.post_url(&openid_config.token_endpoint).form(&[
-                    ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-                    ("device_code", &device_response.device_code),
-                    ("client_id", &config.client_id),
-                ]),
-            )
+            .send(client.post_url(&openid_config.token_endpoint).form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("device_code", &device_response.device_code),
+                ("client_id", &config.client_id),
+            ]))
             .await?;
 
         if response.status().is_success() {
@@ -323,7 +316,10 @@ pub async fn login() -> Result<(), AuthError> {
 
             // Save to keyring
             save_api_key(client.config(), &api_key)?;
-            println!("API key saved to {}", client.config().keyring_path.display());
+            println!(
+                "API key saved to {}",
+                client.config().keyring_path.display()
+            );
             return Ok(());
         }
 
@@ -395,7 +391,9 @@ pub async fn whoami() -> Result<(), AuthError> {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         tracing::error!(%status, %body, "failed to get account info");
-        return Err(AuthError::Authorization("Failed to get account info".into()));
+        return Err(AuthError::Authorization(
+            "Failed to get account info".into(),
+        ));
     }
 
     let data: serde_json::Value = response.json().await?;

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -1,10 +1,12 @@
 //! Authentication actions (login, logout, whoami).
 
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use reqwest::blocking::RequestBuilder;
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use serde::Deserialize;
+use tracing::{debug, info, warn};
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
@@ -66,10 +68,69 @@ impl ApiClient {
         &self.config.domain
     }
 
-    /// Make an authenticated GET request to an API endpoint.
-    pub fn get(&self, path: &str) -> Result<reqwest::blocking::Response, AuthError> {
+    /// Send a request with logging middleware.
+    /// Logs the request method/URL before sending and status/duration after.
+    pub fn send(
+        &self,
+        request: RequestBuilder,
+    ) -> Result<reqwest::blocking::Response, AuthError> {
+        // Build the request to inspect it before sending
+        let request = request.build()?;
+        let method = request.method().clone();
+        let url = request.url().clone();
+
+        debug!(%method, %url, "sending request");
+        let start = Instant::now();
+
+        // Execute the request
+        let response = self.client.execute(request)?;
+
+        let duration = start.elapsed();
+        let status = response.status();
+
+        if status.is_success() {
+            info!(%method, %url, %status, duration_ms = %duration.as_millis(), "request completed");
+        } else {
+            warn!(%method, %url, %status, duration_ms = %duration.as_millis(), "request failed");
+        }
+
+        Ok(response)
+    }
+
+    /// Create a GET request builder.
+    pub fn get_builder(&self, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.config.base_url(), path);
-        Ok(self.client.get(&url).send()?)
+        self.client.get(&url)
+    }
+
+    /// Create a POST request builder.
+    pub fn post_builder(&self, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.config.base_url(), path);
+        self.client.post(&url)
+    }
+
+    /// Create a PUT request builder.
+    pub fn put_builder(&self, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.config.base_url(), path);
+        self.client.put(&url)
+    }
+
+    /// Create a PATCH request builder.
+    pub fn patch_builder(&self, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.config.base_url(), path);
+        self.client.patch(&url)
+    }
+
+    /// Create a DELETE request builder.
+    pub fn delete_builder(&self, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.config.base_url(), path);
+        self.client.delete(&url)
+    }
+
+    /// Create a request builder for any HTTP method.
+    pub fn request_builder(&self, method: reqwest::Method, path: &str) -> RequestBuilder {
+        let url = format!("{}{}", self.config.base_url(), path);
+        self.client.request(method, &url)
     }
 }
 
@@ -305,7 +366,7 @@ pub fn whoami() -> Result<(), AuthError> {
         return Ok(());
     }
 
-    let response = client.get("/api/account")?;
+    let response = client.send(client.get_builder("/api/account"))?;
 
     if !response.status().is_success() {
         let status = response.status();

--- a/src/auth/api_keys.rs
+++ b/src/auth/api_keys.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::actions::ApiClient;
 use super::errors::AuthError;
 use crate::VERSION;
-use crate::config::Config;
 
 /// Request body for creating an API key.
 #[derive(Debug, Serialize)]
@@ -20,12 +20,7 @@ struct ApiKeyResponse {
 }
 
 /// Create a new API key using the access token.
-pub fn create_api_key(
-    client: &reqwest::blocking::Client,
-    config: &Config,
-    access_token: &str,
-) -> Result<String, AuthError> {
-    let url = format!("{}/api/auth/api-keys", config.base_url());
+pub fn create_api_key(client: &ApiClient, access_token: &str) -> Result<String, AuthError> {
     let payload = CreateApiKeyRequest {
         scopes: vec![
             "cloud:read".to_string(),
@@ -36,19 +31,18 @@ pub fn create_api_key(
     };
 
     // TODO: AAU token header is normally added here in anaconda-auth
-    let response = client
-        .post(&url)
-        .bearer_auth(access_token)
-        .json(&payload)
-        .send()?;
+    let response = client.send(
+        client
+            .post_builder("/api/auth/api-keys")
+            .bearer_auth(access_token)
+            .json(&payload),
+    )?;
 
-    if response.status() != reqwest::StatusCode::CREATED {
+    if !response.status().is_success() {
         let status = response.status();
         let body = response.text().unwrap_or_default();
-        return Err(AuthError::Authorization(format!(
-            "Failed to create API key: {} - {}",
-            status, body
-        )));
+        tracing::error!(%status, %body, "failed to create API key");
+        return Err(AuthError::Authorization("Failed to create API key".into()));
     }
 
     let response: ApiKeyResponse = response.json()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ use crate::config::{self, Config};
 use crate::update;
 
 /// Determine log level from args and env before full CLI parsing.
-/// Returns the verbosity level: 0=warn, 1=info, 2=debug, 3+=trace
+/// Returns the verbosity level: 0=off, 1=error, 2=warn, 3=info, 4=debug, 5+=trace
 fn get_verbosity() -> u8 {
     // Check env var first (ANA_LOG or RUST_LOG)
     if std::env::var("ANA_LOG").is_ok() || std::env::var("RUST_LOG").is_ok() {
@@ -45,17 +45,15 @@ fn build_log_filter(verbosity: u8) -> EnvFilter {
         return filter;
     }
 
-    // Otherwise, use verbosity level
-    let app_level = match verbosity {
-        0 => "warn",
-        1 => "info",
-        2 => "debug",
-        _ => "trace",
-    };
-
-    EnvFilter::new(format!(
-        "ana={app_level},anaconda_otel_rs=off,opentelemetry=off,reqwest=off"
-    ))
+    // Verbosity levels: 0=off, 1=error, 2=warn, 3=info, 4=debug, 5+=trace (with libs)
+    match verbosity {
+        0 => EnvFilter::new("off"),
+        1 => EnvFilter::new("ana=error"),
+        2 => EnvFilter::new("ana=warn"),
+        3 => EnvFilter::new("ana=info"),
+        4 => EnvFilter::new("ana=debug"),
+        _ => EnvFilter::new("trace"), // Everything including libs
+    }
 }
 
 /// Build base telemetry attributes with system information.
@@ -277,7 +275,7 @@ pub fn print_main_help() {
           self           Manage the ana installation
 
         Options:
-          -v, --verbose  Increase verbosity (-v, -vv, -vvv)
+          -v, --verbose  Increase verbosity (-v=error, -vv=warn, -vvv=info, -vvvv=debug, -vvvvv=trace)
           -V, --version  Print version
           -h, --help     Print help
 
@@ -330,7 +328,7 @@ pub fn print_auth_help() {
     override_usage = "ana [command] [options]",
 )]
 struct Cli {
-    /// Increase verbosity (-v=info, -vv=debug, -vvv=trace)
+    /// Increase verbosity (-v=error, -vv=warn, -vvv=info, -vvvv=debug, -vvvvv=trace)
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
     verbose: u8,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,12 +6,57 @@ use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_te
 use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use opentelemetry::Value;
+use tracing_subscriber::EnvFilter;
 
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
 use crate::config::{self, Config};
 use crate::update;
+
+/// Determine log level from args and env before full CLI parsing.
+/// Returns the verbosity level: 0=warn, 1=info, 2=debug, 3+=trace
+fn get_verbosity() -> u8 {
+    // Check env var first (ANA_LOG or RUST_LOG)
+    if std::env::var("ANA_LOG").is_ok() || std::env::var("RUST_LOG").is_ok() {
+        return 0; // Let EnvFilter handle it
+    }
+
+    // Check for -v flags in args
+    let mut verbosity = 0u8;
+    for arg in std::env::args().skip(1) {
+        if arg == "-v" || arg == "--verbose" {
+            verbosity = verbosity.saturating_add(1);
+        } else if arg.starts_with("-v") && arg.chars().skip(1).all(|c| c == 'v') {
+            // Handle -vv, -vvv, etc.
+            verbosity = verbosity.saturating_add(arg.len() as u8 - 1);
+        }
+    }
+    verbosity
+}
+
+/// Build the tracing filter based on verbosity level.
+fn build_log_filter(verbosity: u8) -> EnvFilter {
+    // If RUST_LOG or ANA_LOG is set, use that
+    if let Ok(filter) = std::env::var("ANA_LOG") {
+        return EnvFilter::new(filter);
+    }
+    if let Ok(filter) = EnvFilter::try_from_default_env() {
+        return filter;
+    }
+
+    // Otherwise, use verbosity level
+    let app_level = match verbosity {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+
+    EnvFilter::new(format!(
+        "ana={app_level},anaconda_otel_rs=off,opentelemetry=off,reqwest=off"
+    ))
+}
 
 /// Build base telemetry attributes with system information.
 fn system_attrs() -> HashMap<String, Value> {
@@ -23,11 +68,14 @@ fn system_attrs() -> HashMap<String, Value> {
 }
 
 pub fn execute() {
-    // Suppress telemetry logs by default to avoid leaking errors when telemetry fails
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        tracing_subscriber::EnvFilter::new("anaconda_otel_rs=off,opentelemetry=off,reqwest=off")
-    });
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    // Configure logging based on -v flags or ANA_LOG/RUST_LOG env vars
+    let verbosity = get_verbosity();
+    let filter = build_log_filter(verbosity);
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .without_time()
+        .init();
 
     config::setup_telemetry();
 
@@ -36,7 +84,7 @@ pub fn execute() {
     shutdown_telemetry();
 
     if let Err(e) = result {
-        eprintln!("Error: {}", e);
+        tracing::error!("{}", e);
         std::process::exit(1);
     }
 }
@@ -198,10 +246,10 @@ fn handle_parse_error(e: clap::Error) -> Action {
         let args: Vec<String> = std::env::args().collect();
         if args.len() > 1 && args[1] == "self" {
             if args.len() > 2 {
-                eprintln!("Unknown self command: {}", args[2]);
+                tracing::error!("Unknown self command: {}", args[2]);
             }
         } else if args.len() > 1 {
-            eprintln!("Unknown command: {}", args[1]);
+            tracing::error!("Unknown command: {}", args[1]);
         }
         std::process::exit(1);
     }
@@ -229,8 +277,12 @@ pub fn print_main_help() {
           self           Manage the ana installation
 
         Options:
+          -v, --verbose  Increase verbosity (-v, -vv, -vvv)
           -V, --version  Print version
           -h, --help     Print help
+
+        Environment:
+          ANA_LOG        Set log filter (e.g., ANA_LOG=ana=debug)
         "}
     );
 }
@@ -278,6 +330,10 @@ pub fn print_auth_help() {
     override_usage = "ana [command] [options]",
 )]
 struct Cli {
+    /// Increase verbosity (-v=info, -vv=debug, -vvv=trace)
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }


### PR DESCRIPTION
## Summary
- Add `send()` method to `ApiClient` with request/response logging middleware
- Add `get_url()`/`post_url()` methods for full URL requests (OAuth endpoints)
- Refactor `login()` and `create_api_key()` to use `ApiClient` consistently
- Update CLI verbosity levels: `-v`=error, `-vv`=warn, `-vvv`=info, `-vvvv`=debug, `-vvvvv`=trace (with libs)
- Add `tracing::error!` calls before error returns for better debugging
- Log failed HTTP requests at error level with status code

## Test plan
- [ ] Run `ana login -v` and verify error-level logs appear on failures
- [ ] Run `ana login -vvvv` and verify debug logs show request/response details
- [ ] Run `ana whoami -vvvv` and verify logging middleware works
- [ ] Verify default (no flags) produces no log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2960" height="2266" alt="CleanShot 2026-04-06 at 11 09 47@2x" src="https://github.com/user-attachments/assets/9f957cf2-f224-4b7b-a01e-825ecd166569" />
