### PR TITLE
fix: Use shim instead of symlinks on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,15 @@ jobs:
           ANA_SENTRY_DISABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         run: pixi run test-integration
 
+      - name: Run integration tests (PowerShell)
+        if: ${{ runner.os == 'Windows' }}
+        env:
+          ANA_SENTRY_ENVIRONMENT: integration-test
+          # Disable Sentry for pre-merge builds (PRs, merge queue) to avoid polluting error tracking
+          ANA_SENTRY_DISABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+        run: pixi run test-integration
+        shell: pwsh
+
       - name: Build conda package
         run: pixi run build-conda
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,8 @@ jobs:
           github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
       - name: Run unit tests
+        env:
+          RUST_BACKTRACE: 1
         run: pixi run test-release
 
       - name: Build release binary

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,38 @@ fn main() {
     let rattler_version =
         extract_dep_version("Cargo.lock", "rattler").unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=RATTLER_VERSION={}", rattler_version);
+
+    // On Windows, compile the shim binary and place it in OUT_DIR
+    #[cfg(windows)]
+    build_shim();
+}
+
+#[cfg(windows)]
+fn build_shim() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    println!("cargo:rerun-if-changed=src/shim/shim.rs");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let shim_src = PathBuf::from("src/shim/shim.rs");
+    let shim_out = out_dir.join("shim.exe");
+
+    // Use rustc directly to compile the shim as a minimal binary
+    let status = Command::new("rustc")
+        .args([
+            "--edition=2024",
+            "-O", // optimize for size
+            "-o",
+            shim_out.to_str().unwrap(),
+            shim_src.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run rustc for shim");
+
+    if !status.success() {
+        panic!("failed to compile shim binary");
+    }
 }
 
 /// Extract a dependency's resolved version from Cargo.lock.

--- a/src/shim/shim.rs
+++ b/src/shim/shim.rs
@@ -1,0 +1,98 @@
+//! Binary shim that forwards execution to a target specified in shims.cfg.
+//!
+//! The shim:
+//! 1. Gets its own filename (e.g., `pixi.exe` -> `pixi`)
+//! 2. Reads `../tools/shims.cfg` relative to itself
+//! 3. Looks up the target path for its name
+//! 4. Executes the target with all arguments passed through
+//!
+//! shims.cfg format (one entry per line):
+//! ```
+//! pixi=pixi\bin\pixi.exe
+//! anaconda=anaconda-cli\Scripts\anaconda.exe
+//! ```
+
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, exit};
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("shim error: {}", e);
+        exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let shim_path = env::current_exe().map_err(|e| format!("failed to get exe path: {}", e))?;
+    let shim_dir = shim_path.parent().ok_or("shim has no parent directory")?;
+    let shim_name = shim_path
+        .file_stem()
+        .ok_or("shim has no file stem")?
+        .to_string_lossy();
+
+    // Read shims.cfg from ..\tools\shims.cfg
+    let config_path = shim_dir.join("..\\tools\\shims.cfg");
+    let config_content = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("failed to read {}: {}", config_path.display(), e))?;
+
+    // Find matching line: name=path
+    let target_rel = config_content
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .find(|(name, _)| *name == shim_name)
+        .map(|(_, path)| path)
+        .ok_or_else(|| format!("no config found for '{}'", shim_name))?;
+
+    // Parse the path components and build a proper PathBuf
+    // This handles both forward and back slashes in the config
+    let target_path: PathBuf = shim_dir
+        .join("..\\tools")
+        .join(target_rel.replace('/', "\\"));
+
+    if !target_path.exists() {
+        return Err(format!("target not found: {}", target_path.display()));
+    }
+
+    // Execute with all arguments
+    let args: Vec<String> = env::args().skip(1).collect();
+    let status = Command::new(&target_path)
+        .args(&args)
+        .status()
+        .map_err(|e| format!("failed to execute {}: {}", target_path.display(), e))?;
+
+    exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parse_config_line() {
+        let content = "pixi=pixi\\bin\\pixi.exe\nanaconda=anaconda-cli\\Scripts\\anaconda.exe\n";
+        let result: Option<&str> = content
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .find(|(name, _)| *name == "pixi")
+            .map(|(_, path)| path);
+        assert_eq!(result, Some("pixi\\bin\\pixi.exe"));
+    }
+
+    #[test]
+    fn test_parse_config_not_found() {
+        let content = "pixi=pixi\\bin\\pixi.exe\n";
+        let result: Option<&str> = content
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .find(|(name, _)| *name == "unknown")
+            .map(|(_, path)| path);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_path_normalization() {
+        // Config might have forward slashes, we normalize to backslashes
+        let path_from_config = "pixi/bin/pixi.exe";
+        let normalized = path_from_config.replace('/', "\\");
+        assert_eq!(normalized, "pixi\\bin\\pixi.exe");
+    }
+}

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -1,6 +1,6 @@
 //! Package installation from lockfiles via rattler.
 
