### PR TITLE
feat: Add verbosity flags for tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "webbrowser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "time", "fs", "sync"] }
 webbrowser = "1"
+tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 opentelemetry = "0.31.0"
 

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -25,10 +25,12 @@ pub fn run_subcommand(subcommand: &str, args: &[String]) -> Result<(), String> {
     let anaconda_bin = paths::bin_dir().join("anaconda");
 
     if !anaconda_bin.exists() {
-        return Err(format!(
+        let msg = format!(
             "anaconda not found at {}. Run `ana bootstrap` first.",
             anaconda_bin.display()
-        ));
+        );
+        tracing::error!("{}", msg);
+        return Err(msg);
     }
 
     let status = Command::new(&anaconda_bin)
@@ -40,9 +42,11 @@ pub fn run_subcommand(subcommand: &str, args: &[String]) -> Result<(), String> {
     if status.success() {
         Ok(())
     } else {
-        Err(format!(
+        let msg = format!(
             "anaconda exited with code {}",
             status.code().unwrap_or(1)
-        ))
+        );
+        tracing::error!("{}", msg);
+        Err(msg)
     }
 }

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -42,10 +42,7 @@ pub fn run_subcommand(subcommand: &str, args: &[String]) -> Result<(), String> {
     if status.success() {
         Ok(())
     } else {
-        let msg = format!(
-            "anaconda exited with code {}",
-            status.code().unwrap_or(1)
-        );
+        let msg = format!("anaconda exited with code {}", status.code().unwrap_or(1));
         tracing::error!("{}", msg);
         Err(msg)
     }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -209,6 +209,7 @@ pub async fn login() -> Result<(), AuthError> {
 
     loop {
         if start.elapsed() > timeout {
+            tracing::error!("Authentication timed out");
             return Err(AuthError::Timeout);
         }
 
@@ -260,18 +261,22 @@ pub async fn login() -> Result<(), AuthError> {
                 sleep(Duration::from_secs(5)).await;
                 continue;
             }
-            "expired_token" => return Err(AuthError::Timeout),
+            "expired_token" => {
+                tracing::error!("Token expired during authentication");
+                return Err(AuthError::Timeout);
+            }
             "access_denied" => {
+                tracing::error!("Access denied by user");
                 return Err(AuthError::Authorization(
                     "Access denied by user".to_string(),
                 ));
             }
             _ => {
-                return Err(AuthError::Authorization(
-                    error
-                        .error_description
-                        .unwrap_or_else(|| error.error.clone()),
-                ));
+                let msg = error
+                    .error_description
+                    .unwrap_or_else(|| error.error.clone());
+                tracing::error!("Authorization error: {}", msg);
+                return Err(AuthError::Authorization(msg));
             }
         }
     }
@@ -315,6 +320,7 @@ pub async fn whoami() -> Result<(), AuthError> {
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        tracing::error!("Failed to get account info: {} - {}", status, body);
         return Err(AuthError::Authorization(format!(
             "Failed to get account info: {} - {}",
             status, body

--- a/src/auth/api_keys.rs
+++ b/src/auth/api_keys.rs
@@ -45,6 +45,7 @@ pub async fn create_api_key(
     if response.status() != reqwest::StatusCode::CREATED {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        tracing::error!("Failed to create API key: {} - {}", status, body);
         return Err(AuthError::Authorization(format!(
             "Failed to create API key: {} - {}",
             status, body

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,44 @@ use crate::auth;
 use crate::config::{self, Config};
 use crate::update;
 
+/// Log level for tracing output.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum LogLevel {
+    #[default]
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<u8> for LogLevel {
+    fn from(count: u8) -> Self {
+        match count {
+            0 => Self::Off,
+            1 => Self::Error,
+            2 => Self::Warn,
+            3 => Self::Info,
+            4 => Self::Debug,
+            _ => Self::Trace,
+        }
+    }
+}
+
+impl LogLevel {
+    fn as_filter_str(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Error => "ana=error,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+            Self::Warn => "ana=warn,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+            Self::Info => "ana=info,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+            Self::Debug => "ana=debug,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+            Self::Trace => "ana=trace,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+        }
+    }
+}
+
 /// Build base telemetry attributes with system information.
 fn system_attrs() -> HashMap<String, Value> {
     let mut attrs = HashMap::new();
@@ -23,9 +61,9 @@ fn system_attrs() -> HashMap<String, Value> {
 }
 
 pub async fn execute() {
-    let (action, verbosity) = parse();
+    let (action, level) = parse();
 
-    let filter = build_tracing_filter(verbosity);
+    let filter = build_tracing_filter(level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
     config::setup_telemetry();
@@ -41,23 +79,14 @@ pub async fn execute() {
     }
 }
 
-/// Build tracing filter based on verbosity level.
+/// Build tracing filter based on log level.
 /// Respects RUST_LOG env var if set, otherwise uses verbosity flags.
-fn build_tracing_filter(verbosity: u8) -> tracing_subscriber::EnvFilter {
+fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
     if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
         return filter;
     }
 
-    let filter_str = match verbosity {
-        0 => "off",
-        1 => "ana=error,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
-        2 => "ana=warn,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
-        3 => "ana=info,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
-        4 => "ana=debug,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
-        _ => "trace",
-    };
-
-    tracing_subscriber::EnvFilter::new(filter_str)
+    tracing_subscriber::EnvFilter::new(level.as_filter_str())
 }
 
 /// Action to be performed, returned by parse()
@@ -167,12 +196,12 @@ impl Action {
     }
 }
 
-/// Parse CLI arguments and return the action to perform along with verbosity level.
+/// Parse CLI arguments and return the action to perform along with log level.
 /// Exits the process on unrecoverable errors (unknown commands, etc.)
-pub fn parse() -> (Action, u8) {
+pub fn parse() -> (Action, LogLevel) {
     match Cli::try_parse() {
         Ok(cli) => {
-            let verbosity = cli.verbose;
+            let level: LogLevel = cli.verbose.into();
             let action = match cli.command {
                 None => Action::ShowHelp,
                 Some(Commands::Bootstrap) => Action::Bootstrap,
@@ -201,18 +230,18 @@ pub fn parse() -> (Action, u8) {
                 },
                 Some(Commands::Org { args }) => Action::OrgProxy { args },
             };
-            (action, verbosity)
+            (action, level)
         }
         Err(e) => handle_parse_error(e),
     }
 }
 
-fn handle_parse_error(e: clap::Error) -> (Action, u8) {
+fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
     if e.kind() == clap::error::ErrorKind::DisplayHelp {
-        return (Action::ShowHelp, 0);
+        return (Action::ShowHelp, LogLevel::Off);
     }
     if e.kind() == clap::error::ErrorKind::DisplayVersion {
-        return (Action::ShowVersion, 0);
+        return (Action::ShowVersion, LogLevel::Off);
     }
 
     // Handle unknown subcommand errors with custom format

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,15 +23,14 @@ fn system_attrs() -> HashMap<String, Value> {
 }
 
 pub async fn execute() {
-    // Suppress telemetry logs by default to avoid leaking errors when telemetry fails
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        tracing_subscriber::EnvFilter::new("anaconda_otel_rs=off,opentelemetry=off,reqwest=off")
-    });
+    let (action, verbosity) = parse();
+
+    let filter = build_tracing_filter(verbosity);
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
     config::setup_telemetry();
 
-    let result = parse().execute().await;
+    let result = action.execute().await;
 
     shutdown_telemetry();
 
@@ -39,6 +38,25 @@ pub async fn execute() {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
+}
+
+/// Build tracing filter based on verbosity level.
+/// Respects RUST_LOG env var if set, otherwise uses verbosity flags.
+fn build_tracing_filter(verbosity: u8) -> tracing_subscriber::EnvFilter {
+    if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
+        return filter;
+    }
+
+    let filter_str = match verbosity {
+        0 => "off",
+        1 => "ana=error,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+        2 => "ana=warn,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+        3 => "ana=info,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+        4 => "ana=debug,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
+        _ => "trace",
+    };
+
+    tracing_subscriber::EnvFilter::new(filter_str)
 }
 
 /// Action to be performed, returned by parse()
@@ -148,48 +166,52 @@ impl Action {
     }
 }
 
-/// Parse CLI arguments and return the action to perform.
+/// Parse CLI arguments and return the action to perform along with verbosity level.
 /// Exits the process on unrecoverable errors (unknown commands, etc.)
-pub fn parse() -> Action {
+pub fn parse() -> (Action, u8) {
     match Cli::try_parse() {
-        Ok(cli) => match cli.command {
-            None => Action::ShowHelp,
-            Some(Commands::Bootstrap) => Action::Bootstrap,
-            Some(Commands::Config) => Action::ShowConfig,
-            Some(Commands::Login) => Action::Login,
-            Some(Commands::Logout) => Action::Logout,
-            Some(Commands::Whoami) => Action::Whoami,
-            Some(Commands::Auth { command }) => match command {
-                None => Action::ShowAuthHelp,
-                Some(AuthCommands::ApiKey) => Action::ShowApiKey,
-                Some(AuthCommands::Login) => Action::Login,
-                Some(AuthCommands::Logout) => Action::Logout,
-                Some(AuthCommands::Whoami) => Action::Whoami,
-            },
-            Some(Commands::Self_ { command }) => match command {
-                None => Action::ShowSelfHelp,
-                Some(SelfCommands::Update { yes, check, list }) => {
-                    if check {
-                        Action::CheckForUpdate
-                    } else if list {
-                        Action::ShowAvailableVersions
-                    } else {
-                        Action::Update { force: yes }
+        Ok(cli) => {
+            let verbosity = cli.verbose;
+            let action = match cli.command {
+                None => Action::ShowHelp,
+                Some(Commands::Bootstrap) => Action::Bootstrap,
+                Some(Commands::Config) => Action::ShowConfig,
+                Some(Commands::Login) => Action::Login,
+                Some(Commands::Logout) => Action::Logout,
+                Some(Commands::Whoami) => Action::Whoami,
+                Some(Commands::Auth { command }) => match command {
+                    None => Action::ShowAuthHelp,
+                    Some(AuthCommands::ApiKey) => Action::ShowApiKey,
+                    Some(AuthCommands::Login) => Action::Login,
+                    Some(AuthCommands::Logout) => Action::Logout,
+                    Some(AuthCommands::Whoami) => Action::Whoami,
+                },
+                Some(Commands::Self_ { command }) => match command {
+                    None => Action::ShowSelfHelp,
+                    Some(SelfCommands::Update { yes, check, list }) => {
+                        if check {
+                            Action::CheckForUpdate
+                        } else if list {
+                            Action::ShowAvailableVersions
+                        } else {
+                            Action::Update { force: yes }
+                        }
                     }
-                }
-            },
-            Some(Commands::Org { args }) => Action::OrgProxy { args },
-        },
+                },
+                Some(Commands::Org { args }) => Action::OrgProxy { args },
+            };
+            (action, verbosity)
+        }
         Err(e) => handle_parse_error(e),
     }
 }
 
-fn handle_parse_error(e: clap::Error) -> Action {
+fn handle_parse_error(e: clap::Error) -> (Action, u8) {
     if e.kind() == clap::error::ErrorKind::DisplayHelp {
-        return Action::ShowHelp;
+        return (Action::ShowHelp, 0);
     }
     if e.kind() == clap::error::ErrorKind::DisplayVersion {
-        return Action::ShowVersion;
+        return (Action::ShowVersion, 0);
     }
 
     // Handle unknown subcommand errors with custom format
@@ -229,6 +251,7 @@ pub fn print_main_help() {
           self           Manage the ana installation
 
         Options:
+          -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
           -V, --version  Print version
           -h, --help     Print help
         "}
@@ -280,6 +303,10 @@ pub fn print_auth_help() {
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
+
+    /// Increase verbosity (-v=error, -vv=warn, -vvv=info, -vvvv=debug, -vvvvv=trace)
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub async fn execute() {
     shutdown_telemetry();
 
     if let Err(e) = result {
+        tracing::error!("Command failed: {}", e);
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
@@ -220,9 +221,11 @@ fn handle_parse_error(e: clap::Error) -> (Action, u8) {
         let args: Vec<String> = std::env::args().collect();
         if args.len() > 1 && args[1] == "self" {
             if args.len() > 2 {
+                tracing::error!("Unknown self command: {}", args[2]);
                 eprintln!("Unknown self command: {}", args[2]);
             }
         } else if args.len() > 1 {
+            tracing::error!("Unknown command: {}", args[1]);
             eprintln!("Unknown command: {}", args[1]);
         }
         std::process::exit(1);

--- a/src/update.rs
+++ b/src/update.rs
@@ -12,7 +12,10 @@ const GITHUB_REPO: &str = "anaconda/ana-cli";
 fn github_client() -> Result<reqwest::Client, Error> {
     let token = match env::var("GITHUB_TOKEN") {
         Ok(token) if !token.is_empty() => token,
-        _ => return Err(Error::MissingToken),
+        _ => {
+            tracing::error!("GITHUB_TOKEN not set or empty");
+            return Err(Error::MissingToken);
+        }
     };
     reqwest::Client::builder()
         .user_agent("ana-cli")
@@ -89,7 +92,10 @@ fn get_asset_name() -> Result<String, Error> {
         ("macos", "aarch64") => Ok("ana-darwin-arm64".to_string()),
         ("linux", "x86_64") => Ok("ana-linux-x86_64".to_string()),
         ("windows", "x86_64") => Ok("ana-windows-x86_64.exe".to_string()),
-        _ => Err(Error::UnsupportedPlatform(format!("{}-{}", os, arch))),
+        _ => {
+            tracing::error!("Unsupported platform: {}-{}", os, arch);
+            Err(Error::UnsupportedPlatform(format!("{}-{}", os, arch)))
+        }
     }
 }
 
@@ -250,6 +256,7 @@ pub async fn check_for_update(current_version: &str) {
             println!("No releases available.");
         }
         Err(e) => {
+            tracing::error!("Failed to check for update: {}", e);
             eprintln!("Failed to check for update: {}", e);
         }
     }
@@ -259,6 +266,7 @@ pub async fn run_update(current_version: &str, force: bool) {
     let check = match check_update(current_version).await {
         Ok(c) => c,
         Err(e) => {
+            tracing::error!("Failed to check for updates: {}", e);
             eprintln!("Failed to check for updates: {}", e);
             return;
         }
@@ -278,7 +286,10 @@ pub async fn run_update(current_version: &str, force: bool) {
                     "Updated successfully: {} -> {}",
                     current_version, release.tag_name
                 ),
-                Err(e) => eprintln!("Failed to update: {}", e),
+                Err(e) => {
+                    tracing::error!("Failed to update: {}", e);
+                    eprintln!("Failed to update: {}", e);
+                }
             }
         }
         UpdateCheck::AlreadyUpToDate => {
@@ -294,6 +305,7 @@ pub async fn show_available_versions(current_version: &str) {
     let releases = match fetch_available_releases().await {
         Ok(r) => r,
         Err(e) => {
+            tracing::error!("Failed to fetch releases: {}", e);
             eprintln!("Failed to fetch releases: {}", e);
             return;
         }


### PR DESCRIPTION
## Summary
- Add `-v`/`--verbose` flag with incremental verbosity levels for logging
- Levels: `-v` (error), `-vv` (warn), `-vvv` (info), `-vvvv` (debug), `-vvvvv` (trace with all deps)
- Flag is global so it works with any subcommand (e.g., `ana -vvv login`)
- `RUST_LOG` env var still takes precedence when set

## Test plan
- [ ] Verify `ana --help` shows the new `-v, --verbose` option
- [ ] Test `-v` through `-vvvvv` produce appropriate log output
- [ ] Confirm `RUST_LOG=debug ana config` still overrides verbosity flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)