### PR TITLE
feat: Add static user-agent string with platform identification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file_url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ version = "0.0.0"
 dependencies = [
  "anaconda-otel-rs",
  "base64",
+ "cargo-lock",
  "clap",
  "comfy-table",
  "console",
@@ -550,6 +551,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -3660,6 +3673,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -3868,6 +3885,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4390,6 +4416,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.1",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -5341,6 +5406,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 opentelemetry = "0.31.0"
 
+[build-dependencies]
+cargo-lock = "11"
+
 [dev-dependencies]
 temp-env = "0.3"
 tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -18,4 +18,24 @@ fn main() {
     // Expose build target info for Sentry tags
     let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
     println!("cargo:rustc-env=BUILD_TARGET={}", target);
+
+    // Extract rattler version from Cargo.lock for the user-agent string
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    let rattler_version =
+        extract_dep_version("Cargo.lock", "rattler").unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=RATTLER_VERSION={}", rattler_version);
+}
+
+/// Extract a dependency's resolved version from Cargo.lock.
+fn extract_dep_version(lock_path: &str, dep_name: &str) -> Option<String> {
+    let content = std::fs::read_to_string(lock_path).ok()?;
+    let mut found_name = false;
+    for line in content.lines() {
+        if line.starts_with("name = ") && line.contains(&format!("\"{}\"", dep_name)) {
+            found_name = true;
+        } else if found_name && line.starts_with("version = ") {
+            return line.split('"').nth(1).map(|s| s.to_string());
+        }
+    }
+    None
 }

--- a/build.rs
+++ b/build.rs
@@ -28,14 +28,10 @@ fn main() {
 
 /// Extract a dependency's resolved version from Cargo.lock.
 fn extract_dep_version(lock_path: &str, dep_name: &str) -> Option<String> {
-    let content = std::fs::read_to_string(lock_path).ok()?;
-    let mut found_name = false;
-    for line in content.lines() {
-        if line.starts_with("name = ") && line.contains(&format!("\"{}\"", dep_name)) {
-            found_name = true;
-        } else if found_name && line.starts_with("version = ") {
-            return line.split('"').nth(1).map(|s| s.to_string());
-        }
-    }
-    None
+    let lockfile = cargo_lock::Lockfile::load(lock_path).ok()?;
+    lockfile
+        .packages
+        .iter()
+        .find(|p| p.name.as_str() == dep_name)
+        .map(|p| p.version.to_string())
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,7 +33,7 @@ cmd = "python scripts/with_version.py cargo build --release"
 description = "Build the standalone Rust binary in release mode"
 
 [tasks.test]
-cmd = "python scripts/with_version.py cargo test"
+cmd = "python scripts/with_version.py cargo test -- --show-output"
 description = "Run the unit tests"
 
 [tasks.test-integration]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod input;
 mod paths;
 mod qr;
 mod tools;
+pub mod ua;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod input;
 mod paths;
 mod qr;
 mod tools;
-pub mod ua;
+mod ua;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");

--- a/src/ua/mod.rs
+++ b/src/ua/mod.rs
@@ -4,15 +4,18 @@
 //! platform information. The string is computed once and cached for the
 //! lifetime of the process.
 //!
-//! Format: `ana/{version} {kernel}/{release} {os}/{version} rattler/{version}`
+//! Format: `ana/{version} {platform} rattler/{version}`
 //!
 //! Example (macOS): `ana/0.1.0 Darwin/25.2.0 OSX/26.2 rattler/0.40.3`
+//! Example (Linux):  `ana/0.1.0 Linux/6.5.0 ubuntu/22.04 glibc/2.35 rattler/0.40.3`
 
 mod platform;
 
 use std::sync::LazyLock;
 
 use crate::VERSION;
+
+const RATTLER_VERSION: &str = env!("RATTLER_VERSION");
 
 /// Cached user-agent string (computed once per process).
 static USER_AGENT: LazyLock<String> = LazyLock::new(build_user_agent);
@@ -23,7 +26,12 @@ pub fn user_agent() -> &'static str {
 }
 
 fn build_user_agent() -> String {
-    format!("ana/{} {}", VERSION, platform::platform_string())
+    format!(
+        "ana/{} {} rattler/{}",
+        VERSION,
+        platform::platform_string(),
+        RATTLER_VERSION
+    )
 }
 
 #[cfg(test)]

--- a/src/ua/mod.rs
+++ b/src/ua/mod.rs
@@ -45,4 +45,11 @@ mod tests {
             ua
         );
     }
+
+    #[test]
+    fn test_user_agent_print() {
+        let ua = user_agent();
+        eprintln!("User-Agent: {}", ua);
+        assert!(!ua.is_empty());
+    }
 }