-use std::{path::Path, str::FromStr, time::Instant};
+use std::{path::Path, path::PathBuf, str::FromStr, time::Instant};
 
 use indicatif::{MultiProgress, ProgressDrawTarget};
 use miette::{Context, IntoDiagnostic};
@@ -29,14 +29,14 @@ pub async fn install_tool(name: &str) -> miette::Result<()> {
     let lock_content =
         tools::content(name).ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
 
-    let binaries = tools::binaries(name).unwrap_or(&[]);
+    let binaries = tools::binaries(name).unwrap_or(Vec::new());
 
     eprintln!("Installing {} into {}", name, prefix.display());
 
     install_from_lockfile(&prefix, &lock_content).await?;
 
     // Create symlinks in bin directory
-    create_bin_symlinks(&prefix, binaries)?;
+    create_bin_symlinks(&prefix, &binaries)?;
 
     // Tool-specific post-install configuration
     if name == "pixi" {
@@ -122,7 +122,7 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
 }
 
 /// Create symlinks for the tool's binaries in ~/.ana/bin/
-fn create_bin_symlinks(prefix: &Path, binaries: &[&str]) -> miette::Result<()> {
+fn create_bin_symlinks(prefix: &Path, binaries: &[PathBuf]) -> miette::Result<()> {
     let bin_dir = paths::bin_dir();
     std::fs::create_dir_all(&bin_dir)
         .into_diagnostic()
@@ -136,16 +136,20 @@ fn create_bin_symlinks(prefix: &Path, binaries: &[&str]) -> miette::Result<()> {
 }
 
 /// Create a single symlink for a binary.
-fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &str) -> miette::Result<()> {
-    let binary_name = paths::binary_name(binary);
-    let tool_bin = prefix.join("bin").join(&binary_name);
+fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::Result<()> {
+    let tool_bin = if cfg!(unix) {
+        prefix.join(binary)
+    } else {
+        prefix.join(binary).with_extension("exe")
+    };
+    let binary_name = paths::binary_name(binary.file_stem().and_then(|s| s.to_str()).unwrap());
     let symlink_path = bin_dir.join(&binary_name);
 
     // Check if the tool binary exists
     if !tool_bin.exists() {
         eprintln!(
             "   Warning: binary '{}' not found in {}/bin/",
-            binary,
+            binary.file_stem().and_then(|s| s.to_str()).unwrap(),
             prefix.display()
         );
         return Ok(());

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -121,7 +121,7 @@ pub async fn install_from_lockfile(prefix: &Path, lock_content: &str) -> miette:
     Ok(())
 }
 
-/// Create symlinks for the tool's binaries in ~/.ana/bin/
+/// Create symlinks (Unix) or shims (Windows) for the tool's binaries in ~/.ana/bin/
 fn create_bin_symlinks(prefix: &Path, binaries: &[PathBuf]) -> miette::Result<()> {
     let bin_dir = paths::bin_dir();
     std::fs::create_dir_all(&bin_dir)
@@ -129,27 +129,26 @@ fn create_bin_symlinks(prefix: &Path, binaries: &[PathBuf]) -> miette::Result<()
         .context("failed to create bin directory")?;
 
     for binary in binaries {
+        #[cfg(unix)]
         create_bin_symlink(&bin_dir, prefix, binary)?;
+        #[cfg(windows)]
+        create_bin_shim(&bin_dir, prefix, binary)?;
     }
 
     Ok(())
 }
 
+#[cfg(unix)]
 /// Create a single symlink for a binary.
 fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::Result<()> {
-    let tool_bin = if cfg!(unix) {
-        prefix.join(binary)
-    } else {
-        prefix.join(binary).with_extension("exe")
-    };
-    let binary_name = paths::binary_name(binary.file_stem().and_then(|s| s.to_str()).unwrap());
-    let symlink_path = bin_dir.join(&binary_name);
+    let tool_bin = prefix.join(binary);
+    let symlink_path = bin_dir.join(binary.file_name().unwrap());
 
     // Check if the tool binary exists
     if !tool_bin.exists() {
         eprintln!(
-            "   Warning: binary '{}' not found in {}/bin/",
-            binary.file_stem().and_then(|s| s.to_str()).unwrap(),
+            "   Warning: binary '{}' not found in {}",
+            binary.display(),
             prefix.display()
         );
         return Ok(());
@@ -162,25 +161,112 @@ fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::R
             .context("failed to remove existing symlink")?;
     }
 
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(&tool_bin, &symlink_path)
-            .into_diagnostic()
-            .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
-    }
-
-    #[cfg(windows)]
-    {
-        std::os::windows::fs::symlink_file(&tool_bin, &symlink_path)
-            .into_diagnostic()
-            .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
-    }
+    std::os::unix::fs::symlink(&tool_bin, &symlink_path)
+        .into_diagnostic()
+        .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
 
     eprintln!(
         "   Linked {} -> {}",
         symlink_path.display(),
         tool_bin.display()
     );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+/// Embedded shim binary (compiled from src/bin/shim.rs)
+const SHIM_BINARY: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shim.exe"));
+
+#[cfg(windows)]
+/// Create a binary shim for a tool.
+///
+/// Copies the shim executable to bin_dir/<name>.exe and updates shims.cfg
+/// with the mapping from shim name to target binary.
+fn create_bin_shim(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::Result<()> {
+    let tool_bin = prefix.join(binary).with_extension("exe");
+    let shim_name = binary.file_stem().unwrap().to_string_lossy();
+    let shim_path = bin_dir.join(format!("{}.exe", shim_name));
+
+    // Check if the tool binary exists
+    if !tool_bin.exists() {
+        eprintln!(
+            "   Warning: binary '{}' not found in {}",
+            binary.display(),
+            prefix.display()
+        );
+        return Ok(());
+    }
+
+    // Copy shim binary to bin_dir
+    std::fs::write(&shim_path, SHIM_BINARY)
+        .into_diagnostic()
+        .with_context(|| format!("failed to write shim: {}", shim_path.display()))?;
+
+    // Update shims.cfg with the mapping
+    // Format: <tool_name>\<binary_path_with_exe>
+    let tool_name = prefix.file_name().unwrap().to_string_lossy();
+    let rel_target = format!("{}\\{}", tool_name, binary.with_extension("exe").display());
+    update_shims_cfg(&shim_name, &rel_target)?;
+
+    eprintln!(
+        "   Created shim {} -> {}",
+        shim_path.display(),
+        tool_bin.display()
+    );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+/// Update or add an entry in shims.cfg.
+///
+/// The config file is at ~/.ana/tools/shims.cfg with format:
+/// ```
+/// pixi=pixi\bin\pixi.exe
+/// anaconda=anaconda-cli\Scripts\anaconda.exe
+/// ```
+fn update_shims_cfg(shim_name: &str, target_path: &str) -> miette::Result<()> {
+    let config_path = paths::ana_home().join("tools").join("shims.cfg");
+
+    // Read existing config or start empty
+    let mut entries: Vec<(String, String)> = if config_path.exists() {
+        std::fs::read_to_string(&config_path)
+            .into_diagnostic()
+            .context("failed to read shims.cfg")?
+            .lines()
+            .filter_map(|line| {
+                line.split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // Update or add the entry
+    let mut found = false;
+    for (name, path) in &mut entries {
+        if name == shim_name {
+            *path = target_path.to_string();
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        entries.push((shim_name.to_string(), target_path.to_string()));
+    }
+
+    // Write back
+    let content: String = entries
+        .iter()
+        .map(|(k, v)| format!("{}={}\r\n", k, v))
+        .collect::<Vec<_>>()
+        .join("");
+
+    std::fs::write(&config_path, content)
+        .into_diagnostic()
+        .context("failed to write shims.cfg")?;
 
     Ok(())
 }
@@ -208,5 +294,119 @@ mod tests {
             "error should mention parsing: {}",
             err
         );
+    }
+
+    #[cfg(windows)]
+    mod windows_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        #[test]
+        fn test_create_bin_shim_creates_exe_and_config() {
+            let temp = TempDir::new().unwrap();
+            let bin_dir = temp.path().join("bin");
+            let tools_dir = temp.path().join("tools");
+            let prefix = tools_dir.join("mytool");
+            std::fs::create_dir_all(&bin_dir).unwrap();
+            std::fs::create_dir_all(prefix.join("bin")).unwrap();
+
+            // Create fake tool binary
+            let tool_bin = prefix.join("bin").join("mytool.exe");
+            std::fs::write(&tool_bin, "fake binary").unwrap();
+
+            // Set ANA_HOME so shims.cfg goes to our temp dir
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let binary: PathBuf = ["bin", "mytool"].iter().collect();
+                let result = create_bin_shim(&bin_dir, &prefix, &binary);
+                assert!(result.is_ok(), "create_bin_shim failed: {:?}", result);
+
+                // Check shim exe was created
+                let shim_path = bin_dir.join("mytool.exe");
+                assert!(shim_path.exists(), "shim exe should exist");
+
+                // Check shims.cfg was created with correct content
+                let config_path = tools_dir.join("shims.cfg");
+                assert!(config_path.exists(), "shims.cfg should exist");
+                let config_content = std::fs::read_to_string(&config_path).unwrap();
+                assert!(
+                    config_content.contains("mytool=mytool\\bin\\mytool.exe"),
+                    "shims.cfg should contain mapping, got: {}",
+                    config_content
+                );
+            });
+        }
+
+        #[test]
+        fn test_create_bin_shim_skips_missing_binary() {
+            let temp = TempDir::new().unwrap();
+            let bin_dir = temp.path().join("bin");
+            let tools_dir = temp.path().join("tools");
+            let prefix = tools_dir.join("mytool");
+            std::fs::create_dir_all(&bin_dir).unwrap();
+            std::fs::create_dir_all(&prefix).unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let binary: PathBuf = ["bin", "nonexistent"].iter().collect();
+                let result = create_bin_shim(&bin_dir, &prefix, &binary);
+                assert!(result.is_ok(), "should succeed with warning");
+
+                // No shim should be created
+                assert!(!bin_dir.join("nonexistent.exe").exists());
+            });
+        }
+
+        #[test]
+        fn test_update_shims_cfg_creates_new_file() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = update_shims_cfg("pixi", "pixi\\bin\\pixi.exe");
+                assert!(result.is_ok());
+
+                let config_path = tools_dir.join("shims.cfg");
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert_eq!(content, "pixi=pixi\\bin\\pixi.exe\r\n");
+            });
+        }
+
+        #[test]
+        fn test_update_shims_cfg_adds_entry() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            let config_path = tools_dir.join("shims.cfg");
+            std::fs::write(&config_path, "existing=path\\to\\existing.exe\r\n").unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = update_shims_cfg("pixi", "pixi\\bin\\pixi.exe");
+                assert!(result.is_ok());
+
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert!(content.contains("existing=path\\to\\existing.exe\r\n"));
+                assert!(content.contains("pixi=pixi\\bin\\pixi.exe\r\n"));
+            });
+        }
+
+        #[test]
+        fn test_update_shims_cfg_updates_existing_entry() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            let config_path = tools_dir.join("shims.cfg");
+            std::fs::write(&config_path, "pixi=old\\path\\pixi.exe\r\n").unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = update_shims_cfg("pixi", "pixi\\bin\\pixi.exe");
+                assert!(result.is_ok());
+
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert_eq!(content, "pixi=pixi\\bin\\pixi.exe\r\n");
+                assert!(!content.contains("old\\path"));
+            });
+        }
     }
 }

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -1,5 +1,7 @@
 //! List available tools and their installation status.
 
