### PR TITLE
feat: Add runtime Sentry disable flag and environment configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,10 @@ jobs:
         run: pixi run build-release
 
       - name: Run integration tests
+        env:
+          ANA_SENTRY_ENVIRONMENT: integration-test
+          # Disable Sentry for pre-merge builds (PRs, merge queue) to avoid polluting error tracking
+          ANA_SENTRY_DISABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         run: pixi run test-integration
 
       - name: Build conda package

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -160,6 +160,10 @@ mod tests {
             metrics_console_exporter: false,
             metrics_skip_internet_check: true,
             include_prereleases: false,
+            #[cfg(feature = "diagnostics")]
+            sentry_disabled: false,
+            #[cfg(feature = "diagnostics")]
+            sentry_environment: "test".to_string(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,13 @@
 //! | `ANA_ENABLE_TELEMETRY`           | `true`                     | Enable/disable telemetry        |
 //! | `ANA_PRERELEASES`                | `false`                    | Include prereleases in updates  |
 //!
+//! When the `diagnostics` feature is enabled:
+//!
+//! | Variable                         | Default                    | Description                     |
+//! |--------------------------------- |----------------------------|---------------------------------|
+//! | `ANA_SENTRY_DISABLED`            | `false`                    | Disable Sentry error reporting  |
+//! | `ANA_SENTRY_ENVIRONMENT`         | `production`               | Sentry environment tag          |
+//!
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
 
@@ -71,6 +78,10 @@ const DEFAULT_METRICS_CONSOLE_EXPORTER: bool = false;
 const DEFAULT_METRICS_SKIP_INTERNET_CHECK: bool = true;
 const DEFAULT_USE_HTTPS: bool = true;
 const DEFAULT_INCLUDE_PRERELEASES: bool = false;
+#[cfg(feature = "diagnostics")]
+const DEFAULT_SENTRY_DISABLED: bool = false;
+#[cfg(feature = "diagnostics")]
+const DEFAULT_SENTRY_ENVIRONMENT: &str = "production";
 
 /// Global configuration for ana.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -107,6 +118,14 @@ pub struct Config {
 
     /// Whether to include prereleases when checking for updates
     pub include_prereleases: bool,
+
+    /// Whether Sentry error reporting is disabled
+    #[cfg(feature = "diagnostics")]
+    pub sentry_disabled: bool,
+
+    /// Sentry environment tag (e.g., "production", "integration-test")
+    #[cfg(feature = "diagnostics")]
+    pub sentry_environment: String,
 }
 
 impl Default for Config {
@@ -142,6 +161,11 @@ impl Config {
             .unwrap_or_else(|_| default_keyring_path());
         let use_https = parse_bool_env("ANA_USE_HTTPS", DEFAULT_USE_HTTPS);
         let include_prereleases = parse_bool_env("ANA_PRERELEASES", DEFAULT_INCLUDE_PRERELEASES);
+        #[cfg(feature = "diagnostics")]
+        let sentry_disabled = parse_bool_env("ANA_SENTRY_DISABLED", DEFAULT_SENTRY_DISABLED);
+        #[cfg(feature = "diagnostics")]
+        let sentry_environment = env::var("ANA_SENTRY_ENVIRONMENT")
+            .unwrap_or_else(|_| DEFAULT_SENTRY_ENVIRONMENT.to_string());
 
         Self {
             domain,
@@ -155,6 +179,10 @@ impl Config {
             keyring_path,
             use_https,
             include_prereleases,
+            #[cfg(feature = "diagnostics")]
+            sentry_disabled,
+            #[cfg(feature = "diagnostics")]
+            sentry_environment,
         }
     }
 
@@ -244,6 +272,10 @@ mod tests {
             keyring_path: default_keyring_path(),
             use_https: true,
             include_prereleases: false,
+            #[cfg(feature = "diagnostics")]
+            sentry_disabled: false,
+            #[cfg(feature = "diagnostics")]
+            sentry_environment: DEFAULT_SENTRY_ENVIRONMENT.to_string(),
         }
     }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -20,9 +20,7 @@ mod inner {
     /// Returns a guard that must be held for the lifetime of the program.
     /// The DSN is injected at build time; an empty string disables Sentry.
     /// Set ANA_SENTRY_DISABLED=1 at runtime to disable even when DSN is present.
-    pub fn init() -> Guard {
-        let config = Config::load();
-
+    pub fn init(config: &Config) -> Guard {
         if config.sentry_disabled {
             return None;
         }
@@ -31,7 +29,7 @@ mod inner {
             SENTRY_DSN,
             sentry::ClientOptions {
                 release: Some(VERSION.into()),
-                environment: Some(config.sentry_environment.into()),
+                environment: Some(config.sentry_environment.clone().into()),
                 send_default_pii: false,
                 attach_stacktrace: true,
                 ..Default::default()
@@ -50,10 +48,12 @@ mod inner {
 
 #[cfg(not(feature = "diagnostics"))]
 mod inner {
+    use crate::config::Config;
+
     /// Guard is a no-op when diagnostics is disabled.
     pub type Guard = ();
 
-    pub fn init() -> Guard {}
+    pub fn init(_config: &Config) -> Guard {}
 }
 
 pub use inner::*;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -7,27 +7,31 @@
 #[cfg(feature = "diagnostics")]
 mod inner {
     use crate::VERSION;
+    use crate::config::Config;
 
     const SENTRY_DSN: &str = env!("SENTRY_DSN");
     const BUILD_TARGET: &str = env!("BUILD_TARGET");
 
     /// Guard that must be held for the lifetime of the program.
-    pub type Guard = sentry::ClientInitGuard;
+    pub type Guard = Option<sentry::ClientInitGuard>;
 
     /// Initialize the diagnostics system.
     ///
     /// Returns a guard that must be held for the lifetime of the program.
     /// The DSN is injected at build time; an empty string disables Sentry.
+    /// Set ANA_SENTRY_DISABLED=1 at runtime to disable even when DSN is present.
     pub fn init() -> Guard {
+        let config = Config::load();
+
+        if config.sentry_disabled {
+            return None;
+        }
+
         let guard = sentry::init((
             SENTRY_DSN,
             sentry::ClientOptions {
                 release: Some(VERSION.into()),
-                environment: Some(
-                    std::env::var("ANA_ENV")
-                        .unwrap_or_else(|_| "production".to_string())
-                        .into(),
-                ),
+                environment: Some(config.sentry_environment.into()),
                 send_default_pii: false,
                 attach_stacktrace: true,
                 ..Default::default()
@@ -40,7 +44,7 @@ mod inner {
             scope.set_tag("target", BUILD_TARGET);
         });
 
-        guard
+        Some(guard)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ pub const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSe
 
 #[tokio::main]
 async fn main() {
-    let _diagnostics_guard = diagnostics::init();
+    let config = config::Config::load();
+    let _diagnostics_guard = diagnostics::init(&config);
     cli::execute().await;
 }
 


### PR DESCRIPTION
## Summary
- Add `ANA_SENTRY_DISABLED` config option to disable Sentry at runtime (even when DSN is compiled in)
- Add `ANA_SENTRY_ENVIRONMENT` config option to set the Sentry environment tag
- Both config options are gated behind the `diagnostics` feature flag
- Update CI to disable Sentry for pre-merge builds (PRs, merge queue) and set environment to `integration-test` for integration tests

## Test plan
- [ ] Verify build succeeds with `--features diagnostics`
- [ ] Verify build succeeds with `--no-default-features --features feedback`
- [ ] Verify `ANA_SENTRY_DISABLED=true` prevents Sentry initialization
- [ ] Verify `ANA_SENTRY_ENVIRONMENT=test` sets the correct environment tag

🤖 Generated with [Claude Code](https://claude.ai/code)