--- a/src/ua/mod.rs
+++ b/src/ua/mod.rs
@@ -1,0 +1,48 @@
+//! User-agent string construction.
+//!
+//! Produces a static user-agent string compiled from build-time and runtime
+//! platform information. The string is computed once and cached for the
+//! lifetime of the process.
+//!
+//! Format: `ana/{version} {kernel}/{release} {os}/{version} rattler/{version}`
+//!
+//! Example (macOS): `ana/0.1.0 Darwin/25.2.0 OSX/26.2 rattler/0.40.3`
+
+mod platform;
+
+use std::sync::LazyLock;
+
+use crate::VERSION;
+
+/// Cached user-agent string (computed once per process).
+static USER_AGENT: LazyLock<String> = LazyLock::new(build_user_agent);
+
+/// Return the user-agent string.
+pub fn user_agent() -> &'static str {
+    &USER_AGENT
+}
+
+fn build_user_agent() -> String {
+    format!("ana/{} {}", VERSION, platform::platform_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_agent_starts_with_ana() {
+        let ua = user_agent();
+        assert!(ua.starts_with("ana/"), "expected ana/ prefix, got: {}", ua);
+    }
+
+    #[test]
+    fn test_user_agent_contains_rattler() {
+        let ua = user_agent();
+        assert!(
+            ua.contains("rattler/"),
+            "expected rattler/ in UA, got: {}",
+            ua
+        );
+    }
+}

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -1,0 +1,175 @@
+//! Platform identification for the user-agent string.
+//!
+//! Produces: `{kernel}/{release} {os}/{version} rattler/{version}`
+
+use std::sync::LazyLock;
+
+const RATTLER_VERSION: &str = env!("RATTLER_VERSION");
+
+/// Cached platform string (computed once per process).
+static PLATFORM_STRING: LazyLock<String> = LazyLock::new(build_platform_string);
+
+/// Return the platform identification string.
+///
+/// Examples:
+///   macOS:   `Darwin/25.2.0 OSX/26.2 rattler/0.40.3`
+///   Linux:   `Linux/6.5.0 Ubuntu/22.04 rattler/0.40.3`
+///   Windows: `Windows/10.0.22631 rattler/0.40.3`
+pub fn platform_string() -> &'static str {
+    &PLATFORM_STRING
+}
+
+fn build_platform_string() -> String {
+    let mut parts = Vec::new();
+
+    let (system, release) = system_release();
+    parts.push(format!("{}/{}", system, release));
+
+    if let Some((name, version)) = os_distribution() {
+        parts.push(format!("{}/{}", name, version));
+    }
+
+    parts.push(format!("rattler/{}", RATTLER_VERSION));
+
+    parts.join(" ")
+}
+
+/// Get the kernel name and release version via libc::uname.
+#[cfg(unix)]
+fn system_release() -> (String, String) {
+    unsafe {
+        let mut info: libc::utsname = std::mem::zeroed();
+        if libc::uname(&mut info) == 0 {
+            let system = std::ffi::CStr::from_ptr(info.sysname.as_ptr())
+                .to_string_lossy()
+                .into_owned();
+            let release = std::ffi::CStr::from_ptr(info.release.as_ptr())
+                .to_string_lossy()
+                .into_owned();
+            return (system, release);
+        }
+    }
+    (std::env::consts::OS.to_string(), String::from("unknown"))
+}
+
+#[cfg(not(unix))]
+fn system_release() -> (String, String) {
+    let system = match std::env::consts::OS {
+        "windows" => "Windows",
+        other => other,
+    };
+    let release = os_version_windows().unwrap_or_else(|| "unknown".to_string());
+    (system.to_string(), release)
+}
+
+#[cfg(not(unix))]
+fn os_version_windows() -> Option<String> {
+    std::process::Command::new("cmd")
+        .args(["/C", "ver"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            let s = String::from_utf8_lossy(&out.stdout).to_string();
+            // "Microsoft Windows [Version 10.0.22631.4890]"
+            s.split('[')
+                .nth(1)?
+                .split(']')
+                .next()?
+                .strip_prefix("Version ")
+                .map(|v| v.to_string())
+        })
+}
+
+/// Get the OS distribution name and version.
+///
+/// On macOS: returns ("OSX", version) via sw_vers
+/// On Linux: returns distro info via /etc/os-release
+/// On Windows: returns None (system_release already covers it)
+fn os_distribution() -> Option<(String, String)> {
+    #[cfg(target_os = "macos")]
+    {
+        macos_version()
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        linux_distribution()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_version() -> Option<(String, String)> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if version.is_empty() {
+        return None;
+    }
+    Some(("OSX".to_string(), version))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_distribution() -> Option<(String, String)> {
+    let content = std::fs::read_to_string("/etc/os-release").ok()?;
+    let mut name = None;
+    let mut version = None;
+    for line in content.lines() {
+        if let Some(val) = line.strip_prefix("NAME=") {
+            name = Some(val.trim_matches('"').to_string());
+        } else if let Some(val) = line.strip_prefix("VERSION_ID=") {
+            version = Some(val.trim_matches('"').to_string());
+        }
+    }
+    Some((name?, version.unwrap_or_default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_string_not_empty() {
+        let s = platform_string();
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn test_system_release_reasonable() {
+        let (system, release) = system_release();
+        assert!(!system.is_empty());
+        assert!(!release.is_empty());
+        assert_ne!(release, "unknown");
+    }
+
+    #[test]
+    fn test_platform_string_contains_rattler() {
+        let s = platform_string();
+        assert!(
+            s.contains("rattler/"),
+            "expected rattler/ in platform string, got: {}",
+            s
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_includes_osx() {
+        let s = platform_string();
+        assert!(s.contains("Darwin/"), "expected Darwin/, got: {}", s);
+        assert!(s.contains("OSX/"), "expected OSX/, got: {}", s);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_includes_distro() {
+        let s = platform_string();
+        assert!(s.contains("Linux/"), "expected Linux/, got: {}", s);
+    }
+}

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -13,7 +13,7 @@ static PLATFORM_STRING: LazyLock<String> = LazyLock::new(build_platform_string);
 ///
 /// Examples:
 ///   macOS:   `Darwin/25.2.0 OSX/26.2 rattler/0.40.3`
-///   Linux:   `Linux/6.5.0 Ubuntu/22.04 rattler/0.40.3`
+///   Linux:   `Linux/6.5.0 ubuntu/22.04 glibc/2.35 rattler/0.40.3`
 ///   Windows: `Windows/10.0.22631 rattler/0.40.3`
 pub fn platform_string() -> &'static str {
     &PLATFORM_STRING
@@ -27,6 +27,10 @@ fn build_platform_string() -> String {
 
     if let Some((name, version)) = os_distribution() {
         parts.push(format!("{}/{}", name, version));
+    }
+
+    if let Some((family, version)) = libc_version() {
+        parts.push(format!("{}/{}", family, version));
     }
 
     parts.push(format!("rattler/{}", RATTLER_VERSION));
@@ -153,7 +157,36 @@ fn linux_distribution() -> Option<(String, String)> {
             version = Some(val.trim_matches('"').to_string());
         }
     }
-    Some((name?, version.unwrap_or_default()))
+    Some((name?.to_lowercase(), version.unwrap_or_default()))
+}
+
+/// Get the C library family and version.
+///
+/// On Linux (glibc): returns ("glibc", version) via gnu_get_libc_version().
+/// On other platforms: returns None.
+fn libc_version() -> Option<(String, String)> {
+    #[cfg(target_os = "linux")]
+    {
+        linux_libc_version()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_libc_version() -> Option<(String, String)> {
+    unsafe {
+        let ver = std::ffi::CStr::from_ptr(libc::gnu_get_libc_version())
+            .to_string_lossy()
+            .into_owned();
+        if ver.is_empty() {
+            return None;
+        }
+        Some(("glibc".to_string(), ver))
+    }
 }
 
 #[cfg(test)]
@@ -197,5 +230,12 @@ mod tests {
     fn test_linux_includes_distro() {
         let s = platform_string();
         assert!(s.contains("Linux/"), "expected Linux/, got: {}", s);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_includes_glibc() {
+        let s = platform_string();
+        assert!(s.contains("glibc/"), "expected glibc/, got: {}", s);
     }
 }

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -1,6 +1,9 @@
 //! Platform identification for the user-agent string.
 //!
-//! Produces: `{kernel}/{release} {os}/{version} rattler/{version}`
+//! Format aligns with conda's user-agent conventions where possible:
+//!   `{kernel}/{release} {os}/{version} [glibc/{version}] rattler/{version}`
+//!
+//! All platform detection uses direct syscalls or file reads — no subprocesses.
 
 use std::sync::LazyLock;
 
@@ -122,7 +125,11 @@ fn os_distribution() -> Option<(String, String)> {
 
 #[cfg(target_os = "macos")]
 fn macos_version() -> Option<(String, String)> {
-    // Read from SystemVersion.plist instead of shelling out to sw_vers.
+    // Read SystemVersion.plist directly rather than shelling out to sw_vers.
+    // Note: processes linked against SDK <= 10.15 see a shimmed "10.16" here
+    // instead of the real version (11+). This doesn't affect us because we
+    // compile against a modern SDK, but conda's Python-based approach needs
+    // a sw_vers fallback for that reason.
     let content =
         std::fs::read_to_string("/System/Library/CoreServices/SystemVersion.plist").ok()?;
     let version = parse_plist_key(&content, "ProductVersion")?;
@@ -147,6 +154,9 @@ fn parse_plist_key(xml: &str, key: &str) -> Option<String> {
 
 #[cfg(target_os = "linux")]
 fn linux_distribution() -> Option<(String, String)> {
+    // Reads /etc/os-release directly. conda uses the `distro` Python package
+    // which has additional fallbacks (/etc/lsb-release, distro-specific files),
+    // but /etc/os-release is standard on all modern distros.
     let content = std::fs::read_to_string("/etc/os-release").ok()?;
     let mut name = None;
     let mut version = None;
@@ -157,6 +167,7 @@ fn linux_distribution() -> Option<(String, String)> {
             version = Some(val.trim_matches('"').to_string());
         }
     }
+    // Lowercase to match conda's distro.id() convention (e.g. "ubuntu" not "Ubuntu").
     Some((name?.to_lowercase(), version.unwrap_or_default()))
 }
 
@@ -178,6 +189,8 @@ fn libc_version() -> Option<(String, String)> {
 
 #[cfg(target_os = "linux")]
 fn linux_libc_version() -> Option<(String, String)> {
+    // Assumes glibc. musl-based distros (Alpine) won't have this symbol,
+    // but the libc crate's gnu_get_libc_version binding handles that gracefully.
     unsafe {
         let ver = std::ffi::CStr::from_ptr(libc::gnu_get_libc_version())
             .to_string_lossy()

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -140,6 +140,9 @@ mod tests {
         let (system, release) = system_release();
         assert!(!system.is_empty());
         assert!(!release.is_empty());
+        // On Unix, uname always provides a real release string.
+        // On Windows we return "unknown" without a winapi crate.
+        #[cfg(unix)]
         assert_ne!(release, "unknown");
     }
 

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -58,26 +58,9 @@ fn system_release() -> (String, String) {
         "windows" => "Windows",
         other => other,
     };
-    let release = os_version_windows().unwrap_or_else(|| "unknown".to_string());
-    (system.to_string(), release)
-}
-
-#[cfg(not(unix))]
-fn os_version_windows() -> Option<String> {
-    std::process::Command::new("cmd")
-        .args(["/C", "ver"])
-        .output()
-        .ok()
-        .and_then(|out| {
-            let s = String::from_utf8_lossy(&out.stdout).to_string();
-            // "Microsoft Windows [Version 10.0.22631.4890]"
-            s.split('[')
-                .nth(1)?
-                .split(']')
-                .next()?
-                .strip_prefix("Version ")
-                .map(|v| v.to_string())
-        })
+    // Without winapi/windows-sys we can't query the version without a subprocess.
+    // Use "unknown" for now; revisit if Windows support becomes a priority.
+    (system.to_string(), "unknown".to_string())
 }
 
 /// Get the OS distribution name and version.
@@ -104,15 +87,27 @@ fn os_distribution() -> Option<(String, String)> {
 
 #[cfg(target_os = "macos")]
 fn macos_version() -> Option<(String, String)> {
-    let output = std::process::Command::new("sw_vers")
-        .arg("-productVersion")
-        .output()
-        .ok()?;
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if version.is_empty() {
-        return None;
-    }
+    // Read from SystemVersion.plist instead of shelling out to sw_vers.
+    let content =
+        std::fs::read_to_string("/System/Library/CoreServices/SystemVersion.plist").ok()?;
+    let version = parse_plist_key(&content, "ProductVersion")?;
     Some(("OSX".to_string(), version))
+}
+
+/// Extract a string value for `key` from a simple XML plist.
+#[cfg(target_os = "macos")]
+fn parse_plist_key(xml: &str, key: &str) -> Option<String> {
+    let mut lines = xml.lines();
+    while let Some(line) = lines.next() {
+        if line.trim() == format!("<key>{}</key>", key) {
+            let val_line = lines.next()?.trim().to_string();
+            return val_line
+                .strip_prefix("<string>")
+                .and_then(|s| s.strip_suffix("</string>"))
+                .map(|s| s.to_string());
+        }
+    }
+    None
 }
 
 #[cfg(target_os = "linux")]

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -78,7 +78,7 @@ fn system_release() -> (String, String) {
 
     unsafe {
         #[link(name = "ntdll")]
-        extern "system" {
+        unsafe extern "system" {
             fn RtlGetVersion(lp_version_information: *mut OsVersionInfoExW) -> i32;
         }
 

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -1,13 +1,11 @@
 //! Platform identification for the user-agent string.
 //!
 //! Format aligns with conda's user-agent conventions where possible:
-//!   `{kernel}/{release} {os}/{version} [glibc/{version}] rattler/{version}`
+//!   `{kernel}/{release} [{os}/{version}] [glibc/{version}]`
 //!
 //! All platform detection uses direct syscalls or file reads — no subprocesses.
 
 use std::sync::LazyLock;
-
-const RATTLER_VERSION: &str = env!("RATTLER_VERSION");
 
 /// Cached platform string (computed once per process).
 static PLATFORM_STRING: LazyLock<String> = LazyLock::new(build_platform_string);
@@ -15,9 +13,9 @@ static PLATFORM_STRING: LazyLock<String> = LazyLock::new(build_platform_string);
 /// Return the platform identification string.
 ///
 /// Examples:
-///   macOS:   `Darwin/25.2.0 OSX/26.2 rattler/0.40.3`
-///   Linux:   `Linux/6.5.0 ubuntu/22.04 glibc/2.35 rattler/0.40.3`
-///   Windows: `Windows/10.0.22631 rattler/0.40.3`
+///   macOS:   `Darwin/25.2.0 OSX/26.2`
+///   Linux:   `Linux/6.5.0 ubuntu/22.04 glibc/2.35`
+///   Windows: `Windows/10.0.22631`
 pub fn platform_string() -> &'static str {
     &PLATFORM_STRING
 }
@@ -35,8 +33,6 @@ fn build_platform_string() -> String {
     if let Some((family, version)) = libc_version() {
         parts.push(format!("{}/{}", family, version));
     }
-
-    parts.push(format!("rattler/{}", RATTLER_VERSION));
 
     parts.join(" ")
 }
@@ -218,16 +214,6 @@ mod tests {
         assert!(!system.is_empty());
         assert!(!release.is_empty());
         assert_ne!(release, "unknown");
-    }
-
-    #[test]
-    fn test_platform_string_contains_rattler() {
-        let s = platform_string();
-        assert!(
-            s.contains("rattler/"),
-            "expected rattler/ in platform string, got: {}",
-            s
-        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src/ua/platform.rs
+++ b/src/ua/platform.rs
@@ -52,20 +52,51 @@ fn system_release() -> (String, String) {
     (std::env::consts::OS.to_string(), String::from("unknown"))
 }
 
+/// Get the Windows version via RtlGetVersion (ntdll.dll FFI, no crate needed).
+///
+/// Unlike GetVersionEx, RtlGetVersion is not subject to the compatibility
+/// shim that lies about the version on Windows 8.1+.
 #[cfg(not(unix))]
 fn system_release() -> (String, String) {
-    let system = match std::env::consts::OS {
-        "windows" => "Windows",
-        other => other,
-    };
-    // Without winapi/windows-sys we can't query the version without a subprocess.
-    // Use "unknown" for now; revisit if Windows support becomes a priority.
-    (system.to_string(), "unknown".to_string())
+    #[repr(C)]
+    struct OsVersionInfoExW {
+        os_version_info_size: u32,
+        major_version: u32,
+        minor_version: u32,
+        build_number: u32,
+        platform_id: u32,
+        csd_version: [u16; 128],
+        service_pack_major: u16,
+        service_pack_minor: u16,
+        suite_mask: u16,
+        product_type: u8,
+        reserved: u8,
+    }
+
+    unsafe {
+        #[link(name = "ntdll")]
+        extern "system" {
+            fn RtlGetVersion(lp_version_information: *mut OsVersionInfoExW) -> i32;
+        }
+
+        let mut info: OsVersionInfoExW = std::mem::zeroed();
+        info.os_version_info_size = std::mem::size_of::<OsVersionInfoExW>() as u32;
+
+        if RtlGetVersion(&mut info) == 0 {
+            let release = format!(
+                "{}.{}.{}",
+                info.major_version, info.minor_version, info.build_number
+            );
+            return ("Windows".to_string(), release);
+        }
+    }
+
+    ("Windows".to_string(), "unknown".to_string())
 }
 
 /// Get the OS distribution name and version.
 ///
-/// On macOS: returns ("OSX", version) via sw_vers
+/// On macOS: returns ("OSX", version) via SystemVersion.plist
 /// On Linux: returns distro info via /etc/os-release
 /// On Windows: returns None (system_release already covers it)
 fn os_distribution() -> Option<(String, String)> {
@@ -140,9 +171,6 @@ mod tests {
         let (system, release) = system_release();
         assert!(!system.is_empty());
         assert!(!release.is_empty());
-        // On Unix, uname always provides a real release string.
-        // On Windows we return "unknown" without a winapi crate.
-        #[cfg(unix)]
         assert_ne!(release, "unknown");
     }
 


### PR DESCRIPTION
## Motivation

Without a user-agent string, Cloudflare's heuristics sometimes classify our HTTP requests as malicious and block them. Adding a descriptive UA string prevents this.

## Summary

- Add a static user-agent string: `ana/{version} {platform} rattler/{version}`
- Platform detection aligns with conda's user-agent conventions (kernel, OS distribution, glibc)
- All detection uses direct syscalls or file reads — no subprocesses
- Rattler version extracted from `Cargo.lock` at compile time via `build.rs`
- String computed once per process via `LazyLock` and exposed as `ua::user_agent()`

## CI output

```
Linux:   ana/0.0.6.dev15 Linux/6.17.0-1008-azure ubuntu/24.04 glibc/2.39 rattler/0.40.3
macOS:   ana/0.0.6.dev15 Darwin/24.6.0 OSX/15.7.4 rattler/0.40.3
Windows: ana/0.0.6.dev15 Windows/10.0.26100 rattler/0.40.3
```

## Test plan

- [x] `cargo test` — all tests pass on Linux, macOS, and Windows
- [x] CI green on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