+use std::path::PathBuf;
+
 use crate::paths;
 use crate::table::{self, Color};
 
@@ -9,7 +11,7 @@ use super::tools;
 pub struct ToolInfo {
     pub name: &'static str,
     pub installed: bool,
-    pub binaries: &'static [&'static str],
+    pub binaries: Vec<PathBuf>,
 }
 
 /// List all available tools with their installation status.
@@ -19,7 +21,7 @@ pub fn list_tools() -> Vec<ToolInfo> {
         .map(|name| {
             let prefix = paths::tool_prefix(name);
             let installed = prefix.exists();
-            let binaries = tools::binaries(name).unwrap_or(&[]);
+            let binaries = tools::binaries(name).unwrap_or(Vec::new());
             ToolInfo {
                 name,
                 installed,
@@ -41,7 +43,12 @@ pub fn print_tool_list() {
         } else {
             table::cell("✗").fg(Color::Red)
         };
-        let binaries = tool.binaries.join(", ");
+        let binaries = tool
+            .binaries
+            .iter()
+            .filter_map(|b| b.file_stem().and_then(|s| s.to_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
         table.add_row([table::cell(tool.name), status_cell, table::cell(&binaries)]);
     }
 

--- a/src/tools/tools.rs
+++ b/src/tools/tools.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 struct Tool {
     name: &'static str,
     lockfile: &'static str,
-    binaries: &'static [&'static str],
+    binaries: &'static [&'static [&'static str]],
 }
 
 /// Embedded tool configurations.
@@ -14,12 +14,16 @@ const TOOLS: &[Tool] = &[
     Tool {
         name: "anaconda-cli",
         lockfile: include_str!("../../tool-specs/anaconda-cli/pixi.lock"),
-        binaries: &["anaconda"],
+        binaries: if cfg![unix] {
+            &[&["bin", "anaconda"]]
+        } else {
+            &[&["Scripts", "anaconda"]]
+        },
     },
     Tool {
         name: "pixi",
         lockfile: include_str!("../../tool-specs/pixi/pixi.lock"),
-        binaries: &["pixi"],
+        binaries: &[&["bin", "pixi"]],
     },
 ];
 
@@ -41,8 +45,8 @@ pub fn content(name: &str) -> Option<String> {
 }
 
 /// Returns the binaries to symlink for a tool.
-pub fn binaries(name: &str) -> Option<&'static [&'static str]> {
-    find_tool(name).map(|t| t.binaries)
+pub fn binaries(name: &str) -> Option<Vec<PathBuf>> {
+    find_tool(name).map(|t| t.binaries.iter().map(|b| b.iter().collect()).collect())
 }
 
 /// Returns all available tool names.

--- a/src/tools/tools.rs
+++ b/src/tools/tools.rs
@@ -44,9 +44,19 @@ pub fn content(name: &str) -> Option<String> {
     }
 }
 
-/// Returns the binaries to symlink for a tool.
+/// Returns the binaries to link for a tool.
 pub fn binaries(name: &str) -> Option<Vec<PathBuf>> {
     find_tool(name).map(|t| t.binaries.iter().map(|b| b.iter().collect()).collect())
+}
+
+/// Returns the binary names to link for a tool.
+pub fn binary_names(name: &str) -> Option<Vec<&'static str>> {
+    find_tool(name).map(|t| {
+        t.binaries
+            .iter()
+            .filter_map(|b| b.last().copied())
+            .collect()
+    })
 }
 
 /// Returns all available tool names.

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -28,12 +28,12 @@ pub fn uninstall_tool(name: &str, force: bool) -> miette::Result<()> {
     // Collect what will be deleted
     let mut to_delete: Vec<String> = Vec::new();
 
-    // Check for symlinks that will be removed
-    if let Some(binaries) = tools::binaries(name) {
+    // Check for symlinks/shims that will be removed
+    if let Some(binaries) = tools::binary_names(name) {
         for binary in binaries {
-            let symlink_path = bin_dir.join(binary);
-            if symlink_path.exists() || symlink_path.is_symlink() {
-                to_delete.push(format!("  {}", symlink_path.display()));
+            let link_path = paths::bin_path(binary);
+            if link_path.exists() || link_path.is_symlink() {
+                to_delete.push(format!("  {}", link_path.display()));
             }
         }
     }
@@ -57,19 +57,21 @@ pub fn uninstall_tool(name: &str, force: bool) -> miette::Result<()> {
     eprintln!();
     eprintln!("Uninstalling {}...", name);
 
-    // Remove symlinks from bin directory
-    if let Some(binaries) = tools::binaries(name) {
-        for binary in binaries {
-            let symlink_path = bin_dir.join(binary);
-            if symlink_path.exists() || symlink_path.is_symlink() {
-                std::fs::remove_file(&symlink_path)
+    // Remove symlinks/shims from bin directory
+    if let Some(binaries) = tools::binary_names(name) {
+        for binary in &binaries {
+            let link_path = paths::bin_path(binary);
+            if link_path.exists() || link_path.is_symlink() {
+                std::fs::remove_file(&link_path)
                     .into_diagnostic()
-                    .with_context(|| {
-                        format!("failed to remove symlink: {}", symlink_path.display())
-                    })?;
-                eprintln!("   Removed {}", symlink_path.display());
+                    .with_context(|| format!("failed to remove: {}", link_path.display()))?;
+                eprintln!("   Removed {}", link_path.display());
             }
         }
+
+        // On Windows, also remove entries from shims.cfg
+        #[cfg(windows)]
+        remove_shims_cfg_entries(&binaries)?;
     }
 
     // Remove the tool's environment directory
@@ -109,4 +111,131 @@ fn cleanup_empty_dir(path: &std::path::Path) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(windows)]
+/// Remove entries from shims.cfg for the given binary names.
+fn remove_shims_cfg_entries(binaries: &[&str]) -> miette::Result<()> {
+    let config_path = paths::ana_home().join("tools").join("shims.cfg");
+
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&config_path)
+        .into_diagnostic()
+        .context("failed to read shims.cfg")?;
+
+    // Filter out entries for the binaries being removed
+    let new_content: String = content
+        .lines()
+        .filter(|line| {
+            if let Some((name, _)) = line.split_once('=') {
+                !binaries.contains(&name)
+            } else {
+                true
+            }
+        })
+        .map(|line| format!("{}\r\n", line))
+        .collect();
+
+    std::fs::write(&config_path, new_content)
+        .into_diagnostic()
+        .context("failed to write shims.cfg")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    mod windows_tests {
+        use tempfile::TempDir;
+
+        use super::super::remove_shims_cfg_entries;
+
+        #[test]
+        fn test_remove_shims_cfg_entries_removes_single() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            let config_path = tools_dir.join("shims.cfg");
+            std::fs::write(
+                &config_path,
+                "pixi=pixi\\bin\\pixi.exe\r\nanaconda=anaconda-cli\\Scripts\\anaconda.exe\r\n",
+            )
+            .unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = remove_shims_cfg_entries(&["pixi"]);
+                assert!(result.is_ok());
+
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert!(!content.contains("pixi="));
+                assert!(content.contains("anaconda=anaconda-cli\\Scripts\\anaconda.exe"));
+            });
+        }
+
+        #[test]
+        fn test_remove_shims_cfg_entries_removes_multiple() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            let config_path = tools_dir.join("shims.cfg");
+            std::fs::write(
+                &config_path,
+                "pixi=pixi\\bin\\pixi.exe\r\nanaconda=anaconda-cli\\Scripts\\anaconda.exe\r\nother=other\\bin\\other.exe\r\n",
+            )
+            .unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = remove_shims_cfg_entries(&["pixi", "anaconda"]);
+                assert!(result.is_ok());
+
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert!(!content.contains("pixi="));
+                assert!(!content.contains("anaconda="));
+                assert!(content.contains("other=other\\bin\\other.exe"));
+            });
+        }
+
+        #[test]
+        fn test_remove_shims_cfg_entries_handles_missing_file() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = remove_shims_cfg_entries(&["pixi"]);
+                assert!(result.is_ok(), "should succeed when file doesn't exist");
+            });
+        }
+
+        #[test]
+        fn test_remove_shims_cfg_entries_preserves_trailing_newlines() {
+            let temp = TempDir::new().unwrap();
+            let tools_dir = temp.path().join("tools");
+            std::fs::create_dir_all(&tools_dir).unwrap();
+
+            let config_path = tools_dir.join("shims.cfg");
+            std::fs::write(
+                &config_path,
+                "pixi=pixi\\bin\\pixi.exe\r\nanaconda=anaconda-cli\\Scripts\\anaconda.exe\r\n",
+            )
+            .unwrap();
+
+            temp_env::with_var("ANA_HOME", Some(temp.path().to_str().unwrap()), || {
+                let result = remove_shims_cfg_entries(&["pixi"]);
+                assert!(result.is_ok());
+
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                assert!(
+                    content.ends_with("\r\n"),
+                    "should preserve trailing newline"
+                );
+            });
+        }
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -44,7 +44,20 @@ impl std::fmt::Display for Error {
                     f,
                     "GITHUB_TOKEN not set. Required for accessing private repo."
                 )?;
-                writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
+                #[cfg(unix)]
+                {
+                    writeln!(f, "  Run: export GITHUB_TOKEN=$(gh auth token)")
+                }
+                #[cfg(windows)]
+                {
+                    writeln!(f, " Run:")?;
+                    writeln!(f, "   PowerShell: $env:GITHUB_TOKEN=(gh auth token)")?;
+                    writeln!(
+                        f,
+                        "   cmd.exe: for /f %i in ('gh auth token') do set GITHUB_TOKEN=%i"
+                    )?;
+                    writeln!(f, "   git bash: export GITHUB_TOKEN=$(gh auth token)")
+                }
             }
             Error::AssetNotFound(platform) => {
                 write!(f, "No release asset found for platform: {}", platform)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from collections.abc import Callable
 from collections.abc import Generator
 from pathlib import Path
@@ -22,7 +23,7 @@ def _find_repo_root() -> Path:
 
 
 REPO_ROOT = _find_repo_root()
-ON_WINDOWS = os.name == "nt"
+IS_WINDOWS = sys.platform == "win32"
 
 
 @pytest.fixture
@@ -50,7 +51,7 @@ def env_isolated(fake_home: Path) -> dict[str, str]:
         for key, val in os.environ.copy().items()
         if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
     }
