### PR TITLE
refac: Migrate our publish step to use the new reusable github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,6 @@ jobs:
           labels: ${{ needs.release-info.outputs.is_release == 'true' && 'main' || 'dev' }}
           private: true
           force: true
-          verbose: true
 
   # create-github-release:
   #   name: Upload Binaries to GitHub Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,7 @@ jobs:
           labels: ${{ needs.release-info.outputs.is_release == 'true' && 'main' || 'dev' }}
           private: true
           force: true
+          verbose: true
 
   # create-github-release:
   #   name: Upload Binaries to GitHub Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,6 @@ permissions:
   contents: read
 
 on:
-  # TODO: Remove after we test
-  pull_request:
   push:
     branches:
       - main
@@ -75,108 +73,108 @@ jobs:
           force: true
           verbose: true
 
-  # create-github-release:
-  #   name: Upload Binaries to GitHub Release
-  #   runs-on: ubuntu-latest
-  #   needs: [ci, release-info]
-  #   permissions:
-  #     contents: write
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #       with:
-  #         fetch-depth: 0
-  #
-  #     - name: Download binaries
-  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #       with:
-  #         path: binaries
-  #         pattern: binary-*
-  #
-  #     - name: Rename binaries
-  #       run: |
-  #         mkdir -p release-assets
-  #         mv binaries/binary-ubuntu-latest/ana release-assets/ana-linux-x86_64
-  #         mv binaries/binary-macos-latest/ana release-assets/ana-darwin-arm64
-  #         mv binaries/binary-windows-latest/ana.exe release-assets/ana-windows-x86_64.exe
-  #
-  #     - name: Generate checksums
-  #       run: |
-  #         cd release-assets
-  #         for file in *; do
-  #           sha256sum "$file" > "${file}.sha256"
-  #         done
-  #
-  #     # For prereleases (main branch pushes): create automatic prerelease
-  #     - name: Create automatic prerelease
-  #       if: needs.release-info.outputs.is_release == 'false'
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
-  #       run: |
-  #         VERSION="${{ needs.release-info.outputs.version }}"
-  #
-  #         # Delete existing prerelease if it exists (prereleases are recreated each time)
-  #         if gh release view "$VERSION" &>/dev/null; then
-  #           gh release delete "$VERSION" --yes
-  #           git push origin ":refs/tags/$VERSION" 2>/dev/null || true
-  #         fi
-  #
-  #         gh release create "$VERSION" \
-  #           --title "$VERSION" \
-  #           --prerelease \
-  #           --generate-notes \
-  #           release-assets/*
-  #
-  #         # Append footer to release notes
-  #         CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
-  #         NOTES=$(cat <<EOF
-  #         ${CURRENT_BODY}
-  #
-  #         ---
-  #         *Automated prerelease from main branch.*
-  #         EOF
-  #         )
-  #
-  #         gh release edit "$VERSION" --notes "$NOTES"
-  #
-  #     # For releases: upload artifacts to existing draft release, publish it, and update latest
-  #     - name: Publish release
-  #       if: needs.release-info.outputs.is_release == 'true'
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
-  #       run: |
-  #         VERSION="${{ needs.release-info.outputs.version }}"
-  #
-  #         # Check if release exists (draft, prerelease, or published)
-  #         if gh release view "$VERSION" &>/dev/null; then
-  #           echo "Uploading assets to existing release $VERSION"
-  #           gh release upload "$VERSION" release-assets/* --clobber
-  #
-  #           # Publish as full release (remove draft/prerelease flags, mark as latest)
-  #           echo "Publishing release $VERSION"
-  #           gh release edit "$VERSION" --draft=false --prerelease=false --latest
-  #         fi
-  #
-  #         # Update the 'latest' release to point to this version
-  #         if gh release view latest &>/dev/null; then
-  #           echo "Removing existing 'latest' release, for replacement"
-  #           gh release delete latest --yes
-  #           git push origin :refs/tags/latest 2>/dev/null || true
-  #         fi
-  #
-  #         # Delete local tag if it exists (from fetch-depth: 0)
-  #         git tag -d latest 2>/dev/null || true
-  #
-  #         NOTES=$(cat <<EOF
-  #         This release always points to the most recent build.
-  #
-  #         **Version:** ${VERSION}
-  #         EOF
-  #         )
-  #
-  #         echo "Publishing release 'latest'"
-  #         gh release create latest \
-  #           --title "Latest Release" \
-  #           --prerelease \
-  #           --notes "$NOTES" \
-  #           release-assets/*
+  create-github-release:
+    name: Upload Binaries to GitHub Release
+    runs-on: ubuntu-latest
+    needs: [ci, release-info]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: binaries
+          pattern: binary-*
+
+      - name: Rename binaries
+        run: |
+          mkdir -p release-assets
+          mv binaries/binary-ubuntu-latest/ana release-assets/ana-linux-x86_64
+          mv binaries/binary-macos-latest/ana release-assets/ana-darwin-arm64
+          mv binaries/binary-windows-latest/ana.exe release-assets/ana-windows-x86_64.exe
+
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          for file in *; do
+            sha256sum "$file" > "${file}.sha256"
+          done
+
+      # For prereleases (main branch pushes): create automatic prerelease
+      - name: Create automatic prerelease
+        if: needs.release-info.outputs.is_release == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-info.outputs.version }}"
+
+          # Delete existing prerelease if it exists (prereleases are recreated each time)
+          if gh release view "$VERSION" &>/dev/null; then
+            gh release delete "$VERSION" --yes
+            git push origin ":refs/tags/$VERSION" 2>/dev/null || true
+          fi
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --prerelease \
+            --generate-notes \
+            release-assets/*
+
+          # Append footer to release notes
+          CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
+          NOTES=$(cat <<EOF
+          ${CURRENT_BODY}
+
+          ---
+          *Automated prerelease from main branch.*
+          EOF
+          )
+
+          gh release edit "$VERSION" --notes "$NOTES"
+
+      # For releases: upload artifacts to existing draft release, publish it, and update latest
+      - name: Publish release
+        if: needs.release-info.outputs.is_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-info.outputs.version }}"
+
+          # Check if release exists (draft, prerelease, or published)
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "Uploading assets to existing release $VERSION"
+            gh release upload "$VERSION" release-assets/* --clobber
+
+            # Publish as full release (remove draft/prerelease flags, mark as latest)
+            echo "Publishing release $VERSION"
+            gh release edit "$VERSION" --draft=false --prerelease=false --latest
+          fi
+
+          # Update the 'latest' release to point to this version
+          if gh release view latest &>/dev/null; then
+            echo "Removing existing 'latest' release, for replacement"
+            gh release delete latest --yes
+            git push origin :refs/tags/latest 2>/dev/null || true
+          fi
+
+          # Delete local tag if it exists (from fetch-depth: 0)
+          git tag -d latest 2>/dev/null || true
+
+          NOTES=$(cat <<EOF
+          This release always points to the most recent build.
+
+          **Version:** ${VERSION}
+          EOF
+          )
+
+          echo "Publishing release 'latest'"
+          gh release create latest \
+            --title "Latest Release" \
+            --prerelease \
+            --notes "$NOTES" \
+            release-assets/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ permissions:
   contents: read
 
 on:
+  # TODO: Remove after we test
+  pull_request:
   push:
     branches:
       - main
@@ -73,108 +75,108 @@ jobs:
           force: true
           verbose: true
 
-  create-github-release:
-    name: Upload Binaries to GitHub Release
-    runs-on: ubuntu-latest
-    needs: [ci, release-info]
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Download binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: binaries
-          pattern: binary-*
-
-      - name: Rename binaries
-        run: |
-          mkdir -p release-assets
-          mv binaries/binary-ubuntu-latest/ana release-assets/ana-linux-x86_64
-          mv binaries/binary-macos-latest/ana release-assets/ana-darwin-arm64
-          mv binaries/binary-windows-latest/ana.exe release-assets/ana-windows-x86_64.exe
-
-      - name: Generate checksums
-        run: |
-          cd release-assets
-          for file in *; do
-            sha256sum "$file" > "${file}.sha256"
-          done
-
-      # For prereleases (main branch pushes): create automatic prerelease
-      - name: Create automatic prerelease
-        if: needs.release-info.outputs.is_release == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ needs.release-info.outputs.version }}"
-
-          # Delete existing prerelease if it exists (prereleases are recreated each time)
-          if gh release view "$VERSION" &>/dev/null; then
-            gh release delete "$VERSION" --yes
-            git push origin ":refs/tags/$VERSION" 2>/dev/null || true
-          fi
-
-          gh release create "$VERSION" \
-            --title "$VERSION" \
-            --prerelease \
-            --generate-notes \
-            release-assets/*
-
-          # Append footer to release notes
-          CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
-          NOTES=$(cat <<EOF
-          ${CURRENT_BODY}
-
-          ---
-          *Automated prerelease from main branch.*
-          EOF
-          )
-
-          gh release edit "$VERSION" --notes "$NOTES"
-
-      # For releases: upload artifacts to existing draft release, publish it, and update latest
-      - name: Publish release
-        if: needs.release-info.outputs.is_release == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ needs.release-info.outputs.version }}"
-
-          # Check if release exists (draft, prerelease, or published)
-          if gh release view "$VERSION" &>/dev/null; then
-            echo "Uploading assets to existing release $VERSION"
-            gh release upload "$VERSION" release-assets/* --clobber
-
-            # Publish as full release (remove draft/prerelease flags, mark as latest)
-            echo "Publishing release $VERSION"
-            gh release edit "$VERSION" --draft=false --prerelease=false --latest
-          fi
-
-          # Update the 'latest' release to point to this version
-          if gh release view latest &>/dev/null; then
-            echo "Removing existing 'latest' release, for replacement"
-            gh release delete latest --yes
-            git push origin :refs/tags/latest 2>/dev/null || true
-          fi
-
-          # Delete local tag if it exists (from fetch-depth: 0)
-          git tag -d latest 2>/dev/null || true
-
-          NOTES=$(cat <<EOF
-          This release always points to the most recent build.
-
-          **Version:** ${VERSION}
-          EOF
-          )
-
-          echo "Publishing release 'latest'"
-          gh release create latest \
-            --title "Latest Release" \
-            --prerelease \
-            --notes "$NOTES" \
-            release-assets/*
+  # create-github-release:
+  #   name: Upload Binaries to GitHub Release
+  #   runs-on: ubuntu-latest
+  #   needs: [ci, release-info]
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         fetch-depth: 0
+  #
+  #     - name: Download binaries
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #       with:
+  #         path: binaries
+  #         pattern: binary-*
+  #
+  #     - name: Rename binaries
+  #       run: |
+  #         mkdir -p release-assets
+  #         mv binaries/binary-ubuntu-latest/ana release-assets/ana-linux-x86_64
+  #         mv binaries/binary-macos-latest/ana release-assets/ana-darwin-arm64
+  #         mv binaries/binary-windows-latest/ana.exe release-assets/ana-windows-x86_64.exe
+  #
+  #     - name: Generate checksums
+  #       run: |
+  #         cd release-assets
+  #         for file in *; do
+  #           sha256sum "$file" > "${file}.sha256"
+  #         done
+  #
+  #     # For prereleases (main branch pushes): create automatic prerelease
+  #     - name: Create automatic prerelease
+  #       if: needs.release-info.outputs.is_release == 'false'
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         VERSION="${{ needs.release-info.outputs.version }}"
+  #
+  #         # Delete existing prerelease if it exists (prereleases are recreated each time)
+  #         if gh release view "$VERSION" &>/dev/null; then
+  #           gh release delete "$VERSION" --yes
+  #           git push origin ":refs/tags/$VERSION" 2>/dev/null || true
+  #         fi
+  #
+  #         gh release create "$VERSION" \
+  #           --title "$VERSION" \
+  #           --prerelease \
+  #           --generate-notes \
+  #           release-assets/*
+  #
+  #         # Append footer to release notes
+  #         CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
+  #         NOTES=$(cat <<EOF
+  #         ${CURRENT_BODY}
+  #
+  #         ---
+  #         *Automated prerelease from main branch.*
+  #         EOF
+  #         )
+  #
+  #         gh release edit "$VERSION" --notes "$NOTES"
+  #
+  #     # For releases: upload artifacts to existing draft release, publish it, and update latest
+  #     - name: Publish release
+  #       if: needs.release-info.outputs.is_release == 'true'
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         VERSION="${{ needs.release-info.outputs.version }}"
+  #
+  #         # Check if release exists (draft, prerelease, or published)
+  #         if gh release view "$VERSION" &>/dev/null; then
+  #           echo "Uploading assets to existing release $VERSION"
+  #           gh release upload "$VERSION" release-assets/* --clobber
+  #
+  #           # Publish as full release (remove draft/prerelease flags, mark as latest)
+  #           echo "Publishing release $VERSION"
+  #           gh release edit "$VERSION" --draft=false --prerelease=false --latest
+  #         fi
+  #
+  #         # Update the 'latest' release to point to this version
+  #         if gh release view latest &>/dev/null; then
+  #           echo "Removing existing 'latest' release, for replacement"
+  #           gh release delete latest --yes
+  #           git push origin :refs/tags/latest 2>/dev/null || true
+  #         fi
+  #
+  #         # Delete local tag if it exists (from fetch-depth: 0)
+  #         git tag -d latest 2>/dev/null || true
+  #
+  #         NOTES=$(cat <<EOF
+  #         This release always points to the most recent build.
+  #
+  #         **Version:** ${VERSION}
+  #         EOF
+  #         )
+  #
+  #         echo "Publishing release 'latest'"
+  #         gh release create latest \
+  #           --title "Latest Release" \
+  #           --prerelease \
+  #           --notes "$NOTES" \
+  #           release-assets/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to anaconda.org
-        uses: anaconda/github-actions/upload-package@v0.1.0
+        uses: anaconda/github-actions/upload-package@87cc83d84eac5e351be43025afd51126cf558f20 # v0.1.1
         with:
           token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
           owner: anaconda-cloud

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,11 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci, release-info]
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -67,32 +62,16 @@ jobs:
           pattern: conda-*
           merge-multiple: true
 
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+      - name: Upload to anaconda.org
+        uses: anaconda/github-actions/upload-package@v0.1.0
         with:
-          pixi-version: v0.67.0
-
-      - name: Publish
-        env:
-          TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
-        run: |
-          # Use main label for releases, dev label for prereleases
-          if [[ "${{ needs.release-info.outputs.is_release }}" == "true" ]]; then
-            export LABEL="main"
-          else
-            export LABEL="dev"
-          fi
-
-          echo "Publishing to label: $LABEL"
-
-          pixi run anaconda --verbose \
-            --token $TOKEN \
-            upload \
-            --user anaconda-cloud \
-            --label $LABEL \
-            --private \
-            --force \
-            packages/*/*.conda
+          token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+          owner: anaconda-cloud
+          packages: packages/*/*.conda
+          labels: ${{ needs.release-info.outputs.is_release == 'true' && 'main' || 'dev' }}
+          private: true
+          force: true
+          verbose: true
 
   create-github-release:
     name: Upload Binaries to GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -599,7 +599,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1350,7 +1350,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1380,7 +1380,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1428,6 +1428,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1549,15 +1555,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1760,12 +1765,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1896,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1964,20 +1969,20 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2399,9 +2404,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2431,9 +2436,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2520,7 +2525,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2600,7 +2605,7 @@ checksum = "59953de32542217edd1cc5fd52ac7ca2de57d7613a3a3e569370e5ea09231df3"
 dependencies = [
  "ahash",
  "fs-err",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "proptest",
  "tempfile",
@@ -2636,7 +2641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
 dependencies = [
  "boxcar",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "once_cell",
  "pep440_rs",
@@ -2685,9 +2690,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2702,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -2767,7 +2772,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2858,9 +2863,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2868,13 +2873,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2898,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2925,7 +2930,7 @@ dependencies = [
  "fs-err",
  "futures",
  "humantime",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "indicatif",
  "itertools 0.14.0",
  "memchr",
@@ -3005,7 +3010,7 @@ dependencies = [
  "fs-err",
  "glob",
  "hex",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "lazy-regex",
  "memmap2",
@@ -3060,7 +3065,7 @@ dependencies = [
  "ahash",
  "chrono",
  "file_url",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "pep440_rs",
  "pep508_rs",
@@ -3097,7 +3102,7 @@ dependencies = [
  "configparser",
  "dirs",
  "fs-err",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "known-folders",
  "once_cell",
  "plist",
@@ -3214,7 +3219,7 @@ dependencies = [
  "anyhow",
  "enum_dispatch",
  "fs-err",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "rattler_conda_types",
  "rattler_pty",
@@ -3274,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3462,7 +3467,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3525,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3547,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3737,7 +3742,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
@@ -3785,7 +3790,7 @@ checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3862,7 +3867,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3912,7 +3917,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3939,7 +3944,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4417,7 +4422,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4798,7 +4803,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -4829,9 +4834,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-ranges"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+checksum = "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
 dependencies = [
  "smallvec",
 ]
@@ -4896,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4909,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4919,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4929,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4942,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4966,7 +4971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4992,15 +4997,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5441,7 +5446,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5472,7 +5477,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5491,7 +5496,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5628,7 +5633,7 @@ checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "time",
  "typed-path",

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:1b32fcfd-e1b0-4c5f-8fbd-68c61352d01d",
+  "serialNumber": "urn:uuid:211fc3aa-3f45-495e-bb3a-3d7236fa4833",
   "metadata": {
-    "timestamp": "2026-04-13T22:18:33Z",
+    "timestamp": "2026-04-13T23:08:31Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -1358,16 +1358,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.2.59",
+      "version": "1.2.60",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+          "content": "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
         }
       ],
       "licenses": [
@@ -1375,7 +1375,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.2.59",
+      "purl": "pkg:cargo/cc@1.2.60",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3857,6 +3857,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "name": "hashbrown",
+      "version": "0.17.0",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hashbrown@0.17.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/hashbrown"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
       "name": "heck",
       "version": "0.5.0",
@@ -4183,15 +4210,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.8",
       "name": "hyper-rustls",
-      "version": "0.27.7",
+      "version": "0.27.8",
       "description": "Rustls+hyper integration for pure rust HTTPS",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+          "content": "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
         }
       ],
       "licenses": [
@@ -4199,7 +4226,7 @@
           "expression": "Apache-2.0 OR ISC OR MIT"
         }
       ],
-      "purl": "pkg:cargo/hyper-rustls@0.27.7",
+      "purl": "pkg:cargo/hyper-rustls@0.27.8",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4722,15 +4749,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
       "name": "indexmap",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "description": "A hash table with consistent order and fast iteration.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+          "content": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
         }
       ],
       "licenses": [
@@ -4738,7 +4765,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/indexmap@2.13.1",
+      "purl": "pkg:cargo/indexmap@2.14.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5167,16 +5194,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
       "author": "The Rust Project Developers",
       "name": "libc",
-      "version": "0.2.184",
+      "version": "0.2.185",
       "description": "Raw FFI bindings to platform libraries like libc.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+          "content": "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
         }
       ],
       "licenses": [
@@ -5184,7 +5211,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/libc@0.2.184",
+      "purl": "pkg:cargo/libc@0.2.185",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6064,16 +6091,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.113",
       "author": "Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>",
       "name": "openssl-sys",
-      "version": "0.9.112",
+      "version": "0.9.113",
       "description": "FFI bindings to OpenSSL",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+          "content": "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
         }
       ],
       "licenses": [
@@ -6081,7 +6108,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/openssl-sys@0.9.112",
+      "purl": "pkg:cargo/openssl-sys@0.9.113",
       "externalReferences": [
         {
           "type": "other",
@@ -6101,16 +6128,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.77",
       "author": "Steven Fackler <sfackler@gmail.com>",
       "name": "openssl",
-      "version": "0.10.76",
+      "version": "0.10.77",
       "description": "OpenSSL bindings",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+          "content": "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
         }
       ],
       "licenses": [
@@ -6118,7 +6145,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/openssl@0.10.76",
+      "purl": "pkg:cargo/openssl@0.10.77",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6714,16 +6741,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "pkg-config",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "A library to run the pkg-config system tool at build time in order to be used in Cargo build scripts. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+          "content": "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
         }
       ],
       "licenses": [
@@ -6731,7 +6758,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pkg-config@0.3.32",
+      "purl": "pkg:cargo/pkg-config@0.3.33",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7104,16 +7131,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
       "author": "The Rand Project Developers, The Rust Project Developers",
       "name": "rand",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "description": "Random number generators and other randomness functionality. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+          "content": "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
         }
       ],
       "licenses": [
@@ -7121,7 +7148,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rand@0.10.0",
+      "purl": "pkg:cargo/rand@0.10.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7139,16 +7166,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
       "author": "The Rand Project Developers, The Rust Project Developers",
       "name": "rand",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "description": "Random number generators and other randomness functionality. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+          "content": "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
         }
       ],
       "licenses": [
@@ -7156,7 +7183,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rand@0.9.2",
+      "purl": "pkg:cargo/rand@0.9.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7209,16 +7236,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1",
       "author": "The Rand Project Developers",
       "name": "rand_core",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "description": "Core random number generation traits and tools for implementation.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+          "content": "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
         }
       ],
       "licenses": [
@@ -7226,7 +7253,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rand_core@0.10.0",
+      "purl": "pkg:cargo/rand_core@0.10.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8356,15 +8383,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.11",
       "name": "rustls-webpki",
-      "version": "0.103.10",
+      "version": "0.103.11",
       "description": "Web PKI X.509 Certificate Verification.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+          "content": "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
         }
       ],
       "licenses": [
@@ -8372,7 +8399,7 @@
           "expression": "ISC"
         }
       ],
-      "purl": "pkg:cargo/rustls-webpki@0.103.10",
+      "purl": "pkg:cargo/rustls-webpki@0.103.11",
       "externalReferences": [
         {
           "type": "vcs",
@@ -8382,15 +8409,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
       "name": "rustls",
-      "version": "0.23.37",
+      "version": "0.23.38",
       "description": "Rustls is a modern TLS library written in Rust.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+          "content": "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
         }
       ],
       "licenses": [
@@ -8398,7 +8425,7 @@
           "expression": "Apache-2.0 OR ISC OR MIT"
         }
       ],
-      "purl": "pkg:cargo/rustls@0.23.37",
+      "purl": "pkg:cargo/rustls@0.23.38",
       "externalReferences": [
         {
           "type": "website",
@@ -12124,15 +12151,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3",
       "name": "version-ranges",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Performance-optimized type for generic version ranges and operations on them.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+          "content": "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
         }
       ],
       "licenses": [
@@ -12140,7 +12167,7 @@
           "expression": "MPL-2.0"
         }
       ],
-      "purl": "pkg:cargo/version-ranges@0.1.2",
+      "purl": "pkg:cargo/version-ranges@0.1.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -14431,7 +14458,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler@0.40.5",
@@ -14644,7 +14671,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
@@ -14729,7 +14756,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
@@ -14808,11 +14835,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0"
       ]
     },
@@ -14829,7 +14856,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
     {
@@ -14905,7 +14932,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -14919,7 +14946,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15052,7 +15079,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -15114,7 +15141,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15143,7 +15170,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15153,9 +15180,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
         "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
       ]
     },
@@ -15304,22 +15331,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
     {
@@ -15339,7 +15366,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1",
@@ -15370,6 +15397,10 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
       "dependsOn": []
     },
@@ -15381,7 +15412,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
@@ -15434,13 +15465,12 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
@@ -15470,7 +15500,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
@@ -15598,10 +15628,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -15653,7 +15683,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15686,7 +15716,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
       "dependsOn": []
     },
     {
@@ -15735,7 +15765,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15783,7 +15813,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -15791,11 +15821,11 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.113",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.77",
         "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
@@ -15808,7 +15838,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15842,7 +15872,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -15868,24 +15898,24 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.113",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
-        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
+        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.76",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.77",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.112"
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.113"
       ]
     },
     {
@@ -15948,7 +15978,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1"
@@ -15983,7 +16013,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
@@ -15993,7 +16023,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -16013,14 +16043,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2"
+        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#boxcar@0.2.14",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
@@ -16032,7 +16062,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2"
+        "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3"
       ]
     },
     {
@@ -16058,7 +16088,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
       "dependsOn": []
     },
     {
@@ -16094,7 +16124,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
@@ -16146,15 +16176,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0"
+        "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5"
@@ -16168,7 +16198,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1",
       "dependsOn": []
     },
     {
@@ -16194,7 +16224,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
@@ -16268,7 +16298,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
@@ -16317,7 +16347,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.2.7",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
@@ -16348,7 +16378,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
@@ -16427,7 +16457,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1"
@@ -16447,7 +16477,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.44.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.9",
@@ -16505,7 +16535,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
@@ -16559,7 +16589,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.8",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
@@ -16594,7 +16624,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.8",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
@@ -16617,16 +16647,16 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
@@ -16656,7 +16686,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
       ]
     },
@@ -16667,7 +16697,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
@@ -16675,11 +16705,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.10",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.11",
         "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
       ]
@@ -16755,7 +16785,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.47.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
@@ -16765,7 +16795,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.47.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.47.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
@@ -16801,7 +16831,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -16871,7 +16901,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
@@ -16908,7 +16938,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
@@ -16929,7 +16959,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
@@ -16958,13 +16988,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8"
       ]
     },
@@ -17006,14 +17036,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -17085,7 +17115,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.11.0",
@@ -17096,7 +17126,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
     },
@@ -17216,7 +17246,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.37",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1"
       ]
     },
@@ -17244,7 +17274,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.51.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
@@ -17257,7 +17287,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
@@ -17424,7 +17454,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -17534,7 +17564,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -17552,7 +17582,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
       ]
@@ -17564,7 +17594,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -17590,7 +17620,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -17680,7 +17710,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
@@ -17713,8 +17743,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.59",
-        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32"
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.60",
+        "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },
     {
@@ -17731,14 +17761,14 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.8.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.38.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
@@ -17754,7 +17784,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185"
       ]
     },
     {
@@ -17763,7 +17793,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.185",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
       ]
     },
@@ -18008,46 +18038,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
-    }
-  ],
-  "vulnerabilities": [
-    {
-      "id": "RUSTSEC-2026-0097",
-      "description": "[unsound] Rand is unsound with a custom logger using `rand::rng()`",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0097.html"
-      },
-      "ratings": [
-        {
-          "severity": "info",
-          "method": "other"
-        }
-      ],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0097",
-      "description": "[unsound] Rand is unsound with a custom logger using `rand::rng()`",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0097.html"
-      },
-      "ratings": [
-        {
-          "severity": "info",
-          "method": "other"
-        }
-      ],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0"
-        }
-      ]
     }
   ]
 }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:d8553b5e-90f0-4673-b946-b715d3570e6a",
+  "serialNumber": "urn:uuid:1b32fcfd-e1b0-4c5f-8fbd-68c61352d01d",
   "metadata": {
-    "timestamp": "2026-04-08T17:14:13Z",
+    "timestamp": "2026-04-13T22:18:33Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14421,6 +14421,7 @@
       "ref": "path+file:///tmp/ana-cli#ana@0.0.0",
       "dependsOn": [
         "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
@@ -14428,6 +14429,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.184",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
@@ -18006,6 +18008,46 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "id": "RUSTSEC-2026-0097",
+      "description": "[unsound] Rand is unsound with a custom logger using `rand::rng()`",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0097.html"
+      },
+      "ratings": [
+        {
+          "severity": "info",
+          "method": "other"
+        }
+      ],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.2"
+        }
+      ]
+    },
+    {
+      "id": "RUSTSEC-2026-0097",
+      "description": "[unsound] Rand is unsound with a custom logger using `rand::rng()`",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0097.html"
+      },
+      "ratings": [
+        {
+          "severity": "info",
+          "method": "other"
+        }
+      ],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.0"
+        }
+      ]
     }
   ]
 }

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-08T17:14:13Z<br>
+Generated: 2026-04-13T22:18:33Z<br>
 Format: CycloneDX 1.4<br>
 Packages: 463 (65 platform-specific)<br>
 Platforms: linux, macos, windows
-<br>**Security advisories: 0 found at this time**
+<br>**[Security advisories](#security-advisories): 2 (2 INFO) across 2 packages**
 
 ## Packages
 
@@ -254,8 +254,8 @@ Platforms: linux, macos, windows
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT | macos |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
-| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  |  |
-| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  | 1 |
+| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  | 1 |
 | [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
@@ -473,6 +473,13 @@ Platforms: linux, macos, windows
 | [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |  |
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
+
+## Security Advisories
+
+| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
+| --- | --- | --- | :---: | :---: | --- |
+| rand | 0.10.0 | [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) |  |  | INFO |
+| rand | 0.9.2 | [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) |  |  | INFO |
 
 ## License Summary
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-13T22:18:33Z<br>
+Generated: 2026-04-13T23:08:31Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 463 (65 platform-specific)<br>
+Packages: 464 (65 platform-specific)<br>
 Platforms: linux, macos, windows
-<br>**[Security advisories](#security-advisories): 2 (2 INFO) across 2 packages**
+<br>**Security advisories: 0 found at this time**
 
 ## Packages
 
@@ -55,7 +55,7 @@ Platforms: linux, macos, windows
 | [bytestring](https://crates.io/crates/bytestring) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.2.59 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.2.60 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
 | [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
@@ -141,6 +141,7 @@ Platforms: linux, macos, windows
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.17.0 | MIT OR Apache-2.0 |  |  |
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
@@ -153,7 +154,7 @@ Platforms: linux, macos, windows
 | [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
 | [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |  |
-| [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.7 | Apache-2.0 OR ISC OR MIT |  |  |
+| [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.8 | Apache-2.0 OR ISC OR MIT |  |  |
 | [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |  |
 | [iana-time-zone](https://crates.io/crates/iana-time-zone) | 0.1.65 | MIT OR Apache-2.0 | linux, macos |  |
@@ -169,7 +170,7 @@ Platforms: linux, macos, windows
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.1 | Apache-2.0 OR MIT |  |  |
 | [impl-more](https://crates.io/crates/impl-more) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
-| [indexmap](https://crates.io/crates/indexmap) | 2.13.1 | Apache-2.0 OR MIT |  |  |
+| [indexmap](https://crates.io/crates/indexmap) | 2.14.0 | Apache-2.0 OR MIT |  |  |
 | [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
 | [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |  |
 | [iri-string](https://crates.io/crates/iri-string) | 0.7.12 | MIT OR Apache-2.0 |  |  |
@@ -185,7 +186,7 @@ Platforms: linux, macos, windows
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.2 | bzip2-1.0.6 |  |  |
-| [libc](https://crates.io/crates/libc) | 0.2.184 | MIT OR Apache-2.0 |  |  |
+| [libc](https://crates.io/crates/libc) | 0.2.185 | MIT OR Apache-2.0 |  |  |
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
@@ -214,10 +215,10 @@ Platforms: linux, macos, windows
 | [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT | linux, macos |  |
 | [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |  |
 | [once\_cell\_polyfill](https://crates.io/crates/once_cell_polyfill) | 1.70.2 | MIT OR Apache-2.0 | windows |  |
-| [openssl](https://crates.io/crates/openssl) | 0.10.76 | Apache-2.0 | linux |  |
+| [openssl](https://crates.io/crates/openssl) | 0.10.77 | Apache-2.0 | linux |  |
 | [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
 | [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 | linux |  |
-| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.112 | MIT | linux |  |
+| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.113 | MIT | linux |  |
 | [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |  |
 | [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |  |
 | [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |  |
@@ -239,7 +240,7 @@ Platforms: linux, macos, windows
 | [pin-project](https://crates.io/crates/pin-project) | 1.1.11 | Apache-2.0 OR MIT |  |  |
 | [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.11 | Apache-2.0 OR MIT |  |  |
 | [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |  |
-| [pkg-config](https://crates.io/crates/pkg-config) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [pkg-config](https://crates.io/crates/pkg-config) | 0.3.33 | MIT OR Apache-2.0 |  |  |
 | [plist](https://crates.io/crates/plist) | 1.8.0 | MIT | macos |  |
 | [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |  |
 | [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |  |
@@ -254,10 +255,10 @@ Platforms: linux, macos, windows
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.38.4 | MIT | macos |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
-| [rand](https://crates.io/crates/rand) | 0.10.0 | MIT OR Apache-2.0 |  | 1 |
-| [rand](https://crates.io/crates/rand) | 0.9.2 | MIT OR Apache-2.0 |  | 1 |
+| [rand](https://crates.io/crates/rand) | 0.10.1 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.9.4 | MIT OR Apache-2.0 |  |  |
 | [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |  |
-| [rand\_core](https://crates.io/crates/rand_core) | 0.10.0 | MIT OR Apache-2.0 |  |  |
+| [rand\_core](https://crates.io/crates/rand_core) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
 | [rattler](https://crates.io/crates/rattler) | 0.40.5 | BSD-3-Clause |  |  |
@@ -292,9 +293,9 @@ Platforms: linux, macos, windows
 | [rustc\_version](https://crates.io/crates/rustc_version) | 0.4.1 | MIT OR Apache-2.0 |  |  |
 | [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |  |
 | [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux, macos |  |
-| [rustls](https://crates.io/crates/rustls) | 0.23.37 | Apache-2.0 OR ISC OR MIT |  |  |
+| [rustls](https://crates.io/crates/rustls) | 0.23.38 | Apache-2.0 OR ISC OR MIT |  |  |
 | [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |  |
-| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.10 | ISC |  |  |
+| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.11 | ISC |  |  |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
 | [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT | windows |  |
@@ -417,7 +418,7 @@ Platforms: linux, macos, windows
 | [uuid](https://crates.io/crates/uuid) | 1.23.0 | Apache-2.0 OR MIT |  |  |
 | [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |  |
 | [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 | linux |  |
-| [version-ranges](https://crates.io/crates/version-ranges) | 0.1.2 | MPL-2.0 |  |  |
+| [version-ranges](https://crates.io/crates/version-ranges) | 0.1.3 | MPL-2.0 |  |  |
 | [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
@@ -474,18 +475,11 @@ Platforms: linux, macos, windows
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
 
-## Security Advisories
-
-| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
-| --- | --- | --- | :---: | :---: | --- |
-| rand | 0.10.0 | [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) |  |  | INFO |
-| rand | 0.9.2 | [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) |  |  | INFO |
-
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 250 |
+| MIT OR Apache-2.0 | 251 |
 | MIT | 95 |
 | Apache-2.0 OR MIT | 34 |
 | Apache-2.0 | 19 |


### PR DESCRIPTION
## Summary

Refactor the `publish-to-anaconda-dot-org` job to use the new reusable `anaconda/github-actions/upload-package` action instead of inline shell commands.

## Changes

- Replace manual pixi setup + shell script with `anaconda/github-actions/upload-package@v0.1.1`
- Remove unnecessary checkout step (not needed for artifact upload)
- Remove pixi setup step (action handles its own dependencies)
- Simplify label logic using GitHub Actions ternary expression

## Before

```yaml
- name: Checkout
  uses: actions/checkout@v6
- name: Set up pixi
  uses: prefix-dev/setup-pixi@v0.9.4
- name: Publish
  run: |
    if [[ "${{ needs.release-info.outputs.is_release }}" == "true" ]]; then
      export LABEL="main"
    else
      export LABEL="dev"
    fi
    pixi run anaconda --verbose --token $TOKEN upload --user anaconda-cloud --label $LABEL --private --force packages/*/*.conda
```

## After

```yaml
- name: Upload to anaconda.org
  uses: anaconda/github-actions/upload-package@v0.1.1
  with:
    token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
    owner: anaconda-cloud
    packages: packages/*/*.conda
    labels: ${{ needs.release-info.outputs.is_release == 'true' && 'main' || 'dev' }}
    private: true
    force: true
    verbose: true
```

## Test plan

- [ ] Trigger a build on main branch → should upload to `dev` label
- [ ] Create a release tag → should upload to `main` label

🤖 Generated with [Claude Code](https://claude.ai/code)