### PR TITLE
fix: Use hard links on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,8 @@ jobs:
           github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
       - name: Run unit tests
+        env:
+          RUST_BACKTRACE: 1
         run: pixi run test-release
 
       - name: Build release binary

--- a/src/tools/conda_wrapper.rs
+++ b/src/tools/conda_wrapper.rs
@@ -206,7 +206,16 @@ fn print_activation_hint(env_name: &Option<String>) {
 
 /// Get the path to the real conda binary.
 fn get_conda_bin() -> std::path::PathBuf {
-    paths::tool_prefix("conda").join("bin").join("conda")
+    #[cfg(unix)]
+    {
+        paths::tool_prefix("conda").join("bin").join("conda")
+    }
+    #[cfg(not(unix))]
+    {
+        paths::tool_prefix("conda")
+            .join("Scripts")
+            .join("conda.exe")
+    }
 }
 
 /// Hand off to conda, replacing the current process (Unix) or spawning and exiting (Windows).

--- a/src/tools/conda_wrapper.rs
+++ b/src/tools/conda_wrapper.rs
@@ -267,9 +267,13 @@ pub fn is_conda_invocation() -> bool {
     std::env::args()
         .next()
         .and_then(|arg0| {
-            Path::new(&arg0)
-                .file_stem()
-                .map(|name| name == "conda" || name == "conda.exe")
+            Path::new(&arg0).file_name().map(|name| {
+                if cfg!(windows) {
+                    name == "conda" || name == "conda.exe"
+                } else {
+                    name == "conda"
+                }
+            })
         })
         .unwrap_or(false)
 }

--- a/src/tools/conda_wrapper.rs
+++ b/src/tools/conda_wrapper.rs
@@ -266,7 +266,11 @@ fn hand_off_to_conda(args: &[String]) -> i32 {
 pub fn is_conda_invocation() -> bool {
     std::env::args()
         .next()
-        .and_then(|arg0| Path::new(&arg0).file_name().map(|name| name == "conda"))
+        .and_then(|arg0| {
+            Path::new(&arg0)
+                .file_stem()
+                .map(|name| name == "conda" || name == "conda.exe")
+        })
         .unwrap_or(false)
 }
 

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -36,8 +36,8 @@ pub async fn install_tool(name: &str) -> miette::Result<()> {
 
     install_from_lockfile(&prefix, &lock_content).await?;
 
-    // Create symlinks in bin directory
-    create_bin_symlinks(&prefix, binaries, uses_wrapper)?;
+    // Create links in bin directory
+    create_bin_links(&prefix, binaries, uses_wrapper)?;
 
     // Tool-specific post-install configuration
     if name == "pixi" {
@@ -128,8 +128,8 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
     Ok(())
 }
 
-/// Create symlinks for the tool's binaries in ~/.ana/bin/
-fn create_bin_symlinks(prefix: &Path, binaries: &[&str], uses_wrapper: bool) -> miette::Result<()> {
+/// Create links for the tool's binaries in ~/.ana/bin/
+fn create_bin_links(prefix: &Path, binaries: &[&str], uses_wrapper: bool) -> miette::Result<()> {
     let bin_dir = paths::bin_dir();
     std::fs::create_dir_all(&bin_dir)
         .into_diagnostic()
@@ -137,9 +137,9 @@ fn create_bin_symlinks(prefix: &Path, binaries: &[&str], uses_wrapper: bool) -> 
 
     for binary in binaries {
         if uses_wrapper {
-            create_wrapper_symlink(&bin_dir, binary)?;
+            create_wrapper_link(&bin_dir, binary)?;
         } else {
-            create_bin_symlink(&bin_dir, prefix, binary)?;
+            create_bin_link(&bin_dir, prefix, binary)?;
         }
     }
 
@@ -147,7 +147,8 @@ fn create_bin_symlinks(prefix: &Path, binaries: &[&str], uses_wrapper: bool) -> 
 }
 
 /// Create a single symlink for a binary.
-fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Result<()> {
+/// Windows does not support symlinks by default, so hard links are used.
+fn create_bin_link(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Result<()> {
     let binary_name = paths::binary_name(binary);
     let tool_bin = prefix.join("bin").join(&binary_name);
     let symlink_path = bin_dir.join(&binary_name);
@@ -178,7 +179,7 @@ fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Re
 
     #[cfg(windows)]
     {
-        std::os::windows::fs::symlink_file(&tool_bin, &symlink_path)
+        std::fs::hard_link(&tool_bin, &symlink_path)
             .into_diagnostic()
             .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
     }
@@ -196,7 +197,8 @@ fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Re
 ///
 /// This is used for tools that ana wraps (like conda), where ana detects
 /// the binary name and acts as a wrapper for the underlying tool.
-fn create_wrapper_symlink(bin_dir: &Path, binary: &str) -> miette::Result<()> {
+/// Windows does not support symlinks by default, so hard links are used.
+pub fn create_wrapper_link(bin_dir: &Path, binary: &str) -> miette::Result<()> {
     let binary_name = paths::binary_name(binary);
     let symlink_path = bin_dir.join(&binary_name);
 
@@ -221,7 +223,7 @@ fn create_wrapper_symlink(bin_dir: &Path, binary: &str) -> miette::Result<()> {
 
     #[cfg(windows)]
     {
-        std::os::windows::fs::symlink_file(&ana_bin, &symlink_path)
+        std::fs::hard_link(&ana_bin, &symlink_path)
             .into_diagnostic()
             .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
     }

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -1,10 +1,29 @@
 //! Tool uninstallation.
 
 use miette::{Context, IntoDiagnostic};
+use std::path::PathBuf;
 
 use super::tools;
 use crate::input::prompt_yes_no;
 use crate::paths;
+
+pub fn gather_installed_links(bin_dir: &PathBuf, name: &str) -> Vec<PathBuf> {
+    let mut links = Vec::new();
+    // Check for links that will be removed
+    if let Some(binaries) = tools::binaries(name) {
+        for binary in binaries {
+            let symlink_path = if cfg!(unix) {
+                bin_dir.join(binary)
+            } else {
+                bin_dir.join(format!("{binary}.exe"))
+            };
+            if symlink_path.exists() || symlink_path.is_symlink() {
+                links.push(symlink_path);
+            }
+        }
+    }
+    links
+}
 
 /// Uninstall a tool.
 ///
@@ -26,26 +45,15 @@ pub fn uninstall_tool(name: &str, force: bool) -> miette::Result<()> {
     }
 
     // Collect what will be deleted
-    let mut to_delete: Vec<String> = Vec::new();
-
-    // Check for symlinks that will be removed
-    if let Some(binaries) = tools::binaries(name) {
-        for binary in binaries {
-            let symlink_path = bin_dir.join(binary);
-            if symlink_path.exists() || symlink_path.is_symlink() {
-                to_delete.push(format!("  {}", symlink_path.display()));
-            }
-        }
-    }
-
-    // The tool directory itself
-    to_delete.push(format!("  {}", prefix.display()));
+    let installed_links: Vec<PathBuf> = gather_installed_links(&bin_dir, name);
 
     // Show what will be deleted
     eprintln!("The following will be removed:");
-    for item in &to_delete {
-        eprintln!("{}", item);
+    for symlink_path in installed_links.iter() {
+        eprintln!("  {}", symlink_path.display());
     }
+    // The tool directory itself
+    eprintln!("  {}", prefix.display());
     eprintln!();
 
     // Prompt for confirmation unless --force was passed
@@ -57,19 +65,12 @@ pub fn uninstall_tool(name: &str, force: bool) -> miette::Result<()> {
     eprintln!();
     eprintln!("Uninstalling {}...", name);
 
-    // Remove symlinks from bin directory
-    if let Some(binaries) = tools::binaries(name) {
-        for binary in binaries {
-            let symlink_path = bin_dir.join(binary);
-            if symlink_path.exists() || symlink_path.is_symlink() {
-                std::fs::remove_file(&symlink_path)
-                    .into_diagnostic()
-                    .with_context(|| {
-                        format!("failed to remove symlink: {}", symlink_path.display())
-                    })?;
-                eprintln!("   Removed {}", symlink_path.display());
-            }
-        }
+    // Remove links from bin directory
+    for symlink_path in installed_links.into_iter() {
+        std::fs::remove_file(&symlink_path)
+            .into_diagnostic()
+            .with_context(|| format!("failed to remove symlink: {}", symlink_path.display()))?;
+        eprintln!("   Removed {}", symlink_path.display());
     }
 
     // Remove the tool's environment directory

--- a/src/update.rs
+++ b/src/update.rs
@@ -602,21 +602,33 @@ mod tests {
     fn test_recreate_wrapper_links_recreates_existing_links() {
         use crate::tools::tools::{all_tools, binaries, uses_wrapper};
 
-        let temp_dir = std::env::temp_dir().join("ana-test-wrapper-links");
+        struct CleanupGuard(std::path::PathBuf);
+        impl Drop for CleanupGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        // Use a temp directory on the same volume as the executable, since hard links
+        // cannot span different volumes on Windows.
+        let exe_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let temp_dir = exe_dir.join("ana-test-wrapper-links");
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
+        let _cleanup = CleanupGuard(temp_dir.clone());
 
         // Find a wrapper tool to test with
         let wrapper_tool = all_tools().iter().find(|t| uses_wrapper(t)).copied();
         if wrapper_tool.is_none() {
-            // No wrapper tools defined, skip test
-            let _ = std::fs::remove_dir_all(&temp_dir);
             return;
         }
         let tool = wrapper_tool.unwrap();
         let tool_binaries = binaries(tool).unwrap_or(&[]);
         if tool_binaries.is_empty() {
-            let _ = std::fs::remove_dir_all(&temp_dir);
             return;
         }
 
@@ -633,8 +645,5 @@ mod tests {
         assert!(link_path.exists());
         let metadata = std::fs::metadata(&link_path).unwrap();
         assert!(metadata.len() > 5); // Should be larger than "dummy"
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -77,6 +77,7 @@ impl std::fmt::Display for Error {
             Error::UnsupportedPlatform(info) => {
                 write!(f, "Unsupported platform: {}", info)
             }
+            #[cfg(windows)]
             Error::RuntimeError(msg) => {
                 write!(f, "Runtime error: {}", msg)
             }

--- a/src/update.rs
+++ b/src/update.rs
@@ -6,6 +6,16 @@ use tokio::io::AsyncWriteExt;
 use crate::config::Config;
 use crate::http::{bearer_header, build_client};
 use crate::input::prompt_yes_no;
+#[cfg(windows)]
+use crate::paths;
+#[cfg(windows)]
+use crate::tools::install::create_wrapper_link;
+#[cfg(windows)]
+use crate::tools::lockfiles::{all_tools, binaries, uses_wrapper};
+#[cfg(windows)]
+use crate::tools::uninstall::gather_installed_links;
+#[cfg(windows)]
+use std::path::Path;
 
 // We track the repo for releases
 const GITHUB_REPO: &str = "anaconda/ana-cli";
@@ -31,6 +41,7 @@ pub enum Error {
     MissingToken,
     AssetNotFound(String),
     UnsupportedPlatform(String),
+    RuntimeError(String),
 }
 
 impl std::fmt::Display for Error {
@@ -51,10 +62,10 @@ impl std::fmt::Display for Error {
                 #[cfg(windows)]
                 {
                     writeln!(f, " Run:")?;
-                    writeln!(f, "   PowerShell: $env:GH_TOKEN=(gh auth token)")?;
+                    writeln!(f, "   PowerShell: $env:GITHUB_TOKEN=(gh auth token)")?;
                     writeln!(
                         f,
-                        "   cmd.exe: for /f %i in ('gh auth token') do set GH_TOKEN=%i"
+                        "   cmd.exe: for /f %i in ('gh auth token') do set GITHUB_TOKEN=%i"
                     )?;
                     writeln!(f, "   git bash: export GITHUB_TOKEN=$(gh auth token)")
                 }
@@ -64,6 +75,9 @@ impl std::fmt::Display for Error {
             }
             Error::UnsupportedPlatform(info) => {
                 write!(f, "Unsupported platform: {}", info)
+            }
+            Error::RuntimeError(msg) => {
+                write!(f, "Runtime error: {}", msg)
             }
         }
     }
@@ -163,6 +177,36 @@ pub async fn download_and_replace(asset: &Asset) -> Result<(), Error> {
     // Replace the running binary in-place
     self_replace::self_replace(&temp_path).map_err(|e| Error::Io(e.to_string()))?;
 
+    #[cfg(windows)]
+    {
+        // Since Windows uses hardlinks, all wrapper binaries
+        // must be relinked to the new `ana` binary
+        let bin_dir = paths::bin_dir();
+        recreate_wrapper_links(&bin_dir)?;
+    }
+
+    Ok(())
+}
+
+/// Recreate hardlinks for all installed wrapper binaries.
+///
+/// On Windows, wrapper binaries (like conda, mamba) are hardlinks to the ana binary.
+/// After self-replacement, these hardlinks still point to the old binary, so they
+/// must be recreated to point to the new one.
+#[cfg(windows)]
+pub fn recreate_wrapper_links(bin_dir: &Path) -> Result<(), Error> {
+    for tool in all_tools().iter() {
+        if !uses_wrapper(tool) {
+            continue;
+        }
+        if gather_installed_links(&bin_dir.to_path_buf(), tool).is_empty() {
+            continue;
+        }
+        let wrapper_bins = binaries(tool).unwrap_or(&[]);
+        for binary in wrapper_bins {
+            create_wrapper_link(bin_dir, binary).map_err(|e| Error::RuntimeError(e.to_string()))?;
+        }
+    }
     Ok(())
 }
 
@@ -533,5 +577,62 @@ mod tests {
         if get_asset_name().is_ok() {
             assert!(matches!(result, Err(Error::AssetNotFound(_))));
         }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_recreate_wrapper_links_with_no_installed_tools() {
+        // When no wrapper tools are installed, recreate_wrapper_links should succeed
+        // without doing anything
+        let temp_dir = std::env::temp_dir().join("ana-test-empty-bin");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let result = super::recreate_wrapper_links(&temp_dir);
+        assert!(result.is_ok());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_recreate_wrapper_links_recreates_existing_links() {
+        use crate::tools::lockfiles::{all_tools, binaries, uses_wrapper};
+
+        let temp_dir = std::env::temp_dir().join("ana-test-wrapper-links");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        // Find a wrapper tool to test with
+        let wrapper_tool = all_tools().iter().find(|t| uses_wrapper(t)).copied();
+        if wrapper_tool.is_none() {
+            // No wrapper tools defined, skip test
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            return;
+        }
+        let tool = wrapper_tool.unwrap();
+        let tool_binaries = binaries(tool).unwrap_or(&[]);
+        if tool_binaries.is_empty() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            return;
+        }
+
+        // Create a dummy existing link (simulating an installed wrapper)
+        let binary_name = format!("{}.exe", tool_binaries[0]);
+        let link_path = temp_dir.join(&binary_name);
+        std::fs::write(&link_path, b"dummy").unwrap();
+
+        // Run recreate_wrapper_links - it should replace the dummy with a hardlink to ana
+        let result = super::recreate_wrapper_links(&temp_dir);
+        assert!(result.is_ok());
+
+        // Verify the link was recreated (it should now be a hardlink to ana.exe)
+        assert!(link_path.exists());
+        let metadata = std::fs::metadata(&link_path).unwrap();
+        assert!(metadata.len() > 5); // Should be larger than "dummy"
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -11,7 +11,7 @@ use crate::paths;
 #[cfg(windows)]
 use crate::tools::install::create_wrapper_link;
 #[cfg(windows)]
-use crate::tools::lockfiles::{all_tools, binaries, uses_wrapper};
+use crate::tools::tools::{all_tools, binaries, uses_wrapper};
 #[cfg(windows)]
 use crate::tools::uninstall::gather_installed_links;
 #[cfg(windows)]
@@ -598,7 +598,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn test_recreate_wrapper_links_recreates_existing_links() {
-        use crate::tools::lockfiles::{all_tools, binaries, uses_wrapper};
+        use crate::tools::tools::{all_tools, binaries, uses_wrapper};
 
         let temp_dir = std::env::temp_dir().join("ana-test-wrapper-links");
         let _ = std::fs::remove_dir_all(&temp_dir);

--- a/src/update.rs
+++ b/src/update.rs
@@ -41,6 +41,7 @@ pub enum Error {
     MissingToken,
     AssetNotFound(String),
     UnsupportedPlatform(String),
+    #[cfg(windows)]
     RuntimeError(String),
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -44,7 +44,20 @@ impl std::fmt::Display for Error {
                     f,
                     "GITHUB_TOKEN not set. Required for accessing private repo."
                 )?;
-                writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
+                #[cfg(unix)]
+                {
+                    writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
+                }
+                #[cfg(windows)]
+                {
+                    writeln!(f, " Run:")?;
+                    writeln!(f, "   PowerShell: $env:GH_TOKEN=(gh auth token)")?;
+                    writeln!(
+                        f,
+                        "   cmd.exe: for /f %i in ('gh auth token') do set GH_TOKEN=%i"
+                    )?;
+                    writeln!(f, "   git bash: export GITHUB_TOKEN=$(gh auth token)")
+                }
             }
             Error::AssetNotFound(platform) => {
                 write!(f, "No release asset found for platform: {}", platform)

--- a/src/update.rs
+++ b/src/update.rs
@@ -191,7 +191,7 @@ pub async fn download_and_replace(asset: &Asset) -> Result<(), Error> {
 
 /// Recreate hardlinks for all installed wrapper binaries.
 ///
-/// On Windows, wrapper binaries (like conda, mamba) are hardlinks to the ana binary.
+/// On Windows, wrapper binaries (like conda) are hardlinks to the ana binary.
 /// After self-replacement, these hardlinks still point to the old binary, so they
 /// must be recreated to point to the new one.
 #[cfg(windows)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from collections.abc import Callable
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 from mock_auth_server import MockAuthServer
+
+ON_WINDOWS = sys.platform == "win32"
 
 
 def _find_repo_root() -> Path:
@@ -49,7 +52,12 @@ def env_isolated(fake_home: Path) -> dict[str, str]:
         for key, val in os.environ.copy().items()
         if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
     }
-    env["HOME"] = str(fake_home)
+    if ON_WINDOWS:
+        env["USERPROFILE"] = str(fake_home)
+        # Rattler does not reliably detect the default cache in PowerShell
+        env["RATTLER_CACHE_DIR"] = str(fake_home / "cache" / "rattler")
+    else:
+        env["HOME"] = str(fake_home)
     return env
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def run_ana(ana_binary: Path | None, env_isolated: dict[str, str]) -> AnaRunner:
             [str(ana_binary), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             env=env,
             input=input,
             cwd=cwd,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from conftest import AnaRunner
+
+ON_WINDOWS = sys.platform == "win32"
+# On Windows, wrappers have the .exe suffix
+EXT = ".exe" if ON_WINDOWS else ""
+
+
+def _is_link(link: Path) -> bool:
+    """Test if binary is a symlink (Unix) or hardlink (Windows)"""
+
+    if ON_WINDOWS:
+        return os.stat(link).st_nlink > 1
+    return link.is_symlink()
 
 
 class TestHelp:
@@ -232,9 +246,9 @@ class TestBootstrap:
         assert result.returncode == 0
 
         # Verify the symlinked binary exists
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / f"anaconda{EXT}"
         assert bin_path.exists(), f"Binary not found: {bin_path}"
-        assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+        assert _is_link(bin_path), f"Binary is not a link: {bin_path}"
 
     def test_bootstrap_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
@@ -245,7 +259,7 @@ class TestBootstrap:
         assert first_result.returncode == 0
 
         # Verify installation exists
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / f"anaconda{EXT}"
         assert bin_path.exists()
 
         # Second run should indicate already installed
@@ -261,7 +275,7 @@ class TestBootstrap:
         assert result.returncode == 0
 
         # Run the installed anaconda binary
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / f"anaconda{EXT}"
         assert bin_path.exists()
 
         proc = subprocess.run(

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.server
 import os
+import shutil
 import socketserver
 import stat
 import subprocess
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
 
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
 IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS and not shutil.which("sh"):
+    pytest.skip("Tests only work in bash shell on Windows.", allow_module_level=True)
 
 # Create a simple mock binary script that responds to --version and --help
 MOCK_BINARY_SCRIPT = """\

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -255,8 +256,9 @@ class TestCondaWrapper:
         (fish_config / "config.fish").touch()
 
         def cleanup():
-            # Use system rm for faster cleanup of many files (conda installs ~127 packages)
-            subprocess.run(["rm", "-rf", str(home)], check=False)
+            from shutil import rmtree
+
+            rmtree(home, ignore_errors=True)
 
         request.addfinalizer(cleanup)
         return home
@@ -271,7 +273,12 @@ class TestCondaWrapper:
             for key, val in os.environ.copy().items()
             if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
         }
-        env["HOME"] = str(conda_home)
+        if sys.platform == "win32":
+            env["USERPROFILE"] = str(conda_home)
+        else:
+            env["HOME"] = str(conda_home)
+        env["RATTLER_CACHE_DIR"] = str(conda_home / "cache" / "rattler")
+        env["CONDA_PLUGINS_AUTO_ACCEPT_TOS"] = "yes"
         return env
 
     @pytest.fixture(scope="class")
@@ -279,8 +286,6 @@ class TestCondaWrapper:
         self, ana_binary: Path | None, conda_home: Path, conda_env: dict[str, str]
     ) -> Path:
         """Install conda once and return the wrapper binary path."""
-        import sys
-
         if ana_binary is None:
             pytest.skip(
                 "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 from conftest import AnaRunner
+
+ON_WINDOWS = sys.platform == "win32"
+# On Windows, wrappers have the .exe suffix
+EXT = ".exe" if ON_WINDOWS else ""
+
+
+def _is_link(link: Path) -> bool:
+    """Test if binary is a symlink (Unix) or hardlink (Windows)"""
+
+    if ON_WINDOWS:
+        return os.stat(link).st_nlink > 1
+    return link.is_symlink()
 
 
 class TestToolInstallHelp:
@@ -45,16 +58,16 @@ class TestToolInstallPixi:
         assert tool_dir.exists(), f"Tool directory not found: {tool_dir}"
         assert tool_dir.is_dir()
 
-    def test_tool_install_pixi_creates_symlink(
+    def test_tool_install_pixi_creates_link(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
-        """Test that tool install creates a symlinked pixi binary in ~/.ana/bin."""
+        """Test that tool install creates a linked pixi binary in ~/.ana/bin."""
         result = run_ana("tool", "install", "pixi")
         assert result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / f"pixi{EXT}"
         assert bin_path.exists(), f"Binary not found: {bin_path}"
-        assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+        assert _is_link(bin_path), f"Binary is not a link: {bin_path}"
 
     def test_tool_install_pixi_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
@@ -64,7 +77,7 @@ class TestToolInstallPixi:
         first_result = run_ana("tool", "install", "pixi")
         assert first_result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / f"pixi{EXT}"
         assert bin_path.exists()
 
         # Second run should indicate already up to date
@@ -79,7 +92,7 @@ class TestToolInstallPixi:
         result = run_ana("tool", "install", "pixi")
         assert result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / f"pixi{EXT}"
         assert bin_path.exists()
 
         proc = subprocess.run(
@@ -176,7 +189,7 @@ class TestToolUninstall:
         assert install_result.returncode == 0
 
         tool_dir = fake_home / ".ana" / "tools" / "pixi"
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / f"pixi{EXT}"
         assert tool_dir.exists()
         assert bin_path.exists()
 
@@ -201,8 +214,8 @@ class TestToolUninstall:
         uninstall_result = run_ana("tool", "uninstall", "pixi", "--yes")
         assert uninstall_result.returncode == 0
         assert "The following will be removed:" in uninstall_result.stderr
-        assert ".ana/bin/pixi" in uninstall_result.stderr
-        assert ".ana/tools/pixi" in uninstall_result.stderr
+        assert str(Path(".ana/bin/pixi")) in uninstall_result.stderr
+        assert str(Path(".ana/tools/pixi")) in uninstall_result.stderr
 
 
 class TestToolInstallConda:
@@ -219,24 +232,29 @@ class TestToolInstallConda:
         assert tool_dir.exists(), f"Tool directory not found: {tool_dir}"
         assert tool_dir.is_dir()
 
-    def test_tool_install_conda_creates_wrapper_symlink(
+    def test_tool_install_conda_creates_wrapper_link(
         self, run_ana: AnaRunner, fake_home: Path, ana_binary: Path
     ) -> None:
-        """Test that tool install creates a wrapper symlink that points to ana."""
+        """Test that tool install creates a wrapper link that points to ana."""
         result = run_ana("tool", "install", "conda")
         assert result.returncode == 0
         assert "(wrapper)" in result.stderr
 
-        bin_path = fake_home / ".ana" / "bin" / "conda"
+        bin_path = fake_home / ".ana" / "bin" / f"conda{EXT}"
         assert bin_path.exists(), f"Binary not found: {bin_path}"
-        assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+        assert _is_link(bin_path), f"Binary is not a link: {bin_path}"
 
-        # Verify the symlink points to the ana binary, not to the actual conda
-        target = bin_path.resolve()
-        assert target == ana_binary.resolve(), (
-            f"Wrapper symlink should point to ana binary, "
-            f"got {target} instead of {ana_binary.resolve()}"
-        )
+        if not ON_WINDOWS:
+            # Verify the symlink points to the ana binary, not to the actual conda
+            target = bin_path.resolve()
+            assert target == ana_binary.resolve(), (
+                f"Wrapper symlink should point to ana binary, "
+                f"got {target} instead of {ana_binary.resolve()}"
+            )
+        else:
+            assert bin_path.read_bytes() == ana_binary.read_bytes(), (
+                "Wrapper link should be identical to ana binary."
+            )
 
 
 class TestCondaWrapper:
@@ -273,11 +291,12 @@ class TestCondaWrapper:
             for key, val in os.environ.copy().items()
             if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
         }
-        if sys.platform == "win32":
+        if ON_WINDOWS:
             env["USERPROFILE"] = str(conda_home)
+            # Rattler does not reliably detect the default cache in PowerShell
+            env["RATTLER_CACHE_DIR"] = str(conda_home / "cache" / "rattler")
         else:
             env["HOME"] = str(conda_home)
-        env["RATTLER_CACHE_DIR"] = str(conda_home / "cache" / "rattler")
         env["CONDA_PLUGINS_AUTO_ACCEPT_TOS"] = "yes"
         return env
 
@@ -299,9 +318,7 @@ class TestCondaWrapper:
         )
         assert result.returncode == 0, f"Failed to install conda: {result.stderr}"
 
-        # On Windows, the wrapper is conda.exe; on Unix it's just conda
-        wrapper_name = "conda.exe" if sys.platform == "win32" else "conda"
-        wrapper = conda_home / ".ana" / "bin" / wrapper_name
+        wrapper = conda_home / ".ana" / "bin" / f"conda{EXT}"
         assert wrapper.exists(), f"Wrapper not found at {wrapper}"
         return wrapper
 


### PR DESCRIPTION
## Summary

Windows does not support symlinks by default and require developer mode to be enabled (see also the [rust documentation](https://doc.rust-lang.org/stable/std/os/windows/fs/fn.symlink_file.html#limitations)). This requires administrator privileges, which not every user has. To reliably work, files will need to be hard-linked.

As a consequence, all files that are wrappers must be relinked on `ana self update`.

Additionally, this PR contains a few general Windows fixes for the `conda` tool implementation and integration tests.

## Important limitations

It is required that these hard links be on the same drive as `ana.exe`. Since everything is installed inside the `ana` directory, this is not a problem. This can cause issues when designing tests though since the temporary directory of the GitHub runner is on `D:\`.

## AI disclosure

AI was used to answer general rust questions and debug. Claude wrote the unit tests in `update.rs`.