-    if ON_WINDOWS:
+    if IS_WINDOWS:
         env["USERPROFILE"] = str(fake_home)
     else:
         env["HOME"] = str(fake_home)
@@ -71,7 +72,7 @@ def ana_binary() -> Path | None:
         if path.exists() and path.is_file():
             return path
 
-    ana_bin = "ana.exe" if ON_WINDOWS else "ana"
+    ana_bin = "ana.exe" if IS_WINDOWS else "ana"
 
     for subpath in ["target/release", "target/debug"]:
         binary = REPO_ROOT / subpath / ana_bin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,10 @@ def env_isolated(fake_home: Path) -> dict[str, str]:
         for key, val in os.environ.copy().items()
         if not key.startswith("ANA_") and key != "GITHUB_TOKEN"
     }
-    env["HOME"] = str(fake_home)
+    if ON_WINDOWS:
+        env["USERPROFILE"] = str(fake_home)
+    else:
+        env["HOME"] = str(fake_home)
     return env
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def _find_repo_root() -> Path:
 
 
 REPO_ROOT = _find_repo_root()
+ON_WINDOWS = os.name == "nt"
 
 
 @pytest.fixture
@@ -67,8 +68,10 @@ def ana_binary() -> Path | None:
         if path.exists() and path.is_file():
             return path
 
