### PR TITLE
fix: Use real UTC timestamp in SBOM and sanitize local paths

### DIFF
--- a/SBOM.json
+++ b/SBOM.json
@@ -2,8 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
+  "serialNumber": "urn:uuid:22b0cd8e-7894-443b-bc19-ffd4e2e1bf6e",
   "metadata": {
-    "timestamp": "1970-01-01T00:00:00.000000000Z",
+    "timestamp": "2026-04-08T15:31:40Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -13,15 +14,15 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "ana@0.0.0",
+      "bom-ref": "path+file:///tmp/ana-cli#ana@0.0.0",
       "name": "ana",
       "version": "0.0.0",
       "scope": "required",
-      "purl": "pkg:cargo/ana@0.0.0?download_url=",
+      "purl": "pkg:cargo/ana@0.0.0?download_url=file://.",
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0 bin-target-0",
+          "bom-ref": "path+file:///tmp/ana-cli#ana@0.0.0 bin-target-0",
           "name": "ana",
           "version": "0.0.0",
           "purl": "pkg:cargo/ana@0.0.0?download_url=file://.#src/main.rs"
@@ -14479,7 +14480,7 @@
       ]
     },
     {
-      "ref": "path+file:///Users/mgrant/Repos/ana-cli#ana@0.0.0",
+      "ref": "path+file:///tmp/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 1970-01-01T00:00:00.000000000Z<br>
+Generated: 2026-04-08T15:31:40Z<br>
 Format: CycloneDX 1.4<br>
 Packages: 465 (65 platform-specific)<br>
 Platforms: linux, macos, windows

--- a/scripts/sbom-process.py
+++ b/scripts/sbom-process.py
@@ -15,6 +15,8 @@ import argparse
 import json
 import os
 import re
+from datetime import datetime
+from datetime import timezone
 from urllib.parse import unquote
 
 # Mapping from Rust target triples to short platform labels
@@ -27,6 +29,23 @@ TARGET_LABELS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+_LOCAL_PATH_RE = re.compile(r"path\+file:///[^#\"]+(?=#)")
+
+
+def _sanitize_local_paths(sbom: dict) -> None:
+    """Replace absolute local paths with a generic placeholder in-place.
+
+    cargo-cyclonedx embeds the developer's workspace path in bom-ref, purl,
+    and dependency ref fields.  We round-trip through JSON so every occurrence
+    is caught regardless of where it appears in the tree.
+    """
+    raw = json.dumps(sbom)
+    sanitized = _LOCAL_PATH_RE.sub("path+file:///tmp/ana-cli", raw)
+    if sanitized != raw:
+        sbom.clear()
+        sbom.update(json.loads(sanitized))
 
 
 def md_escape(text: str) -> str:
@@ -138,16 +157,9 @@ def merge_target_sboms(
                 {"name": "cdx:ana:platforms", "value": ",".join(sorted(platforms))}
             )
 
-    # Sanitize local filesystem paths from metadata (cargo-cyclonedx embeds
-    # the developer's absolute path in bom-ref and purl).
-    meta_comp = combined.get("metadata", {}).get("component", {})
-    for field in ("bom-ref", "purl"):
-        val = meta_comp.get(field, "")
-        if "file:///" in val:
-            # Keep only the fragment after '#' (e.g. "ana@0.0.0")
-            meta_comp[field] = val.split("#")[-1] if "#" in val else val
-        elif "file://." in val:
-            meta_comp[field] = val.replace("file://.", "")
+    # Sanitize local filesystem paths (cargo-cyclonedx embeds the developer's
+    # absolute path in bom-ref, purl, and dependency ref fields).
+    _sanitize_local_paths(combined)
 
     # Update metadata properties to reflect all merged target triples
     all_triples = sorted(TARGET_LABELS.keys())
@@ -156,6 +168,14 @@ def merge_target_sboms(
         if prop.get("name") == "cdx:rustc:sbom:target:triple":
             prop["value"] = ",".join(all_triples)
             break
+
+    # Set timestamp to current UTC time (CycloneDX convention).
+    # material_content() excludes metadata, so a timestamp-only change
+    # won't trigger a rewrite.
+    now = datetime.now(tz=timezone.utc)
+    combined.setdefault("metadata", {})["timestamp"] = now.strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
 
     # Bump specVersion to 1.4 since we use the vulnerabilities field (added in 1.4)
     combined["specVersion"] = "1.4"
@@ -507,9 +527,11 @@ def _strip_volatile(comp: dict) -> dict:
 
 
 def material_content(data: dict) -> tuple[list, list]:
-    """Extract the material (non-metadata) content for comparison.
+    """Extract the material content for comparison.
 
     Strips bom-ref fields since they may change between runs.
+    Excludes metadata (including timestamp) and dependencies (which
+    contain volatile bom-ref values).
     """
     comps = [_strip_volatile(c) for c in data.get("components", [])]
     vulns = data.get("vulnerabilities", [])

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -19,11 +19,11 @@ fi
 # Target triples for per-platform SBOM generation
 TARGETS=(x86_64-unknown-linux-gnu aarch64-apple-darwin x86_64-pc-windows-msvc)
 
-# Generate per-target CycloneDX SBOMs (reproducible timestamp)
+# Generate per-target CycloneDX SBOMs
 TARGET_FILES=()
 for target in "${TARGETS[@]}"; do
     echo "==> Generating SBOM for $target"
-    SOURCE_DATE_EPOCH=0 cargo cyclonedx --format json --target "$target" \
+    cargo cyclonedx --format json --target "$target" \
         --override-filename "ana-${target}"
     TARGET_FILES+=("ana-${target}.json")
 done


### PR DESCRIPTION
## Summary

Two SBOM processing fixes:

- **Real UTC timestamp**: Replace the fixed `1970-01-01T00:00:00Z` epoch with the actual generation time. The original `SOURCE_DATE_EPOCH=0` was used to produce reproducible per-target SBOMs, but this leaked into the final merged SBOM as a misleading timestamp. The `material_content()` comparison already excludes metadata, so timestamp-only changes do not trigger unnecessary SBOM rewrites — the reproducibility concern is fully addressed at the comparison layer.

- **Complete path sanitization**: The previous sanitization only handled `metadata.component.bom-ref` and `purl`, missing the `dependencies[].ref` field. Replaced with a global regex substitution that rewrites every occurrence of the developer's local workspace path (e.g. `path+file:///Users/foo/Repos/ana-cli#...`) to a generic `path+file:///tmp/ana-cli#...`.

## Test plan

- [ ] Pre-commit SBOM freshness hook passes
- [ ] `pixi run sbom` reports "No material changes" on re-run (timestamp-only change correctly skipped)
- [ ] `grep -c '/Users/' SBOM.json` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
