### PR TITLE
feat: Add basic internal feedback utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "webbrowser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = "1.0"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "time", "fs", "sync"] }
+urlencoding = "2"
 webbrowser = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ libc = "0.2"
 [features]
 # TODO(mattkram): For the early project phase, we will enable diagnostics in our builds by
 #                 default. We will review this behavior before public release.
-default = ["diagnostics"]
-diagnostics = ["sentry"]
+default = ["diagnostics", "feedback"]
+diagnostics = ["dep:sentry"]
+feedback = ["dep:urlencoding"]
 
 [dependencies]
 base64 = "0.22"
@@ -48,7 +49,3 @@ cargo-lock = "11"
 [dev-dependencies]
 temp-env = "0.3"
 tempfile = "3"
-
-[features]
-default = ["feedback"]
-feedback = ["dep:urlencoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "time", "fs", "sync"] }
-urlencoding = "2"
+urlencoding = { version = "2", optional = true }
 webbrowser = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
@@ -48,3 +48,7 @@ cargo-lock = "11"
 [dev-dependencies]
 temp-env = "0.3"
 tempfile = "3"
+
+[features]
+default = ["feedback"]
+feedback = ["dep:urlencoding"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use opentelemetry::Value;
 
+#[cfg(feature = "feedback")]
 use crate::FEEDBACK_BASE_URL;
 use crate::VERSION;
 use crate::anaconda_cli;
@@ -91,6 +92,7 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
 }
 
 /// Feedback type for the feedback form
+#[cfg(feature = "feedback")]
 #[derive(Clone, Copy)]
 pub enum FeedbackType {
     Bug,
@@ -113,6 +115,7 @@ pub enum Action {
     ShowAvailableVersions,
     Bootstrap,
     OrgProxy { args: Vec<String> },
+    #[cfg(feature = "feedback")]
     OpenFeedback {
         feedback_type: Option<FeedbackType>,
         description: Option<String>,
@@ -136,6 +139,7 @@ impl Action {
             Action::ShowAvailableVersions => "self.update.list",
             Action::Bootstrap => "bootstrap",
             Action::OrgProxy { .. } => "org",
+            #[cfg(feature = "feedback")]
             Action::OpenFeedback { .. } => "feedback",
         }
     }
@@ -205,6 +209,7 @@ impl Action {
                 update::show_available_versions(VERSION).await;
                 Ok(())
             }
+            #[cfg(feature = "feedback")]
             Action::OpenFeedback {
                 feedback_type,
                 description,
@@ -226,6 +231,7 @@ pub fn parse() -> (Action, LogLevel) {
                 None => Action::ShowHelp,
                 Some(Commands::Bootstrap) => Action::Bootstrap,
                 Some(Commands::Config) => Action::ShowConfig,
+                #[cfg(feature = "feedback")]
                 Some(Commands::Feedback {
                     bug,
                     feature,
@@ -246,6 +252,7 @@ pub fn parse() -> (Action, LogLevel) {
                 },
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSelfHelp,
+                    #[cfg(feature = "feedback")]
                     Some(SelfCommands::Feedback {
                         bug,
                         feature,
@@ -272,6 +279,7 @@ pub fn parse() -> (Action, LogLevel) {
     }
 }
 
+#[cfg(feature = "feedback")]
 fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
     if bug {
         Some(FeedbackType::Bug)
@@ -310,6 +318,7 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
     e.exit();
 }
 
+#[cfg(feature = "feedback")]
 pub fn print_main_help() {
     println!(
         "{}",
@@ -337,6 +346,33 @@ pub fn print_main_help() {
     );
 }
 
+#[cfg(not(feature = "feedback"))]
+pub fn print_main_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        ana {VERSION}
+
+        Usage: ana [command] [options]
+
+        Commands:
+          auth           Authentication commands
+          bootstrap      Install the Anaconda CLI
+          config         Show current configuration
+          login          Log in to Anaconda
+          logout         Log out from Anaconda
+          org            Interact with anaconda.org
+          whoami         Display information about the logged-in user
+          self           Manage the ana installation
+
+        Options:
+          -V, --version  Print version
+          -h, --help     Print help
+        "}
+    );
+}
+
+#[cfg(feature = "feedback")]
 pub fn print_self_help() {
     println!(
         "{}",
@@ -347,6 +383,21 @@ pub fn print_self_help() {
 
         Commands:
           feedback  Open the feedback form
+          update    Update ana to the latest version
+        "}
+    );
+}
+
+#[cfg(not(feature = "feedback"))]
+pub fn print_self_help() {
+    println!(
+        "{}",
+        formatdoc! {"
+        Manage the installation
+
+        Usage: ana self <command> [options]
+
+        Commands:
           update    Update ana to the latest version
         "}
     );
@@ -409,6 +460,7 @@ enum Commands {
     Config,
 
     /// Open the feedback form
+    #[cfg(feature = "feedback")]
     Feedback {
         /// Report a bug
         #[arg(long, conflicts_with = "feature")]
@@ -473,6 +525,7 @@ enum AuthCommands {
 #[derive(Subcommand)]
 enum SelfCommands {
     /// Open the feedback form
+    #[cfg(feature = "feedback")]
     Feedback {
         /// Report a bug
         #[arg(long, conflicts_with = "feature")]
@@ -503,6 +556,7 @@ enum SelfCommands {
     },
 }
 
+#[cfg(feature = "feedback")]
 fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>) {
     let mut params = vec![("usp", "pp_url".to_string())];
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use opentelemetry::Value;
 
-use crate::FEEDBACK_URL;
+use crate::FEEDBACK_BASE_URL;
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
@@ -90,6 +90,13 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
     tracing_subscriber::EnvFilter::new(level.as_filter_str())
 }
 
+/// Feedback type for the feedback form
+#[derive(Clone, Copy)]
+pub enum FeedbackType {
+    Bug,
+    Feature,
+}
+
 /// Action to be performed, returned by parse()
 pub enum Action {
     ShowHelp,
@@ -106,7 +113,10 @@ pub enum Action {
     ShowAvailableVersions,
     Bootstrap,
     OrgProxy { args: Vec<String> },
-    OpenFeedback,
+    OpenFeedback {
+        feedback_type: Option<FeedbackType>,
+        description: Option<String>,
+    },
 }
 
 impl Action {
@@ -126,7 +136,7 @@ impl Action {
             Action::ShowAvailableVersions => "self.update.list",
             Action::Bootstrap => "bootstrap",
             Action::OrgProxy { .. } => "org",
-            Action::OpenFeedback => "feedback",
+            Action::OpenFeedback { .. } => "feedback",
         }
     }
 
@@ -195,8 +205,11 @@ impl Action {
                 update::show_available_versions(VERSION).await;
                 Ok(())
             }
-            Action::OpenFeedback => {
-                open_feedback();
+            Action::OpenFeedback {
+                feedback_type,
+                description,
+            } => {
+                open_feedback(feedback_type, description);
                 Ok(())
             }
         }
@@ -213,7 +226,14 @@ pub fn parse() -> (Action, LogLevel) {
                 None => Action::ShowHelp,
                 Some(Commands::Bootstrap) => Action::Bootstrap,
                 Some(Commands::Config) => Action::ShowConfig,
-                Some(Commands::Feedback) => Action::OpenFeedback,
+                Some(Commands::Feedback {
+                    bug,
+                    feature,
+                    description,
+                }) => Action::OpenFeedback {
+                    feedback_type: parse_feedback_type(bug, feature),
+                    description,
+                },
                 Some(Commands::Login) => Action::Login,
                 Some(Commands::Logout) => Action::Logout,
                 Some(Commands::Whoami) => Action::Whoami,
@@ -226,7 +246,14 @@ pub fn parse() -> (Action, LogLevel) {
                 },
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSelfHelp,
-                    Some(SelfCommands::Feedback) => Action::OpenFeedback,
+                    Some(SelfCommands::Feedback {
+                        bug,
+                        feature,
+                        description,
+                    }) => Action::OpenFeedback {
+                        feedback_type: parse_feedback_type(bug, feature),
+                        description,
+                    },
                     Some(SelfCommands::Update { yes, check, list }) => {
                         if check {
                             Action::CheckForUpdate
@@ -242,6 +269,16 @@ pub fn parse() -> (Action, LogLevel) {
             (action, level)
         }
         Err(e) => handle_parse_error(e),
+    }
+}
+
+fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
+    if bug {
+        Some(FeedbackType::Bug)
+    } else if feature {
+        Some(FeedbackType::Feature)
+    } else {
+        None
     }
 }
 
@@ -372,7 +409,19 @@ enum Commands {
     Config,
 
     /// Open the feedback form
-    Feedback,
+    Feedback {
+        /// Report a bug
+        #[arg(long, conflicts_with = "feature")]
+        bug: bool,
+
+        /// Request a feature
+        #[arg(long, conflicts_with = "bug")]
+        feature: bool,
+
+        /// Pre-fill the description
+        #[arg(short, long)]
+        description: Option<String>,
+    },
 
     /// Log in to Anaconda
     Login,
@@ -424,7 +473,19 @@ enum AuthCommands {
 #[derive(Subcommand)]
 enum SelfCommands {
     /// Open the feedback form
-    Feedback,
+    Feedback {
+        /// Report a bug
+        #[arg(long, conflicts_with = "feature")]
+        bug: bool,
+
+        /// Request a feature
+        #[arg(long, conflicts_with = "bug")]
+        feature: bool,
+
+        /// Pre-fill the description
+        #[arg(short, long)]
+        description: Option<String>,
+    },
 
     /// Update ana to the latest version
     Update {
@@ -442,11 +503,33 @@ enum SelfCommands {
     },
 }
 
-fn open_feedback() {
+fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>) {
+    let mut params = vec![("usp", "pp_url".to_string())];
+
+    if let Some(ft) = feedback_type {
+        let type_value = match ft {
+            FeedbackType::Bug => "Bug",
+            FeedbackType::Feature => "Feature / Enhancement request",
+        };
+        params.push(("entry.4106043", type_value.to_string()));
+    }
+
+    if let Some(desc) = description {
+        params.push(("entry.1043077041", desc));
+    }
+
+    let query_string: String = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let url = format!("{}?{}", FEEDBACK_BASE_URL, query_string);
+
     println!("Opening feedback form...");
-    if let Err(e) = webbrowser::open(FEEDBACK_URL) {
+    if let Err(e) = webbrowser::open(&url) {
         eprintln!("Failed to open browser: {}", e);
-        println!("Please visit: {}", FEEDBACK_URL);
+        println!("Please visit: {}", url);
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -471,7 +471,6 @@ enum Commands {
         feature: bool,
 
         /// Pre-fill the description
-        #[arg(short, long)]
         description: Option<String>,
     },
 
@@ -536,7 +535,6 @@ enum SelfCommands {
         feature: bool,
 
         /// Pre-fill the description
-        #[arg(short, long)]
         description: Option<String>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -227,15 +227,6 @@ pub fn parse() -> (Action, LogLevel) {
                 None => Action::ShowHelp,
                 Some(Commands::Bootstrap) => Action::Bootstrap,
                 Some(Commands::Config) => Action::ShowConfig,
-                #[cfg(feature = "feedback")]
-                Some(Commands::Feedback {
-                    bug,
-                    feature,
-                    description,
-                }) => Action::OpenFeedback {
-                    feedback_type: feedback::parse_feedback_type(bug, feature),
-                    description,
-                },
                 Some(Commands::Login) => Action::Login,
                 Some(Commands::Logout) => Action::Logout,
                 Some(Commands::Whoami) => Action::Whoami,
@@ -304,11 +295,6 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
 }
 
 pub fn print_main_help() {
-    let feedback_line = if cfg!(feature = "feedback") {
-        "  feedback       Open the feedback form\n"
-    } else {
-        ""
-    };
     println!(
         "ana {VERSION}
 
@@ -318,7 +304,7 @@ Commands:
   auth           Authentication commands
   bootstrap      Install the Anaconda CLI
   config         Show current configuration
-{feedback_line}  login          Log in to Anaconda
+  login          Log in to Anaconda
   logout         Log out from Anaconda
   org            Interact with anaconda.org
   whoami         Display information about the logged-in user
@@ -402,21 +388,6 @@ enum Commands {
 
     /// Show current configuration
     Config,
-
-    /// Open the feedback form
-    #[cfg(feature = "feedback")]
-    Feedback {
-        /// Report a bug
-        #[arg(long, conflicts_with = "feature")]
-        bug: bool,
-
-        /// Request a feature
-        #[arg(long, conflicts_with = "bug")]
-        feature: bool,
-
-        /// Pre-fill the description
-        description: Option<String>,
-    },
 
     /// Log in to Anaconda
     Login,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,11 +110,15 @@ pub enum Action {
     Logout,
     ShowApiKey,
     Whoami,
-    Update { force: bool },
+    Update {
+        force: bool,
+    },
     CheckForUpdate,
     ShowAvailableVersions,
     Bootstrap,
-    OrgProxy { args: Vec<String> },
+    OrgProxy {
+        args: Vec<String>,
+    },
     #[cfg(feature = "feedback")]
     OpenFeedback {
         feedback_type: Option<FeedbackType>,
@@ -578,10 +582,9 @@ fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String
 
     let url = format!("{}?{}", FEEDBACK_BASE_URL, query_string);
 
-    println!("Opening feedback form...");
+    println!("Opening feedback form: {}", url);
     if let Err(e) = webbrowser::open(&url) {
         eprintln!("Failed to open browser: {}", e);
-        println!("Please visit: {}", url);
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,12 +7,12 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use opentelemetry::Value;
 
-#[cfg(feature = "feedback")]
-use crate::FEEDBACK_BASE_URL;
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
 use crate::config::{self, Config};
+#[cfg(feature = "feedback")]
+use crate::feedback::{self, FeedbackType};
 use crate::update;
 
 /// Log level for tracing output.
@@ -89,14 +89,6 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
     }
 
     tracing_subscriber::EnvFilter::new(level.as_filter_str())
-}
-
-/// Feedback type for the feedback form
-#[cfg(feature = "feedback")]
-#[derive(Clone, Copy)]
-pub enum FeedbackType {
-    Bug,
-    Feature,
 }
 
 /// Action to be performed, returned by parse()
@@ -218,7 +210,7 @@ impl Action {
                 feedback_type,
                 description,
             } => {
-                open_feedback(feedback_type, description);
+                feedback::open_feedback(feedback_type, description);
                 Ok(())
             }
         }
@@ -241,7 +233,7 @@ pub fn parse() -> (Action, LogLevel) {
                     feature,
                     description,
                 }) => Action::OpenFeedback {
-                    feedback_type: parse_feedback_type(bug, feature),
+                    feedback_type: feedback::parse_feedback_type(bug, feature),
                     description,
                 },
                 Some(Commands::Login) => Action::Login,
@@ -262,7 +254,7 @@ pub fn parse() -> (Action, LogLevel) {
                         feature,
                         description,
                     }) => Action::OpenFeedback {
-                        feedback_type: parse_feedback_type(bug, feature),
+                        feedback_type: feedback::parse_feedback_type(bug, feature),
                         description,
                     },
                     Some(SelfCommands::Update { yes, check, list }) => {
@@ -280,17 +272,6 @@ pub fn parse() -> (Action, LogLevel) {
             (action, level)
         }
         Err(e) => handle_parse_error(e),
-    }
-}
-
-#[cfg(feature = "feedback")]
-fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
-    if bug {
-        Some(FeedbackType::Bug)
-    } else if feature {
-        Some(FeedbackType::Feature)
-    } else {
-        None
     }
 }
 
@@ -322,88 +303,47 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
     e.exit();
 }
 
-#[cfg(feature = "feedback")]
 pub fn print_main_help() {
+    let feedback_line = if cfg!(feature = "feedback") {
+        "  feedback       Open the feedback form\n"
+    } else {
+        ""
+    };
     println!(
-        "{}",
-        formatdoc! {"
-        ana {VERSION}
+        "ana {VERSION}
 
-        Usage: ana [command] [options]
+Usage: ana [command] [options]
 
-        Commands:
-          auth           Authentication commands
-          bootstrap      Install the Anaconda CLI
-          config         Show current configuration
-          feedback       Open the feedback form
-          login          Log in to Anaconda
-          logout         Log out from Anaconda
-          org            Interact with anaconda.org
-          whoami         Display information about the logged-in user
-          self           Manage the ana installation
+Commands:
+  auth           Authentication commands
+  bootstrap      Install the Anaconda CLI
+  config         Show current configuration
+{feedback_line}  login          Log in to Anaconda
+  logout         Log out from Anaconda
+  org            Interact with anaconda.org
+  whoami         Display information about the logged-in user
+  self           Manage the ana installation
 
-        Options:
-          -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
-          -V, --version  Print version
-          -h, --help     Print help
-        "}
+Options:
+  -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
+  -V, --version  Print version
+  -h, --help     Print help"
     );
 }
 
-#[cfg(not(feature = "feedback"))]
-pub fn print_main_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        ana {VERSION}
-
-        Usage: ana [command] [options]
-
-        Commands:
-          auth           Authentication commands
-          bootstrap      Install the Anaconda CLI
-          config         Show current configuration
-          login          Log in to Anaconda
-          logout         Log out from Anaconda
-          org            Interact with anaconda.org
-          whoami         Display information about the logged-in user
-          self           Manage the ana installation
-
-        Options:
-          -V, --version  Print version
-          -h, --help     Print help
-        "}
-    );
-}
-
-#[cfg(feature = "feedback")]
 pub fn print_self_help() {
+    let feedback_line = if cfg!(feature = "feedback") {
+        "  feedback  Open the feedback form\n"
+    } else {
+        ""
+    };
     println!(
-        "{}",
-        formatdoc! {"
-        Manage the installation
+        "Manage the installation
 
-        Usage: ana self <command> [options]
+Usage: ana self <command> [options]
 
-        Commands:
-          feedback  Open the feedback form
-          update    Update ana to the latest version
-        "}
-    );
-}
-
-#[cfg(not(feature = "feedback"))]
-pub fn print_self_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        Manage the installation
-
-        Usage: ana self <command> [options]
-
-        Commands:
-          update    Update ana to the latest version
-        "}
+Commands:
+{feedback_line}  update    Update ana to the latest version"
     );
 }
 
@@ -556,36 +496,6 @@ enum SelfCommands {
         #[arg(long, conflicts_with_all = ["yes", "check"])]
         list: bool,
     },
-}
-
-#[cfg(feature = "feedback")]
-fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>) {
-    let mut params = vec![("usp", "pp_url".to_string())];
-
-    if let Some(ft) = feedback_type {
-        let type_value = match ft {
-            FeedbackType::Bug => "Bug",
-            FeedbackType::Feature => "Feature / Enhancement request",
-        };
-        params.push(("entry.1875536722", type_value.to_string()));
-    }
-
-    if let Some(desc) = description {
-        params.push(("entry.949440629", desc));
-    }
-
-    let query_string: String = params
-        .iter()
-        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-        .collect::<Vec<_>>()
-        .join("&");
-
-    let url = format!("{}?{}", FEEDBACK_BASE_URL, query_string);
-
-    println!("Opening feedback form: {}", url);
-    if let Err(e) = webbrowser::open(&url) {
-        eprintln!("Failed to open browser: {}", e);
-    }
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,6 +226,7 @@ pub fn parse() -> (Action, LogLevel) {
                 },
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSelfHelp,
+                    Some(SelfCommands::Feedback) => Action::OpenFeedback,
                     Some(SelfCommands::Update { yes, check, list }) => {
                         if check {
                             Action::CheckForUpdate
@@ -308,6 +309,7 @@ pub fn print_self_help() {
         Usage: ana self <command> [options]
 
         Commands:
+          feedback  Open the feedback form
           update    Update ana to the latest version
         "}
     );
@@ -421,6 +423,9 @@ enum AuthCommands {
 
 #[derive(Subcommand)]
 enum SelfCommands {
+    /// Open the feedback form
+    Feedback,
+
     /// Update ana to the latest version
     Update {
         /// Skip confirmation prompt

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -511,11 +511,11 @@ fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String
             FeedbackType::Bug => "Bug",
             FeedbackType::Feature => "Feature / Enhancement request",
         };
-        params.push(("entry.4106043", type_value.to_string()));
+        params.push(("entry.1875536722", type_value.to_string()));
     }
 
     if let Some(desc) = description {
-        params.push(("entry.1043077041", desc));
+        params.push(("entry.949440629", desc));
     }
 
     let query_string: String = params

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -296,40 +296,47 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
 
 pub fn print_main_help() {
     println!(
-        "ana {VERSION}
+        "{}",
+        formatdoc! {"
+        ana {VERSION}
 
-Usage: ana [command] [options]
+        Usage: ana [command] [options]
 
-Commands:
-  auth           Authentication commands
-  bootstrap      Install the Anaconda CLI
-  config         Show current configuration
-  login          Log in to Anaconda
-  logout         Log out from Anaconda
-  org            Interact with anaconda.org
-  whoami         Display information about the logged-in user
-  self           Manage the ana installation
+        Commands:
+          auth           Authentication commands
+          bootstrap      Install the Anaconda CLI
+          config         Show current configuration
+          login          Log in to Anaconda
+          logout         Log out from Anaconda
+          org            Interact with anaconda.org
+          whoami         Display information about the logged-in user
+          self           Manage the ana installation
 
-Options:
-  -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
-  -V, --version  Print version
-  -h, --help     Print help"
+        Options:
+          -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
+          -V, --version  Print version
+          -h, --help     Print help
+        "}
     );
 }
 
 pub fn print_self_help() {
     let feedback_line = if cfg!(feature = "feedback") {
-        "  feedback  Open the feedback form\n"
+        "feedback  Open the feedback form\n  "
     } else {
-        ""
+        "  "
     };
     println!(
-        "Manage the installation
+        "{}",
+        formatdoc! {"
+        Manage the installation
 
-Usage: ana self <command> [options]
+        Usage: ana self <command> [options]
 
-Commands:
-{feedback_line}  update    Update ana to the latest version"
+        Commands:
+          {feedback_line}\
+          update    Update ana to the latest version
+        "}
     );
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use indoc::formatdoc;
 use opentelemetry::Value;
 
+use crate::FEEDBACK_URL;
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
@@ -105,6 +106,7 @@ pub enum Action {
     ShowAvailableVersions,
     Bootstrap,
     OrgProxy { args: Vec<String> },
+    OpenFeedback,
 }
 
 impl Action {
@@ -124,6 +126,7 @@ impl Action {
             Action::ShowAvailableVersions => "self.update.list",
             Action::Bootstrap => "bootstrap",
             Action::OrgProxy { .. } => "org",
+            Action::OpenFeedback => "feedback",
         }
     }
 
@@ -192,6 +195,10 @@ impl Action {
                 update::show_available_versions(VERSION).await;
                 Ok(())
             }
+            Action::OpenFeedback => {
+                open_feedback();
+                Ok(())
+            }
         }
     }
 }
@@ -206,6 +213,7 @@ pub fn parse() -> (Action, LogLevel) {
                 None => Action::ShowHelp,
                 Some(Commands::Bootstrap) => Action::Bootstrap,
                 Some(Commands::Config) => Action::ShowConfig,
+                Some(Commands::Feedback) => Action::OpenFeedback,
                 Some(Commands::Login) => Action::Login,
                 Some(Commands::Logout) => Action::Logout,
                 Some(Commands::Whoami) => Action::Whoami,
@@ -276,6 +284,7 @@ pub fn print_main_help() {
           auth           Authentication commands
           bootstrap      Install the Anaconda CLI
           config         Show current configuration
+          feedback       Open the feedback form
           login          Log in to Anaconda
           logout         Log out from Anaconda
           org            Interact with anaconda.org
@@ -360,6 +369,9 @@ enum Commands {
     /// Show current configuration
     Config,
 
+    /// Open the feedback form
+    Feedback,
+
     /// Log in to Anaconda
     Login,
 
@@ -423,6 +435,14 @@ enum SelfCommands {
         #[arg(long, conflicts_with_all = ["yes", "check"])]
         list: bool,
     },
+}
+
+fn open_feedback() {
+    println!("Opening feedback form...");
+    if let Err(e) = webbrowser::open(FEEDBACK_URL) {
+        eprintln!("Failed to open browser: {}", e);
+        println!("Please visit: {}", FEEDBACK_URL);
+    }
 }
 
 #[cfg(test)]

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,0 +1,47 @@
+const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
+
+/// Feedback type for the feedback form
+#[derive(Clone, Copy)]
+pub enum FeedbackType {
+    Bug,
+    Feature,
+}
+
+pub fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
+    if bug {
+        Some(FeedbackType::Bug)
+    } else if feature {
+        Some(FeedbackType::Feature)
+    } else {
+        None
+    }
+}
+
+pub fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>) {
+    let mut params = vec![("usp", "pp_url".to_string())];
+
+    if let Some(ft) = feedback_type {
+        let type_value = match ft {
+            FeedbackType::Bug => "Bug",
+            FeedbackType::Feature => "Feature / Enhancement request",
+        };
+        params.push(("entry.1875536722", type_value.to_string()));
+    }
+
+    if let Some(desc) = description {
+        params.push(("entry.949440629", desc));
+    }
+
+    let query_string: String = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let url = format!("{}?{}", FEEDBACK_BASE_URL, query_string);
+
+    println!("Opening feedback form: {}", url);
+    if let Err(e) = webbrowser::open(&url) {
+        eprintln!("Failed to open browser: {}", e);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ mod auth;
 mod cli;
 mod config;
 mod diagnostics;
+#[cfg(feature = "feedback")]
+mod feedback;
 mod input;
 mod paths;
 mod qr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod ua;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
-pub const FEEDBACK_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform?usp=publish-editor";
+pub const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod ua;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
+#[cfg(feature = "feedback")]
 pub const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod ua;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
+pub const FEEDBACK_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform?usp=publish-editor";
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Summary

Adds a basic feedback utility. For now, we are just capturing this with a Google form. We will either decide to remove this, or build a more direct feedback mechanism in the future.

This allows users to run:

* `ana self feedback` -> Open the form in the browser
* `ana self feedback --bug "Something broke"` -> Pre-fill the form
* `ana self feedback --feature "I have a really great idea for a new feature"` -> Pre-fill the form

The command supports the following types:

* `--bug`
* `--feature`

And supports an optional string description to fill the form.

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-366](https://anaconda.atlassian.net/browse/CLI-366)


[CLI-366]: https://anaconda.atlassian.net/browse/CLI-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