### PR TITLE
fix: Add user-agent to all HTTP clients and enable bootstrap CI tests

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -45,6 +45,7 @@ impl ApiClient {
         }
 
         let client = reqwest::Client::builder()
+            .user_agent(crate::ua::user_agent())
             .timeout(REQUEST_TIMEOUT)
             .default_headers(default_headers)
             .build()?;
@@ -112,6 +113,7 @@ pub async fn login() -> Result<(), AuthError> {
     // URLs from openid-configuration etc.
     let config = Config::load();
     let client = reqwest::Client::builder()
+        .user_agent(crate::ua::user_agent())
         .timeout(REQUEST_TIMEOUT)
         .build()?;
 

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -178,6 +178,7 @@ fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Re
 /// Create an HTTP client for downloading packages.
 fn make_download_client() -> reqwest_middleware::ClientWithMiddleware {
     let client = reqwest::Client::builder()
+        .user_agent(crate::ua::user_agent())
         .no_gzip()
         .build()
         .expect("failed to create HTTP client");

--- a/src/update.rs
+++ b/src/update.rs
@@ -18,7 +18,7 @@ fn github_client() -> Result<reqwest::Client, Error> {
         }
     };
     reqwest::Client::builder()
-        .user_agent("ana-cli")
+        .user_agent(crate::ua::user_agent())
         .default_headers({
             let mut headers = reqwest::header::HeaderMap::new();
             headers.insert(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,20 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 from pathlib import Path
 
-import pytest
 from conftest import AnaRunner
-
-# Skip tests that require downloading from repo.anaconda.com in CI
-# GitHub Actions runners get 403 Forbidden from the Anaconda repository
-requires_anaconda_repo = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Requires authenticated access to repo.anaconda.com",
-)
 
 
 class TestHelp:
@@ -176,7 +167,6 @@ class TestBootstrap:
         assert "bootstrap" in result.stdout
         assert "Install the Anaconda CLI" in result.stdout
 
-    @requires_anaconda_repo
     def test_bootstrap_installs_anaconda_cli(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
@@ -190,7 +180,6 @@ class TestBootstrap:
         assert tool_dir.exists(), f"Tool directory not found: {tool_dir}"
         assert tool_dir.is_dir()
 
-    @requires_anaconda_repo
     def test_bootstrap_creates_symlinked_binary(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
@@ -203,7 +192,6 @@ class TestBootstrap:
         assert bin_path.exists(), f"Binary not found: {bin_path}"
         assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
 
-    @requires_anaconda_repo
     def test_bootstrap_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
@@ -221,7 +209,6 @@ class TestBootstrap:
         assert second_result.returncode == 0
         assert "already installed" in second_result.stderr
 
-    @requires_anaconda_repo
     def test_bootstrap_anaconda_binary_runs(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Several HTTP clients were missing user-agent headers. The package download client (`make_download_client()`) had no user-agent at all, causing `403 Forbidden` from `repo.anaconda.com` and breaking `ana bootstrap` in CI. The update client had a hardcoded `"ana-cli"` string instead of the standard UA. The auth clients (ApiClient and login flow) had no user-agent.

This PR adds `ua::user_agent()` to all HTTP clients and removes the `requires_anaconda_repo` CI skip marker so bootstrap tests actually run.

#90 added the `ua` module but only wired it into the static user-agent header — it missed these client construction sites.

## What changes

- `src/tools/install.rs`: Add `.user_agent(crate::ua::user_agent())` to rattler download client
- `src/update.rs`: Replace hardcoded `"ana-cli"` with `ua::user_agent()`
- `src/auth/actions.rs`: Add user-agent to ApiClient and login device-auth flow
- `tests/test_cli.py`: Remove `requires_anaconda_repo` skip decorator from 4 bootstrap tests

The following tests now run in CI:
- `test_bootstrap_installs_anaconda_cli`
- `test_bootstrap_creates_symlinked_binary`
- `test_bootstrap_already_installed`
- `test_bootstrap_anaconda_binary_runs`

## Test plan

- [x] CI passes on all platforms (macOS, Linux, Windows)
- [x] Bootstrap tests no longer skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
