### PR TITLE
feat: Add styled help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.40.4"
+version = "0.40.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a9b758727bf8da342d130a432ab0ea9d6038b5d45334b8da786b57af18c34"
+checksum = "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
 dependencies = [
  "anyhow",
  "console",
@@ -2969,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fff3f818935d482ad9924c1a3bd6a67c1c8b8d52108cfad77ca1ae238093b3"
+checksum = "1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.44.4"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d4876670a3950e8fb06afb43fbfb57bc720adb25f5d9b5d832474737e3b2f"
+checksum = "251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a"
 dependencies = [
  "ahash",
  "chrono",
@@ -3063,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5b4cf6588333d0c0085e54ad3585991484c110e6f6766048027ba57ea8d7b"
+checksum = "1aa3bf13f08eea64abc5bef5a17893359817dea93248764e25a3701057e99d6c"
 dependencies = [
  "ahash",
  "chrono",
@@ -3099,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.54"
+version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa3a564e1defa136ffec1a0759e3677b98134b1645641e97e9b49bd3f5ff785"
+checksum = "be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a"
 dependencies = [
  "chrono",
  "configparser",
@@ -3130,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce99c6891e5a7b1945319c06fc34afa9dddb9c4b14890a997db5a47c1c8d5871"
+checksum = "6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3155,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079242c60d98e352409bae13227a1c587fa3c5d7fd6902f4ded924a6dbcf3b41"
+checksum = "b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -3217,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbe8db04cca2f2b159c536f688176391d4883f1068b221440d99d8c92c2654d"
+checksum = "a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -3238,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "5.2.0"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c71d23b06b1b2fc3c98ccfd0b3110753509cf82fe3610f6a8e0c4439ef6016"
+checksum = "a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817"
 dependencies = [
  "chrono",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1058,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1597,7 +1597,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1922,7 +1922,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2199,7 +2199,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3530,7 +3530,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,7 +4218,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4228,7 +4228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5082,7 +5082,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,6 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "indicatif",
- "indoc",
  "libc",
  "miette",
  "opentelemetry",
@@ -1782,15 +1781,6 @@ dependencies = [
  "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 console = "0.16"
 indicatif = "0.18"
-indoc = "2"
 miette = { version = "7.6", features = ["fancy"] }
 rattler = { version = "0.40", default-features = false, features = ["indicatif"] }
 rattler_cache = { version = "0.6", default-features = false }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:22b0cd8e-7894-443b-bc19-ffd4e2e1bf6e",
+  "serialNumber": "urn:uuid:d8553b5e-90f0-4673-b946-b715d3570e6a",
   "metadata": {
-    "timestamp": "2026-04-08T15:31:40Z",
+    "timestamp": "2026-04-08T17:14:13Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -4782,37 +4782,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
-      "author": "David Tolnay <dtolnay@gmail.com>",
-      "name": "indoc",
-      "version": "2.0.7",
-      "description": "Indented document literals",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/indoc@2.0.7",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/indoc"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/dtolnay/indoc"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
       "author": "Kris Price <kris@krisprice.nz>",
       "name": "ipnet",
@@ -8438,37 +8407,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/rustls/rustls"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
-      "author": "David Tolnay <dtolnay@gmail.com>",
-      "name": "rustversion",
-      "version": "1.0.22",
-      "description": "Conditional compilation according to rustc compiler version",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/rustversion@1.0.22",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/rustversion"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/dtolnay/rustversion"
         }
       ]
     },
@@ -14491,7 +14429,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
-        "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
@@ -15115,7 +15052,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15534,7 +15471,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -15673,12 +15610,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#indoc@2.0.7",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22"
       ]
     },
     {
@@ -15893,7 +15824,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -16752,10 +16683,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustversion@1.0.22",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
@@ -17178,14 +17105,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -17859,7 +17786,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {

--- a/SBOM.json
+++ b/SBOM.json
@@ -7345,16 +7345,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler",
-      "version": "0.40.4",
+      "version": "0.40.5",
       "description": "Rust library to install conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ef6a9b758727bf8da342d130a432ab0ea9d6038b5d45334b8da786b57af18c34"
+          "content": "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
         }
       ],
       "licenses": [
@@ -7362,7 +7362,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler@0.40.4",
+      "purl": "pkg:cargo/rattler@0.40.5",
       "externalReferences": [
         {
           "type": "website",
@@ -7376,15 +7376,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.20",
       "name": "rattler_cache",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "description": "A crate to manage the caching of data in rattler",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a9fff3f818935d482ad9924c1a3bd6a67c1c8b8d52108cfad77ca1ae238093b3"
+          "content": "1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4"
         }
       ],
       "licenses": [
@@ -7392,7 +7392,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_cache@0.6.19",
+      "purl": "pkg:cargo/rattler_cache@0.6.20",
       "externalReferences": [
         {
           "type": "website",
@@ -7406,16 +7406,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_conda_types",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "description": "Rust data types for common types used within the Conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "150d4876670a3950e8fb06afb43fbfb57bc720adb25f5d9b5d832474737e3b2f"
+          "content": "251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a"
         }
       ],
       "licenses": [
@@ -7423,7 +7423,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_conda_types@0.44.4",
+      "purl": "pkg:cargo/rattler_conda_types@0.44.5",
       "externalReferences": [
         {
           "type": "website",
@@ -7468,16 +7468,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.6",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.27.5",
+      "version": "0.27.6",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "3ca5b4cf6588333d0c0085e54ad3585991484c110e6f6766048027ba57ea8d7b"
+          "content": "1aa3bf13f08eea64abc5bef5a17893359817dea93248764e25a3701057e99d6c"
         }
       ],
       "licenses": [
@@ -7485,7 +7485,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.27.5",
+      "purl": "pkg:cargo/rattler_lock@0.27.6",
       "externalReferences": [
         {
           "type": "website",
@@ -7530,16 +7530,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.55",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_menuinst",
-      "version": "0.2.54",
+      "version": "0.2.55",
       "description": "Install menu entries for a Conda package",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "bfa3a564e1defa136ffec1a0759e3677b98134b1645641e97e9b49bd3f5ff785"
+          "content": "be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a"
         }
       ],
       "licenses": [
@@ -7547,7 +7547,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_menuinst@0.2.54",
+      "purl": "pkg:cargo/rattler_menuinst@0.2.55",
       "externalReferences": [
         {
           "type": "website",
@@ -7561,16 +7561,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.8",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_networking",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "description": "Authenticated requests in the conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ce99c6891e5a7b1945319c06fc34afa9dddb9c4b14890a997db5a47c1c8d5871"
+          "content": "6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e"
         }
       ],
       "licenses": [
@@ -7578,7 +7578,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_networking@0.26.7",
+      "purl": "pkg:cargo/rattler_networking@0.26.8",
       "externalReferences": [
         {
           "type": "website",
@@ -7592,16 +7592,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.8",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_package_streaming",
-      "version": "0.24.7",
+      "version": "0.24.8",
       "description": "Extract and stream of Conda package archives",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "079242c60d98e352409bae13227a1c587fa3c5d7fd6902f4ded924a6dbcf3b41"
+          "content": "b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f"
         }
       ],
       "licenses": [
@@ -7609,7 +7609,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_package_streaming@0.24.7",
+      "purl": "pkg:cargo/rattler_package_streaming@0.24.8",
       "externalReferences": [
         {
           "type": "website",
@@ -7684,16 +7684,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.8",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_shell",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "description": "A crate to help with activation and deactivation of a conda environment",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ccbe8db04cca2f2b159c536f688176391d4883f1068b221440d99d8c92c2654d"
+          "content": "a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b"
         }
       ],
       "licenses": [
@@ -7701,7 +7701,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_shell@0.26.7",
+      "purl": "pkg:cargo/rattler_shell@0.26.8",
       "externalReferences": [
         {
           "type": "website",
@@ -7715,16 +7715,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "94c71d23b06b1b2fc3c98ccfd0b3110753509cf82fe3610f6a8e0c4439ef6016"
+          "content": "a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817"
         }
       ],
       "licenses": [
@@ -7732,7 +7732,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@5.2.0",
+      "purl": "pkg:cargo/rattler_solve@5.2.1",
       "externalReferences": [
         {
           "type": "website",
@@ -14495,10 +14495,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.20",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.6",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
@@ -16251,7 +16251,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
@@ -16269,13 +16269,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.7",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.20",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.55",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.8",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.8",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.8",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -16294,7 +16294,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.19",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.6.20",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
@@ -16306,10 +16306,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.8",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.8",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
@@ -16324,7 +16324,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
@@ -16379,7 +16379,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.5",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.27.6",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
@@ -16388,9 +16388,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
@@ -16409,7 +16409,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.54",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.55",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
@@ -16420,8 +16420,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.8",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
@@ -16437,7 +16437,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
@@ -16458,7 +16458,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.24.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
@@ -16472,9 +16472,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.26.8",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
@@ -16509,14 +16509,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.26.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
@@ -16527,12 +16527,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@5.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.2.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",

--- a/SBOM.md
+++ b/SBOM.md
@@ -261,19 +261,19 @@ Platforms: linux, macos, windows
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
-| [rattler](https://crates.io/crates/rattler) | 0.40.4 | BSD-3-Clause |  |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.19 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.4 | BSD-3-Clause |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.40.5 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.6.20 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.44.5 | BSD-3-Clause |  |  |
 | [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.2.3 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.5 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.27.6 | BSD-3-Clause |  |  |
 | [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.0.12 | BSD-3-Clause |  |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.54 | BSD-3-Clause |  |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.7 | BSD-3-Clause |  |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.7 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.55 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.26.8 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.24.8 | BSD-3-Clause |  |  |
 | [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.9 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.1.13 | BSD-3-Clause |  |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.7 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.2.0 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.26.8 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 5.2.1 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.11.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-08T15:31:40Z<br>
+Generated: 2026-04-08T17:14:13Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 465 (65 platform-specific)<br>
+Packages: 463 (65 platform-specific)<br>
 Platforms: linux, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -171,7 +171,6 @@ Platforms: linux, macos, windows
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |  |
 | [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
-| [indoc](https://crates.io/crates/indoc) | 2.0.7 | MIT OR Apache-2.0 |  |  |
 | [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |  |
 | [iri-string](https://crates.io/crates/iri-string) | 0.7.12 | MIT OR Apache-2.0 |  |  |
 | [is\_ci](https://crates.io/crates/is_ci) | 1.2.0 | ISC |  |  |
@@ -296,7 +295,6 @@ Platforms: linux, macos, windows
 | [rustls](https://crates.io/crates/rustls) | 0.23.37 | Apache-2.0 OR ISC OR MIT |  |  |
 | [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |  |
 | [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.10 | ISC |  |  |
-| [rustversion](https://crates.io/crates/rustversion) | 1.0.22 | MIT OR Apache-2.0 |  |  |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
 | [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT | windows |  |
@@ -480,7 +478,7 @@ Platforms: linux, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 252 |
+| MIT OR Apache-2.0 | 250 |
 | MIT | 95 |
 | Apache-2.0 OR MIT | 34 |
 | Apache-2.0 | 19 |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,11 +173,11 @@ impl Action {
                 Ok(())
             }
             Action::ShowSelfHelp => {
-                help::print_self_help();
+                help::print_subcommand_help(&get_subcommand("self"));
                 Ok(())
             }
             Action::ShowAuthHelp => {
-                help::print_auth_help();
+                help::print_subcommand_help(&get_subcommand("auth"));
                 Ok(())
             }
             Action::ShowVersion => {
@@ -306,6 +306,15 @@ fn get_subcommand_descriptions() -> HashMap<String, String> {
             )
         })
         .collect()
+}
+
+/// Get a subcommand's clap Command by name
+fn get_subcommand(name: &str) -> clap::Command {
+    Cli::command()
+        .get_subcommands()
+        .find(|s| s.get_name() == name)
+        .cloned()
+        .expect("subcommand should exist")
 }
 
 #[derive(Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,8 +94,7 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
 /// Action to be performed, returned by parse()
 pub enum Action {
     ShowHelp,
-    ShowSelfHelp,
-    ShowAuthHelp,
+    ShowSubcommandHelp(String),
     ShowVersion,
     ShowConfig,
     Login,
@@ -122,8 +121,7 @@ impl Action {
     fn match_action_name(&self) -> &'static str {
         match self {
             Action::ShowHelp => "help",
-            Action::ShowSelfHelp => "self.help",
-            Action::ShowAuthHelp => "auth.help",
+            Action::ShowSubcommandHelp(_) => "subcommand.help",
             Action::ShowVersion => "version",
             Action::ShowConfig => "config",
             Action::Login => "login",
@@ -172,12 +170,8 @@ impl Action {
                 help::print_help(subcommands);
                 Ok(())
             }
-            Action::ShowSelfHelp => {
-                help::print_subcommand_help(&get_subcommand("self"));
-                Ok(())
-            }
-            Action::ShowAuthHelp => {
-                help::print_subcommand_help(&get_subcommand("auth"));
+            Action::ShowSubcommandHelp(name) => {
+                help::print_subcommand_help(&get_subcommand(&name));
                 Ok(())
             }
             Action::ShowVersion => {
@@ -232,14 +226,14 @@ pub fn parse() -> (Action, LogLevel) {
                 Some(Commands::Logout) => Action::Logout,
                 Some(Commands::Whoami) => Action::Whoami,
                 Some(Commands::Auth { command }) => match command {
-                    None => Action::ShowAuthHelp,
+                    None => Action::ShowSubcommandHelp("auth".to_string()),
                     Some(AuthCommands::ApiKey) => Action::ShowApiKey,
                     Some(AuthCommands::Login) => Action::Login,
                     Some(AuthCommands::Logout) => Action::Logout,
                     Some(AuthCommands::Whoami) => Action::Whoami,
                 },
                 Some(Commands::Self_ { command }) => match command {
-                    None => Action::ShowSelfHelp,
+                    None => Action::ShowSubcommandHelp("self".to_string()),
                     #[cfg(feature = "feedback")]
                     Some(SelfCommands::Feedback {
                         bug,
@@ -267,8 +261,27 @@ pub fn parse() -> (Action, LogLevel) {
     }
 }
 
+/// Check if a string is a valid subcommand name
+fn is_valid_subcommand(name: &str) -> bool {
+    Cli::command()
+        .get_subcommands()
+        .any(|s| s.get_name() == name)
+}
+
 fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
     if e.kind() == clap::error::ErrorKind::DisplayHelp {
+        // Check if help was requested for a subcommand
+        let args: Vec<String> = std::env::args().collect();
+        if args.len() > 1 {
+            let subcommand = &args[1];
+            // Check if it's a valid subcommand (not a flag)
+            if !subcommand.starts_with('-') && is_valid_subcommand(subcommand) {
+                return (
+                    Action::ShowSubcommandHelp(subcommand.clone()),
+                    LogLevel::Off,
+                );
+            }
+        }
         return (Action::ShowHelp, LogLevel::Off);
     }
     if e.kind() == clap::error::ErrorKind::DisplayVersion {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,7 @@ use std::env::consts::{ARCH, OS};
 use std::time::Instant;
 
 use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
-use clap::{Parser, Subcommand};
-use indoc::formatdoc;
+use clap::{CommandFactory, Parser, Subcommand};
 use opentelemetry::Value;
 
 use crate::VERSION;
@@ -13,6 +12,7 @@ use crate::auth;
 use crate::config::{self, Config};
 #[cfg(feature = "feedback")]
 use crate::feedback::{self, FeedbackType};
+use crate::help;
 use crate::update;
 
 /// Log level for tracing output.
@@ -168,15 +168,16 @@ impl Action {
     async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Action::ShowHelp => {
-                print_main_help();
+                let subcommands = get_subcommand_descriptions();
+                help::print_help(subcommands);
                 Ok(())
             }
             Action::ShowSelfHelp => {
-                print_self_help();
+                help::print_self_help();
                 Ok(())
             }
             Action::ShowAuthHelp => {
-                print_auth_help();
+                help::print_auth_help();
                 Ok(())
             }
             Action::ShowVersion => {
@@ -294,67 +295,17 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
     e.exit();
 }
 
-pub fn print_main_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        ana {VERSION}
-
-        Usage: ana [command] [options]
-
-        Commands:
-          auth           Authentication commands
-          bootstrap      Install the Anaconda CLI
-          config         Show current configuration
-          login          Log in to Anaconda
-          logout         Log out from Anaconda
-          org            Interact with anaconda.org
-          whoami         Display information about the logged-in user
-          self           Manage the ana installation
-
-        Options:
-          -v, --verbose  Increase verbosity (use multiple times: -vvvvv for trace)
-          -V, --version  Print version
-          -h, --help     Print help
-        "}
-    );
-}
-
-pub fn print_self_help() {
-    let feedback_line = if cfg!(feature = "feedback") {
-        "feedback  Open the feedback form\n  "
-    } else {
-        "  "
-    };
-    println!(
-        "{}",
-        formatdoc! {"
-        Manage the installation
-
-        Usage: ana self <command> [options]
-
-        Commands:
-          {feedback_line}\
-          update    Update ana to the latest version
-        "}
-    );
-}
-
-pub fn print_auth_help() {
-    println!(
-        "{}",
-        formatdoc! {"
-        Authentication commands
-
-        Usage: ana auth <command> [options]
-
-        Commands:
-          api-key   Display the API key for the logged-in user
-          login     Log in to Anaconda
-          logout    Log out from Anaconda
-          whoami    Display information about the logged-in user
-        "}
-    );
+/// Get subcommand names and descriptions from clap for help introspection
+fn get_subcommand_descriptions() -> HashMap<String, String> {
+    Cli::command()
+        .get_subcommands()
+        .map(|s| {
+            (
+                s.get_name().to_string(),
+                s.get_about().map(|a| a.to_string()).unwrap_or_default(),
+            )
+        })
+        .collect()
 }
 
 #[derive(Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -437,4 +437,25 @@ mod tests {
         // Verify clap setup is valid
         Cli::command().debug_assert();
     }
+
+    #[test]
+    fn test_all_subcommands_in_help_sections() {
+        let cmd = Cli::command();
+        let clap_subcommands: std::collections::HashSet<_> =
+            cmd.get_subcommands().map(|s| s.get_name()).collect();
+
+        let help_section_commands: std::collections::HashSet<_> =
+            help::get_all_section_commands().into_iter().collect();
+
+        let missing: Vec<_> = clap_subcommands
+            .difference(&help_section_commands)
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "Subcommands missing from help sections: {:?}. \
+             Add them to HELP_SECTIONS in src/help/data.rs",
+            missing
+        );
+    }
 }

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -1,0 +1,39 @@
+/// Command definition for help output
+pub(super) struct HelpCommand {
+    pub(super) name: &'static str,
+}
+
+impl HelpCommand {
+    const fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+}
+
+/// Section definition for help output
+pub(super) struct HelpSection {
+    pub(super) name: &'static str,
+    pub(super) commands: &'static [HelpCommand],
+}
+
+/// Help sections with commands (only real, implemented commands)
+pub(super) const HELP_SECTIONS: &[HelpSection] = &[
+    HelpSection {
+        name: "ACCOUNT",
+        commands: &[
+            HelpCommand::new("login"),
+            HelpCommand::new("logout"),
+            HelpCommand::new("whoami"),
+            HelpCommand::new("auth"),
+        ],
+    },
+    HelpSection {
+        name: "TOOLCHAIN",
+        commands: &[HelpCommand::new("config"), HelpCommand::new("self")],
+    },
+];
+
+/// Examples for the help output (using real commands)
+pub(super) const HELP_EXAMPLES: &[(&str, &str)] = &[
+    ("Log into your Anaconda account", "ana login"),
+    ("Update ana to the latest version", "ana self update"),
+];

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -27,8 +27,16 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
         ],
     },
     HelpSection {
+        name: "PACKAGES",
+        commands: &[HelpCommand::new("org")],
+    },
+    HelpSection {
         name: "TOOLCHAIN",
-        commands: &[HelpCommand::new("config"), HelpCommand::new("self")],
+        commands: &[
+            HelpCommand::new("bootstrap"),
+            HelpCommand::new("config"),
+            HelpCommand::new("self"),
+        ],
     },
 ];
 
@@ -37,3 +45,12 @@ pub(super) const HELP_EXAMPLES: &[(&str, &str)] = &[
     ("Log into your Anaconda account", "ana login"),
     ("Update ana to the latest version", "ana self update"),
 ];
+
+/// Get all command names defined in help sections (for testing)
+#[cfg(test)]
+pub fn get_all_section_commands() -> Vec<&'static str> {
+    HELP_SECTIONS
+        .iter()
+        .flat_map(|s| s.commands.iter().map(|c| c.name))
+        .collect()
+}

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -5,6 +5,9 @@ pub(super) struct HelpSection {
 }
 
 /// Help sections with commands (only real, implemented commands)
+/// TODO(mattkram): It would be more ergonomic to define sections alongside each
+///                 subcommand but the implementation of that is complicated. For
+///                 now, assuming YAGNI and asserting inclusing via unit tests.
 pub(super) const HELP_SECTIONS: &[HelpSection] = &[
     HelpSection {
         name: "ACCOUNT",

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -1,42 +1,22 @@
-/// Command definition for help output
-pub(super) struct HelpCommand {
-    pub(super) name: &'static str,
-}
-
-impl HelpCommand {
-    const fn new(name: &'static str) -> Self {
-        Self { name }
-    }
-}
-
 /// Section definition for help output
 pub(super) struct HelpSection {
     pub(super) name: &'static str,
-    pub(super) commands: &'static [HelpCommand],
+    pub(super) commands: &'static [&'static str],
 }
 
 /// Help sections with commands (only real, implemented commands)
 pub(super) const HELP_SECTIONS: &[HelpSection] = &[
     HelpSection {
         name: "ACCOUNT",
-        commands: &[
-            HelpCommand::new("login"),
-            HelpCommand::new("logout"),
-            HelpCommand::new("whoami"),
-            HelpCommand::new("auth"),
-        ],
+        commands: &["login", "logout", "whoami", "auth"],
     },
     HelpSection {
         name: "PACKAGES",
-        commands: &[HelpCommand::new("org")],
+        commands: &["org"],
     },
     HelpSection {
         name: "TOOLCHAIN",
-        commands: &[
-            HelpCommand::new("bootstrap"),
-            HelpCommand::new("config"),
-            HelpCommand::new("self"),
-        ],
+        commands: &["bootstrap", "config", "self"],
     },
 ];
 
@@ -51,6 +31,6 @@ pub(super) const HELP_EXAMPLES: &[(&str, &str)] = &[
 pub fn get_all_section_commands() -> Vec<&'static str> {
     HELP_SECTIONS
         .iter()
-        .flat_map(|s| s.commands.iter().map(|c| c.name))
+        .flat_map(|s| s.commands.iter().copied())
         .collect()
 }

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -1,0 +1,5 @@
+mod data;
+mod styles;
+mod term;
+
+pub use term::{print_auth_help, print_help, print_self_help};

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -2,4 +2,6 @@ mod data;
 mod styles;
 mod term;
 
+#[cfg(test)]
+pub use data::get_all_section_commands;
 pub use term::{print_auth_help, print_help, print_self_help};

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -4,4 +4,4 @@ mod term;
 
 #[cfg(test)]
 pub use data::get_all_section_commands;
-pub use term::{print_auth_help, print_help, print_self_help};
+pub use term::{print_help, print_subcommand_help};

--- a/src/help/styles.rs
+++ b/src/help/styles.rs
@@ -1,0 +1,41 @@
+use console::{Color, Style};
+
+/// Convert a hex color string to a console Color
+fn hex_color(hex: &str) -> Color {
+    let hex = hex.trim_start_matches('#');
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
+    Color::TrueColor(r, g, b)
+}
+
+/// Styles for help output matching UX design
+#[allow(dead_code)]
+pub(super) enum HelpStyle {
+    Section,    // green headers
+    Command,    // blue command names
+    Desc,       // gray descriptions
+    Dim,        // dim gray for comments/hints
+    Error,      // error red
+    Warning,    // warning yellow
+    BoxBorder,  // dim border on box background
+    BoxDesc,    // light description text on box background
+    BoxCommand, // blue command text on box background
+}
+
+impl HelpStyle {
+    pub fn style(&self) -> Style {
+        let box_bg = hex_color("#161b22");
+        match self {
+            Self::Section => Style::new().fg(hex_color("#3fb950")).bold(),
+            Self::Command => Style::new().fg(hex_color("#79c0ff")),
+            Self::Desc => Style::new().fg(hex_color("#8b949e")),
+            Self::Dim => Style::new().fg(hex_color("#6e7681")),
+            Self::Error => Style::new().fg(hex_color("#f85149")),
+            Self::Warning => Style::new().fg(hex_color("#d29922")),
+            Self::BoxBorder => Style::new().fg(hex_color("#30363d")).bg(box_bg),
+            Self::BoxDesc => Style::new().fg(hex_color("#e6edf3")).bg(box_bg),
+            Self::BoxCommand => Style::new().fg(hex_color("#79c0ff")).bg(box_bg).bold(),
+        }
+    }
+}

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -156,49 +156,34 @@ pub fn print_help(subcommands: HashMap<String, String>) {
     print_footer(&term);
 }
 
-/// Help for `ana self` subcommand
-pub fn print_self_help() {
+/// Help for a subcommand (e.g., `ana self`, `ana auth`)
+pub fn print_subcommand_help(cmd: &clap::Command) {
     let term = Term::stdout();
 
-    let _ = term.write_line("Manage the ana installation");
-    let _ = term.write_line("");
+    // Description
+    if let Some(about) = cmd.get_about() {
+        let _ = term.write_line(&about.to_string());
+        let _ = term.write_line("");
+    }
+
+    // Usage
+    let name = cmd.get_name();
     let _ = term.write_line(
         &HelpStyle::Dim
             .style()
-            .apply_to("Usage: ana self <command> [options]")
+            .apply_to(format!("Usage: ana {name} <command> [options]"))
             .to_string(),
     );
     let _ = term.write_line("");
 
+    // Commands
     print_section(&term, "COMMANDS");
-    print_command_row(&term, "update", "Update ana to the latest version");
-}
-
-/// Help for `ana auth` subcommand
-pub fn print_auth_help() {
-    let term = Term::stdout();
-
-    let _ = term.write_line("Authentication commands");
-    let _ = term.write_line("");
-    let _ = term.write_line(
-        &HelpStyle::Dim
-            .style()
-            .apply_to("Usage: ana auth <command> [options]")
-            .to_string(),
-    );
-    let _ = term.write_line("");
-
-    print_section(&term, "COMMANDS");
-    print_command_row(
-        &term,
-        "api-key",
-        "Display the API key for the logged-in user",
-    );
-    print_command_row(&term, "login", "Log in to Anaconda");
-    print_command_row(&term, "logout", "Log out from Anaconda");
-    print_command_row(
-        &term,
-        "whoami",
-        "Display information about the logged-in user",
-    );
+    for subcmd in cmd.get_subcommands() {
+        let name = subcmd.get_name();
+        let desc = subcmd
+            .get_about()
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+        print_command_row(&term, name, &desc);
+    }
 }

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -114,8 +114,8 @@ fn print_section_blocks(term: &Term, subcommands: &HashMap<String, String>) {
         print_section(term, section.name);
 
         for cmd in section.commands {
-            let desc = subcommands.get(cmd.name).map(|s| s.as_str()).unwrap_or("");
-            print_command_row(term, cmd.name, desc);
+            let desc = subcommands.get(*cmd).map(|s| s.as_str()).unwrap_or("");
+            print_command_row(term, cmd, desc);
         }
 
         let _ = term.write_line("");

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -156,7 +156,7 @@ pub fn print_help(subcommands: HashMap<String, String>) {
     print_footer(&term);
 }
 
-/// Help for a subcommand (e.g., `ana self`, `ana auth`)
+/// Help for a subcommand (e.g., `ana self`, `ana auth`, `ana bootstrap`)
 pub fn print_subcommand_help(cmd: &clap::Command) {
     let term = Term::stdout();
 
@@ -166,19 +166,27 @@ pub fn print_subcommand_help(cmd: &clap::Command) {
         let _ = term.write_line("");
     }
 
-    // Usage (from clap's override or generated)
+    // Usage - render and ensure it starts with "ana "
     let usage = cmd.clone().render_usage().to_string();
+    let usage = if usage.starts_with("Usage: ana ") {
+        usage
+    } else {
+        usage.replacen("Usage: ", "Usage: ana ", 1)
+    };
     let _ = term.write_line(&HelpStyle::Dim.style().apply_to(usage).to_string());
     let _ = term.write_line("");
 
-    // Commands
-    print_section(&term, "COMMANDS");
-    for subcmd in cmd.get_subcommands() {
-        let name = subcmd.get_name();
-        let desc = subcmd
-            .get_about()
-            .map(|a| a.to_string())
-            .unwrap_or_default();
-        print_command_row(&term, name, &desc);
+    // Commands (only if there are subcommands)
+    let subcommands: Vec<_> = cmd.get_subcommands().collect();
+    if !subcommands.is_empty() {
+        print_section(&term, "COMMANDS");
+        for subcmd in subcommands {
+            let name = subcmd.get_name();
+            let desc = subcmd
+                .get_about()
+                .map(|a| a.to_string())
+                .unwrap_or_default();
+            print_command_row(&term, name, &desc);
+        }
     }
 }

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -166,14 +166,9 @@ pub fn print_subcommand_help(cmd: &clap::Command) {
         let _ = term.write_line("");
     }
 
-    // Usage
-    let name = cmd.get_name();
-    let _ = term.write_line(
-        &HelpStyle::Dim
-            .style()
-            .apply_to(format!("Usage: ana {name} <command> [options]"))
-            .to_string(),
-    );
+    // Usage (from clap's override or generated)
+    let usage = cmd.clone().render_usage().to_string();
+    let _ = term.write_line(&HelpStyle::Dim.style().apply_to(usage).to_string());
     let _ = term.write_line("");
 
     // Commands

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -1,0 +1,204 @@
+use std::collections::HashMap;
+
+use console::Term;
+
+use super::data::{HELP_EXAMPLES, HELP_SECTIONS};
+use super::styles::HelpStyle;
+use crate::VERSION;
+
+/// Print a command row: "  command      description"
+fn print_command_row(term: &Term, name: &str, desc: &str) {
+    let styled_name = HelpStyle::Command.style().apply_to(name);
+    let styled_desc = HelpStyle::Desc.style().apply_to(desc);
+    let _ = term.write_line(&format!("  {styled_name:<20} {styled_desc}"));
+}
+
+/// Print a section header
+fn print_section(term: &Term, name: &str) {
+    let _ = term.write_line(
+        &HelpStyle::Section
+            .style()
+            .apply_to(name.to_uppercase())
+            .to_string(),
+    );
+}
+
+/// Print the header at the top of the help output
+fn print_header(term: &Term) {
+    let _ = term.write_line(&format!(
+        "{} {}",
+        HelpStyle::Command.style().apply_to("ana"),
+        VERSION
+    ));
+    let tagline = "Manage your Anaconda toolchain and account.";
+    let _ = term.write_line(&HelpStyle::Desc.style().apply_to(tagline).to_string());
+    let _ = term.write_line("");
+    let _ = term.write_line(
+        &HelpStyle::Desc
+            .style()
+            .apply_to("Usage: ana [OPTIONS] COMMAND [ARGS]...")
+            .to_string(),
+    );
+    let _ = term.write_line("");
+}
+
+/// Print the examples block in a styled box with rounded corners
+fn print_examples_block(term: &Term) {
+    print_section(term, "EXAMPLES");
+
+    let margin = "  ";
+    let inner_width: usize = 76;
+    let cmd_indent = "  "; // Indent for command lines
+    let border = HelpStyle::BoxBorder.style();
+    let bg = HelpStyle::BoxDesc.style(); // For consistent background
+
+    // Box-drawing characters for rounded corners
+    let horizontal = "─";
+
+    // Top border
+    let _ = term.write_line(&format!(
+        "{margin}{}{}{}",
+        border.apply_to("╭"),
+        border.apply_to(horizontal.repeat(inner_width)),
+        border.apply_to("╮")
+    ));
+
+    // Content lines
+    for (i, (desc, command)) in HELP_EXAMPLES.iter().enumerate() {
+        // Description line (as shell comment)
+        let comment = format!("# {desc}");
+        let padding = inner_width.saturating_sub(comment.len() + 1);
+        let padded_desc = format!(" {comment}{}", " ".repeat(padding));
+        let _ = term.write_line(&format!(
+            "{margin}{}{}{}",
+            border.apply_to("│"),
+            HelpStyle::BoxDesc.style().apply_to(&padded_desc),
+            border.apply_to("│")
+        ));
+
+        // Command line (indented)
+        let cmd_with_indent = format!("{cmd_indent}{command}");
+        let padding = inner_width.saturating_sub(cmd_with_indent.len() + 1);
+        let padded_cmd = format!(" {cmd_with_indent}{}", " ".repeat(padding));
+        let _ = term.write_line(&format!(
+            "{margin}{}{}{}",
+            border.apply_to("│"),
+            HelpStyle::BoxCommand.style().apply_to(&padded_cmd),
+            border.apply_to("│")
+        ));
+
+        // Add spacing between examples (except after last)
+        if i < HELP_EXAMPLES.len() - 1 {
+            let empty_line = " ".repeat(inner_width);
+            let _ = term.write_line(&format!(
+                "{margin}{}{}{}",
+                border.apply_to("│"),
+                bg.apply_to(&empty_line),
+                border.apply_to("│")
+            ));
+        }
+    }
+
+    // Bottom border
+    let _ = term.write_line(&format!(
+        "{margin}{}{}{}",
+        border.apply_to("╰"),
+        border.apply_to(horizontal.repeat(inner_width)),
+        border.apply_to("╯")
+    ));
+    let _ = term.write_line("");
+}
+
+fn print_section_blocks(term: &Term, subcommands: &HashMap<String, String>) {
+    for section in HELP_SECTIONS {
+        print_section(term, section.name);
+
+        for cmd in section.commands {
+            let desc = subcommands.get(cmd.name).map(|s| s.as_str()).unwrap_or("");
+            print_command_row(term, cmd.name, desc);
+        }
+
+        let _ = term.write_line("");
+    }
+}
+
+fn print_options_block(term: &Term) {
+    print_section(term, "OPTIONS");
+    print_command_row(
+        term,
+        "-v, --verbose",
+        "Increase verbosity (can be repeated)",
+    );
+    print_command_row(term, "-V, --version", "Show the ana version and exit");
+    print_command_row(term, "-h, --help", "Show this message and exit");
+    let _ = term.write_line("");
+}
+
+/// Print the footer at bottom of help output
+fn print_footer(term: &Term) {
+    let _ = term.write_line(&format!(
+        "{} {}",
+        HelpStyle::Desc
+            .style()
+            .apply_to("Full documentation and guides at"),
+        HelpStyle::Section.style().apply_to("→ docs.anaconda.com"),
+    ));
+}
+
+/// Main help output
+pub fn print_help(subcommands: HashMap<String, String>) {
+    let term = Term::stdout();
+
+    print_header(&term);
+    print_examples_block(&term);
+    print_section_blocks(&term, &subcommands);
+    print_options_block(&term);
+    print_footer(&term);
+}
+
+/// Help for `ana self` subcommand
+pub fn print_self_help() {
+    let term = Term::stdout();
+
+    let _ = term.write_line("Manage the ana installation");
+    let _ = term.write_line("");
+    let _ = term.write_line(
+        &HelpStyle::Dim
+            .style()
+            .apply_to("Usage: ana self <command> [options]")
+            .to_string(),
+    );
+    let _ = term.write_line("");
+
+    print_section(&term, "COMMANDS");
+    print_command_row(&term, "update", "Update ana to the latest version");
+}
+
+/// Help for `ana auth` subcommand
+pub fn print_auth_help() {
+    let term = Term::stdout();
+
+    let _ = term.write_line("Authentication commands");
+    let _ = term.write_line("");
+    let _ = term.write_line(
+        &HelpStyle::Dim
+            .style()
+            .apply_to("Usage: ana auth <command> [options]")
+            .to_string(),
+    );
+    let _ = term.write_line("");
+
+    print_section(&term, "COMMANDS");
+    print_command_row(
+        &term,
+        "api-key",
+        "Display the API key for the logged-in user",
+    );
+    print_command_row(&term, "login", "Log in to Anaconda");
+    print_command_row(&term, "logout", "Log out from Anaconda");
+    print_command_row(
+        &term,
+        "whoami",
+        "Display information about the logged-in user",
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod diagnostics;
 #[cfg(feature = "feedback")]
 mod feedback;
+mod help;
 mod http;
 mod input;
 mod paths;

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,24 +15,23 @@ class TestHelp:
     def test_help_flag(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
         assert result.returncode == 0
-        assert "Usage: ana [command] [options]" in result.stdout
+        assert "Manage your" in result.stdout
 
     def test_help_short_flag(self, run_ana: AnaRunner) -> None:
         result = run_ana("-h")
         assert result.returncode == 0
-        assert "Usage: ana [command] [options]" in result.stdout
+        assert "Manage your" in result.stdout
 
     def test_no_args_shows_help(self, run_ana: AnaRunner) -> None:
         result = run_ana()
         assert result.returncode == 0
-        assert "Usage: ana [command] [options]" in result.stdout
+        assert "Manage your" in result.stdout
 
     def test_help_shows_version_in_header(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
-        # Header should be "ana {version}" on first line
+        # Header should be "ana (v{version})" on first line
         first_line = result.stdout.split("\n")[0]
-        assert first_line.startswith("ana ")
-        assert re.match(r"ana \d+\.\d+\.\d+", first_line)
+        assert re.match(r"ana \(v\d+\.\d+\.\d+", first_line)
 
     def test_help_shows_self_command(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,62 @@ class TestHelp:
         assert "-h, --help" in result.stdout
 
 
+class TestSubcommandHelp:
+    """Tests for --help on subcommands."""
+
+    def test_bootstrap_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("bootstrap", "--help")
+        assert result.returncode == 0
+        assert "Install the Anaconda CLI" in result.stdout
+        assert "Usage: ana bootstrap" in result.stdout
+
+    def test_config_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("config", "--help")
+        assert result.returncode == 0
+        assert "Show current configuration" in result.stdout
+        assert "Usage: ana config" in result.stdout
+
+    def test_login_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("login", "--help")
+        assert result.returncode == 0
+        assert "Log in to Anaconda" in result.stdout
+        assert "Usage: ana login" in result.stdout
+
+    def test_logout_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("logout", "--help")
+        assert result.returncode == 0
+        assert "Log out from Anaconda" in result.stdout
+        assert "Usage: ana logout" in result.stdout
+
+    def test_whoami_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("whoami", "--help")
+        assert result.returncode == 0
+        assert "Display information about the logged-in user" in result.stdout
+        assert "Usage: ana whoami" in result.stdout
+
+    def test_self_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("self", "--help")
+        assert result.returncode == 0
+        assert "Manage the ana installation" in result.stdout
+        assert "Usage: ana self" in result.stdout
+        assert "COMMANDS" in result.stdout
+        assert "update" in result.stdout
+
+    def test_auth_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("auth", "--help")
+        assert result.returncode == 0
+        assert "Authentication commands" in result.stdout
+        assert "Usage: ana auth" in result.stdout
+        assert "COMMANDS" in result.stdout
+        assert "api-key" in result.stdout
+
+    def test_org_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("org", "--help")
+        assert result.returncode == 0
+        assert "Interact with anaconda.org" in result.stdout
+        assert "Usage: ana org" in result.stdout
+
+
 class TestVersion:
     """Tests for --version output."""
 
@@ -149,11 +205,6 @@ class TestLogin:
         result = run_ana("--help")
         assert result.returncode == 0
         assert "login" in result.stdout
-        assert "Log in to Anaconda" in result.stdout
-
-    def test_login_help(self, run_ana: AnaRunner) -> None:
-        result = run_ana("login", "--help")
-        assert result.returncode == 0
         assert "Log in to Anaconda" in result.stdout
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,11 +160,6 @@ class TestLogin:
 class TestBootstrap:
     """Tests for 'ana bootstrap' subcommand."""
 
-    def test_bootstrap_help(self, run_ana: AnaRunner) -> None:
-        result = run_ana("bootstrap", "--help")
-        assert result.returncode == 0
-        assert "Install the Anaconda CLI" in result.stdout
-
     def test_bootstrap_installs_anaconda_cli(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,9 +29,9 @@ class TestHelp:
 
     def test_help_shows_version_in_header(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
-        # Header should be "ana (v{version})" on first line
+        # Header should be "ana {version}" on first line
         first_line = result.stdout.split("\n")[0]
-        assert re.match(r"ana \(v\d+\.\d+\.\d+", first_line)
+        assert re.match(r"ana \d+\.\d+\.\d+", first_line)
 
     def test_help_shows_self_command(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
@@ -160,10 +160,9 @@ class TestLogin:
 class TestBootstrap:
     """Tests for 'ana bootstrap' subcommand."""
 
-    def test_help_shows_bootstrap_command(self, run_ana: AnaRunner) -> None:
-        result = run_ana("--help")
+    def test_bootstrap_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("bootstrap", "--help")
         assert result.returncode == 0
-        assert "bootstrap" in result.stdout
         assert "Install the Anaconda CLI" in result.stdout
 
     def test_bootstrap_installs_anaconda_cli(


### PR DESCRIPTION
## Summary

Re-implements the help output based on the upcoming UX designs. The current state is shown below. Although the future number of subcommands will grow, the current implementation focuses on introducing styles, while matching the level of implemented subcommands that are currently available.

I have done my best here to leverage the existing introspection capabilities of `clap`, while adding support for custom styles and output layout. There are still a few areas where the code structure is not ideal and requires manual management (sections, specifically). As we evolve, it may become worthwhile to add some more complex internals around this, but I found that at this time it wouldn't really be worth implementing custom decorator macros. Instead, I opted for unit testing to ensure subcommands are included (at top level), and integration tests for output of various subcommands. This felt like an appropriate tradeoff at this level of project maturity.

<img width="684" height="716" alt="image" src="https://github.com/user-attachments/assets/461abace-641a-4ffb-a189-310599131261" />

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-381](https://anaconda.atlassian.net/browse/CLI-381)

[CLI-381]: https://anaconda.atlassian.net/browse/CLI-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