-    for subpath in ["target/release/ana", "target/debug/ana"]:
-        binary = REPO_ROOT / subpath
+    ana_bin = "ana.exe" if ON_WINDOWS else "ana"
+
+    for subpath in ["target/release", "target/debug"]:
+        binary = REPO_ROOT / subpath / ana_bin
         if binary.exists():
             return binary
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def run_ana(ana_binary: Path | None, env_isolated: dict[str, str]) -> AnaRunner:
             [str(ana_binary), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             env=env,
             input=input,
             cwd=cwd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ def env_isolated(fake_home: Path) -> dict[str, str]:
     }
     if IS_WINDOWS:
         env["USERPROFILE"] = str(fake_home)
+        # Rattler does not reliably detect the default cache for Windows tests
+        env["RATTLER_CACHE_DIR"] = str(fake_home / "cache" / "rattler")
     else:
         env["HOME"] = str(fake_home)
     return env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from conftest import AnaRunner
+
+IS_WINDOWS = sys.platform == "win32"
+ANACONDA_BIN = "anaconda.exe" if IS_WINDOWS else "anaconda"
 
 
 class TestHelp:
@@ -232,9 +236,19 @@ class TestBootstrap:
         assert result.returncode == 0
 
         # Verify the symlinked binary exists
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
         assert bin_path.exists(), f"Binary not found: {bin_path}"
