### PR TITLE
feat: Add `ana init main-x`

### DIFF
--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -131,6 +131,12 @@ fn load_keyring(config: &Config) -> Result<Keyring, AuthError> {
     }
 
     let contents = fs::read_to_string(path).map_err(|e| keyring_io_error("read", e))?;
+
+    // Handle empty file as empty keyring
+    if contents.trim().is_empty() {
+        return Ok(Keyring::new());
+    }
+
     let keyring: Keyring =
         serde_json::from_str(&contents).map_err(|e| AuthError::Keyring(e.to_string()))?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ use crate::config::{self, Config};
 #[cfg(feature = "feedback")]
 use crate::feedback::{self, FeedbackType};
 use crate::help;
+use crate::init;
 use crate::tools;
 use crate::update;
 
@@ -124,6 +125,7 @@ pub enum Action {
         force: bool,
     },
     ToolList,
+    InitMainX,
 }
 
 impl Action {
@@ -147,6 +149,7 @@ impl Action {
             Action::ToolInstall { .. } => "tool.install",
             Action::ToolUninstall { .. } => "tool.uninstall",
             Action::ToolList => "tool.list",
+            Action::InitMainX => "init.main-x",
         }
     }
 
@@ -232,6 +235,10 @@ impl Action {
                 feedback::open_feedback(feedback_type, description);
                 Ok(())
             }
+            Action::InitMainX => {
+                init::init_main_x().await?;
+                Ok(())
+            }
         }
     }
 }
@@ -285,6 +292,10 @@ pub fn parse() -> (Action, LogLevel) {
                     Some(ToolCommands::Uninstall { name, force }) => {
                         Action::ToolUninstall { name, force }
                     }
+                },
+                Some(Commands::Init { command }) => match command {
+                    None => Action::ShowSubcommandHelp("init".to_string()),
+                    Some(InitCommands::MainX) => Action::InitMainX,
                 },
             };
             (action, level)
@@ -442,6 +453,17 @@ enum Commands {
         #[command(subcommand)]
         command: Option<ToolCommands>,
     },
