### PR TITLE
feat: Update default domains to prod

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,12 +65,11 @@ fn try_setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// TODO(mattkram): Update default to anaconda.com before public release
-const DEFAULT_DOMAIN: &str = "stage.anaconda.com";
+const DEFAULT_DOMAIN: &str = "anaconda.com";
 const DEFAULT_CLIENT_ID: &str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a";
 const DEFAULT_SSL_VERIFY: bool = true;
 const DEFAULT_OPEN_BROWSER: bool = true;
-const DEFAULT_METRICS_ENDPOINT: &str = "https://metrics.auth.anacondaconnect.com/v1/metrics";
+const DEFAULT_METRICS_ENDPOINT: &str = "https://metrics.anaconda.com/v1/metrics";
 const DEFAULT_METRICS_EXPORT_INTERVAL_MS: i64 = 1000;
 const DEFAULT_METRICS_CONSOLE_EXPORTER: bool = false;
 const DEFAULT_METRICS_SKIP_INTERNET_CHECK: bool = true;


### PR DESCRIPTION
## Summary

Updates the default domains to production, for more straightforward user testing. Specifically, login and API requests are now to `https://anaconda.com`, and metrics will be sent to `https://metrics.anaconda.com/v1/metrics`.

Values can still be over-ridden locally via environment variables if needed.

Jira: [CLI-495](https://anaconda.atlassian.net/browse/CLI-495)

[CLI-495]: https://anaconda.atlassian.net/browse/CLI-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