### PR TITLE
feat: Add CommandContext for telemetry attributes

### DIFF
--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -13,7 +13,7 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     }
 
     eprintln!("Installing anaconda-cli...");
-    tools::install::install_tool("anaconda-cli", ctx)
+    tools::install::install_tool(ctx, "anaconda-cli")
         .await
         .map_err(|e| format!("{:?}", e))?;
 
@@ -22,9 +22,9 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
 }
 
 pub fn run_subcommand(
+    _ctx: &mut CommandContext,
     subcommand: &str,
     args: &[String],
-    _ctx: &mut CommandContext,
 ) -> Result<(), String> {
     let anaconda_bin = paths::bin_path("anaconda");
 

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -21,7 +21,11 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     Ok(())
 }
 
-pub fn run_subcommand(subcommand: &str, args: &[String], _ctx: &mut CommandContext) -> Result<(), String> {
+pub fn run_subcommand(
+    subcommand: &str,
+    args: &[String],
+    _ctx: &mut CommandContext,
+) -> Result<(), String> {
     let anaconda_bin = paths::bin_path("anaconda");
 
     if !anaconda_bin.exists() {

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,9 +1,10 @@
 use std::process::Command;
 
+use crate::context::CommandContext;
 use crate::paths;
 use crate::tools;
 
-pub async fn run_bootstrap() -> Result<(), String> {
+pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     let anaconda_bin = paths::bin_path("anaconda");
 
     if anaconda_bin.exists() {
@@ -12,7 +13,7 @@ pub async fn run_bootstrap() -> Result<(), String> {
     }
 
     eprintln!("Installing anaconda-cli...");
-    tools::install::install_tool("anaconda-cli")
+    tools::install::install_tool("anaconda-cli", ctx)
         .await
         .map_err(|e| format!("{:?}", e))?;
 
@@ -20,7 +21,7 @@ pub async fn run_bootstrap() -> Result<(), String> {
     Ok(())
 }
 
-pub fn run_subcommand(subcommand: &str, args: &[String]) -> Result<(), String> {
+pub fn run_subcommand(subcommand: &str, args: &[String], _ctx: &mut CommandContext) -> Result<(), String> {
     let anaconda_bin = paths::bin_path("anaconda");
 
     if !anaconda_bin.exists() {

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -9,6 +9,7 @@ use super::api_keys::create_api_key;
 use super::errors::AuthError;
 use super::keyring::{delete_api_key, get_api_key, save_api_key};
 use crate::config::Config;
+use crate::context::CommandContext;
 use crate::http::{Client, bearer_header, build_client};
 use crate::input::KeyListener;
 
@@ -122,7 +123,7 @@ struct TokenErrorResponse {
 }
 
 /// Perform the device authorization flow.
-pub async fn login() -> Result<(), AuthError> {
+pub async fn login(_ctx: &mut CommandContext) -> Result<(), AuthError> {
     // We use a new, unauthenticated client instead of ApiClient, since
     // login by definition happens first. It ends up being simpler to do
     // this, at least for now, because the auth flow needs to follow direct
@@ -299,7 +300,7 @@ pub async fn login() -> Result<(), AuthError> {
 }
 
 /// Log out by removing the API key for the current domain.
-pub fn logout() -> Result<(), AuthError> {
+pub fn logout(_ctx: &mut CommandContext) -> Result<(), AuthError> {
     let config = Config::load();
     delete_api_key(&config)?;
     println!("Logged out from {}", config.domain);
@@ -307,7 +308,7 @@ pub fn logout() -> Result<(), AuthError> {
 }
 
 /// Display the API key for the current domain.
-pub fn show_api_key() -> Result<(), AuthError> {
+pub fn show_api_key(_ctx: &mut CommandContext) -> Result<(), AuthError> {
     let config = Config::load();
 
     match get_api_key(&config)? {
@@ -322,7 +323,7 @@ pub fn show_api_key() -> Result<(), AuthError> {
 }
 
 /// Display information about the logged-in user.
-pub async fn whoami() -> Result<(), AuthError> {
+pub async fn whoami(_ctx: &mut CommandContext) -> Result<(), AuthError> {
     let client = ApiClient::new()?;
 
     if !client.is_authenticated() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,13 +195,13 @@ impl Action {
                 Ok(())
             }
             Action::Bootstrap => Ok(anaconda_cli::run_bootstrap(ctx).await?),
-            Action::OrgProxy { args } => Ok(anaconda_cli::run_subcommand("org", &args, ctx)?),
+            Action::OrgProxy { args } => Ok(anaconda_cli::run_subcommand(ctx, "org", &args)?),
             Action::ToolInstall { name } => {
-                tools::install::install_tool(&name, ctx).await?;
+                tools::install::install_tool(ctx, &name).await?;
                 Ok(())
             }
             Action::ToolUninstall { name, force } => {
-                tools::uninstall::uninstall_tool(&name, force, ctx)?;
+                tools::uninstall::uninstall_tool(ctx, &name, force)?;
                 Ok(())
             }
             Action::ToolList => {
@@ -213,15 +213,15 @@ impl Action {
             Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
             Action::Whoami { json } => Ok(auth::whoami(ctx, json).await?),
             Action::Update { force } => {
-                update::run_update(VERSION, force, ctx).await;
+                update::run_update(ctx, VERSION, force).await;
                 Ok(())
             }
             Action::CheckForUpdate => {
-                update::check_for_update(VERSION, ctx).await;
+                update::check_for_update(ctx, VERSION).await;
                 Ok(())
             }
             Action::ShowAvailableVersions => {
-                update::show_available_versions(VERSION, ctx).await;
+                update::show_available_versions(ctx, VERSION).await;
                 Ok(())
             }
             #[cfg(feature = "feedback")]
@@ -229,7 +229,7 @@ impl Action {
                 feedback_type,
                 description,
             } => {
-                feedback::open_feedback(feedback_type, description, ctx);
+                feedback::open_feedback(ctx, feedback_type, description);
                 Ok(())
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,11 +154,19 @@ impl Action {
         match &result {
             Ok(_) => {
                 increment_counter("cli_command_success", 1, ctx.telemetry.attrs());
-                record_histogram("cli_command_success_duration_ms", duration_ms, ctx.telemetry.into_attrs());
+                record_histogram(
+                    "cli_command_success_duration_ms",
+                    duration_ms,
+                    ctx.telemetry.into_attrs(),
+                );
             }
             Err(_) => {
                 increment_counter("cli_command_failure", 1, ctx.telemetry.attrs());
-                record_histogram("cli_command_failure_duration_ms", duration_ms, ctx.telemetry.into_attrs());
+                record_histogram(
+                    "cli_command_failure_duration_ms",
+                    duration_ms,
+                    ctx.telemetry.into_attrs(),
+                );
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,7 +211,7 @@ impl Action {
             Action::Login => Ok(auth::login(ctx).await?),
             Action::Logout => Ok(auth::logout(ctx)?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
-            Action::Whoami { json } => Ok(auth::whoami(ctx).await?),
+            Action::Whoami { json } => Ok(auth::whoami(ctx, json).await?),
             Action::Update { force } => {
                 update::run_update(VERSION, force, ctx).await;
                 Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
-use std::env::consts::{ARCH, OS};
 use std::time::Instant;
 
 use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
 use clap::{CommandFactory, Parser, Subcommand};
-use opentelemetry::Value;
 
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
 use crate::config::{self, Config};
+use crate::context::CommandContext;
 #[cfg(feature = "feedback")]
 use crate::feedback::{self, FeedbackType};
 use crate::help;
@@ -52,15 +51,6 @@ impl LogLevel {
             Self::Trace => "ana=trace,anaconda_otel_rs=off,opentelemetry=off,reqwest=off",
         }
     }
-}
-
-/// Build base telemetry attributes with system information.
-fn system_attrs() -> HashMap<String, Value> {
-    let mut attrs = HashMap::new();
-    attrs.insert("os".to_string(), OS.into());
-    attrs.insert("arch".to_string(), ARCH.into());
-    attrs.insert("version".to_string(), VERSION.into());
-    attrs
 }
 
 pub async fn execute() {
@@ -153,29 +143,29 @@ impl Action {
     /// Execute the action with telemetry middleware
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         let name = self.match_action_name();
-        let mut attrs = system_attrs();
-        attrs.insert("command".to_string(), name.into());
-        increment_counter("cli_command_invoked", 1, attrs.clone());
+        let mut ctx = CommandContext::new();
+        ctx.telemetry.add("command", name);
+        increment_counter("cli_command_invoked", 1, ctx.telemetry.attrs());
 
         let start = Instant::now();
-        let result = self.run().await;
+        let result = self.run(&mut ctx).await;
         let duration_ms = start.elapsed().as_millis() as f64;
 
         match &result {
             Ok(_) => {
-                increment_counter("cli_command_success", 1, attrs.clone());
-                record_histogram("cli_command_success_duration_ms", duration_ms, attrs);
+                increment_counter("cli_command_success", 1, ctx.telemetry.attrs());
+                record_histogram("cli_command_success_duration_ms", duration_ms, ctx.telemetry.into_attrs());
             }
             Err(_) => {
-                increment_counter("cli_command_failure", 1, attrs.clone());
-                record_histogram("cli_command_failure_duration_ms", duration_ms, attrs);
+                increment_counter("cli_command_failure", 1, ctx.telemetry.attrs());
+                record_histogram("cli_command_failure_duration_ms", duration_ms, ctx.telemetry.into_attrs());
             }
         }
 
         result
     }
 
-    async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn run(self, ctx: &mut CommandContext) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Action::ShowHelp => {
                 let subcommands = get_subcommand_descriptions();
@@ -194,34 +184,34 @@ impl Action {
                 Config::load().print_table();
                 Ok(())
             }
-            Action::Bootstrap => Ok(anaconda_cli::run_bootstrap().await?),
-            Action::OrgProxy { args } => Ok(anaconda_cli::run_subcommand("org", &args)?),
+            Action::Bootstrap => Ok(anaconda_cli::run_bootstrap(ctx).await?),
+            Action::OrgProxy { args } => Ok(anaconda_cli::run_subcommand("org", &args, ctx)?),
             Action::ToolInstall { name } => {
-                tools::install::install_tool(&name).await?;
+                tools::install::install_tool(&name, ctx).await?;
                 Ok(())
             }
             Action::ToolUninstall { name, force } => {
-                tools::uninstall::uninstall_tool(&name, force)?;
+                tools::uninstall::uninstall_tool(&name, force, ctx)?;
                 Ok(())
             }
             Action::ToolList => {
-                tools::list::print_tool_list();
+                tools::list::print_tool_list(ctx);
                 Ok(())
             }
-            Action::Login => Ok(auth::login().await?),
-            Action::Logout => Ok(auth::logout()?),
-            Action::ShowApiKey => Ok(auth::show_api_key()?),
-            Action::Whoami => Ok(auth::whoami().await?),
+            Action::Login => Ok(auth::login(ctx).await?),
+            Action::Logout => Ok(auth::logout(ctx)?),
+            Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
+            Action::Whoami => Ok(auth::whoami(ctx).await?),
             Action::Update { force } => {
-                update::run_update(VERSION, force).await;
+                update::run_update(VERSION, force, ctx).await;
                 Ok(())
             }
             Action::CheckForUpdate => {
-                update::check_for_update(VERSION).await;
+                update::check_for_update(VERSION, ctx).await;
                 Ok(())
             }
             Action::ShowAvailableVersions => {
-                update::show_available_versions(VERSION).await;
+                update::show_available_versions(VERSION, ctx).await;
                 Ok(())
             }
             #[cfg(feature = "feedback")]
@@ -229,7 +219,7 @@ impl Action {
                 feedback_type,
                 description,
             } => {
-                feedback::open_feedback(feedback_type, description);
+                feedback::open_feedback(feedback_type, description, ctx);
                 Ok(())
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,7 +211,7 @@ impl Action {
             Action::Login => Ok(auth::login(ctx).await?),
             Action::Logout => Ok(auth::logout(ctx)?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
-            Action::Whoami {json} => Ok(auth::whoami(ctx).await?),
+            Action::Whoami { json } => Ok(auth::whoami(ctx).await?),
             Action::Update { force } => {
                 update::run_update(VERSION, force, ctx).await;
                 Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,65 @@
+//! Command execution context passed through the call stack.
+//!
+//! Similar to Go's context pattern, this carries cross-cutting concerns
+//! (telemetry, config, etc.) without polluting function signatures.
+
+use std::collections::HashMap;
+use std::env::consts::{ARCH, OS};
+
+use opentelemetry::Value;
+
+use crate::VERSION;
+
+/// Telemetry context for collecting command-specific attributes.
+#[derive(Debug, Default)]
+pub struct TelemetryContext {
+    attrs: HashMap<String, Value>,
+}
+
+impl TelemetryContext {
+    /// Create a new telemetry context with system attributes pre-populated.
+    fn new() -> Self {
+        let mut attrs = HashMap::new();
+        attrs.insert("os".to_string(), OS.into());
+        attrs.insert("arch".to_string(), ARCH.into());
+        attrs.insert("version".to_string(), VERSION.into());
+        Self { attrs }
+    }
+
+    /// Add an attribute.
+    pub fn add(&mut self, key: impl Into<String>, value: impl Into<Value>) {
+        self.attrs.insert(key.into(), value.into());
+    }
+
+    /// Get the attributes for recording.
+    pub(crate) fn into_attrs(self) -> HashMap<String, Value> {
+        self.attrs
+    }
+
+    /// Clone attributes for intermediate recording.
+    pub(crate) fn attrs(&self) -> HashMap<String, Value> {
+        self.attrs.clone()
+    }
+}
+
+/// Command execution context passed through the call stack.
+#[derive(Debug)]
+pub struct CommandContext {
+    /// Telemetry attributes collector.
+    pub telemetry: TelemetryContext,
+}
+
+impl CommandContext {
+    /// Create a new command context.
+    pub fn new() -> Self {
+        Self {
+            telemetry: TelemetryContext::new(),
+        }
+    }
+}
+
+impl Default for CommandContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,3 +1,5 @@
+use crate::context::CommandContext;
+
 const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
 
 /// Feedback type for the feedback form
@@ -17,7 +19,7 @@ pub fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
     }
 }
 
-pub fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>) {
+pub fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>, _ctx: &mut CommandContext) {
     let mut params = vec![("usp", "pp_url".to_string())];
 
     if let Some(ft) = feedback_type {

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -19,7 +19,11 @@ pub fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
     }
 }
 
-pub fn open_feedback(feedback_type: Option<FeedbackType>, description: Option<String>, _ctx: &mut CommandContext) {
+pub fn open_feedback(
+    feedback_type: Option<FeedbackType>,
+    description: Option<String>,
+    _ctx: &mut CommandContext,
+) {
     let mut params = vec![("usp", "pp_url".to_string())];
 
     if let Some(ft) = feedback_type {

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -20,9 +20,9 @@ pub fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
 }
 
 pub fn open_feedback(
+    _ctx: &mut CommandContext,
     feedback_type: Option<FeedbackType>,
     description: Option<String>,
-    _ctx: &mut CommandContext,
 ) {
     let mut params = vec![("usp", "pp_url".to_string())];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod anaconda_cli;
 mod auth;
 mod cli;
 mod config;
+mod context;
 mod diagnostics;
 #[cfg(feature = "feedback")]
 mod feedback;

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -13,6 +13,7 @@ use rattler_conda_types::{Platform, PrefixRecord};
 use rattler_lock::LockFile;
 
 use super::{pixi_config, tools};
+use crate::context::CommandContext;
 use crate::paths;
 
 /// Global progress bar for installation feedback.
@@ -23,7 +24,9 @@ static MULTI_PROGRESS: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock:
 });
 
 /// Install a tool from its lockfile.
-pub async fn install_tool(name: &str) -> miette::Result<()> {
+pub async fn install_tool(name: &str, ctx: &mut CommandContext) -> miette::Result<()> {
+    ctx.telemetry.add("tool_name", name.to_string());
+
     let prefix = paths::tool_prefix(name);
 
     let lock_content =

--- a/src/tools/install.rs
+++ b/src/tools/install.rs
@@ -24,7 +24,7 @@ static MULTI_PROGRESS: std::sync::LazyLock<MultiProgress> = std::sync::LazyLock:
 });
 
 /// Install a tool from its lockfile.
-pub async fn install_tool(name: &str, ctx: &mut CommandContext) -> miette::Result<()> {
+pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
     ctx.telemetry.add("tool_name", name.to_string());
 
     let prefix = paths::tool_prefix(name);

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -1,5 +1,6 @@
 //! List available tools and their installation status.
 
+use crate::context::CommandContext;
 use crate::paths;
 use crate::table::{self, Color};
 
@@ -30,7 +31,7 @@ pub fn list_tools() -> Vec<ToolInfo> {
 }
 
 /// Print the tool list as a formatted table.
-pub fn print_tool_list() {
+pub fn print_tool_list(_ctx: &mut CommandContext) {
     let tools = list_tools();
 
     let mut table = table::new(["Name", "Installed", "Binaries"]);

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -11,7 +11,7 @@ use crate::paths;
 ///
 /// Removes the tool's environment and any symlinks in the bin directory.
 /// Cleans up empty directories afterward.
-pub fn uninstall_tool(name: &str, force: bool, ctx: &mut CommandContext) -> miette::Result<()> {
+pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
     ctx.telemetry.add("tool_name", name.to_string());
 
     // Verify the tool is known

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -3,6 +3,7 @@
 use miette::{Context, IntoDiagnostic};
 
 use super::tools;
+use crate::context::CommandContext;
 use crate::input::prompt_yes_no;
 use crate::paths;
 
@@ -10,7 +11,9 @@ use crate::paths;
 ///
 /// Removes the tool's environment and any symlinks in the bin directory.
 /// Cleans up empty directories afterward.
-pub fn uninstall_tool(name: &str, force: bool) -> miette::Result<()> {
+pub fn uninstall_tool(name: &str, force: bool, ctx: &mut CommandContext) -> miette::Result<()> {
+    ctx.telemetry.add("tool_name", name.to_string());
+
     // Verify the tool is known
     if tools::binaries(name).is_none() {
         return Err(miette::miette!("unknown tool: {}", name));

--- a/src/update.rs
+++ b/src/update.rs
@@ -254,7 +254,7 @@ pub async fn apply_update(release: &Release) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn check_for_update(current_version: &str, _ctx: &mut CommandContext) {
+pub async fn check_for_update(_ctx: &mut CommandContext, current_version: &str) {
     match check_update(current_version).await {
         Ok(UpdateCheck::Available(release)) => {
             println!(
@@ -275,7 +275,7 @@ pub async fn check_for_update(current_version: &str, _ctx: &mut CommandContext) 
     }
 }
 
-pub async fn run_update(current_version: &str, force: bool, _ctx: &mut CommandContext) {
+pub async fn run_update(_ctx: &mut CommandContext, current_version: &str, force: bool) {
     let check = match check_update(current_version).await {
         Ok(c) => c,
         Err(e) => {
@@ -314,7 +314,7 @@ pub async fn run_update(current_version: &str, force: bool, _ctx: &mut CommandCo
     }
 }
 
-pub async fn show_available_versions(current_version: &str, _ctx: &mut CommandContext) {
+pub async fn show_available_versions(_ctx: &mut CommandContext, current_version: &str) {
     let releases = match fetch_available_releases().await {
         Ok(r) => r,
         Err(e) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,6 +4,7 @@ use std::env;
 use tokio::io::AsyncWriteExt;
 
 use crate::config::Config;
+use crate::context::CommandContext;
 use crate::http::{bearer_header, build_client};
 use crate::input::prompt_yes_no;
 
@@ -240,7 +241,7 @@ pub async fn apply_update(release: &Release) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn check_for_update(current_version: &str) {
+pub async fn check_for_update(current_version: &str, _ctx: &mut CommandContext) {
     match check_update(current_version).await {
         Ok(UpdateCheck::Available(release)) => {
             println!(
@@ -261,7 +262,7 @@ pub async fn check_for_update(current_version: &str) {
     }
 }
 
-pub async fn run_update(current_version: &str, force: bool) {
+pub async fn run_update(current_version: &str, force: bool, _ctx: &mut CommandContext) {
     let check = match check_update(current_version).await {
         Ok(c) => c,
         Err(e) => {
@@ -300,7 +301,7 @@ pub async fn run_update(current_version: &str, force: bool) {
     }
 }
 
-pub async fn show_available_versions(current_version: &str) {
+pub async fn show_available_versions(current_version: &str, _ctx: &mut CommandContext) {
     let releases = match fetch_available_releases().await {
         Ok(r) => r,
         Err(e) => {


### PR DESCRIPTION
## Summary

Introduces a `CommandContext` struct that carries cross-cutting concerns through the command call stack, inspired by Go's `context.Context` pattern.

### The Pattern

In Go, it's common to pass a `context.Context` as the first parameter to functions that need access to request-scoped values, cancellation signals, or deadlines. This PR adopts a similar approach for ana-cli:

```rust
pub struct CommandContext {
    pub telemetry: TelemetryContext,
    // Future: config, auth_state, etc.
}
```

Commands receive `&mut CommandContext` and can add telemetry attributes at any depth in the call stack:

```rust
pub async fn install_tool(name: &str, ctx: &mut CommandContext) -> miette::Result<()> {
    ctx.telemetry.add("tool_name", name.to_string());
    // ...
}
```

### Why This Pattern?

- **Extensibility**: New cross-cutting concerns (config, auth state, cancellation) can be added to `CommandContext` without changing function signatures everywhere
- **Telemetry flexibility**: Commands can add attributes from anywhere in the call stack, not just at the top level
- **Clean separation**: Context lives in its own module (`src/context.rs`), keeping `cli.rs` focused on command dispatch

### Changes

- Add `src/context.rs` with `TelemetryContext` and `CommandContext`
- Pass `&mut CommandContext` to all command functions
- Tool install/uninstall now capture `tool_name` attribute automatically
- Common attributes (`os`, `arch`, `version`, `command`) are set automatically

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (80 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)