+
+    /// Initialize Anaconda services
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana init <command> [options]"
+    )]
+    Init {
+        #[command(subcommand)]
+        command: Option<InitCommands>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -512,6 +534,13 @@ enum ToolCommands {
         #[arg(short = 'y', long = "yes")]
         force: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum InitCommands {
+    /// Configure Main-X channel for early access packages
+    #[command(name = "main-x")]
+    MainX,
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,9 +220,9 @@ impl Config {
     }
 }
 
-/// Get the default keyring path (~/.ana/keyring or $ANA_HOME/keyring).
+/// Get the default keyring path (~/.anaconda/keyring or $ANA_KEYRING_PATH).
 fn default_keyring_path() -> PathBuf {
-    crate::paths::ana_home().join("keyring")
+    crate::paths::home_dir().join(".anaconda").join("keyring")
 }
 
 /// Parse a boolean from a string value.
@@ -400,8 +400,8 @@ mod tests {
     #[test]
     fn test_config_default_keyring_path() {
         let config = Config::load();
-        // Should end with .ana/keyring
-        assert!(config.keyring_path.ends_with(".ana/keyring"));
+        // Should end with .anaconda/keyring
+        assert!(config.keyring_path.ends_with(".anaconda/keyring"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,12 +65,11 @@ fn try_setup_telemetry() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// TODO(mattkram): Update default to anaconda.com before public release
-const DEFAULT_DOMAIN: &str = "stage.anaconda.com";
+const DEFAULT_DOMAIN: &str = "anaconda.com";
 const DEFAULT_CLIENT_ID: &str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a";
 const DEFAULT_SSL_VERIFY: bool = true;
 const DEFAULT_OPEN_BROWSER: bool = true;
-const DEFAULT_METRICS_ENDPOINT: &str = "https://metrics.auth.anacondaconnect.com/v1/metrics";
+const DEFAULT_METRICS_ENDPOINT: &str = "https://metrics.anaconda.com/v1/metrics";
 const DEFAULT_METRICS_EXPORT_INTERVAL_MS: i64 = 1000;
 const DEFAULT_METRICS_CONSOLE_EXPORTER: bool = false;
 const DEFAULT_METRICS_SKIP_INTERNET_CHECK: bool = true;

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -21,6 +21,10 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
         name: "TOOLCHAIN",
         commands: &["tool", "bootstrap", "config", "self"],
     },
+    HelpSection {
+        name: "SETUP",
+        commands: &["init"],
+    },
 ];
 
 /// Examples for the help output (using real commands)

--- a/src/init/main_x.rs
+++ b/src/init/main_x.rs
@@ -10,13 +10,14 @@ use miette::{Context, IntoDiagnostic};
 use crate::auth;
 use crate::paths;
 
+const MAIN_CHANNEL: &str = "https://repo.anaconda.com/pkgs/main";
 const MAIN_X_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main-x";
 
 /// Initialize Main-X channel access.
 ///
 /// This command:
 /// 1. Ensures the user is logged in to Anaconda
-/// 2. Adds the Main-X channel to conda configuration
+/// 2. Adds the Main-X channel to conda configuration (with main channel for fallback)
 /// 3. Provides instructions for reverting the changes
 pub async fn init_main_x() -> miette::Result<()> {
     eprintln!("Initializing Main-X channel access...");
@@ -25,8 +26,8 @@ pub async fn init_main_x() -> miette::Result<()> {
     // Step 1: Check login status and prompt if needed
     ensure_logged_in().await?;
 
-    // Step 2: Configure conda channel
-    configure_conda_channel()?;
+    // Step 2: Configure conda channels
+    configure_conda_channels()?;
 
     // Step 3: Show success message and undo instructions
     eprintln!();
@@ -62,35 +63,75 @@ async fn ensure_logged_in() -> miette::Result<()> {
     }
 }
 
-/// Configure conda to use the Main-X channel.
-fn configure_conda_channel() -> miette::Result<()> {
+/// Configure conda to use the Main-X channel with main as fallback.
+///
+/// Ensures that:
+/// - main-x is present in channels
+/// - main is present in channels (for fallback)
+/// - main has higher precedence than main-x (appears earlier in the list)
+fn configure_conda_channels() -> miette::Result<()> {
     eprintln!("Configuring conda channels...");
 
     let conda_bin = find_conda()?;
+    let current_channels = get_configured_channels(&conda_bin)?;
 
-    // Check if channel is already configured
-    if is_channel_configured(&conda_bin)? {
-        eprintln!("  Main-X channel is already configured.");
+    let has_main = current_channels.iter().any(|c| c == MAIN_CHANNEL);
+    let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
+
+    // Check if main comes before main-x (correct precedence)
+    let main_before_main_x = if has_main && has_main_x {
+        let main_pos = current_channels.iter().position(|c| c == MAIN_CHANNEL);
+        let main_x_pos = current_channels.iter().position(|c| c == MAIN_X_CHANNEL);
+        main_pos < main_x_pos
+    } else {
+        true // Will be configured correctly below
+    };
+
+    if has_main && has_main_x && main_before_main_x {
+        eprintln!("  Channels already configured correctly.");
         return Ok(());
     }
 
-    // Add the channel (prepend so it has higher priority)
-    eprintln!("  Adding Main-X channel: {}", MAIN_X_CHANNEL);
+    // Add channels as needed, using --add (prepend) to set precedence
+    // We add main-x first, then main, so main ends up with higher precedence
 
-    let status = Command::new(&conda_bin)
-        .args(["config", "--add", "channels", MAIN_X_CHANNEL])
+    if !has_main_x {
+        eprintln!("  Adding Main-X channel: {}", MAIN_X_CHANNEL);
+        run_conda_config(&conda_bin, &["--add", "channels", MAIN_X_CHANNEL])?;
+    }
+
+    if !has_main {
+        eprintln!("  Adding main channel: {}", MAIN_CHANNEL);
+        run_conda_config(&conda_bin, &["--add", "channels", MAIN_CHANNEL])?;
+    } else if has_main_x && !main_before_main_x {
+        // main exists but has lower precedence than main-x, need to fix
+        eprintln!("  Adjusting channel precedence (main should be higher than main-x)...");
+        // Remove and re-add main to move it to the top
+        run_conda_config(&conda_bin, &["--remove", "channels", MAIN_CHANNEL])?;
+        run_conda_config(&conda_bin, &["--add", "channels", MAIN_CHANNEL])?;
+    }
+
+    eprintln!("  Channels configured successfully.");
+
+    Ok(())
+}
+
+/// Run a conda config command.
+fn run_conda_config(conda_bin: &Path, args: &[&str]) -> miette::Result<()> {
+    let status = Command::new(conda_bin)
+        .arg("config")
+        .args(args)
         .status()
         .into_diagnostic()
         .context("failed to run conda config")?;
 
     if !status.success() {
         return Err(miette::miette!(
-            "conda config failed with exit code: {}",
+            "conda config {} failed with exit code: {}",
+            args.join(" "),
             status
         ));
     }
-
-    eprintln!("  Channel added successfully.");
 
     Ok(())
 }
@@ -120,21 +161,42 @@ fn find_conda() -> miette::Result<std::path::PathBuf> {
     }
 }
 
-/// Check if the Main-X channel is already in the conda configuration.
-fn is_channel_configured(conda_bin: &Path) -> miette::Result<bool> {
+/// Get the list of currently configured channels from conda config --show.
+///
+/// The output format is:
+/// ```
+/// channels:
+///   - conda-forge
+///   - defaults
+/// ```
+fn get_configured_channels(conda_bin: &Path) -> miette::Result<Vec<String>> {
     let output = Command::new(conda_bin)
         .args(["config", "--show", "channels"])
         .output()
         .into_diagnostic()
-        .context("failed to run conda config --show")?;
+        .context("failed to run conda config --show channels")?;
 
     if !output.status.success() {
-        // If command fails, assume channel is not configured
-        return Ok(false);
+        // If command fails, assume no channels configured
+        return Ok(vec![]);
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(stdout.contains(MAIN_X_CHANNEL))
+
+    // Parse YAML-like output: skip "channels:" line, then extract "  - <channel>" lines
+    let channels: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- ") {
+                Some(trimmed.strip_prefix("- ").unwrap().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(channels)
 }
 
 #[cfg(test)]
@@ -142,7 +204,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_main_x_channel_constant() {
+    fn test_channel_constants() {
+        assert_eq!(MAIN_CHANNEL, "https://repo.anaconda.com/pkgs/main");
         assert_eq!(MAIN_X_CHANNEL, "https://repo.anaconda.cloud/repo/main-x");
+    }
+
+    #[test]
+    fn test_parse_channels_output() {
+        let output = "channels:\n  - conda-forge\n  - defaults\n";
+        let channels: Vec<String> = output
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.starts_with("- ") {
+                    Some(trimmed.strip_prefix("- ").unwrap().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(channels, vec!["conda-forge", "defaults"]);
     }
 }

--- a/src/init/main_x.rs
+++ b/src/init/main_x.rs
@@ -1,0 +1,148 @@
+//! Main-X channel initialization.
+//!
+//! Configures conda to use the Anaconda Main-X channel for early access packages.
+
+use std::path::Path;
+use std::process::Command;
+
+use miette::{Context, IntoDiagnostic};
+
+use crate::auth;
+use crate::paths;
+
+const MAIN_X_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main-x";
+
+/// Initialize Main-X channel access.
+///
+/// This command:
+/// 1. Ensures the user is logged in to Anaconda
+/// 2. Adds the Main-X channel to conda configuration
+/// 3. Provides instructions for reverting the changes
+pub async fn init_main_x() -> miette::Result<()> {
+    eprintln!("Initializing Main-X channel access...");
+    eprintln!();
+
+    // Step 1: Check login status and prompt if needed
+    ensure_logged_in().await?;
+
+    // Step 2: Configure conda channel
+    configure_conda_channel()?;
+
+    // Step 3: Show success message and undo instructions
+    eprintln!();
+    eprintln!("Main-X channel configured successfully!");
+    eprintln!();
+    eprintln!("You can now install packages from the Main-X channel.");
+    eprintln!();
+    eprintln!("To undo this configuration, run:");
+    eprintln!("  conda config --remove channels {}", MAIN_X_CHANNEL);
+
+    Ok(())
+}
+
+/// Ensure the user is logged in, prompting them to login if not.
+async fn ensure_logged_in() -> miette::Result<()> {
+    eprintln!("Checking authentication status...");
+
+    // Try to get API key to check if logged in
+    let config = crate::config::Config::load();
+    match auth::get_api_key(&config) {
+        Ok(Some(_)) => {
+            eprintln!("  Already logged in.");
+            Ok(())
+        }
+        Ok(None) | Err(_) => {
+            eprintln!("  Not logged in. Starting login flow...");
+            eprintln!();
+            auth::login()
+                .await
+                .map_err(|e| miette::miette!("Login failed: {}", e))?;
+            Ok(())
+        }
+    }
+}
+
+/// Configure conda to use the Main-X channel.
+fn configure_conda_channel() -> miette::Result<()> {
+    eprintln!("Configuring conda channels...");
+
+    let conda_bin = find_conda()?;
+
+    // Check if channel is already configured
+    if is_channel_configured(&conda_bin)? {
+        eprintln!("  Main-X channel is already configured.");
+        return Ok(());
+    }
+
+    // Add the channel (prepend so it has higher priority)
+    eprintln!("  Adding Main-X channel: {}", MAIN_X_CHANNEL);
+
+    let status = Command::new(&conda_bin)
+        .args(["config", "--add", "channels", MAIN_X_CHANNEL])
+        .status()
+        .into_diagnostic()
+        .context("failed to run conda config")?;
+
+    if !status.success() {
+        return Err(miette::miette!(
+            "conda config failed with exit code: {}",
+            status
+        ));
+    }
+
+    eprintln!("  Channel added successfully.");
+
+    Ok(())
+}
+
+/// Find the conda binary.
+///
+/// First checks if conda is installed via ana (in ~/.ana/tools/conda),
+/// then falls back to looking in PATH.
+fn find_conda() -> miette::Result<std::path::PathBuf> {
+    // Check ana-managed conda first
+    let ana_conda = paths::tool_prefix("conda")
+        .join("bin")
+        .join(paths::binary_name("conda"));
+    if ana_conda.exists() {
+        return Ok(ana_conda);
+    }
+
+    // Check if conda is in PATH by trying to run it
+    let conda_path = std::path::PathBuf::from("conda");
+    let check = Command::new(&conda_path).arg("--version").output();
+
+    match check {
+        Ok(output) if output.status.success() => Ok(conda_path),
+        _ => Err(miette::miette!(
+            "conda not found. Install it with: ana tool install conda"
+        )),
+    }
+}
+
+/// Check if the Main-X channel is already in the conda configuration.
+fn is_channel_configured(conda_bin: &Path) -> miette::Result<bool> {
+    let output = Command::new(conda_bin)
+        .args(["config", "--show", "channels"])
+        .output()
+        .into_diagnostic()
+        .context("failed to run conda config --show")?;
+
+    if !output.status.success() {
+        // If command fails, assume channel is not configured
+        return Ok(false);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.contains(MAIN_X_CHANNEL))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_main_x_channel_constant() {
+        assert_eq!(MAIN_X_CHANNEL, "https://repo.anaconda.cloud/repo/main-x");
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1,0 +1,5 @@
+//! Initialization commands for Anaconda services.
+
+mod main_x;
+
+pub use main_x::init_main_x;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod diagnostics;
 mod feedback;
 mod help;
 mod http;
+mod init;
 mod input;
 mod paths;
 mod qr;


### PR DESCRIPTION
## Summary

Adds the ability for users to easily initialize their conda configuration for the `main-x` channel.

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: [CLI-413](https://anaconda.atlassian.net/browse/CLI-413)


[CLI-413]: https://anaconda.atlassian.net/browse/CLI-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