-        assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+        tools_dir = fake_home / ".ana" / "tools"
+        if IS_WINDOWS:
+            shim_cfg = tools_dir / "shims.cfg"
+            assert (
+                "anaconda=anaconda-cli\\Scripts\\anaconda.exe\r\n"
+                in shim_cfg.read_text(newline="")
+            )
+        else:
+            src_file = tools_dir / "anaconda-cli" / "bin" / "anaconda"
+            assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+            assert bin_path.samefile(src_file)
 
     def test_bootstrap_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
@@ -245,7 +259,7 @@ class TestBootstrap:
         assert first_result.returncode == 0
 
         # Verify installation exists
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
         assert bin_path.exists()
 
         # Second run should indicate already installed
@@ -261,7 +275,7 @@ class TestBootstrap:
         assert result.returncode == 0
 
         # Run the installed anaconda binary
-        bin_path = fake_home / ".ana" / "bin" / "anaconda"
+        bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
         assert bin_path.exists()
 
         proc = subprocess.run(

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.server
 import os
+import shutil
 import socketserver
 import stat
 import subprocess
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
 
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.sh"
 IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS and not shutil.which("sh"):
+    pytest.skip("Tests only work in bash shell on Windows.", allow_module_level=True)
 
 # Create a simple mock binary script that responds to --version and --help
 MOCK_BINARY_SCRIPT = """\

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 from conftest import AnaRunner
+
+IS_WINDOWS = sys.platform == "win32"
+PIXI_BIN = "pixi.exe" if IS_WINDOWS else "pixi"
 
 
 class TestToolInstallHelp:
@@ -50,9 +54,16 @@ class TestToolInstallPixi:
         result = run_ana("tool", "install", "pixi")
         assert result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / PIXI_BIN
         assert bin_path.exists(), f"Binary not found: {bin_path}"
-        assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+        tools_dir = fake_home / ".ana" / "tools"
+        if IS_WINDOWS:
+            shim_cfg = tools_dir / "shims.cfg"
+            assert "pixi=pixi\\bin\\pixi.exe\r\n" in shim_cfg.read_text(newline="")
+        else:
+            src_file = tools_dir / "pixi" / "bin" / "pixi"
+            assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
+            assert bin_path.samefile(src_file)
 
     def test_tool_install_pixi_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
@@ -62,7 +73,7 @@ class TestToolInstallPixi:
         first_result = run_ana("tool", "install", "pixi")
         assert first_result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / PIXI_BIN
         assert bin_path.exists()
 
         # Second run should indicate already up to date
@@ -77,7 +88,7 @@ class TestToolInstallPixi:
         result = run_ana("tool", "install", "pixi")
         assert result.returncode == 0
 
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / PIXI_BIN
         assert bin_path.exists()
 
         proc = subprocess.run(
@@ -174,7 +185,7 @@ class TestToolUninstall:
         assert install_result.returncode == 0
 
         tool_dir = fake_home / ".ana" / "tools" / "pixi"
-        bin_path = fake_home / ".ana" / "bin" / "pixi"
+        bin_path = fake_home / ".ana" / "bin" / PIXI_BIN
         assert tool_dir.exists()
         assert bin_path.exists()
 
@@ -199,5 +210,5 @@ class TestToolUninstall:
         uninstall_result = run_ana("tool", "uninstall", "pixi", "--yes")
         assert uninstall_result.returncode == 0
         assert "The following will be removed:" in uninstall_result.stderr
-        assert ".ana/bin/pixi" in uninstall_result.stderr
-        assert ".ana/tools/pixi" in uninstall_result.stderr
+        assert str(Path(".ana/bin/pixi")) in uninstall_result.stderr
+        assert str(Path(".ana/tools/pixi")) in uninstall_result.stderr


### PR DESCRIPTION
## Summary

Windows does not support symlinks by default and require developer mode to be enabled (see also the [rust documentation](https://doc.rust-lang.org/stable/std/os/windows/fs/fn.symlink_file.html#limitations)). This requires administrator privileges, which not every user has. Hard links are not an appropriate alternative because they do not work across drives and require regeneration whenever the original binary updates.

Instead, use a compiled shim that just forwards the call to the appropriate binary. Shimming is a common way to solve the symlink problem on Windows and is deployed by tools like chocolatey or even `conda` (the `.exe` entry points in `Scripts` just call the `.py` file of the same name). I tested this with in PowerShell, Cygwin, MSYS2, cmd.exe, and Git Bash.

The shim is statically compiled and embedded into the `ana` binary. When a tool is installed, that binary blob will be written into `bin` with the name of binary it shims (i.e., the shim for `pixi` is `bin\pixi.exe`). When called, the shim does two things:

1. It reads the `shims.cfg` file and find the entry that corresponds to the binary name. For pixi, it will find the line that contains `pixi=`. The value is the file path to the actual binary relative to the `tools` directory.
1. It then calls that binary and forwards all command line arguments to the function call.

`shims.cfg` is created at runtime and updated every time a tool is installed or uninstalled.

This PR also fixes a few other Windows errors and issues:

* Use the `anaconda.exe` binary inside `Scripts`, not `bin`. This required a refactor for how we store `binaries` in the `Tool` object.
* Add instructions for how to set the GitHub token in Windows-native formats.
* Several integration test fixes:
  * Patch `USERPROFILE` instead of `HOME` and also set the rattler cache directory in integration tests.
  * Ensure that UTF-8 encoding is used in subprocess calls or non-ASCII characters aren't rendered properly (Windows uses UTF-16).
  * Skip shell tests outside of GitBash
  * Run integration tests in PowerShell to ensure they are compatible with native Windows shells
  * Use Windows-appropriate conventions in integration tests (backslashes in path strings, `.exe` file endings for binaries)

## Ticket(s)
Jira: [CLI-492](https://anaconda.atlassian.net/browse/CLI-492)

## AI disclosure

Claude was used to help create the shim code, answer general rust questions, and debug. Claude wrote the unit tests in the rust code.

[CLI-492]: https://anaconda.atlassian.net/browse/CLI-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