### PR TITLE
feat: Improved UX for auth commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cargo-lock",
+ "chrono",
  "clap",
  "comfy-table",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ feedback = ["dep:urlencoding"]
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 futures-util = "0.3"
 dirs = "6"
 http = "1"

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:211fc3aa-3f45-495e-bb3a-3d7236fa4833",
+  "serialNumber": "urn:uuid:2e59e5d5-ff30-466e-ae40-30f9059be427",
   "metadata": {
-    "timestamp": "2026-04-13T23:08:31Z",
+    "timestamp": "2026-04-20T22:40:31Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14451,6 +14451,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
@@ -18038,6 +18039,36 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "id": "RUSTSEC-2026-0098",
+      "description": "Name constraints for URI names were ignored and therefore accepted.\n\nNote this library does not provide an API for asserting URI names, and URI name constraints are otherwise not implemented.  URI name constraints are now rejected unconditionally.\n\nSince name constraints are restrictions on otherwise properly-issued certificates, this bug is reachable only after signature verification and requires misissuance to exploit.\n\nThis vulnerability is identified as [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5). Thank you to @1seal for the report.",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0098.html"
+      },
+      "ratings": [],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.11"
+        }
+      ]
+    },
+    {
+      "id": "RUSTSEC-2026-0099",
+      "description": "Permitted subtree name constraints for DNS names were accepted for certificates asserting a wildcard name.\n\nThis was incorrect because, given a name constraint of `accept.example.com`, `*.example.com` could feasibly allow a name of `reject.example.com` which is outside the constraint.\nThis is very similar to [CVE-2025-61727](https://go.dev/issue/76442).\n\nSince name constraints are restrictions on otherwise properly-issued certificates, this bug is reachable only after signature verification and requires misissuance to exploit.\n\nThis vulnerability is identified as [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh). Thank you to @1seal for the report.",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0099.html"
+      },
+      "ratings": [],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.11"
+        }
+      ]
     }
   ]
 }

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-04-13T23:08:31Z<br>
+Generated: 2026-04-20T22:40:31Z<br>
 Format: CycloneDX 1.4<br>
 Packages: 464 (65 platform-specific)<br>
 Platforms: linux, macos, windows
