### PR TITLE
fix: Use git commit timestamps for CI lockfile and SBOM freshness checks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.ANACONDA_BOT_TOKEN }}
+          fetch-depth: 0
 
       - name: Configure git for private repos
         run: |

--- a/scripts/update_lockfiles.sh
+++ b/scripts/update_lockfiles.sh
@@ -10,10 +10,33 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_DIR"
 
-# Regenerate Cargo.lock if Cargo.toml is newer or lock is missing
-if [ ! -f Cargo.lock ] || [ Cargo.toml -nt Cargo.lock ]; then
-    echo "==> Regenerating Cargo.lock"
+# Regenerate Cargo.lock when needed.
+# In CI, use git commit timestamps (file timestamps are unreliable after
+# checkout). Locally, use the file timestamp heuristic.
+if [ ! -f Cargo.lock ]; then
+    echo "==> Generating Cargo.lock (missing)"
     cargo generate-lockfile
+elif [ -n "${CI:-}" ]; then
+    toml_ts=$(git log -1 --format=%ct -- Cargo.toml 2>/dev/null || echo 0)
+    lock_ts=$(git log -1 --format=%ct -- Cargo.lock 2>/dev/null || echo 0)
+    if [ "$toml_ts" -gt "$lock_ts" ]; then
+        echo "==> Regenerating Cargo.lock (Cargo.toml committed more recently)"
+        cargo generate-lockfile
+    fi
+elif [ Cargo.toml -nt Cargo.lock ]; then
+    echo "==> Regenerating Cargo.lock (Cargo.toml newer)"
+    cargo generate-lockfile
+fi
+
+# In CI, skip SBOM regeneration if SBOM.json is already up to date with
+# Cargo.lock. Compare the commit timestamps of the last change to each file.
+if [ -n "${CI:-}" ]; then
+    lock_ts=$(git log -1 --format=%ct -- Cargo.lock 2>/dev/null || echo 0)
+    sbom_ts=$(git log -1 --format=%ct -- SBOM.json 2>/dev/null || echo 0)
+    if [ "$lock_ts" -le "$sbom_ts" ]; then
+        echo "==> SBOM is up to date with Cargo.lock, skipping"
+        exit 0
+    fi
 fi
 
 # Target triples for per-platform SBOM generation


### PR DESCRIPTION
## Summary

- Fix spurious `Cargo.lock` regeneration in CI pre-commit that produced bot commits
- File timestamps are unreliable after `actions/checkout`, so `cargo generate-lockfile` was running unnecessarily and resolving to newer patch versions
- In CI, use `git log` commit timestamps to determine freshness:
  - `Cargo.toml` vs `Cargo.lock` for lockfile regeneration
  - `Cargo.lock` vs `SBOM.json` for SBOM regeneration
- Add `fetch-depth: 0` to checkout step so full history is available
- Local pre-commit behavior unchanged (file timestamp heuristic)

## Test plan
- [x] shellcheck passes
- [x] CI pre-commit job skips lockfile regeneration when Cargo.toml is unchanged
- [x] CI pre-commit job skips SBOM regeneration when SBOM.json is up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
