### PR TITLE
fix: Replace cargo clean with SENTRY_DSN hash in cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,11 +73,11 @@ jobs:
         with:
           pixi-version: v0.66.0
 
-      - name: Build release binary
-        run: pixi run build-release
-
       - name: Run unit tests
         run: pixi run test-release
+
+      - name: Build release binary
+        run: pixi run build-release
 
       - name: Run integration tests
         run: pixi run test-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,10 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Hash SENTRY_DSN for cache key
+        id: dsn-hash
+        run: echo "hash=$(echo -n "$SENTRY_DSN" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
       - name: Cache Cargo registry and build
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -60,8 +64,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          # Include a hash of SENTRY_DSN so cached artifacts are invalidated
+          # when the DSN changes (build.rs embeds it at compile time).
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-dsn-${{ steps.dsn-hash.outputs.hash }}
           restore-keys: |
+            cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-dsn-
             cargo-${{ runner.os }}-
 
       - name: Set up pixi
@@ -69,13 +76,11 @@ jobs:
         with:
           pixi-version: v0.66.0
 
+      - name: Build release binary
+        run: pixi run build-release
+
       - name: Run unit tests
         run: pixi run test-release
-
-      - name: Build as standalone binary
-        run: |
-          cargo clean
-          pixi run build-release
 
       - name: Run integration tests
         run: pixi run test-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,9 +67,6 @@ jobs:
           # Include a hash of SENTRY_DSN so cached artifacts are invalidated
           # when the DSN changes (build.rs embeds it at compile time).
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-dsn-${{ steps.dsn-hash.outputs.hash }}
-          restore-keys: |
-            cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-dsn-
-            cargo-${{ runner.os }}-
 
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4


### PR DESCRIPTION
## Summary

- **Remove `cargo clean`** from the build step, which was completely defeating the Cargo cache (every CI run recompiled from scratch despite cache hits)
- **Hash `SENTRY_DSN` value into the cache key** so cached artifacts are automatically invalidated when the DSN changes — this properly addresses the concern from PR #92 without the sledgehammer of wiping the entire cache

### Relationship to PR #92

PR #92 introduced `cargo clean` to ensure that `SENTRY_DSN` (embedded at compile time via `build.rs`) would not be missing from release binaries when the cache was restored from a run without the secret. This PR replaces that approach with a more targeted solution: a SHA-256 hash of the `SENTRY_DSN` value is included in the cache key itself. When the DSN value changes (or goes from unset to set), the cache key changes, forcing a full rebuild. When it stays the same, the cache is reused — saving ~5 minutes of compile time per CI run.

## Test plan

- [ ] First CI run completes successfully (cold cache or cache miss due to new key format)
- [ ] Second CI run reuses the cache (look for "Cache restored successfully" followed by incremental/no-op compilation, not a full rebuild from `proc-macro2`/`quote`/`syn`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
