### PR TITLE
fix: Ensure `SENTRY_DSN` properly injected during build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,8 @@ jobs:
           pixi-version: v0.66.0
 
       - name: Run tests
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run test
 
@@ -57,6 +59,8 @@ jobs:
           pixi run build-release
 
       - name: Run integration tests
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run test-integration
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
   build-and-test:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,14 +38,10 @@ jobs:
           pixi-version: v0.66.0
 
       - name: Run tests
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run test
 
       - name: Verify SENTRY_DSN is set
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         shell: bash
         run: |
           if [ -n "$SENTRY_DSN" ]; then
@@ -53,15 +51,11 @@ jobs:
           fi
 
       - name: Build as standalone binary
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           cargo clean
           pixi run build-release
 
       - name: Run integration tests
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run test-integration
 
@@ -75,6 +69,8 @@ jobs:
   build-conda:
     name: Build Conda (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,8 +91,6 @@ jobs:
           pixi-version: v0.66.0
 
       - name: Verify SENTRY_DSN is set
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         shell: bash
         run: |
           if [ -n "$SENTRY_DSN" ]; then
@@ -106,8 +100,6 @@ jobs:
           fi
 
       - name: Build as conda package
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           pixi run build-conda
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,15 +41,6 @@ jobs:
         run: |
           pixi run test
 
-      - name: Verify SENTRY_DSN is set
-        shell: bash
-        run: |
-          if [ -n "$SENTRY_DSN" ]; then
-            echo "SENTRY_DSN is set (length: ${#SENTRY_DSN})"
-          else
-            echo "WARNING: SENTRY_DSN is empty or not set"
-          fi
-
       - name: Build as standalone binary
         run: |
           cargo clean
@@ -89,15 +80,6 @@ jobs:
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           pixi-version: v0.66.0
-
-      - name: Verify SENTRY_DSN is set
-        shell: bash
-        run: |
-          if [ -n "$SENTRY_DSN" ]; then
-            echo "SENTRY_DSN is set (length: ${#SENTRY_DSN})"
-          else
-            echo "WARNING: SENTRY_DSN is empty or not set"
-          fi
 
       - name: Build as conda package
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          cargo clean
           pixi run build-release
 
       - name: Run integration tests

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
     // Sentry DSN is injected at build time. If not set, defaults to empty string
     // which will disable Sentry at runtime.
     let sentry_dsn = std::env::var("SENTRY_DSN").unwrap_or_default();
+    println!("cargo:warning=SENTRY_DSN length: {}", sentry_dsn.len());
     println!("cargo:rustc-env=SENTRY_DSN={}", sentry_dsn);
 
     // Expose build target info for Sentry tags

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,6 @@ fn main() {
     // Sentry DSN is injected at build time. If not set, defaults to empty string
     // which will disable Sentry at runtime.
     let sentry_dsn = std::env::var("SENTRY_DSN").unwrap_or_default();
-    println!("cargo:warning=SENTRY_DSN length: {}", sentry_dsn.len());
     println!("cargo:rustc-env=SENTRY_DSN={}", sentry_dsn);
 
     // Expose build target info for Sentry tags


### PR DESCRIPTION
## Summary

Fixes SENTRY_DSN not being embedded in release binaries.

**Root cause:** The test step ran `cargo test` without `SENTRY_DSN` set, which compiled the binary without the DSN. Even though `build.rs` has `cargo:rerun-if-env-changed=SENTRY_DSN`, cargo's incremental compilation didn't properly rebuild when the env var was later set for the release build.

**Fix:**
- Set `SENTRY_DSN` at the job level so all steps have access to it
- Run `cargo clean` before the release build to ensure a fresh compilation

Also removes the debug verify steps and build.rs warning that were used to diagnose the issue.

## Test plan
- [x] CI shows `SENTRY_DSN length: 95` for all cargo invocations
- [ ] After merge, verify release binary contains the DSN: `strings ana | grep -E "https://.*@.*sentry"`