-<br>**Security advisories: 0 found at this time**
+<br>**[Security advisories](#security-advisories): 2 across 1 package**
 
 ## Packages
 
@@ -295,7 +295,7 @@ Platforms: linux, macos, windows
 | [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux, macos |  |
 | [rustls](https://crates.io/crates/rustls) | 0.23.38 | Apache-2.0 OR ISC OR MIT |  |  |
 | [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.0 | MIT OR Apache-2.0 |  |  |
-| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.11 | ISC |  |  |
+| [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.11 | ISC |  | 2 |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
 | [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT | windows |  |
@@ -474,6 +474,13 @@ Platforms: linux, macos, windows
 | [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |  |
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
+
+## Security Advisories
+
+| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
+| --- | --- | --- | :---: | :---: | --- |
+| rustls-webpki | 0.103.11 | [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) |  |  |  |
+| rustls-webpki | 0.103.11 | [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html) |  |  |  |
 
 ## License Summary
 

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -462,10 +462,10 @@ pub fn logout() -> Result<(), AuthError> {
         "Logged out of {}",
         status::highlight(&config.domain)
     ));
-    status::success("Token removed from system keyring");
+    status::success("API key removed from system keyring");
     status::warn(&format!(
         "To fully revoke your token visit {}",
-        status::highlight(&format!("{}/settings/tokens", config.domain))
+        status::highlight(&format!("{}/app/profile/api-keys", config.domain))
     ));
     Ok(())
 }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -122,6 +122,95 @@ struct TokenErrorResponse {
     error_description: Option<String>,
 }
 
+/// Account information from the API.
+#[derive(Debug, Deserialize)]
+struct AccountInfo {
+    email: Option<String>,
+    user: Option<UserInfo>,
+}
+
+/// User information nested in account response.
+#[derive(Debug, Deserialize)]
+struct UserInfo {
+    username: Option<String>,
+}
+
+/// API key information from the API.
+#[derive(Debug, Deserialize)]
+struct ApiKeyInfo {
+    expires_at: Option<String>,
+}
+
+/// Print logged-in user status line.
+///
+/// Example: `✓ Logged in as kford@anaconda.com (anaconda)`
+fn print_logged_in_status(email: &str, org: &str) {
+    status::success(&format!(
+        "Logged in as {} ({})",
+        status::highlight(email),
+        org
+    ));
+}
+
+/// Calculate days from today until a date string (YYYY-MM-DD format).
+fn days_until_date(date_str: &str) -> Option<i64> {
+    let expires = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()?;
+    let today = chrono::Utc::now().date_naive();
+    Some((expires - today).num_days())
+}
+
+/// Print token expiration info.
+///
+/// Example: `  expires    2026-04-09 (365 days)`
+fn print_expiration(expires_at: &str) {
+    // Parse the expiration date and calculate days remaining
+    if let Some(days_remaining) = days_until_date(&expires_at[..10]) {
+        let days_str = if days_remaining == 1 {
+            "1 day".to_string()
+        } else {
+            format!("{} days", days_remaining)
+        };
+        eprintln!(
+            "  {}{}{}",
+            status::dim("expires    "),
+            status::highlight(&expires_at[..10]),
+            status::dim(&format!(" ({days_str})"))
+        );
+    }
+}
+
+/// Combined login information for display.
+struct LoginInfo {
+    email: String,
+    org: String,
+    expires_at: Option<String>,
+}
+
+/// Fetch login info (account + API key expiration) for display after login.
+async fn fetch_login_info(config: &Config) -> Result<LoginInfo, AuthError> {
+    let client = ApiClient::new()?;
+
+    // Fetch account info
+    let account_response = client.get("/api/account").send().await?;
+    let account: AccountInfo = account_response.json().await?;
+
+    let email = account
+        .email
+        .or_else(|| account.user.and_then(|u| u.username))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Fetch API key info for expiration
+    let keys_response = client.get("/api/auth/api-keys").send().await?;
+    let keys: Vec<ApiKeyInfo> = keys_response.json().await.unwrap_or_default();
+    let expires_at = keys.first().and_then(|k| k.expires_at.clone());
+
+    Ok(LoginInfo {
+        email,
+        org: config.domain.clone(),
+        expires_at,
+    })
+}
+
 /// Perform the device authorization flow.
 pub async fn login() -> Result<(), AuthError> {
     // We use a new, unauthenticated client instead of ApiClient, since
@@ -277,7 +366,16 @@ pub async fn login() -> Result<(), AuthError> {
 
             // Save to keyring
             save_api_key(&config, &api_key)?;
-            status::success("Token stored in system keyring");
+            status::success("Token stored in keyring");
+
+            // Fetch and display user info
+            if let Ok(login_info) = fetch_login_info(&config).await {
+                print_logged_in_status(&login_info.email, &login_info.org);
+                if let Some(ref expires_at) = login_info.expires_at {
+                    print_expiration(expires_at);
+                }
+            }
+
             return Ok(());
         }
 

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -137,7 +137,7 @@ struct SubscriptionInfo {
 
 /// Print logged-in user status line.
 ///
-/// Example: `✓ Logged in as kford@anaconda.com (anaconda)`
+/// Example: `✓ Logged in as user@example.com (example)`
 fn print_logged_in_status(email: &str, org: &str) {
     status::success(&format!(
         "Logged in as {} ({})",
@@ -483,7 +483,7 @@ pub fn show_api_key() -> Result<(), AuthError> {
 
 /// Print a labeled key-value line for whoami output.
 ///
-/// Example: `  name        Jane Ngo`
+/// Example: `  name        Alice Smith`
 fn print_kv(key: &str, value: &str) {
     // Pad key to 12 chars (longest key "username" is 8 + 4 spaces = 12)
     // Pad plain text first, then apply styling (ANSI codes break format padding)

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -28,7 +28,6 @@ fn print_qr(qr: &str) {
 pub struct ApiClient {
     inner: Client,
     api_key: Option<String>,
-    domain: String,
 }
 
 impl ApiClient {
@@ -47,18 +46,12 @@ impl ApiClient {
         Ok(Self {
             inner: client,
             api_key,
-            domain: config.domain,
         })
     }
 
     /// Check if the client has valid credentials.
     pub fn is_authenticated(&self) -> bool {
         self.api_key.is_some()
-    }
-
-    /// Get the configured domain.
-    pub fn domain(&self) -> &str {
-        &self.domain
     }
 
     /// GET request.

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -19,11 +19,11 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Print a QR code to the terminal with indentation.
 fn print_qr(qr: &str) {
-    status::blank_line();
+    eprintln!();
     for line in qr.lines() {
         eprintln!("    {}", line);
     }
-    status::blank_line();
+    eprintln!();
 }
 
 /// HTTP client with configuration and optional authentication.

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -430,7 +430,7 @@ pub fn logout() -> Result<(), AuthError> {
     status::success("API key removed from system keyring");
     status::warn(&format!(
         "To fully revoke your token visit {}",
-        status::highlight(&format!("{}/app/profile/api-keys", config.domain))
+        status::highlight(&format!("{}/app/profile/api-keys", config.base_url()))
     ));
     Ok(())
 }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -632,8 +632,8 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
                 if let Some(days) = days_until_date(&date_part) {
                     let (duration_str, is_expired) = format_duration(days);
                     let suffix = if is_expired {
-                        use crate::ui::styles::{RED, style_for};
-                        format!(" ({})", style_for(RED).apply_to(&duration_str))
+                        use crate::ui::styles::UiColor;
+                        format!(" ({})", UiColor::Red.apply_to(&duration_str))
                     } else {
                         status::dim(&format!(" ({})", duration_str))
                     };
@@ -675,8 +675,8 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
 
 /// Style a section header (green, uppercase).
 fn style_section(name: &str) -> String {
-    use crate::ui::styles::{GREEN, style_for};
-    style_for(GREEN).apply_to(name.to_uppercase()).to_string()
+    use crate::ui::styles::UiColor;
+    UiColor::Green.apply_to(name.to_uppercase()).to_string()
 }
 
 #[cfg(test)]

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -2,12 +2,14 @@
 
 use std::time::Duration;
 
-use serde::Deserialize;
 use tokio::time::sleep;
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
 use super::keyring::{delete_api_key, get_api_key, save_api_key};
+use super::responses::{
+    AccountResponse, DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse,
+};
 use crate::config::Config;
 use crate::http::{Client, bearer_header, build_client};
 use crate::input::KeyListener;
@@ -82,50 +84,6 @@ impl ApiClient {
     pub fn delete(&self, url: &str) -> reqwest_middleware::RequestBuilder {
         self.inner.delete(url)
     }
-}
-
-/// OpenID Connect discovery document.
-#[derive(Debug, Deserialize)]
-struct OpenIdConfig {
-    device_authorization_endpoint: Option<String>,
-    token_endpoint: String,
-}
-
-/// Response from the device authorization endpoint.
-#[derive(Debug, Deserialize)]
-struct DeviceAuthResponse {
-    device_code: String,
-    user_code: String,
-    verification_uri: String,
-    verification_uri_complete: Option<String>,
-    expires_in: u64,
-    interval: Option<u64>,
-}
-
-/// Response from the token endpoint.
-#[derive(Debug, Deserialize)]
-struct TokenResponse {
-    access_token: String,
-}
-
-/// Error response from the token endpoint during polling.
-#[derive(Debug, Deserialize)]
-struct TokenErrorResponse {
-    error: String,
-    error_description: Option<String>,
-}
-
-/// Account information from the API.
-#[derive(Debug, Deserialize)]
-struct AccountResponse {
-    user: Option<UserInfo>,
-}
-
-/// User information nested in account response.
-#[derive(Debug, Deserialize)]
-struct UserInfo {
-    username: Option<String>,
-    email: Option<String>,
 }
 
 /// Print logged-in user status line.

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -124,20 +124,21 @@ struct TokenErrorResponse {
 
 /// Account information from the API.
 #[derive(Debug, Deserialize)]
-struct AccountInfo {
-    email: Option<String>,
+struct AccountResponse {
     user: Option<UserInfo>,
+    subscriptions: Option<Vec<SubscriptionInfo>>,
 }
 
 /// User information nested in account response.
 #[derive(Debug, Deserialize)]
 struct UserInfo {
     username: Option<String>,
+    email: Option<String>,
 }
 
-/// API key information from the API.
+/// Subscription information from the API.
 #[derive(Debug, Deserialize)]
-struct ApiKeyInfo {
+struct SubscriptionInfo {
     expires_at: Option<String>,
 }
 
@@ -192,17 +193,21 @@ async fn fetch_login_info(config: &Config) -> Result<LoginInfo, AuthError> {
 
     // Fetch account info
     let account_response = client.get("/api/account").send().await?;
-    let account: AccountInfo = account_response.json().await?;
+    let account: AccountResponse = account_response.json().await?;
 
     let email = account
-        .email
-        .or_else(|| account.user.and_then(|u| u.username))
+        .user
+        .as_ref()
+        .and_then(|u| u.email.clone())
+        .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Fetch API key info for expiration
-    let keys_response = client.get("/api/auth/api-keys").send().await?;
-    let keys: Vec<ApiKeyInfo> = keys_response.json().await.unwrap_or_default();
-    let expires_at = keys.first().and_then(|k| k.expires_at.clone());
+    // Get expiration from first subscription
+    let expires_at = account
+        .subscriptions
+        .as_ref()
+        .and_then(|subs| subs.first())
+        .and_then(|s| s.expires_at.clone());
 
     Ok(LoginInfo {
         email,
@@ -441,8 +446,33 @@ pub fn show_api_key() -> Result<(), AuthError> {
     Ok(())
 }
 
+/// Print a labeled key-value line for whoami output.
+///
+/// Example: `  name        Jane Ngo`
+fn print_kv(key: &str, value: &str) {
+    // Pad key to 12 chars (longest key "username" is 8 + 4 spaces = 12)
+    // Pad plain text first, then apply styling (ANSI codes break format padding)
+    eprintln!(
+        "  {}{}",
+        status::dim(&format!("{:<12}", key)),
+        status::highlight(value)
+    );
+}
+
+/// Mask an API key, showing only the prefix.
+///
+/// Example: `pfx_****************************`
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 4 {
+        format!("{}_{}", &key[..3], "*".repeat(28))
+    } else {
+        "*".repeat(32)
+    }
+}
+
 /// Display information about the logged-in user.
-pub async fn whoami() -> Result<(), AuthError> {
+pub async fn whoami(json: bool) -> Result<(), AuthError> {
+    let config = Config::load();
     let client = ApiClient::new()?;
 
     if !client.is_authenticated() {
@@ -467,12 +497,102 @@ pub async fn whoami() -> Result<(), AuthError> {
     }
 
     let data: serde_json::Value = response.json().await?;
-    let pretty = serde_json::to_string_pretty(&data).unwrap_or_default();
 
-    println!("Your info ({}):", client.domain());
-    println!("{}", pretty);
+    // JSON output mode
+    if json {
+        let pretty = serde_json::to_string_pretty(&data).unwrap_or_default();
+        println!("{}", pretty);
+        return Ok(());
+    }
+
+    // Styled output mode
+    let user = data.get("user");
+
+    // Account section
+    eprintln!("{}", style_section("account"));
+
+    // Build name from first_name + last_name
+    let first = user
+        .and_then(|u| u.get("first_name"))
+        .and_then(|v| v.as_str());
+    let last = user
+        .and_then(|u| u.get("last_name"))
+        .and_then(|v| v.as_str());
+    match (first, last) {
+        (Some(f), Some(l)) => print_kv("name", &format!("{} {}", f, l)),
+        (Some(f), None) => print_kv("name", f),
+        (None, Some(l)) => print_kv("name", l),
+        _ => {}
+    }
+
+    if let Some(username) = user
+        .and_then(|u| u.get("username"))
+        .and_then(|v| v.as_str())
+    {
+        print_kv("username", username);
+    }
+    if let Some(email) = user.and_then(|u| u.get("email")).and_then(|v| v.as_str()) {
+        print_kv("email", email);
+    }
+    print_kv("org", &config.domain);
+
+    // Subscription section (if available)
+    if let Some(subscriptions) = data.get("subscriptions").and_then(|v| v.as_array()) {
+        if let Some(subscription) = subscriptions.first() {
+            status::blank_line();
+            eprintln!("{}", style_section("subscription"));
+            if let Some(plan) = subscription.get("product_code").and_then(|v| v.as_str()) {
+                print_kv("plan", plan);
+            }
+            if let Some(expires) = subscription.get("expires_at").and_then(|v| v.as_str()) {
+                // Handle ISO 8601 format (2035-01-02T00:00:00Z)
+                let date_part = if expires.len() >= 10 {
+                    &expires[..10]
+                } else {
+                    expires
+                };
+                if let Some(days) = days_until_date(date_part) {
+                    let days_str = if days == 1 {
+                        "1 day".to_string()
+                    } else {
+                        format!("{} days", days)
+                    };
+                    eprintln!(
+                        "  {}{}{}",
+                        status::dim(&format!("{:<12}", "expires")),
+                        status::highlight(date_part),
+                        status::dim(&format!(" ({days_str})"))
+                    );
+                } else {
+                    print_kv("expires", date_part);
+                }
+            }
+        }
+    }
+
+    // Token info section
+    status::blank_line();
+    eprintln!("{}", style_section("token"));
+    if let Some(api_key) = get_api_key(&config)? {
+        eprintln!(
+            "  {}{}",
+            status::dim(&format!("{:<12}", "value")),
+            status::dim(&mask_api_key(&api_key))
+        );
+    }
+    eprintln!(
+        "  {}{}",
+        status::dim(&format!("{:<12}", "storage")),
+        status::dim("system keyring")
+    );
 
     Ok(())
+}
+
+/// Style a section header (green, uppercase).
+fn style_section(name: &str) -> String {
+    use crate::ui::styles::{GREEN, style_for};
+    style_for(GREEN).apply_to(name.to_uppercase()).to_string()
 }
 
 #[cfg(test)]

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -231,6 +231,18 @@ pub async fn login() -> Result<(), AuthError> {
     // URLs from openid-configuration etc.
     let config = Config::load();
 
+    // Check if already logged in
+    if get_api_key(&config)?.is_some() {
+        status::warn(&format!(
+            "Already logged in to {}",
+            status::highlight(&config.domain)
+        ));
+        if !crate::input::prompt_yes_no("Login again?") {
+            // Return early if user declines to log in again
+            return Ok(());
+        }
+    }
+
     let client = build_client(reqwest::Client::builder().timeout(REQUEST_TIMEOUT))?;
 
     // Fetch OpenID configuration
@@ -422,6 +434,16 @@ pub async fn login() -> Result<(), AuthError> {
 /// Log out by removing the API key for the current domain.
 pub fn logout() -> Result<(), AuthError> {
     let config = Config::load();
+
+    // Check if already logged out
+    if get_api_key(&config)?.is_none() {
+        status::warn(&format!(
+            "Not logged in to {}",
+            status::highlight(&config.domain)
+        ));
+        return Ok(());
+    }
+
     delete_api_key(&config)?;
     status::success(&format!(
         "Logged out of {}",

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -93,50 +93,53 @@ fn print_logged_in_status(email: &str) {
     status::success(&format!("Logged in as {}", status::highlight(email)));
 }
 
-/// Calculate days from today until a date string (YYYY-MM-DD format).
-fn days_until_date(date_str: &str) -> Option<i64> {
-    let expires = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()?;
-    let today = chrono::Utc::now().date_naive();
-    Some((expires - today).num_days())
+/// Parse a date string (YYYY-MM-DD format) into a NaiveDate.
+fn parse_date(date_str: &str) -> Option<chrono::NaiveDate> {
+    chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()
 }
 
-/// Format a duration in days as a human-readable string.
+/// Format a duration from today to a target date as a human-readable string.
+///
+/// Uses chrono's date arithmetic to correctly handle leap years.
 ///
 /// Returns (formatted_string, is_expired).
 /// Examples:
-/// - 400 days -> ("1 year, 35 days", false)
-/// - 1 day -> ("1 day", false)
-/// - -30 days -> ("expired", true)
-fn format_duration(days: i64) -> (String, bool) {
-    if days < 0 {
+/// - 400 days from now -> ("1 year, 35 days", false)
+/// - 1 day from now -> ("1 day", false)
+/// - past date -> ("expired", true)
+fn format_duration_until(target: chrono::NaiveDate) -> (String, bool) {
+    let today = chrono::Utc::now().date_naive();
+
+    if target < today {
         return ("expired".to_string(), true);
     }
 
-    let years = days / 365;
-    let remaining_days = days % 365;
+    // Calculate years by finding how many full years fit
+    let mut years = 0i32;
+    let mut date_after_years = today;
+    while let Some(next) = date_after_years.checked_add_months(chrono::Months::new(12)) {
+        if next <= target {
+            years += 1;
+            date_after_years = next;
+        } else {
+            break;
+        }
+    }
+
+    // Remaining days after subtracting full years
+    let remaining_days = (target - date_after_years).num_days();
+
+    let year_unit = if years == 1 { "year" } else { "years" };
+    let day_unit = if remaining_days == 1 { "day" } else { "days" };
 
     let s = if years > 0 {
         if remaining_days == 0 {
-            if years == 1 {
-                "1 year".to_string()
-            } else {
-                format!("{} years", years)
-            }
-        } else if remaining_days == 1 {
-            if years == 1 {
-                "1 year, 1 day".to_string()
-            } else {
-                format!("{} years, 1 day", years)
-            }
-        } else if years == 1 {
-            format!("1 year, {} days", remaining_days)
+            format!("{} {}", years, year_unit)
         } else {
-            format!("{} years, {} days", years, remaining_days)
+            format!("{} {}, {} {}", years, year_unit, remaining_days, day_unit)
         }
-    } else if days == 1 {
-        "1 day".to_string()
     } else {
-        format!("{} days", days)
+        format!("{} {}", remaining_days, day_unit)
     };
 
     (s, false)
@@ -146,8 +149,8 @@ fn format_duration(days: i64) -> (String, bool) {
 ///
 /// Example: `  expires      2027-04-20 (1 year)`
 fn print_token_expiration(expires_at: &str) {
-    if let Some(days) = days_until_date(expires_at) {
-        let (duration_str, _) = format_duration(days);
+    if let Some(target_date) = parse_date(expires_at) {
+        let (duration_str, _) = format_duration_until(target_date);
         // "Logged in as " is 13 chars; "  expires" is 9 chars; need 4 more spaces
         eprintln!(
             "  {}{}{}",
@@ -574,8 +577,8 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
             let pad_width = max_label_width + 4; // 4 spaces after longest label
 
             for (label, date_part) in rows {
-                if let Some(days) = days_until_date(&date_part) {
-                    let (duration_str, is_expired) = format_duration(days);
+                if let Some(target_date) = parse_date(&date_part) {
+                    let (duration_str, is_expired) = format_duration_until(target_date);
                     let suffix = if is_expired {
                         use crate::ui::styles::UiColor;
                         format!(" ({})", UiColor::Red.apply_to(&duration_str))
@@ -699,5 +702,72 @@ mod tests {
             response.error_description,
             Some("User denied access".to_string())
         );
+    }
+
+    #[test]
+    fn test_format_duration_until_expired() {
+        let yesterday = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
+        let (s, expired) = format_duration_until(yesterday);
+        assert_eq!(s, "expired");
+        assert!(expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_today() {
+        let today = chrono::Utc::now().date_naive();
+        let (s, expired) = format_duration_until(today);
+        assert_eq!(s, "0 days");
+        assert!(!expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_one_day() {
+        let tomorrow = chrono::Utc::now().date_naive() + chrono::Duration::days(1);
+        let (s, expired) = format_duration_until(tomorrow);
+        assert_eq!(s, "1 day");
+        assert!(!expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_multiple_days() {
+        let future = chrono::Utc::now().date_naive() + chrono::Duration::days(42);
+        let (s, expired) = format_duration_until(future);
+        assert_eq!(s, "42 days");
+        assert!(!expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_one_year() {
+        let today = chrono::Utc::now().date_naive();
+        // Add exactly one year using months to handle leap years correctly
+        let one_year_later = today
+            .checked_add_months(chrono::Months::new(12))
+            .expect("valid date");
+        let (s, expired) = format_duration_until(one_year_later);
+        assert_eq!(s, "1 year");
+        assert!(!expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_year_and_days() {
+        let today = chrono::Utc::now().date_naive();
+        let one_year_later = today
+            .checked_add_months(chrono::Months::new(12))
+            .expect("valid date");
+        let target = one_year_later + chrono::Duration::days(30);
+        let (s, expired) = format_duration_until(target);
+        assert_eq!(s, "1 year, 30 days");
+        assert!(!expired);
+    }
+
+    #[test]
+    fn test_format_duration_until_multiple_years() {
+        let today = chrono::Utc::now().date_naive();
+        let two_years_later = today
+            .checked_add_months(chrono::Months::new(24))
+            .expect("valid date");
+        let (s, expired) = format_duration_until(two_years_later);
+        assert_eq!(s, "2 years");
+        assert!(!expired);
     }
 }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -186,13 +186,14 @@ fn format_duration(days: i64) -> (String, bool) {
 
 /// Print token expiration info.
 ///
-/// Example: `  expires    2027-04-20 (1 year)`
+/// Example: `  expires      2027-04-20 (1 year)`
 fn print_token_expiration(expires_at: &str) {
     if let Some(days) = days_until_date(expires_at) {
         let (duration_str, _) = format_duration(days);
+        // "Logged in as " is 13 chars; "  expires" is 9 chars; need 4 more spaces
         eprintln!(
             "  {}{}{}",
-            status::dim("expires    "),
+            status::dim("expires      "),
             status::highlight(expires_at),
             status::dim(&format!(" ({})", duration_str))
         );
@@ -377,7 +378,7 @@ pub async fn login() -> Result<(), AuthError> {
 
             // Save to keyring
             save_api_key(&config, &api_key_result.api_key)?;
-            status::success("Token stored in keyring");
+            status::success("API key stored in keyring");
 
             // Fetch and display user info
             if let Ok(login_info) = fetch_login_info().await {

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -160,6 +160,48 @@ fn days_until_date(date_str: &str) -> Option<i64> {
     Some((expires - today).num_days())
 }
 
+/// Format a duration in days as a human-readable string.
+///
+/// Returns (formatted_string, is_expired).
+/// Examples:
+/// - 400 days -> ("1 year, 35 days", false)
+/// - 1 day -> ("1 day", false)
+/// - -30 days -> ("expired", true)
+fn format_duration(days: i64) -> (String, bool) {
+    if days < 0 {
+        return ("expired".to_string(), true);
+    }
+
+    let years = days / 365;
+    let remaining_days = days % 365;
+
+    let s = if years > 0 {
+        if remaining_days == 0 {
+            if years == 1 {
+                "1 year".to_string()
+            } else {
+                format!("{} years", years)
+            }
+        } else if remaining_days == 1 {
+            if years == 1 {
+                "1 year, 1 day".to_string()
+            } else {
+                format!("{} years, 1 day", years)
+            }
+        } else if years == 1 {
+            format!("1 year, {} days", remaining_days)
+        } else {
+            format!("{} years, {} days", years, remaining_days)
+        }
+    } else if days == 1 {
+        "1 day".to_string()
+    } else {
+        format!("{} days", days)
+    };
+
+    (s, false)
+}
+
 /// Print token expiration info.
 ///
 /// Example: `  expires    2026-04-09 (365 days)`
@@ -484,7 +526,7 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
         return Ok(());
     }
 
-    let response = client.get("/api/account").send().await?;
+    let response = client.get("/api/auth/sessions/whoami").send().await?;
 
     if !response.status().is_success() {
         let resp_status = response.status();
@@ -506,17 +548,18 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
     }
 
     // Styled output mode
-    let user = data.get("user");
+    // Data is nested under passport.profile for user info
+    let profile = data.get("passport").and_then(|p| p.get("profile"));
 
     // Account section
     eprintln!("{}", style_section("account"));
 
     // Build name from first_name + last_name
-    let first = user
-        .and_then(|u| u.get("first_name"))
+    let first = profile
+        .and_then(|p| p.get("first_name"))
         .and_then(|v| v.as_str());
-    let last = user
-        .and_then(|u| u.get("last_name"))
+    let last = profile
+        .and_then(|p| p.get("last_name"))
         .and_then(|v| v.as_str());
     match (first, last) {
         (Some(f), Some(l)) => print_kv("name", &format!("{} {}", f, l)),
@@ -525,46 +568,87 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
         _ => {}
     }
 
-    if let Some(username) = user
-        .and_then(|u| u.get("username"))
+    if let Some(username) = profile
+        .and_then(|p| p.get("username"))
         .and_then(|v| v.as_str())
     {
         print_kv("username", username);
     }
-    if let Some(email) = user.and_then(|u| u.get("email")).and_then(|v| v.as_str()) {
+    if let Some(email) = profile
+        .and_then(|p| p.get("email"))
+        .and_then(|v| v.as_str())
+    {
         print_kv("email", email);
     }
-    print_kv("org", &config.domain);
 
-    // Subscription section (if available)
-    if let Some(subscriptions) = data.get("subscriptions").and_then(|v| v.as_array()) {
-        if let Some(subscription) = subscriptions.first() {
+    // Organizations section - shows orgs with their subscriptions
+    let organizations = data
+        .get("passport")
+        .and_then(|p| p.get("organizations"))
+        .and_then(|v| v.as_array());
+
+    if let Some(orgs) = organizations {
+        // Filter to orgs that have subscription attributes
+        let orgs_with_subs: Vec<_> = orgs
+            .iter()
+            .filter_map(|org| {
+                let title = org.get("title").and_then(|v| v.as_str())?;
+                let attrs = org.get("attributes").and_then(|v| v.as_array())?;
+                let sub = attrs
+                    .iter()
+                    .find(|a| a.get("group").and_then(|v| v.as_str()) == Some("subscriptions"))?;
+                let sub_id = sub.get("id").and_then(|v| v.as_str())?;
+                let expires = sub
+                    .get("data")
+                    .and_then(|d| d.get("expires_at"))
+                    .and_then(|v| v.as_str())?;
+                Some((title, sub_id, expires))
+            })
+            .collect();
+
+        if !orgs_with_subs.is_empty() {
             status::blank_line();
-            eprintln!("{}", style_section("subscription"));
-            if let Some(plan) = subscription.get("product_code").and_then(|v| v.as_str()) {
-                print_kv("plan", plan);
-            }
-            if let Some(expires) = subscription.get("expires_at").and_then(|v| v.as_str()) {
-                // Handle ISO 8601 format (2035-01-02T00:00:00Z)
-                let date_part = if expires.len() >= 10 {
-                    &expires[..10]
-                } else {
-                    expires
-                };
-                if let Some(days) = days_until_date(date_part) {
-                    let days_str = if days == 1 {
-                        "1 day".to_string()
+            eprintln!("{}", style_section("subscriptions"));
+
+            // Build labels and find max width for alignment
+            let rows: Vec<_> = orgs_with_subs
+                .iter()
+                .map(|(org_title, sub_id, expires)| {
+                    let sub_type = sub_id.split('_').next().unwrap_or(sub_id);
+                    let label = format!("{} ({})", org_title, sub_type);
+                    let date_part = if expires.len() >= 10 {
+                        &expires[..10]
                     } else {
-                        format!("{} days", days)
+                        *expires
+                    };
+                    (label, date_part.to_string())
+                })
+                .collect();
+
+            let max_label_width = rows.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
+            let pad_width = max_label_width + 4; // 4 spaces after longest label
+
+            for (label, date_part) in rows {
+                if let Some(days) = days_until_date(&date_part) {
+                    let (duration_str, is_expired) = format_duration(days);
+                    let suffix = if is_expired {
+                        use crate::ui::styles::{RED, style_for};
+                        format!(" ({})", style_for(RED).apply_to(&duration_str))
+                    } else {
+                        status::dim(&format!(" ({})", duration_str))
                     };
                     eprintln!(
                         "  {}{}{}",
-                        status::dim(&format!("{:<12}", "expires")),
-                        status::highlight(date_part),
-                        status::dim(&format!(" ({days_str})"))
+                        status::dim(&format!("{:<width$}", label, width = pad_width)),
+                        status::highlight(&date_part),
+                        suffix
                     );
                 } else {
-                    print_kv("expires", date_part);
+                    eprintln!(
+                        "  {}{}",
+                        status::dim(&format!("{:<width$}", label, width = pad_width)),
+                        status::highlight(&date_part)
+                    );
                 }
             }
         }
@@ -583,7 +667,7 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
     eprintln!(
         "  {}{}",
         status::dim(&format!("{:<12}", "storage")),
-        status::dim("system keyring")
+        status::dim(&config.keyring_path.display().to_string())
     );
 
     Ok(())

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -11,16 +11,17 @@ use super::keyring::{delete_api_key, get_api_key, save_api_key};
 use crate::config::Config;
 use crate::http::{Client, bearer_header, build_client};
 use crate::input::KeyListener;
+use crate::ui::status;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Print a QR code to the terminal with indentation.
 fn print_qr(qr: &str) {
-    println!();
+    status::blank_line();
     for line in qr.lines() {
-        println!("    {}", line);
+        eprintln!("    {}", line);
     }
-    println!();
+    status::blank_line();
 }
 
 /// HTTP client with configuration and optional authentication.
@@ -187,29 +188,40 @@ pub async fn login() -> Result<(), AuthError> {
     let mut qr_shown = false;
     if browser_opened {
         // Browser opened — clean layout, offer QR on demand
-        println!("To authenticate, visit:");
-        println!();
-        println!("  {}", display_uri);
+        status::info(&format!(
+            "Opening {} in your browser...",
+            status::highlight(&config.domain)
+        ));
+        status::blank_line();
+        status::info("To authenticate, visit:");
+        status::blank_line();
+        eprintln!("  {}", status::highlight(display_uri));
         if device_response.verification_uri_complete.is_none() {
-            println!();
-            println!("And enter the code: {}", device_response.user_code);
+            status::blank_line();
+            status::info(&format!(
+                "And enter the code: {}",
+                status::highlight(&device_response.user_code)
+            ));
         }
-        println!();
+        status::blank_line();
         if qr_output.is_some() {
-            println!("Waiting for authentication... (press q for QR code)");
+            status::waiting("Waiting for authentication... (press q for QR code)");
         } else {
-            println!("Waiting for authentication...");
+            status::waiting("Waiting for authentication...");
         }
     } else {
-        println!("To authenticate, scan the QR code or visit:");
-        println!();
-        println!("  {}", display_uri);
+        status::info("To authenticate, scan the QR code or visit:");
+        status::blank_line();
+        eprintln!("  {}", status::highlight(display_uri));
         if device_response.verification_uri_complete.is_none() {
-            println!();
-            println!("And enter the code: {}", device_response.user_code);
+            status::blank_line();
+            status::info(&format!(
+                "And enter the code: {}",
+                status::highlight(&device_response.user_code)
+            ));
         }
-        println!();
-        println!("Waiting for authentication...");
+        status::blank_line();
+        status::waiting("Waiting for authentication...");
 
         // No browser — show QR code immediately
         if let Some(ref qr) = qr_output {
@@ -257,16 +269,15 @@ pub async fn login() -> Result<(), AuthError> {
 
         if response.status().is_success() {
             let token: TokenResponse = response.json().await?;
-            println!();
-            println!("Successfully authenticated!");
+            status::blank_line();
+            status::success("Authentication complete");
 
             // Create API key
-            println!("Creating API key...");
             let api_key = create_api_key(&client, &config, &token.access_token).await?;
 
             // Save to keyring
             save_api_key(&config, &api_key)?;
-            println!("API key saved to {}", config.keyring_path.display());
+            status::success("Token stored in system keyring");
             return Ok(());
         }
 
@@ -302,7 +313,15 @@ pub async fn login() -> Result<(), AuthError> {
 pub fn logout() -> Result<(), AuthError> {
     let config = Config::load();
     delete_api_key(&config)?;
-    println!("Logged out from {}", config.domain);
+    status::success(&format!(
+        "Logged out of {}",
+        status::highlight(&config.domain)
+    ));
+    status::success("Token removed from system keyring");
+    status::warn(&format!(
+        "To fully revoke your token visit {}",
+        status::highlight(&format!("{}/settings/tokens", config.domain))
+    ));
     Ok(())
 }
 
@@ -313,8 +332,11 @@ pub fn show_api_key() -> Result<(), AuthError> {
     match get_api_key(&config)? {
         Some(key) => println!("{}", key),
         None => {
-            println!("Not logged in to {}", config.domain);
-            println!("Run `ana login` to authenticate.");
+            status::error("not logged in");
+            status::info(&format!(
+                "Run {} to authenticate.",
+                status::highlight("ana login")
+            ));
         }
     }
 
@@ -326,20 +348,23 @@ pub async fn whoami() -> Result<(), AuthError> {
     let client = ApiClient::new()?;
 
     if !client.is_authenticated() {
-        println!("Not logged in to {}", client.domain());
-        println!("Run `ana login` to authenticate.");
+        status::error("not logged in");
+        status::info(&format!(
+            "Run {} to authenticate.",
+            status::highlight("ana login")
+        ));
         return Ok(());
     }
 
     let response = client.get("/api/account").send().await?;
 
     if !response.status().is_success() {
-        let status = response.status();
+        let resp_status = response.status();
         let body = response.text().await.unwrap_or_default();
-        tracing::error!("Failed to get account info: {} - {}", status, body);
+        tracing::error!("Failed to get account info: {} - {}", resp_status, body);
         return Err(AuthError::Authorization(format!(
             "Failed to get account info: {} - {}",
-            status, body
+            resp_status, body
         )));
     }
 

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -545,7 +545,7 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
     let profile = data.get("passport").and_then(|p| p.get("profile"));
 
     // Account section
-    eprintln!("{}", style_section("account"));
+    eprintln!("{}", status::section("account"));
 
     // Build name from first_name + last_name
     let first = profile
@@ -601,7 +601,7 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
 
         if !orgs_with_subs.is_empty() {
             status::blank_line();
-            eprintln!("{}", style_section("subscriptions"));
+            eprintln!("{}", status::section("subscriptions"));
 
             // Build labels and find max width for alignment
             let rows: Vec<_> = orgs_with_subs
@@ -649,7 +649,7 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
 
     // Token info section
     status::blank_line();
-    eprintln!("{}", style_section("token"));
+    eprintln!("{}", status::section("token"));
     if let Some(api_key) = get_api_key(&config)? {
         eprintln!(
             "  {}{}",
@@ -664,12 +664,6 @@ pub async fn whoami(json: bool) -> Result<(), AuthError> {
     );
 
     Ok(())
-}
-
-/// Style a section header (green, uppercase).
-fn style_section(name: &str) -> String {
-    use crate::ui::styles::UiColor;
-    UiColor::Green.apply_to(name.to_uppercase()).to_string()
 }
 
 #[cfg(test)]

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -119,7 +119,6 @@ struct TokenErrorResponse {
 #[derive(Debug, Deserialize)]
 struct AccountResponse {
     user: Option<UserInfo>,
-    subscriptions: Option<Vec<SubscriptionInfo>>,
 }
 
 /// User information nested in account response.
@@ -129,21 +128,11 @@ struct UserInfo {
     email: Option<String>,
 }
 
-/// Subscription information from the API.
-#[derive(Debug, Deserialize)]
-struct SubscriptionInfo {
-    expires_at: Option<String>,
-}
-
 /// Print logged-in user status line.
 ///
-/// Example: `✓ Logged in as user@example.com (example)`
-fn print_logged_in_status(email: &str, org: &str) {
-    status::success(&format!(
-        "Logged in as {} ({})",
-        status::highlight(email),
-        org
-    ));
+/// Example: `✓ Logged in as user@example.com`
+fn print_logged_in_status(email: &str) {
+    status::success(&format!("Logged in as {}", status::highlight(email)));
 }
 
 /// Calculate days from today until a date string (YYYY-MM-DD format).
@@ -197,20 +186,15 @@ fn format_duration(days: i64) -> (String, bool) {
 
 /// Print token expiration info.
 ///
-/// Example: `  expires    2026-04-09 (365 days)`
-fn print_expiration(expires_at: &str) {
-    // Parse the expiration date and calculate days remaining
-    if let Some(days_remaining) = days_until_date(&expires_at[..10]) {
-        let days_str = if days_remaining == 1 {
-            "1 day".to_string()
-        } else {
-            format!("{} days", days_remaining)
-        };
+/// Example: `  expires    2027-04-20 (1 year)`
+fn print_token_expiration(expires_at: &str) {
+    if let Some(days) = days_until_date(expires_at) {
+        let (duration_str, _) = format_duration(days);
         eprintln!(
             "  {}{}{}",
             status::dim("expires    "),
-            status::highlight(&expires_at[..10]),
-            status::dim(&format!(" ({days_str})"))
+            status::highlight(expires_at),
+            status::dim(&format!(" ({})", duration_str))
         );
     }
 }
@@ -218,12 +202,10 @@ fn print_expiration(expires_at: &str) {
 /// Combined login information for display.
 struct LoginInfo {
     email: String,
-    org: String,
-    expires_at: Option<String>,
 }
 
-/// Fetch login info (account + API key expiration) for display after login.
-async fn fetch_login_info(config: &Config) -> Result<LoginInfo, AuthError> {
+/// Fetch login info for display after login.
+async fn fetch_login_info() -> Result<LoginInfo, AuthError> {
     let client = ApiClient::new()?;
 
     // Fetch account info
@@ -237,18 +219,7 @@ async fn fetch_login_info(config: &Config) -> Result<LoginInfo, AuthError> {
         .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Get expiration from first subscription
-    let expires_at = account
-        .subscriptions
-        .as_ref()
-        .and_then(|subs| subs.first())
-        .and_then(|s| s.expires_at.clone());
-
-    Ok(LoginInfo {
-        email,
-        org: config.domain.clone(),
-        expires_at,
-    })
+    Ok(LoginInfo { email })
 }
 
 /// Perform the device authorization flow.
@@ -402,17 +373,17 @@ pub async fn login() -> Result<(), AuthError> {
             status::success("Authentication complete");
 
             // Create API key
-            let api_key = create_api_key(&client, &config, &token.access_token).await?;
+            let api_key_result = create_api_key(&client, &config, &token.access_token).await?;
 
             // Save to keyring
-            save_api_key(&config, &api_key)?;
+            save_api_key(&config, &api_key_result.api_key)?;
             status::success("Token stored in keyring");
 
             // Fetch and display user info
-            if let Ok(login_info) = fetch_login_info(&config).await {
-                print_logged_in_status(&login_info.email, &login_info.org);
-                if let Some(ref expires_at) = login_info.expires_at {
-                    print_expiration(expires_at);
+            if let Ok(login_info) = fetch_login_info().await {
+                print_logged_in_status(&login_info.email);
+                if let Some(ref expires_at) = api_key_result.expires_at {
+                    print_token_expiration(expires_at);
                 }
             }
 

--- a/src/auth/api_keys.rs
+++ b/src/auth/api_keys.rs
@@ -1,5 +1,6 @@
 //! API key management.
 
+use base64::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::errors::AuthError;
@@ -19,12 +20,43 @@ struct ApiKeyResponse {
     api_key: String,
 }
 
+/// JWT payload containing expiration timestamp.
+#[derive(Debug, Deserialize)]
+struct JwtPayload {
+    exp: i64,
+}
+
+/// Result of creating an API key.
+pub struct ApiKeyResult {
+    pub api_key: String,
+    pub expires_at: Option<String>,
+}
+
+/// Extract expiration date from a JWT token.
+///
+/// Returns the expiration as a YYYY-MM-DD string, or None if parsing fails.
+fn extract_jwt_expiration(token: &str) -> Option<String> {
+    // JWT format: header.payload.signature
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    // Decode the payload (middle part) - JWT uses base64url encoding
+    let payload_bytes = BASE64_URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
+    let payload: JwtPayload = serde_json::from_slice(&payload_bytes).ok()?;
+
+    // Convert Unix timestamp to date string
+    let datetime = chrono::DateTime::from_timestamp(payload.exp, 0)?;
+    Some(datetime.format("%Y-%m-%d").to_string())
+}
+
 /// Create a new API key using the access token.
 pub async fn create_api_key(
     client: &reqwest_middleware::ClientWithMiddleware,
     config: &Config,
     access_token: &str,
-) -> Result<String, AuthError> {
+) -> Result<ApiKeyResult, AuthError> {
     let url = format!("{}/api/auth/api-keys", config.base_url());
     let payload = CreateApiKeyRequest {
         scopes: vec![
@@ -53,7 +85,12 @@ pub async fn create_api_key(
     }
 
     let response: ApiKeyResponse = response.json().await?;
-    Ok(response.api_key)
+    let expires_at = extract_jwt_expiration(&response.api_key);
+
+    Ok(ApiKeyResult {
+        api_key: response.api_key,
+        expires_at,
+    })
 }
 
 #[cfg(test)]

--- a/src/auth/api_keys.rs
+++ b/src/auth/api_keys.rs
@@ -1,6 +1,7 @@
 //! API key management.
 
-use base64::prelude::*;
+use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use serde::{Deserialize, Serialize};
 
 use super::errors::AuthError;

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -131,6 +131,12 @@ fn load_keyring(config: &Config) -> Result<Keyring, AuthError> {
     }
 
     let contents = fs::read_to_string(path).map_err(|e| keyring_io_error("read", e))?;
+
+    // Handle empty file as empty keyring
+    if contents.trim().is_empty() {
+        return Ok(Keyring::new());
+    }
+
     let keyring: Keyring =
         serde_json::from_str(&contents).map_err(|e| AuthError::Keyring(e.to_string()))?;
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -4,6 +4,7 @@ mod actions;
 mod api_keys;
 mod errors;
 mod keyring;
+mod responses;
 
 pub use actions::{login, logout, show_api_key, whoami};
 pub use keyring::get_api_key;

--- a/src/auth/responses.rs
+++ b/src/auth/responses.rs
@@ -1,0 +1,47 @@
+//! JSON response types for authentication APIs.
+
+use serde::Deserialize;
+
+/// OpenID Connect discovery document.
+#[derive(Debug, Deserialize)]
+pub struct OpenIdConfig {
+    pub device_authorization_endpoint: Option<String>,
+    pub token_endpoint: String,
+}
+
+/// Response from the device authorization endpoint.
+#[derive(Debug, Deserialize)]
+pub struct DeviceAuthResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: Option<String>,
+    pub expires_in: u64,
+    pub interval: Option<u64>,
+}
+
+/// Response from the token endpoint.
+#[derive(Debug, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+}
+
+/// Error response from the token endpoint during polling.
+#[derive(Debug, Deserialize)]
+pub struct TokenErrorResponse {
+    pub error: String,
+    pub error_description: Option<String>,
+}
+
+/// Account information from the API.
+#[derive(Debug, Deserialize)]
+pub struct AccountResponse {
+    pub user: Option<UserInfo>,
+}
+
+/// User information nested in account response.
+#[derive(Debug, Deserialize)]
+pub struct UserInfo {
+    pub username: Option<String>,
+    pub email: Option<String>,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,7 +101,9 @@ pub enum Action {
     Login,
     Logout,
     ShowApiKey,
-    Whoami,
+    Whoami {
+        json: bool,
+    },
     Update {
         force: bool,
     },
@@ -136,7 +138,7 @@ impl Action {
             Action::Login => "login",
             Action::Logout => "logout",
             Action::ShowApiKey => "auth.api-key",
-            Action::Whoami => "whoami",
+            Action::Whoami { .. } => "whoami",
             Action::Update { .. } => "self.update",
             Action::CheckForUpdate => "self.update.check",
             Action::ShowAvailableVersions => "self.update.list",
@@ -211,7 +213,7 @@ impl Action {
             Action::Login => Ok(auth::login().await?),
             Action::Logout => Ok(auth::logout()?),
             Action::ShowApiKey => Ok(auth::show_api_key()?),
-            Action::Whoami => Ok(auth::whoami().await?),
+            Action::Whoami { json } => Ok(auth::whoami(json).await?),
             Action::Update { force } => {
                 update::run_update(VERSION, force).await;
                 Ok(())
@@ -248,13 +250,13 @@ pub fn parse() -> (Action, LogLevel) {
                 Some(Commands::Config) => Action::ShowConfig,
                 Some(Commands::Login) => Action::Login,
                 Some(Commands::Logout) => Action::Logout,
-                Some(Commands::Whoami) => Action::Whoami,
+                Some(Commands::Whoami { json }) => Action::Whoami { json },
                 Some(Commands::Auth { command }) => match command {
                     None => Action::ShowSubcommandHelp("auth".to_string()),
                     Some(AuthCommands::ApiKey) => Action::ShowApiKey,
                     Some(AuthCommands::Login) => Action::Login,
                     Some(AuthCommands::Logout) => Action::Logout,
-                    Some(AuthCommands::Whoami) => Action::Whoami,
+                    Some(AuthCommands::Whoami { json }) => Action::Whoami { json },
                 },
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSubcommandHelp("self".to_string()),
@@ -408,7 +410,11 @@ enum Commands {
     Logout,
 
     /// Display information about the logged-in user
-    Whoami,
+    Whoami {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Manage the ana installation
     #[command(
@@ -456,7 +462,11 @@ enum AuthCommands {
     Logout,
 
     /// Display information about the logged-in user
-    Whoami,
+    Whoami {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,9 +220,9 @@ impl Config {
     }
 }
 
-/// Get the default keyring path (~/.ana/keyring or $ANA_HOME/keyring).
+/// Get the default keyring path (~/.anaconda/keyring or $ANA_KEYRING_PATH).
 fn default_keyring_path() -> PathBuf {
-    crate::paths::ana_home().join("keyring")
+    crate::paths::home_dir().join(".anaconda").join("keyring")
 }
 
 /// Parse a boolean from a string value.
@@ -400,8 +400,8 @@ mod tests {
     #[test]
     fn test_config_default_keyring_path() {
         let config = Config::load();
-        // Should end with .ana/keyring
-        assert!(config.keyring_path.ends_with(".ana/keyring"));
+        // Should end with .anaconda/keyring
+        assert!(config.keyring_path.ends_with(".anaconda/keyring"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,7 +220,7 @@ impl Config {
     }
 }
 
-/// Get the default keyring path (~/.anaconda/keyring or $ANA_KEYRING_PATH).
+/// Get the default keyring path
 fn default_keyring_path() -> PathBuf {
     crate::paths::home_dir().join(".anaconda").join("keyring")
 }

--- a/src/help/styles.rs
+++ b/src/help/styles.rs
@@ -2,9 +2,7 @@
 
 use console::Style;
 
-use crate::ui::styles::{
-    AMBER, BLUE, BOX_BG, BOX_BORDER, BOX_TEXT, DESC, DIM, GREEN, RED, hex_color,
-};
+use crate::ui::styles::UiColor;
 
 /// Styles for help output matching UX design
 #[allow(dead_code)]
@@ -22,17 +20,17 @@ pub(super) enum HelpStyle {
 
 impl HelpStyle {
     pub fn style(&self) -> Style {
-        let box_bg = hex_color(BOX_BG);
+        let box_bg = UiColor::BoxBg.color();
         match self {
-            Self::Section => Style::new().fg(hex_color(GREEN)).bold(),
-            Self::Command => Style::new().fg(hex_color(BLUE)),
-            Self::Desc => Style::new().fg(hex_color(DESC)),
-            Self::Dim => Style::new().fg(hex_color(DIM)),
-            Self::Error => Style::new().fg(hex_color(RED)),
-            Self::Warning => Style::new().fg(hex_color(AMBER)),
-            Self::BoxBorder => Style::new().fg(hex_color(BOX_BORDER)).bg(box_bg),
-            Self::BoxDesc => Style::new().fg(hex_color(BOX_TEXT)).bg(box_bg),
-            Self::BoxCommand => Style::new().fg(hex_color(BLUE)).bg(box_bg).bold(),
+            Self::Section => Style::new().fg(UiColor::Green.color()).bold(),
+            Self::Command => Style::new().fg(UiColor::Blue.color()),
+            Self::Desc => Style::new().fg(UiColor::Desc.color()),
+            Self::Dim => Style::new().fg(UiColor::Dim.color()),
+            Self::Error => Style::new().fg(UiColor::Red.color()),
+            Self::Warning => Style::new().fg(UiColor::Amber.color()),
+            Self::BoxBorder => Style::new().fg(UiColor::BoxBorder.color()).bg(box_bg),
+            Self::BoxDesc => Style::new().fg(UiColor::BoxText.color()).bg(box_bg),
+            Self::BoxCommand => Style::new().fg(UiColor::Blue.color()).bg(box_bg).bold(),
         }
     }
 }

--- a/src/help/styles.rs
+++ b/src/help/styles.rs
@@ -1,13 +1,10 @@
-use console::{Color, Style};
+//! Help-specific styles built on top of shared UI styles.
 
-/// Convert a hex color string to a console Color
-fn hex_color(hex: &str) -> Color {
-    let hex = hex.trim_start_matches('#');
-    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
-    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
-    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
-    Color::TrueColor(r, g, b)
-}
+use console::Style;
+
+use crate::ui::styles::{
+    AMBER, BLUE, BOX_BG, BOX_BORDER, BOX_TEXT, DESC, DIM, GREEN, RED, hex_color,
+};
 
 /// Styles for help output matching UX design
 #[allow(dead_code)]
@@ -25,17 +22,17 @@ pub(super) enum HelpStyle {
 
 impl HelpStyle {
     pub fn style(&self) -> Style {
-        let box_bg = hex_color("#161b22");
+        let box_bg = hex_color(BOX_BG);
         match self {
-            Self::Section => Style::new().fg(hex_color("#3fb950")).bold(),
-            Self::Command => Style::new().fg(hex_color("#79c0ff")),
-            Self::Desc => Style::new().fg(hex_color("#8b949e")),
-            Self::Dim => Style::new().fg(hex_color("#6e7681")),
-            Self::Error => Style::new().fg(hex_color("#f85149")),
-            Self::Warning => Style::new().fg(hex_color("#d29922")),
-            Self::BoxBorder => Style::new().fg(hex_color("#30363d")).bg(box_bg),
-            Self::BoxDesc => Style::new().fg(hex_color("#e6edf3")).bg(box_bg),
-            Self::BoxCommand => Style::new().fg(hex_color("#79c0ff")).bg(box_bg).bold(),
+            Self::Section => Style::new().fg(hex_color(GREEN)).bold(),
+            Self::Command => Style::new().fg(hex_color(BLUE)),
+            Self::Desc => Style::new().fg(hex_color(DESC)),
+            Self::Dim => Style::new().fg(hex_color(DIM)),
+            Self::Error => Style::new().fg(hex_color(RED)),
+            Self::Warning => Style::new().fg(hex_color(AMBER)),
+            Self::BoxBorder => Style::new().fg(hex_color(BOX_BORDER)).bg(box_bg),
+            Self::BoxDesc => Style::new().fg(hex_color(BOX_TEXT)).bg(box_bg),
+            Self::BoxCommand => Style::new().fg(hex_color(BLUE)).bg(box_bg).bold(),
         }
     }
 }

--- a/src/help/styles.rs
+++ b/src/help/styles.rs
@@ -20,17 +20,16 @@ pub(super) enum HelpStyle {
 
 impl HelpStyle {
     pub fn style(&self) -> Style {
-        let box_bg = UiColor::BoxBg.color();
         match self {
-            Self::Section => Style::new().fg(UiColor::Green.color()).bold(),
-            Self::Command => Style::new().fg(UiColor::Blue.color()),
-            Self::Desc => Style::new().fg(UiColor::Desc.color()),
-            Self::Dim => Style::new().fg(UiColor::Dim.color()),
-            Self::Error => Style::new().fg(UiColor::Red.color()),
-            Self::Warning => Style::new().fg(UiColor::Amber.color()),
-            Self::BoxBorder => Style::new().fg(UiColor::BoxBorder.color()).bg(box_bg),
-            Self::BoxDesc => Style::new().fg(UiColor::BoxText.color()).bg(box_bg),
-            Self::BoxCommand => Style::new().fg(UiColor::Blue.color()).bg(box_bg).bold(),
+            Self::Section => UiColor::Green.bold(),
+            Self::Command => UiColor::Blue.style(),
+            Self::Desc => UiColor::Desc.style(),
+            Self::Dim => UiColor::Dim.style(),
+            Self::Error => UiColor::Red.style(),
+            Self::Warning => UiColor::Amber.style(),
+            Self::BoxBorder => UiColor::BoxBorder.on(UiColor::BoxBg),
+            Self::BoxDesc => UiColor::BoxText.on(UiColor::BoxBg),
+            Self::BoxCommand => UiColor::Blue.on(UiColor::BoxBg).bold(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,10 @@ mod http;
 mod input;
 mod paths;
 mod qr;
-mod status;
 mod table;
 mod tools;
 mod ua;
+mod ui;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod http;
 mod input;
 mod paths;
 mod qr;
+mod status;
 mod table;
 mod tools;
 mod ua;

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,95 @@
+//! Status output utilities for consistent CLI feedback.
+//!
+//! Provides styled output functions matching the UX design spec:
+//! - Success: green checkmark (✓)
+//! - Error: red "error:" prefix
+//! - Warning: amber exclamation (!)
+//! - Info: plain text
+//! - Waiting: dim text for in-progress states
+
+use console::{Color, Style};
+
+// Design spec colors
+const GREEN: &str = "#3fb950";
+const RED: &str = "#f85149";
+const AMBER: &str = "#e3b341";
+const BLUE: &str = "#79c0ff";
+const DIM: &str = "#6e7681";
+
+/// Convert a hex color string to a console Color.
+fn hex_color(hex: &str) -> Color {
+    let hex = hex.trim_start_matches('#');
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
+    Color::TrueColor(r, g, b)
+}
+
+/// Get a style for a given hex color.
+fn style_for(hex: &str) -> Style {
+    Style::new().fg(hex_color(hex))
+}
+
+/// Print a success message with green checkmark.
+///
+/// Example output: `✓ Authentication complete`
+pub fn success(msg: &str) {
+    eprintln!("{} {}", style_for(GREEN).apply_to("✓"), msg);
+}
+
+/// Print an error message with red "error:" prefix.
+///
+/// Example output: `error: not logged in`
+pub fn error(msg: &str) {
+    eprintln!("{} {}", style_for(RED).apply_to("error:"), msg);
+}
+
+/// Print a warning message with amber exclamation.
+///
+/// Example output: `! To fully revoke your token visit anaconda.com/settings/tokens`
+pub fn warn(msg: &str) {
+    eprintln!("{} {}", style_for(AMBER).apply_to("!"), msg);
+}
+
+/// Print an info message (plain text).
+///
+/// Example output: `Opening anaconda.com in your browser...`
+pub fn info(msg: &str) {
+    eprintln!("{}", msg);
+}
+
+/// Print a waiting/in-progress message in dim text.
+///
+/// Example output: `Waiting for authentication...`
+pub fn waiting(msg: &str) {
+    eprintln!("{}", style_for(DIM).apply_to(msg));
+}
+
+/// Return text styled as highlighted (blue).
+///
+/// Use this for values like usernames, emails, commands.
+pub fn highlight(text: &str) -> String {
+    style_for(BLUE).apply_to(text).to_string()
+}
+
+/// Return text styled as dim.
+///
+/// Use this for secondary information, hints.
+pub fn dim(text: &str) -> String {
+    style_for(DIM).apply_to(text).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_color() {
+        match hex_color("#3fb950") {
+            Color::TrueColor(r, g, b) => {
+                assert_eq!((r, g, b), (63, 185, 80));
+            }
+            _ => panic!("Expected TrueColor"),
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,8 @@
+//! UI utilities for consistent CLI output.
+//!
+//! This module provides:
+//! - `styles`: Shared color and style definitions
+//! - `status`: Status output functions (success, error, warn, etc.)
+
+pub mod status;
+pub mod styles;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -64,3 +64,8 @@ pub fn highlight(text: &str) -> String {
 pub fn dim(text: &str) -> String {
     style_for(DIM).apply_to(text).to_string()
 }
+
+/// Print a blank line to stderr.
+pub fn blank_line() {
+    eprintln!();
+}

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -16,6 +16,13 @@ pub fn success(msg: &str) {
     eprintln!("{} {}", style_for(GREEN).apply_to("✓"), msg);
 }
 
+/// Print an exciting success message with sparkles.
+///
+/// Use for final completion messages. Example output: `✨ You can now install packages!`
+pub fn great_success(msg: &str) {
+    eprintln!("{} {}", style_for(GREEN).apply_to("✨"), msg);
+}
+
 /// Print an error message with red "error:" prefix.
 ///
 /// Example output: `error: not logged in`

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -69,3 +69,10 @@ pub fn dim(text: &str) -> String {
 pub fn blank_line() {
     eprintln!();
 }
+
+/// Return text styled as a section header (green, uppercase).
+///
+/// Use this for section headers like "ACCOUNT", "SUBSCRIPTIONS".
+pub fn section(name: &str) -> String {
+    UiColor::Green.apply_to(name.to_uppercase()).to_string()
+}

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -16,13 +16,6 @@ pub fn success(msg: &str) {
     eprintln!("{} {}", UiColor::Green.apply_to("✓"), msg);
 }
 
-/// Print an exciting success message with sparkles.
-///
-/// Use for final completion messages. Example output: `✨ You can now install packages!`
-pub fn great_success(msg: &str) {
-    eprintln!("{} {}", UiColor::Green.apply_to("✨"), msg);
-}
-
 /// Print an error message with red "error:" prefix.
 ///
 /// Example output: `error: not logged in`

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -7,28 +7,7 @@
 //! - Info: plain text
 //! - Waiting: dim text for in-progress states
 
-use console::{Color, Style};
-
-// Design spec colors
-const GREEN: &str = "#3fb950";
-const RED: &str = "#f85149";
-const AMBER: &str = "#e3b341";
-const BLUE: &str = "#79c0ff";
-const DIM: &str = "#6e7681";
-
-/// Convert a hex color string to a console Color.
-fn hex_color(hex: &str) -> Color {
-    let hex = hex.trim_start_matches('#');
-    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
-    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
-    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
-    Color::TrueColor(r, g, b)
-}
-
-/// Get a style for a given hex color.
-fn style_for(hex: &str) -> Style {
-    Style::new().fg(hex_color(hex))
-}
+use super::styles::{AMBER, BLUE, DIM, GREEN, RED, style_for};
 
 /// Print a success message with green checkmark.
 ///
@@ -77,19 +56,4 @@ pub fn highlight(text: &str) -> String {
 /// Use this for secondary information, hints.
 pub fn dim(text: &str) -> String {
     style_for(DIM).apply_to(text).to_string()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_hex_color() {
-        match hex_color("#3fb950") {
-            Color::TrueColor(r, g, b) => {
-                assert_eq!((r, g, b), (63, 185, 80));
-            }
-            _ => panic!("Expected TrueColor"),
-        }
-    }
 }

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -7,34 +7,34 @@
 //! - Info: plain text
 //! - Waiting: dim text for in-progress states
 
-use super::styles::{AMBER, BLUE, DIM, GREEN, RED, style_for};
+use super::styles::UiColor;
 
 /// Print a success message with green checkmark.
 ///
 /// Example output: `✓ Authentication complete`
 pub fn success(msg: &str) {
-    eprintln!("{} {}", style_for(GREEN).apply_to("✓"), msg);
+    eprintln!("{} {}", UiColor::Green.apply_to("✓"), msg);
 }
 
 /// Print an exciting success message with sparkles.
 ///
 /// Use for final completion messages. Example output: `✨ You can now install packages!`
 pub fn great_success(msg: &str) {
-    eprintln!("{} {}", style_for(GREEN).apply_to("✨"), msg);
+    eprintln!("{} {}", UiColor::Green.apply_to("✨"), msg);
 }
 
 /// Print an error message with red "error:" prefix.
 ///
 /// Example output: `error: not logged in`
 pub fn error(msg: &str) {
-    eprintln!("{} {}", style_for(RED).apply_to("error:"), msg);
+    eprintln!("{} {}", UiColor::Red.apply_to("error:"), msg);
 }
 
 /// Print a warning message with amber exclamation.
 ///
 /// Example output: `! To fully revoke your token visit anaconda.com/settings/tokens`
 pub fn warn(msg: &str) {
-    eprintln!("{} {}", style_for(AMBER).apply_to("!"), msg);
+    eprintln!("{} {}", UiColor::Amber.apply_to("!"), msg);
 }
 
 /// Print an info message (plain text).
@@ -48,21 +48,21 @@ pub fn info(msg: &str) {
 ///
 /// Example output: `Waiting for authentication...`
 pub fn waiting(msg: &str) {
-    eprintln!("{}", style_for(DIM).apply_to(msg));
+    eprintln!("{}", UiColor::Dim.apply_to(msg));
 }
 
 /// Return text styled as highlighted (blue).
 ///
 /// Use this for values like usernames, emails, commands.
 pub fn highlight(text: &str) -> String {
-    style_for(BLUE).apply_to(text).to_string()
+    UiColor::Blue.apply_to(text).to_string()
 }
 
 /// Return text styled as dim.
 ///
 /// Use this for secondary information, hints.
 pub fn dim(text: &str) -> String {
-    style_for(DIM).apply_to(text).to_string()
+    UiColor::Dim.apply_to(text).to_string()
 }
 
 /// Print a blank line to stderr.

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -1,0 +1,55 @@
+//! Shared color and style definitions for CLI output.
+//!
+//! All colors match the UX design spec.
+
+use console::{Color, Style};
+
+// Design spec colors
+pub const GREEN: &str = "#3fb950";
+pub const RED: &str = "#f85149";
+pub const AMBER: &str = "#e3b341";
+pub const BLUE: &str = "#79c0ff";
+pub const DIM: &str = "#6e7681";
+pub const DESC: &str = "#8b949e";
+pub const BOX_BG: &str = "#161b22";
+pub const BOX_BORDER: &str = "#30363d";
+pub const BOX_TEXT: &str = "#e6edf3";
+
+/// Convert a hex color string to a console Color.
+pub fn hex_color(hex: &str) -> Color {
+    let hex = hex.trim_start_matches('#');
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
+    Color::TrueColor(r, g, b)
+}
+
+/// Get a style for a given hex color.
+pub fn style_for(hex: &str) -> Style {
+    Style::new().fg(hex_color(hex))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_color() {
+        match hex_color("#3fb950") {
+            Color::TrueColor(r, g, b) => {
+                assert_eq!((r, g, b), (63, 185, 80));
+            }
+            _ => panic!("Expected TrueColor"),
+        }
+    }
+
+    #[test]
+    fn test_hex_color_without_hash() {
+        match hex_color("79c0ff") {
+            Color::TrueColor(r, g, b) => {
+                assert_eq!((r, g, b), (121, 192, 255));
+            }
+            _ => panic!("Expected TrueColor"),
+        }
+    }
+}

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -47,7 +47,7 @@ impl UiColor {
     /// Apply this color to text, returning a styled object.
     ///
     /// Shorthand for `UiColor::Red.style().apply_to(text)`.
-    pub fn apply_to<D>(&self, val: D) -> StyledObject<D> {
+    pub fn apply_to<T>(&self, val: T) -> StyledObject<T> {
         self.style().apply_to(val)
     }
 

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -4,17 +4,6 @@
 
 use console::{Color, Style, StyledObject};
 
-// Design spec colors (hex values)
-const GREEN: &str = "#3fb950";
-const RED: &str = "#f85149";
-const AMBER: &str = "#e3b341";
-const BLUE: &str = "#79c0ff";
-const DIM: &str = "#6e7681";
-const DESC: &str = "#8b949e";
-const BOX_BG: &str = "#161b22";
-const BOX_BORDER: &str = "#30363d";
-const BOX_TEXT: &str = "#e6edf3";
-
 /// UI colors from the design spec.
 #[derive(Clone, Copy)]
 pub enum UiColor {
@@ -33,15 +22,15 @@ impl UiColor {
     /// Get the hex value for this color.
     fn hex(&self) -> &'static str {
         match self {
-            Self::Green => GREEN,
-            Self::Red => RED,
-            Self::Amber => AMBER,
-            Self::Blue => BLUE,
-            Self::Dim => DIM,
-            Self::Desc => DESC,
-            Self::BoxBg => BOX_BG,
-            Self::BoxBorder => BOX_BORDER,
-            Self::BoxText => BOX_TEXT,
+            Self::Green => "#3fb950",
+            Self::Red => "#f85149",
+            Self::Amber => "#e3b341",
+            Self::Blue => "#79c0ff",
+            Self::Dim => "#6e7681",
+            Self::Desc => "#8b949e",
+            Self::BoxBg => "#161b22",
+            Self::BoxBorder => "#30363d",
+            Self::BoxText => "#e6edf3",
         }
     }
 

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -50,6 +50,16 @@ impl UiColor {
     pub fn apply_to<D>(&self, val: D) -> StyledObject<D> {
         self.style().apply_to(val)
     }
+
+    /// Get a bold Style with this color as foreground.
+    pub fn bold(&self) -> Style {
+        self.style().bold()
+    }
+
+    /// Get a Style with this color as foreground and another as background.
+    pub fn on(&self, bg: UiColor) -> Style {
+        self.style().bg(bg.color())
+    }
 }
 
 /// Convert a hex color string to a console Color.

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -2,21 +2,69 @@
 //!
 //! All colors match the UX design spec.
 
-use console::{Color, Style};
+use console::{Color, Style, StyledObject};
 
-// Design spec colors
-pub const GREEN: &str = "#3fb950";
-pub const RED: &str = "#f85149";
-pub const AMBER: &str = "#e3b341";
-pub const BLUE: &str = "#79c0ff";
-pub const DIM: &str = "#6e7681";
-pub const DESC: &str = "#8b949e";
-pub const BOX_BG: &str = "#161b22";
-pub const BOX_BORDER: &str = "#30363d";
-pub const BOX_TEXT: &str = "#e6edf3";
+// Design spec colors (hex values)
+const GREEN: &str = "#3fb950";
+const RED: &str = "#f85149";
+const AMBER: &str = "#e3b341";
+const BLUE: &str = "#79c0ff";
+const DIM: &str = "#6e7681";
+const DESC: &str = "#8b949e";
+const BOX_BG: &str = "#161b22";
+const BOX_BORDER: &str = "#30363d";
+const BOX_TEXT: &str = "#e6edf3";
+
+/// UI colors from the design spec.
+#[derive(Clone, Copy)]
+pub enum UiColor {
+    Green,
+    Red,
+    Amber,
+    Blue,
+    Dim,
+    Desc,
+    BoxBg,
+    BoxBorder,
+    BoxText,
+}
+
+impl UiColor {
+    /// Get the hex value for this color.
+    fn hex(&self) -> &'static str {
+        match self {
+            Self::Green => GREEN,
+            Self::Red => RED,
+            Self::Amber => AMBER,
+            Self::Blue => BLUE,
+            Self::Dim => DIM,
+            Self::Desc => DESC,
+            Self::BoxBg => BOX_BG,
+            Self::BoxBorder => BOX_BORDER,
+            Self::BoxText => BOX_TEXT,
+        }
+    }
+
+    /// Convert to a console Color.
+    pub fn color(&self) -> Color {
+        hex_to_color(self.hex())
+    }
+
+    /// Get a Style with this color as foreground.
+    pub fn style(&self) -> Style {
+        Style::new().fg(self.color())
+    }
+
+    /// Apply this color to text, returning a styled object.
+    ///
+    /// Shorthand for `UiColor::Red.style().apply_to(text)`.
+    pub fn apply_to<D>(&self, val: D) -> StyledObject<D> {
+        self.style().apply_to(val)
+    }
+}
 
 /// Convert a hex color string to a console Color.
-pub fn hex_color(hex: &str) -> Color {
+fn hex_to_color(hex: &str) -> Color {
     let hex = hex.trim_start_matches('#');
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
     let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
@@ -24,18 +72,13 @@ pub fn hex_color(hex: &str) -> Color {
     Color::TrueColor(r, g, b)
 }
 
-/// Get a style for a given hex color.
-pub fn style_for(hex: &str) -> Style {
-    Style::new().fg(hex_color(hex))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_hex_color() {
-        match hex_color("#3fb950") {
+    fn test_ui_color_green() {
+        match UiColor::Green.color() {
             Color::TrueColor(r, g, b) => {
                 assert_eq!((r, g, b), (63, 185, 80));
             }
@@ -44,8 +87,8 @@ mod tests {
     }
 
     #[test]
-    fn test_hex_color_without_hash() {
-        match hex_color("79c0ff") {
+    fn test_ui_color_blue() {
+        match UiColor::Blue.color() {
             Color::TrueColor(r, g, b) => {
                 assert_eq!((r, g, b), (121, 192, 255));
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,38 +38,39 @@ def assert_output_contains(text: str, *patterns: str) -> None:
 
     for pattern in patterns:
         idx = text.find(pattern, pos)
-        if idx < 0:
-            # Build error message with context
-            lines = text.splitlines()
-            # Find which line we're at
-            chars_seen = 0
-            current_line = 0
-            for i, line in enumerate(lines):
-                if chars_seen + len(line) >= pos:
-                    current_line = i
-                    break
-                chars_seen += len(line) + 1  # +1 for newline
+        if idx >= 0:
+            matched.append(pattern)
+            pos = idx + len(pattern)
+            continue
 
-            # Show context: a few lines before and after current position
-            start_line = max(0, current_line - 2)
-            end_line = min(len(lines), current_line + 5)
-            context_lines = lines[start_line:end_line]
-            context = "\n".join(
-                f"  {'>' if i == current_line - start_line else ' '} {line}"
-                for i, line in enumerate(context_lines)
-            )
+        # Pattern not found - build error message with context
+        lines = text.splitlines()
+        # Find which line we're at
+        chars_seen = 0
+        current_line = 0
+        for i, line in enumerate(lines):
+            if chars_seen + len(line) >= pos:
+                current_line = i
+                break
+            chars_seen += len(line) + 1  # +1 for newline
 
-            matched_str = "\n  - ".join([""] + matched) if matched else " (none)"
-            msg = (
-                f"Pattern not found: {pattern!r}\n\n"
-                f"Already matched:{matched_str}\n\n"
-                f"Searching from line {current_line + 1}:\n{context}\n\n"
-                f"Full output:\n{text}"
-            )
-            raise AssertionError(msg)
+        # Show context: a few lines before and after current position
+        start_line = max(0, current_line - 2)
+        end_line = min(len(lines), current_line + 5)
+        context_lines = lines[start_line:end_line]
+        context = "\n".join(
+            f"  {'>' if i == current_line - start_line else ' '} {line}"
+            for i, line in enumerate(context_lines)
+        )
 
-        matched.append(pattern)
-        pos = idx + len(pattern)
+        matched_str = "\n  - ".join([""] + matched) if matched else " (none)"
+        msg = (
+            f"Pattern not found: {pattern!r}\n\n"
+            f"Already matched:{matched_str}\n\n"
+            f"Searching from line {current_line + 1}:\n{context}\n\n"
+            f"Full output:\n{text}"
+        )
+        raise AssertionError(msg)
 
 
 def _find_repo_root() -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,85 +4,13 @@ from __future__ import annotations
 
 import os
 import subprocess
-from collections.abc import Callable
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from helpers import REPO_ROOT
+from helpers import AnaRunner
 from mock_auth_server import MockAuthServer
-
-
-def assert_output_contains(text: str, *patterns: str) -> None:
-    """Assert that patterns appear in text in order.
-
-    Provides clear error messages showing:
-    - Which pattern failed to match
-    - What patterns matched before it
-    - The relevant portion of text around the search position
-
-    Args:
-        text: The text to search (e.g., result.stderr)
-        *patterns: Strings that should appear in order
-
-    Example:
-        assert_output_contains(
-            result.stderr,
-            "ACCOUNT",
-            "username",
-            "testuser",
-            "SUBSCRIPTIONS",
-        )
-    """
-    pos = 0
-    matched = []
-
-    for pattern in patterns:
-        idx = text.find(pattern, pos)
-        if idx >= 0:
-            matched.append(pattern)
-            pos = idx + len(pattern)
-            continue
-
-        # Pattern not found - build error message with context
-        lines = text.splitlines()
-        # Find which line we're at
-        chars_seen = 0
-        current_line = 0
-        for i, line in enumerate(lines):
-            if chars_seen + len(line) >= pos:
-                current_line = i
-                break
-            chars_seen += len(line) + 1  # +1 for newline
-
-        # Show context: a few lines before and after current position
-        start_line = max(0, current_line - 2)
-        end_line = min(len(lines), current_line + 5)
-        context_lines = lines[start_line:end_line]
-        context = "\n".join(
-            f"  {'>' if i == current_line - start_line else ' '} {line}"
-            for i, line in enumerate(context_lines)
-        )
-
-        matched_str = "\n  - ".join([""] + matched) if matched else " (none)"
-        msg = (
-            f"Pattern not found: {pattern!r}\n\n"
-            f"Already matched:{matched_str}\n\n"
-            f"Searching from line {current_line + 1}:\n{context}\n\n"
-            f"Full output:\n{text}"
-        )
-        raise AssertionError(msg)
-
-
-def _find_repo_root() -> Path:
-    """Find the repository root by looking for .git directory."""
-    path = Path(__file__).resolve()
-    for parent in path.parents:
-        if (parent / ".git").exists():
-            return parent
-    raise RuntimeError("Could not find repository root")
-
-
-REPO_ROOT = _find_repo_root()
 
 
 @pytest.fixture
@@ -134,9 +62,6 @@ def ana_binary() -> Path | None:
             return binary
 
     return None
-
-
-AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,66 @@ import pytest
 from mock_auth_server import MockAuthServer
 
 
+def assert_output_contains(text: str, *patterns: str) -> None:
+    """Assert that patterns appear in text in order.
+
+    Provides clear error messages showing:
+    - Which pattern failed to match
+    - What patterns matched before it
+    - The relevant portion of text around the search position
+
+    Args:
+        text: The text to search (e.g., result.stderr)
+        *patterns: Strings that should appear in order
+
+    Example:
+        assert_output_contains(
+            result.stderr,
+            "ACCOUNT",
+            "username",
+            "testuser",
+            "SUBSCRIPTIONS",
+        )
+    """
+    pos = 0
+    matched = []
+
+    for pattern in patterns:
+        idx = text.find(pattern, pos)
+        if idx < 0:
+            # Build error message with context
+            lines = text.splitlines()
+            # Find which line we're at
+            chars_seen = 0
+            current_line = 0
+            for i, line in enumerate(lines):
+                if chars_seen + len(line) >= pos:
+                    current_line = i
+                    break
+                chars_seen += len(line) + 1  # +1 for newline
+
+            # Show context: a few lines before and after current position
+            start_line = max(0, current_line - 2)
+            end_line = min(len(lines), current_line + 5)
+            context_lines = lines[start_line:end_line]
+            context = "\n".join(
+                f"  {'>' if i == current_line - start_line else ' '} {line}"
+                for i, line in enumerate(context_lines)
+            )
+
+            matched_str = "\n  - ".join([""] + matched) if matched else " (none)"
+            msg = (
+                f"Pattern not found: {pattern!r}\n\n"
+                f"Already matched:{matched_str}\n\n"
+                f"Searching from line {current_line + 1}:\n{context}\n\n"
+                f"Full output:\n{text}"
+            )
+            raise AssertionError(msg)
+
+        matched.append(pattern)
+        pos = idx + len(pattern)
+
+
 def _find_repo_root() -> Path:
     """Find the repository root by looking for .git directory."""
     path = Path(__file__).resolve()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,82 @@
+"""Test helpers and utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+
+def _find_repo_root() -> Path:
+    """Find the repository root by looking for .git directory."""
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError("Could not find repository root")
+
+
+REPO_ROOT = _find_repo_root()
+
+AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def assert_output_contains(text: str, *patterns: str) -> None:
+    """Assert that patterns appear in text in order.
+
+    Provides clear error messages showing:
+    - Which pattern failed to match
+    - What patterns matched before it
+    - The relevant portion of text around the search position
+
+    Args:
+        text: The text to search (e.g., result.stderr)
+        *patterns: Strings that should appear in order
+
+    Example:
+        assert_output_contains(
+            result.stderr,
+            "ACCOUNT",
+            "username",
+            "testuser",
+            "SUBSCRIPTIONS",
+        )
+    """
+    pos = 0
+    matched = []
+
+    for pattern in patterns:
+        idx = text.find(pattern, pos)
+        if idx >= 0:
+            matched.append(pattern)
+            pos = idx + len(pattern)
+            continue
+
+        # Pattern not found - build error message with context
+        lines = text.splitlines()
+        # Find which line we're at
+        chars_seen = 0
+        current_line = 0
+        for i, line in enumerate(lines):
+            if chars_seen + len(line) >= pos:
+                current_line = i
+                break
+            chars_seen += len(line) + 1  # +1 for newline
+
+        # Show context: a few lines before and after current position
+        start_line = max(0, current_line - 2)
+        end_line = min(len(lines), current_line + 5)
+        context_lines = lines[start_line:end_line]
+        context = "\n".join(
+            f"  {'>' if i == current_line - start_line else ' '} {line}"
+            for i, line in enumerate(context_lines)
+        )
+
+        matched_str = "\n  - ".join([""] + matched) if matched else " (none)"
+        msg = (
+            f"Pattern not found: {pattern!r}\n\n"
+            f"Already matched:{matched_str}\n\n"
+            f"Searching from line {current_line + 1}:\n{context}\n\n"
+            f"Full output:\n{text}"
+        )
+        raise AssertionError(msg)

--- a/tests/mock_auth_server.py
+++ b/tests/mock_auth_server.py
@@ -6,10 +6,12 @@ This server mimics the Anaconda authentication endpoints:
 - /oauth/token (token exchange)
 - /api/account (user info)
 - /api/auth/api-keys (API key creation)
+- /api/auth/sessions/whoami (user info with organizations)
 """
 
 from __future__ import annotations
 
+import base64
 import json
 import threading
 import time
@@ -35,7 +37,59 @@ MOCK_USER = {
     "subscriptions": [],
 }
 
-MOCK_API_KEY = "mock-api-key-12345"
+# Whoami response (used by the new styled output)
+MOCK_WHOAMI = {
+    "identity": {"id": "test-user-id"},
+    "passport": {
+        "user_id": "test-user-id",
+        "profile": {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "username": "testuser",
+        },
+        "organizations": [
+            {
+                "org_id": "test-org-id",
+                "name": "test-org",
+                "title": "Test Organization",
+                "role": "member",
+                "attributes": [
+                    {
+                        "id": "test_subscription",
+                        "group": "subscriptions",
+                        "data": {"expires_at": "2030-01-01 00:00:00+00:00"},
+                    }
+                ],
+            }
+        ],
+    },
+}
+
+
+def _create_mock_jwt() -> str:
+    """Create a mock JWT with an expiration claim (1 year from now)."""
+    # JWT header
+    header = {"alg": "none", "typ": "JWT"}
+    # JWT payload with exp claim (1 year from now)
+    exp_timestamp = int(time.time()) + 365 * 24 * 60 * 60
+    payload = {
+        "exp": exp_timestamp,
+        "sub": "test-user-id",
+        "scopes": ["cloud:read", "cloud:write", "repo:read"],
+    }
+    # Encode as base64url (no padding)
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
+    )
+    payload_b64 = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    )
+    # Return JWT (no signature for mock)
+    return f"{header_b64}.{payload_b64}."
+
+
+MOCK_API_KEY = _create_mock_jwt()
 MOCK_ACCESS_TOKEN = "mock-access-token-67890"
 MOCK_DEVICE_CODE = "mock-device-code"
 MOCK_USER_CODE = "TEST-1234"
@@ -76,6 +130,8 @@ class MockAuthHandler(BaseHTTPRequestHandler):
             self._handle_openid_config()
         elif self.path == "/api/account":
             self._handle_account()
+        elif self.path == "/api/auth/sessions/whoami":
+            self._handle_whoami()
         else:
             self.send_error(404)
 
@@ -179,6 +235,15 @@ class MockAuthHandler(BaseHTTPRequestHandler):
             return
 
         self._send_json(MOCK_USER)
+
+    def _handle_whoami(self) -> None:
+        """Handle whoami request (new styled output endpoint)."""
+        token = self._get_auth_header()
+        if not token:
+            self._send_error_json("unauthorized", "Missing authorization", 401)
+            return
+
+        self._send_json(MOCK_WHOAMI)
 
     def _handle_create_api_key(self) -> None:
         """Handle API key creation."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,7 @@ class TestLogin:
         # Message varies based on QR display: "visit:" or "scan the QR code or visit:"
         assert "visit:" in result.stderr
         assert "Authentication complete" in result.stderr
-        assert "Token stored in keyring" in result.stderr
+        assert "API key stored in keyring" in result.stderr
         assert "Logged in as" in result.stderr
         assert "test@example.com" in result.stderr
         assert keyring_path.exists()
@@ -88,10 +88,11 @@ class TestLogout:
         run_ana: AnaRunner,
         auth_env: dict[str, str],
     ) -> None:
-        """Logout when not logged in should succeed silently."""
+        """Logout when not logged in should warn and succeed."""
         result = run_ana("logout", env=auth_env)
 
         assert result.returncode == 0
+        assert "Not logged in" in result.stderr
 
     def test_logout_via_auth_subcommand(
         self,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from conftest import AnaRunner
 from conftest import assert_output_contains
 from mock_auth_server import MockAuthServer
@@ -13,14 +14,16 @@ from mock_auth_server import MockAuthServer
 class TestLogin:
     """Tests for 'ana login' command."""
 
+    @pytest.mark.parametrize("args", [["login"], ["auth", "login"]])
     def test_login_creates_keyring(
         self,
+        args: list[str],
         run_ana: AnaRunner,
         auth_env: dict[str, str],
         keyring_path: Path,
     ) -> None:
         """Login should create keyring file with API key."""
-        result = run_ana("login", env=auth_env)
+        result = run_ana(*args, env=auth_env)
 
         assert result.returncode == 0
         assert_output_contains(
@@ -47,19 +50,6 @@ class TestLogin:
         keyring_data = json.loads(keyring_path.read_text())
         assert "Anaconda Cloud" in keyring_data
         assert mock_auth_server.domain in keyring_data["Anaconda Cloud"]
-
-    def test_login_via_auth_subcommand(
-        self,
-        run_ana: AnaRunner,
-        auth_env: dict[str, str],
-        keyring_path: Path,
-    ) -> None:
-        """'ana auth login' should work the same as 'ana login'."""
-        result = run_ana("auth", "login", env=auth_env)
-
-        assert result.returncode == 0
-        assert "Authentication complete" in result.stderr
-        assert keyring_path.exists()
 
 
 class TestLogout:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,8 +6,8 @@ import json
 from pathlib import Path
 
 import pytest
-from conftest import AnaRunner
-from conftest import assert_output_contains
+from helpers import AnaRunner
+from helpers import assert_output_contains
 from mock_auth_server import MockAuthServer
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -55,8 +55,10 @@ class TestLogin:
 class TestLogout:
     """Tests for 'ana logout' command."""
 
+    @pytest.mark.parametrize("args", [["logout"], ["auth", "logout"]])
     def test_logout_removes_key(
         self,
+        args: list[str],
         run_ana: AnaRunner,
         auth_env: dict[str, str],
         keyring_path: Path,
@@ -68,7 +70,7 @@ class TestLogout:
         assert keyring_path.exists()
 
         # Then logout
-        result = run_ana("logout", env=auth_env)
+        result = run_ana(*args, env=auth_env)
 
         assert result.returncode == 0
         assert f"Logged out of {mock_auth_server.domain}" in result.stderr
@@ -85,20 +87,6 @@ class TestLogout:
 
         assert result.returncode == 0
         assert "Not logged in" in result.stderr
-
-    def test_logout_via_auth_subcommand(
-        self,
-        run_ana: AnaRunner,
-        auth_env: dict[str, str],
-        keyring_path: Path,
-        mock_auth_server: MockAuthServer,
-    ) -> None:
-        """'ana auth logout' should work the same as 'ana logout'."""
-        run_ana("login", env=auth_env)
-        result = run_ana("auth", "logout", env=auth_env)
-
-        assert result.returncode == 0
-        assert f"Logged out of {mock_auth_server.domain}" in result.stderr
 
 
 class TestApiKey:
@@ -170,15 +158,17 @@ class TestAuthHelp:
 class TestWhoami:
     """Tests for 'ana whoami' command."""
 
+    @pytest.mark.parametrize("args", [["whoami"], ["auth", "whoami"]])
     def test_whoami_when_logged_in(
         self,
+        args: list[str],
         run_ana: AnaRunner,
         auth_env: dict[str, str],
-        mock_auth_server: MockAuthServer,
+        keyring_path: Path,
     ) -> None:
         """Whoami should display user info when logged in."""
         run_ana("login", env=auth_env)
-        result = run_ana("whoami", env=auth_env)
+        result = run_ana(*args, env=auth_env)
 
         assert result.returncode == 0
         assert_output_contains(
@@ -187,40 +177,9 @@ class TestWhoami:
             "Test User",
             "testuser",
             "test@example.com",
-        )
-
-    def test_whoami_shows_subscriptions(
-        self,
-        run_ana: AnaRunner,
-        auth_env: dict[str, str],
-    ) -> None:
-        """Whoami should display subscription info."""
-        run_ana("login", env=auth_env)
-        result = run_ana("whoami", env=auth_env)
-
-        assert result.returncode == 0
-        assert_output_contains(
-            result.stderr,
-            "ACCOUNT",
             "SUBSCRIPTIONS",
             "Test Organization",
             "2030-01-01",
-        )
-
-    def test_whoami_shows_token_info(
-        self,
-        run_ana: AnaRunner,
-        auth_env: dict[str, str],
-        keyring_path: Path,
-    ) -> None:
-        """Whoami should display token info."""
-        run_ana("login", env=auth_env)
-        result = run_ana("whoami", env=auth_env)
-
-        assert result.returncode == 0
-        assert_output_contains(
-            result.stderr,
-            "SUBSCRIPTIONS",
             "TOKEN",
             str(keyring_path),
         )
@@ -229,7 +188,6 @@ class TestWhoami:
         self,
         run_ana: AnaRunner,
         auth_env: dict[str, str],
-        mock_auth_server: MockAuthServer,
     ) -> None:
         """Whoami should show helpful message when not logged in."""
         result = run_ana("whoami", env=auth_env)
@@ -240,19 +198,6 @@ class TestWhoami:
             "not logged in",
             "ana login",
         )
-
-    def test_whoami_via_auth_subcommand(
-        self,
-        run_ana: AnaRunner,
-        auth_env: dict[str, str],
-        mock_auth_server: MockAuthServer,
-    ) -> None:
-        """'ana auth whoami' should work the same as 'ana whoami'."""
-        run_ana("login", env=auth_env)
-        result = run_ana("auth", "whoami", env=auth_env)
-
-        assert result.returncode == 0
-        assert "ACCOUNT" in result.stderr
 
     def test_whoami_json_flag(
         self,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from conftest import AnaRunner
+from conftest import assert_output_contains
 from mock_auth_server import MockAuthServer
 
 
@@ -22,14 +23,15 @@ class TestLogin:
         result = run_ana("login", env=auth_env)
 
         assert result.returncode == 0
-
-        # Status messages go to stderr
-        # Message varies based on QR display: "visit:" or "scan the QR code or visit:"
-        assert "visit:" in result.stderr
-        assert "Authentication complete" in result.stderr
-        assert "API key stored in keyring" in result.stderr
-        assert "Logged in as" in result.stderr
-        assert "test@example.com" in result.stderr
+        assert_output_contains(
+            result.stderr,
+            "visit:",  # Message varies: "visit:" or "scan the QR code or visit:"
+            "Authentication complete",
+            "API key stored in keyring",
+            "Logged in as",
+            "test@example.com",
+            "expires",
+        )
         assert keyring_path.exists()
 
     def test_login_keyring_format(
@@ -189,10 +191,13 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert "ACCOUNT" in result.stderr
-        assert "testuser" in result.stderr
-        assert "test@example.com" in result.stderr
-        assert "Test User" in result.stderr
+        assert_output_contains(
+            result.stderr,
+            "ACCOUNT",
+            "Test User",
+            "testuser",
+            "test@example.com",
+        )
 
     def test_whoami_shows_subscriptions(
         self,
@@ -204,9 +209,13 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert "SUBSCRIPTIONS" in result.stderr
-        assert "Test Organization" in result.stderr
-        assert "2030-01-01" in result.stderr
+        assert_output_contains(
+            result.stderr,
+            "ACCOUNT",
+            "SUBSCRIPTIONS",
+            "Test Organization",
+            "2030-01-01",
+        )
 
     def test_whoami_shows_token_info(
         self,
@@ -219,8 +228,12 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert "TOKEN" in result.stderr
-        assert str(keyring_path) in result.stderr
+        assert_output_contains(
+            result.stderr,
+            "SUBSCRIPTIONS",
+            "TOKEN",
+            str(keyring_path),
+        )
 
     def test_whoami_when_not_logged_in(
         self,
@@ -232,8 +245,11 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert "not logged in" in result.stderr
-        assert "ana login" in result.stderr
+        assert_output_contains(
+            result.stderr,
+            "not logged in",
+            "ana login",
+        )
 
     def test_whoami_via_auth_subcommand(
         self,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 from conftest import AnaRunner
-from mock_auth_server import MOCK_API_KEY
 from mock_auth_server import MockAuthServer
 
 
@@ -24,10 +23,13 @@ class TestLogin:
 
         assert result.returncode == 0
 
+        # Status messages go to stderr
         # Message varies based on QR display: "visit:" or "scan the QR code or visit:"
-        assert "visit:" in result.stdout
-        assert "Successfully authenticated!" in result.stdout
-        assert "API key saved to" in result.stdout
+        assert "visit:" in result.stderr
+        assert "Authentication complete" in result.stderr
+        assert "Token stored in keyring" in result.stderr
+        assert "Logged in as" in result.stderr
+        assert "test@example.com" in result.stderr
         assert keyring_path.exists()
 
     def test_login_keyring_format(
@@ -54,7 +56,7 @@ class TestLogin:
         result = run_ana("auth", "login", env=auth_env)
 
         assert result.returncode == 0
-        assert "Successfully authenticated!" in result.stdout
+        assert "Authentication complete" in result.stderr
         assert keyring_path.exists()
 
 
@@ -77,7 +79,7 @@ class TestLogout:
         result = run_ana("logout", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Logged out from {mock_auth_server.domain}" in result.stdout
+        assert f"Logged out of {mock_auth_server.domain}" in result.stderr
         # Keyring should be deleted when empty
         assert not keyring_path.exists()
 
@@ -103,7 +105,7 @@ class TestLogout:
         result = run_ana("auth", "logout", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Logged out from {mock_auth_server.domain}" in result.stdout
+        assert f"Logged out of {mock_auth_server.domain}" in result.stderr
 
 
 class TestApiKey:
@@ -119,7 +121,8 @@ class TestApiKey:
         result = run_ana("auth", "api-key", env=auth_env)
 
         assert result.returncode == 0
-        assert MOCK_API_KEY in result.stdout
+        # API key is a JWT (header.payload.signature format)
+        assert result.stdout.strip().count(".") == 2
 
     def test_api_key_when_not_logged_in(
         self,
@@ -131,8 +134,8 @@ class TestApiKey:
         result = run_ana("auth", "api-key", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Not logged in to {mock_auth_server.domain}" in result.stdout
-        assert "Run `ana login` to authenticate." in result.stdout
+        assert "not logged in" in result.stderr
+        assert "ana login" in result.stderr
 
     def test_api_key_output_is_clean(
         self,
@@ -143,8 +146,11 @@ class TestApiKey:
         run_ana("login", env=auth_env)
         result = run_ana("auth", "api-key", env=auth_env)
 
-        # Should be just the key with a newline
-        assert result.stdout.strip() == MOCK_API_KEY
+        # Should be just the key with a newline (no extra output)
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1
+        # API key is a JWT
+        assert lines[0].count(".") == 2
 
 
 class TestAuthHelp:
@@ -182,9 +188,38 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Your info ({mock_auth_server.domain}):" in result.stdout
-        assert "testuser" in result.stdout
-        assert "test@example.com" in result.stdout
+        assert "ACCOUNT" in result.stderr
+        assert "testuser" in result.stderr
+        assert "test@example.com" in result.stderr
+        assert "Test User" in result.stderr
+
+    def test_whoami_shows_subscriptions(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+    ) -> None:
+        """Whoami should display subscription info."""
+        run_ana("login", env=auth_env)
+        result = run_ana("whoami", env=auth_env)
+
+        assert result.returncode == 0
+        assert "SUBSCRIPTIONS" in result.stderr
+        assert "Test Organization" in result.stderr
+        assert "2030-01-01" in result.stderr
+
+    def test_whoami_shows_token_info(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        keyring_path: Path,
+    ) -> None:
+        """Whoami should display token info."""
+        run_ana("login", env=auth_env)
+        result = run_ana("whoami", env=auth_env)
+
+        assert result.returncode == 0
+        assert "TOKEN" in result.stderr
+        assert str(keyring_path) in result.stderr
 
     def test_whoami_when_not_logged_in(
         self,
@@ -196,8 +231,8 @@ class TestWhoami:
         result = run_ana("whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Not logged in to {mock_auth_server.domain}" in result.stdout
-        assert "Run `ana login` to authenticate." in result.stdout
+        assert "not logged in" in result.stderr
+        assert "ana login" in result.stderr
 
     def test_whoami_via_auth_subcommand(
         self,
@@ -210,7 +245,24 @@ class TestWhoami:
         result = run_ana("auth", "whoami", env=auth_env)
 
         assert result.returncode == 0
-        assert f"Your info ({mock_auth_server.domain}):" in result.stdout
+        assert "ACCOUNT" in result.stderr
+
+    def test_whoami_json_flag(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+    ) -> None:
+        """Whoami with --json should output raw JSON."""
+        run_ana("login", env=auth_env)
+        result = run_ana("whoami", "--json", env=auth_env)
+
+        assert result.returncode == 0
+        # Should be valid JSON
+        import json
+
+        data = json.loads(result.stdout)
+        assert "passport" in data
+        assert "profile" in data["passport"]
 
 
 class TestMultipleDomains:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from conftest import AnaRunner
+from helpers import AnaRunner
 
 
 class TestHelp:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conftest import REPO_ROOT
+from helpers import REPO_ROOT
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from conftest import AnaRunner
+from helpers import AnaRunner
 
 
 class TestToolInstallHelp:


### PR DESCRIPTION
## Summary

- Adds a unified `ui` module with `status` and `styles` submodules for consistent CLI output
- Improves `ana login` to show user info and token expiration after successful authentication
- Improves `ana whoami` with styled output showing account, subscriptions, and token info
- Adds `--json` flag to `ana whoami` for machine-readable output
- Fixes keyring to use same location as anaconda-auth (`~/.anaconda/keyring`)
- Fixes handling of empty keyring files
- Adds login/logout state checks with user prompts

## UI Module

New `ui::status` functions for consistent output:
- `success()` - green checkmark (✓)
- `great_success()` - sparkle emoji (✨) for final completion messages
- `error()` - red "error:" prefix
- `warn()` - amber exclamation (!)
- `info()` - plain text
- `waiting()` - dim text for in-progress states
- `highlight()` - blue text for values
- `dim()` - gray text for secondary info

## `ana whoami` Output

```
ACCOUNT
  name        Alice Smith
  username    asmith
  email       alice@example.com

SUBSCRIPTIONS
  Org Name (security)         2035-01-02 (8 years, 258 days)
  Another Org (commercial)    2027-01-01 (255 days)

TOKEN
  value       eyJ_****************************
  storage     /Users/user/.anaconda/keyring
```

- Shows all organizations with their subscription types and expiration dates
- Formats duration as "X years, Y days" for longer periods
- Shows "expired" in red for past expiration dates
- Token is masked, storage shows actual keyring path

## Login/Logout Improvements

- `ana login` now prompts "Login again? [y/N]" if already logged in
- `ana logout` now warns "Not logged in to {domain}" if already logged out
- Logout message includes full URL with https:// prefix for token revocation

## Example

Here is an example of the updated styling across the auth command lifecycle:

<img width="652" height="777" alt="image" src="https://github.com/user-attachments/assets/a3f564fa-122a-4666-87ec-38af53ca8b51" />

## Test plan

- [ ] Run `ana login` - should show styled output, user info, and token expiration after auth
- [ ] Run `ana login` when already logged in - should prompt before re-authenticating
- [ ] Run `ana logout` - should show styled confirmation with revocation URL
- [ ] Run `ana logout` when already logged out - should warn and exit gracefully
- [ ] Run `ana whoami` - should show styled account/subscription/token info
- [ ] Run `ana whoami --json` - should output raw JSON
- [ ] Run `ana whoami` when logged out - should show error with login hint

