### PR TITLE
chore: Add Jira release automation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ audit.raw.json
 
 # local dev config
 .claude/
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Ana CLI
+
+A command-line tool for Anaconda platform management.
+
+## Development
+
+### Build and test
+```bash
+cargo build
+cargo test
+```
+
+### Pre-commit
+The repo uses pre-commit hooks. Run `pre-commit install` after cloning.
+
+## Release Process
+
+When creating a new release:
+
+1. **GitHub Release** - Created automatically via GitHub Actions when a tag is pushed
+2. **Jira Release** - Run the script to sync with Jira:
+   ```bash
+   source .env  # Contains ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN
+   pixi run python scripts/create_jira_release.py v0.0.9
+   ```
+
+### What the Jira release script does
+- Creates a Jira release named `ana-cli vX.Y.Z` in the CLI project
+- Links to the GitHub release in the description
+- Finds Jira issue references (e.g., `CLI-123`) in PR descriptions and sets their Fix Version
+- Creates a QA Story with testing notes, including:
+  - Links to each PR (excluding Renovate/bot PRs)
+  - Grouped by type (Features, Bug Fixes, Maintenance)
+
+### Manual Jira release (if needed)
+If you need to create a Jira release manually or via Claude:
+- **Project**: CLI (ID: 11160)
+- **Naming convention**: `ana-cli vX.Y.Z`
+- **Description**: Include link to GitHub release
+- **QA Story**: Create a Story issue type with testing notes, linked to the release via Fix Version
+- **PR links**: When mentioning PRs in testing notes, always include clickable links to GitHub
+
+### Environment setup for Jira API
+Create a `.env` file (gitignored) with:
+```
+ATLASSIAN_USER_EMAIL=your-email@anaconda.com
+ATLASSIAN_API_TOKEN=your-token-from-atlassian
+```
+Get your API token at: https://id.atlassian.com/manage-profile/security/api-tokens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,19 +18,32 @@ The repo uses pre-commit hooks. Run `pre-commit install` after cloning.
 When creating a new release:
 
 1. **GitHub Release** - Created automatically via GitHub Actions when a tag is pushed
-2. **Jira Release** - Run the script to sync with Jira:
+2. **Jira Release** - Two-step process with human review:
    ```bash
    source .env  # Contains ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN
-   pixi run python scripts/create_jira_release.py v0.0.9
+
+   # Step 1: Generate QA notes for review
+   pixi run python scripts/create_jira_release.py v0.0.9 --generate-notes > qa_notes.md
+
+   # Step 2: Edit qa_notes.md - synthesize testing guidance from PR descriptions
+   # Remove the quoted PR descriptions after writing testing notes
+
+   # Step 3: Create Jira release with reviewed notes
+   pixi run python scripts/create_jira_release.py v0.0.9 --notes-file qa_notes.md
    ```
 
 ### What the Jira release script does
-- Creates a Jira release named `ana-cli vX.Y.Z` in the CLI project
-- Links to the GitHub release in the description
-- Finds Jira issue references (e.g., `CLI-123`) in PR descriptions and sets their Fix Version
-- Creates a QA Story with testing notes, including:
-  - Links to each PR (excluding Renovate/bot PRs)
-  - Grouped by type (Features, Bug Fixes, Maintenance)
+- **Step 1 (--generate-notes)**: Fetches GitHub release, extracts PRs, outputs markdown with PR descriptions for review
+- **Step 2 (human review)**: You synthesize testing guidance from PR descriptions, removing the quoted raw descriptions
+- **Step 3 (--notes-file)**: Creates Jira release, updates Fix Versions on linked issues, creates QA Story with your reviewed notes
+
+### Writing good QA notes
+When reviewing the generated markdown:
+- Focus on user-facing behavior changes
+- Synthesize the PR description into clear testing steps
+- Skip internal/CI changes that don't need QA testing
+- Include specific commands to run and expected outcomes
+- Remove the quoted `> PR description` blocks after synthesizing
 
 ### Manual Jira release (if needed)
 If you need to create a Jira release manually or via Claude:

--- a/pixi.lock
+++ b/pixi.lock
@@ -126,7 +126,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py314h2e6c369_0.conda
@@ -261,7 +261,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py314haad56a0_0.conda
@@ -396,7 +396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rattler-build-0.62.0-he94b42d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py314h9f07db2_0.conda
@@ -2792,22 +2792,22 @@ packages:
   license_family: MIT
   size: 51788
   timestamp: 1760379115194
-- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
-  sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
-  md5: c65df89a0b2e321045a9e01d1337b182
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+  sha256: c0249bc4bf4c0e8e06d0e7b4d117a5d593cc4ab2144d5006d6d47c83cb0af18e
+  md5: 10afbb4dbf06ff959ad25a92ccee6e59
   depends:
   - python >=3.10
-  - certifi >=2017.4.17
+  - certifi >=2023.5.7
   - charset-normalizer >=2,<4
   - idna >=2.5,<4
-  - urllib3 >=1.21.1,<3
+  - urllib3 >=1.26,<3
   - python
   constrains:
   - chardet >=3.0.2,<6
   license: Apache-2.0
   license_family: APACHE
-  size: 63602
-  timestamp: 1766926974520
+  size: 63712
+  timestamp: 1774894783063
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
   sha256: c0b815e72bb3f08b67d60d5e02251bbb0164905b5f72942ff5b6d2a339640630
   md5: 66de8645e324fda0ea6ef28c2f99a2ab

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ anaconda-client = ">=1.14.1,<2"
 cargo-auditable = ">=0.7,<1"
 cargo-audit = ">=0.22,<1"
 cargo-cyclonedx = ">=0.5,<1"
+requests = ">=2.33.1,<3"
 
 [tasks.pre-commit]
 cmd = "pre-commit run --verbose --show-diff-on-failure --color=always --all-files"

--- a/scripts/create_jira_release.py
+++ b/scripts/create_jira_release.py
@@ -28,6 +28,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from dataclasses import field
+from datetime import date
+from datetime import datetime
 from typing import Any
 
 import requests
@@ -67,6 +69,7 @@ class PullRequest:
 class ReleaseInfo:
     version: str
     github_url: str
+    published_at: date
     prs: list[PullRequest] = field(default_factory=list)
 
     @property
@@ -166,7 +169,13 @@ def gh(*args: str) -> str:
 
 def get_github_release(version: str) -> dict:
     output = gh(
-        "release", "view", version, "--repo", GITHUB_REPO, "--json", "tagName,body,url"
+        "release",
+        "view",
+        version,
+        "--repo",
+        GITHUB_REPO,
+        "--json",
+        "tagName,body,url,publishedAt",
     )
     return json.loads(output)
 
@@ -204,6 +213,9 @@ def fetch_release_info(version: str, quiet: bool = False) -> ReleaseInfo:
         print(f"Fetching GitHub release {version}...", file=sys.stderr)
     release = get_github_release(version)
     github_url = release["url"]
+    published_at = datetime.fromisoformat(
+        release["publishedAt"].replace("Z", "+00:00")
+    ).date()
 
     if not quiet:
         print("Extracting PRs from release notes...", file=sys.stderr)
@@ -232,7 +244,12 @@ def fetch_release_info(version: str, quiet: bool = False) -> ReleaseInfo:
             if not quiet:
                 print(f"    Warning: Could not fetch PR #{num}", file=sys.stderr)
 
-    return ReleaseInfo(version=version, github_url=github_url, prs=prs)
+    return ReleaseInfo(
+        version=version,
+        github_url=github_url,
+        published_at=published_at,
+        prs=prs,
+    )
 
 
 def generate_notes_markdown(release: ReleaseInfo) -> str:
@@ -472,12 +489,10 @@ def cmd_create_release(args: argparse.Namespace) -> int:
 
     # Create Jira version
     print(f"Creating Jira release '{release.version_name}'...")
-    from datetime import date
-
     version_result = jira.create_version(
         name=release.version_name,
         description=f"GitHub Release: {release.github_url}",
-        release_date=date.today().isoformat(),
+        release_date=release.published_at.isoformat(),
     )
     version_id = version_result["id"]
     print(f"  Created with ID: {version_id}")

--- a/scripts/create_jira_release.py
+++ b/scripts/create_jira_release.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Create a Jira release for ana-cli and generate QA testing notes.
+
+Usage:
+    python scripts/create_jira_release.py v0.0.8
+
+Required environment variables:
+    ATLASSIAN_USER_EMAIL - Your Atlassian account email
+    ATLASSIAN_API_TOKEN  - API token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+You can set these in a .env file and source it before running.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+JIRA_BASE_URL = "https://anaconda.atlassian.net"
+JIRA_PROJECT_KEY = "CLI"
+JIRA_PROJECT_ID = 11160
+GITHUB_REPO = "anaconda/ana-cli"
+
+
+@dataclass
+class PullRequest:
+    number: int
+    title: str
+    author: str
+    jira_link: str | None
+    is_bot: bool
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{GITHUB_REPO}/pull/{self.number}"
+
+    @property
+    def category(self) -> str:
+        title_lower = self.title.lower()
+        if title_lower.startswith("feat"):
+            return "feature"
+        elif title_lower.startswith("fix"):
+            return "fix"
+        elif title_lower.startswith(("refac", "chore", "docs", "test", "ci")):
+            return "maintenance"
+        return "other"
+
+
+class JiraClient:
+    def __init__(self, email: str, api_token: str):
+        self.auth = (email, api_token)
+        self.base_url = JIRA_BASE_URL
+
+    def _request(
+        self, method: str, endpoint: str, data: dict | None = None
+    ) -> dict | None:
+        url = f"{self.base_url}/rest/api/3{endpoint}"
+        headers = {"Content-Type": "application/json"}
+
+        response = requests.request(
+            method,
+            url,
+            auth=self.auth,
+            headers=headers,
+            json=data,
+        )
+
+        if response.status_code == 204:
+            return None
+
+        if not response.ok:
+            raise RuntimeError(
+                f"Jira API error ({response.status_code}): {response.text}"
+            )
+
+        return response.json()
+
+    def get_versions(self) -> list[dict]:
+        result = self._request("GET", f"/project/{JIRA_PROJECT_KEY}/versions")
+        return result or []
+
+    def version_exists(self, name: str) -> bool:
+        return any(v["name"] == name for v in self.get_versions())
+
+    def create_version(self, name: str, description: str, release_date: str) -> dict:
+        return self._request(
+            "POST",
+            "/version",
+            {
+                "name": name,
+                "description": description,
+                "projectId": JIRA_PROJECT_ID,
+                "released": True,
+                "releaseDate": release_date,
+            },
+        )
+
+    def update_issue_fix_version(self, issue_key: str, version_id: str) -> None:
+        self._request(
+            "PUT",
+            f"/issue/{issue_key}",
+            {"fields": {"fixVersions": [{"id": version_id}]}},
+        )
+
+    def create_issue(
+        self,
+        summary: str,
+        description: dict,
+        issue_type_id: str = "10003",  # Story
+        fix_version_id: str | None = None,
+    ) -> dict:
+        fields = {
+            "project": {"key": JIRA_PROJECT_KEY},
+            "issuetype": {"id": issue_type_id},
+            "summary": summary,
+            "description": description,
+        }
+        if fix_version_id:
+            fields["fixVersions"] = [{"id": fix_version_id}]
+
+        return self._request("POST", "/issue", {"fields": fields})
+
+
+def gh(*args: str) -> str:
+    """Run a GitHub CLI command and return stdout."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def get_github_release(version: str) -> dict:
+    output = gh(
+        "release", "view", version, "--repo", GITHUB_REPO, "--json", "tagName,body,url"
+    )
+    return json.loads(output)
+
+
+def get_pr_details(pr_number: int) -> dict:
+    output = gh(
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        GITHUB_REPO,
+        "--json",
+        "title,body,author",
+    )
+    return json.loads(output)
+
+
+def extract_pr_numbers(release_body: str) -> list[int]:
+    """Extract PR numbers from release notes body."""
+    matches = re.findall(r"pull/(\d+)", release_body)
+    return sorted(set(int(m) for m in matches))
+
+
+def extract_jira_link(pr_body: str) -> str | None:
+    """Extract Jira issue key from PR body."""
+    if not pr_body:
+        return None
+    match = re.search(r"CLI-\d+", pr_body)
+    return match.group(0) if match else None
+
+
+def build_pr_list(pr_numbers: list[int]) -> list[PullRequest]:
+    """Fetch details for each PR and build PullRequest objects."""
+    prs = []
+    for num in pr_numbers:
+        print(f"  Fetching PR #{num}...")
+        try:
+            details = get_pr_details(num)
+            author = details.get("author", {}).get("login", "unknown")
+            is_bot = "renovate" in author.lower() or "bot" in author.lower()
+
+            prs.append(
+                PullRequest(
+                    number=num,
+                    title=details.get("title", f"PR #{num}"),
+                    author=author,
+                    jira_link=extract_jira_link(details.get("body", "")),
+                    is_bot=is_bot,
+                )
+            )
+        except subprocess.CalledProcessError:
+            print(f"    Warning: Could not fetch PR #{num}")
+
+    return prs
+
+
+def build_adf_document(github_url: str, prs: list[PullRequest]) -> dict:
+    """Build Atlassian Document Format for QA testing notes."""
+    content: list[dict[str, Any]] = []
+
+    # Header
+    content.append(heading("Release Info", level=2))
+    content.append(
+        paragraph(
+            text("GitHub Release: "),
+            link("Release Notes", github_url),
+        )
+    )
+
+    # Group PRs by category (excluding bots)
+    non_bot_prs = [pr for pr in prs if not pr.is_bot]
+    features = [pr for pr in non_bot_prs if pr.category == "feature"]
+    fixes = [pr for pr in non_bot_prs if pr.category == "fix"]
+    maintenance = [pr for pr in non_bot_prs if pr.category == "maintenance"]
+    other = [pr for pr in non_bot_prs if pr.category == "other"]
+
+    def pr_list_item(pr: PullRequest) -> dict:
+        return list_item(
+            paragraph(
+                link(f"PR #{pr.number}", pr.url, bold=True),
+                text(f" - {pr.title}"),
+            )
+        )
+
+    if features:
+        content.append(heading("Features", level=2))
+        content.append(bullet_list([pr_list_item(pr) for pr in features]))
+
+    if fixes:
+        content.append(heading("Bug Fixes", level=2))
+        content.append(bullet_list([pr_list_item(pr) for pr in fixes]))
+
+    if maintenance:
+        content.append(heading("Maintenance", level=2))
+        content.append(bullet_list([pr_list_item(pr) for pr in maintenance]))
+
+    if other:
+        content.append(heading("Other Changes", level=2))
+        content.append(bullet_list([pr_list_item(pr) for pr in other]))
+
+    return {"type": "doc", "version": 1, "content": content}
+
+
+# ADF helper functions
+def text(value: str, bold: bool = False, code: bool = False) -> dict:
+    node = {"type": "text", "text": value}
+    marks = []
+    if bold:
+        marks.append({"type": "strong"})
+    if code:
+        marks.append({"type": "code"})
+    if marks:
+        node["marks"] = marks
+    return node
+
+
+def link(label: str, url: str, bold: bool = False) -> dict:
+    marks = [{"type": "link", "attrs": {"href": url}}]
+    if bold:
+        marks.append({"type": "strong"})
+    return {"type": "text", "text": label, "marks": marks}
+
+
+def paragraph(*nodes: dict) -> dict:
+    return {"type": "paragraph", "content": list(nodes)}
+
+
+def heading(value: str, level: int = 1) -> dict:
+    return {
+        "type": "heading",
+        "attrs": {"level": level},
+        "content": [text(value)],
+    }
+
+
+def list_item(*nodes: dict) -> dict:
+    return {"type": "listItem", "content": list(nodes)}
+
+
+def bullet_list(items: list[dict]) -> dict:
+    return {"type": "bulletList", "content": items}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/create_jira_release.py <version>")
+        print("Example: python scripts/create_jira_release.py v0.0.8")
+        sys.exit(1)
+
+    version = sys.argv[1]
+    version_name = f"ana-cli {version}"
+
+    # Check environment
+    email = os.environ.get("ATLASSIAN_USER_EMAIL")
+    token = os.environ.get("ATLASSIAN_API_TOKEN")
+
+    if not email or not token:
+        print("Error: ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN must be set")
+        print("Create a .env file and source it, or export the variables directly.")
+        sys.exit(1)
+
+    jira = JiraClient(email, token)
+
+    # Check if version already exists
+    if jira.version_exists(version_name):
+        print(f"Error: Jira version '{version_name}' already exists")
+        sys.exit(1)
+
+    # Get GitHub release
+    print(f"Fetching GitHub release {version}...")
+    release = get_github_release(version)
+    github_url = release["url"]
+
+    # Extract and process PRs
+    print("Extracting PRs from release notes...")
+    pr_numbers = extract_pr_numbers(release["body"])
+    prs = build_pr_list(pr_numbers)
+
+    # Create Jira version
+    print(f"Creating Jira release '{version_name}'...")
+    from datetime import date
+
+    version_result = jira.create_version(
+        name=version_name,
+        description=f"GitHub Release: {github_url}",
+        release_date=date.today().isoformat(),
+    )
+    version_id = version_result["id"]
+    print(f"  Created with ID: {version_id}")
+
+    # Update Fix Version on linked Jira issues
+    jira_issues = [pr.jira_link for pr in prs if pr.jira_link]
+    for issue_key in jira_issues:
+        print(f"Updating Fix Version on {issue_key}...")
+        jira.update_issue_fix_version(issue_key, version_id)
+
+    # Create QA Story
+    print("Creating QA testing story...")
+    qa_description = build_adf_document(github_url, prs)
+    qa_result = jira.create_issue(
+        summary=f"QA Testing Notes for {version_name}",
+        description=qa_description,
+        fix_version_id=version_id,
+    )
+    qa_key = qa_result["key"]
+
+    # Summary
+    print()
+    print("Done!")
+    print(f"  Jira Release: {JIRA_BASE_URL}/projects/CLI/versions/{version_id}")
+    print(f"  QA Story:     {JIRA_BASE_URL}/browse/{qa_key}")
+    if jira_issues:
+        print(f"  Updated Fix Version on: {', '.join(jira_issues)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_jira_release.py
+++ b/scripts/create_jira_release.py
@@ -2,10 +2,16 @@
 """
 Create a Jira release for ana-cli and generate QA testing notes.
 
-Usage:
-    python scripts/create_jira_release.py v0.0.8
+Two-step workflow:
+    1. Generate notes for review:
+       python scripts/create_jira_release.py v0.0.9 --generate-notes > qa_notes.md
 
-Required environment variables:
+    2. Create release with reviewed notes:
+       python scripts/create_jira_release.py v0.0.9 --notes-file qa_notes.md
+       # or via stdin:
+       cat qa_notes.md | python scripts/create_jira_release.py v0.0.9 --notes-stdin
+
+Required environment variables (for step 2 only):
     ATLASSIAN_USER_EMAIL - Your Atlassian account email
     ATLASSIAN_API_TOKEN  - API token from https://id.atlassian.com/manage-profile/security/api-tokens
 
@@ -14,12 +20,14 @@ You can set these in a .env file and source it before running.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 
 import requests
@@ -34,6 +42,7 @@ GITHUB_REPO = "anaconda/ana-cli"
 class PullRequest:
     number: int
     title: str
+    body: str
     author: str
     jira_link: str | None
     is_bot: bool
@@ -52,6 +61,21 @@ class PullRequest:
         elif title_lower.startswith(("refac", "chore", "docs", "test", "ci")):
             return "maintenance"
         return "other"
+
+
+@dataclass
+class ReleaseInfo:
+    version: str
+    github_url: str
+    prs: list[PullRequest] = field(default_factory=list)
+
+    @property
+    def version_name(self) -> str:
+        return f"ana-cli {self.version}"
+
+    @property
+    def jira_issues(self) -> list[str]:
+        return [pr.jira_link for pr in self.prs if pr.jira_link]
 
 
 class JiraClient:
@@ -174,11 +198,21 @@ def extract_jira_link(pr_body: str) -> str | None:
     return match.group(0) if match else None
 
 
-def build_pr_list(pr_numbers: list[int]) -> list[PullRequest]:
-    """Fetch details for each PR and build PullRequest objects."""
+def fetch_release_info(version: str, quiet: bool = False) -> ReleaseInfo:
+    """Fetch GitHub release and PR details."""
+    if not quiet:
+        print(f"Fetching GitHub release {version}...", file=sys.stderr)
+    release = get_github_release(version)
+    github_url = release["url"]
+
+    if not quiet:
+        print("Extracting PRs from release notes...", file=sys.stderr)
+    pr_numbers = extract_pr_numbers(release["body"])
+
     prs = []
     for num in pr_numbers:
-        print(f"  Fetching PR #{num}...")
+        if not quiet:
+            print(f"  Fetching PR #{num}...", file=sys.stderr)
         try:
             details = get_pr_details(num)
             author = details.get("author", {}).get("login", "unknown")
@@ -188,19 +222,121 @@ def build_pr_list(pr_numbers: list[int]) -> list[PullRequest]:
                 PullRequest(
                     number=num,
                     title=details.get("title", f"PR #{num}"),
+                    body=details.get("body", ""),
                     author=author,
                     jira_link=extract_jira_link(details.get("body", "")),
                     is_bot=is_bot,
                 )
             )
         except subprocess.CalledProcessError:
-            print(f"    Warning: Could not fetch PR #{num}")
+            if not quiet:
+                print(f"    Warning: Could not fetch PR #{num}", file=sys.stderr)
 
-    return prs
+    return ReleaseInfo(version=version, github_url=github_url, prs=prs)
 
 
-def build_adf_document(github_url: str, prs: list[PullRequest]) -> dict:
-    """Build Atlassian Document Format for QA testing notes."""
+def generate_notes_markdown(release: ReleaseInfo) -> str:
+    """Generate markdown QA notes for human review."""
+    lines = []
+    lines.append(f"# QA Testing Notes for {release.version_name}")
+    lines.append("")
+    lines.append(f"GitHub Release: {release.github_url}")
+    lines.append("")
+
+    non_bot_prs = [pr for pr in release.prs if not pr.is_bot]
+    features = [pr for pr in non_bot_prs if pr.category == "feature"]
+    fixes = [pr for pr in non_bot_prs if pr.category == "fix"]
+    maintenance = [pr for pr in non_bot_prs if pr.category == "maintenance"]
+    other = [pr for pr in non_bot_prs if pr.category == "other"]
+
+    def write_pr_section(prs: list[PullRequest], header: str) -> None:
+        if not prs:
+            return
+        lines.append(f"## {header}")
+        lines.append("")
+        for pr in prs:
+            lines.append(f"### [PR #{pr.number}]({pr.url}) - {pr.title}")
+            lines.append("")
+            lines.append("**Testing notes:**")
+            lines.append("")
+            lines.append(
+                "<!-- Synthesize testing guidance from the PR description below -->"
+            )
+            lines.append(
+                "<!-- Delete the PR description after writing testing notes -->"
+            )
+            lines.append("")
+            if pr.body:
+                for body_line in pr.body.split("\n"):
+                    lines.append(f"> {body_line}")
+            else:
+                lines.append("> (No PR description)")
+            lines.append("")
+
+    write_pr_section(features, "Features")
+    write_pr_section(fixes, "Bug Fixes")
+    write_pr_section(maintenance, "Maintenance (no user-facing testing needed)")
+    write_pr_section(other, "Other Changes")
+
+    if release.jira_issues:
+        lines.append("## Linked Jira Issues")
+        lines.append("")
+        lines.append("The following issues will have their Fix Version updated:")
+        lines.append("")
+        for issue in release.jira_issues:
+            lines.append(f"- [{issue}]({JIRA_BASE_URL}/browse/{issue})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def parse_notes_markdown(content: str) -> tuple[str, dict[str, str]]:
+    """
+    Parse reviewed markdown notes.
+
+    Returns:
+        tuple of (github_url, {pr_number: testing_notes})
+    """
+    github_url = ""
+    pr_notes: dict[str, str] = {}
+
+    # Extract GitHub URL
+    url_match = re.search(r"GitHub Release: (https://[^\s]+)", content)
+    if url_match:
+        github_url = url_match.group(1)
+
+    # Extract PR sections - look for ### [PR #N] headers followed by testing notes
+    pr_pattern = re.compile(
+        r"### \[PR #(\d+)\][^\n]*\n"
+        r".*?\*\*Testing notes:\*\*\s*\n"
+        r"(.*?)"
+        r"(?=### \[PR #|\n## |$)",
+        re.DOTALL,
+    )
+
+    for match in pr_pattern.finditer(content):
+        pr_num = match.group(1)
+        notes_section = match.group(2).strip()
+
+        # Remove HTML comments and quoted PR description
+        lines = []
+        for line in notes_section.split("\n"):
+            line = line.strip()
+            if line.startswith("<!--") or line.startswith(">"):
+                continue
+            if line:
+                lines.append(line)
+
+        if lines:
+            pr_notes[pr_num] = "\n".join(lines)
+
+    return github_url, pr_notes
+
+
+def build_adf_from_notes(
+    release: ReleaseInfo, pr_notes: dict[str, str]
+) -> dict[str, Any]:
+    """Build Atlassian Document Format from reviewed notes."""
     content: list[dict[str, Any]] = []
 
     # Header
@@ -208,48 +344,55 @@ def build_adf_document(github_url: str, prs: list[PullRequest]) -> dict:
     content.append(
         paragraph(
             text("GitHub Release: "),
-            link("Release Notes", github_url),
+            link("Release Notes", release.github_url),
         )
     )
 
-    # Group PRs by category (excluding bots)
-    non_bot_prs = [pr for pr in prs if not pr.is_bot]
+    non_bot_prs = [pr for pr in release.prs if not pr.is_bot]
     features = [pr for pr in non_bot_prs if pr.category == "feature"]
     fixes = [pr for pr in non_bot_prs if pr.category == "fix"]
     maintenance = [pr for pr in non_bot_prs if pr.category == "maintenance"]
     other = [pr for pr in non_bot_prs if pr.category == "other"]
 
-    def pr_list_item(pr: PullRequest) -> dict:
-        return list_item(
-            paragraph(
-                link(f"PR #{pr.number}", pr.url, bold=True),
-                text(f" - {pr.title}"),
-            )
-        )
+    def build_pr_section(prs: list[PullRequest], header: str) -> None:
+        if not prs:
+            return
+        content.append(heading(header, level=2))
 
-    if features:
-        content.append(heading("Features", level=2))
-        content.append(bullet_list([pr_list_item(pr) for pr in features]))
+        items = []
+        for pr in prs:
+            pr_num_str = str(pr.number)
+            notes = pr_notes.get(pr_num_str, "")
 
-    if fixes:
-        content.append(heading("Bug Fixes", level=2))
-        content.append(bullet_list([pr_list_item(pr) for pr in fixes]))
+            item_content = [
+                paragraph(
+                    link(f"PR #{pr.number}", pr.url, bold=True),
+                    text(f" - {pr.title}"),
+                )
+            ]
 
-    if maintenance:
-        content.append(heading("Maintenance", level=2))
-        content.append(bullet_list([pr_list_item(pr) for pr in maintenance]))
+            if notes:
+                # Add testing notes as sub-content
+                for note_line in notes.split("\n"):
+                    if note_line.strip():
+                        item_content.append(paragraph(text(note_line)))
 
-    if other:
-        content.append(heading("Other Changes", level=2))
-        content.append(bullet_list([pr_list_item(pr) for pr in other]))
+            items.append(list_item(*item_content))
+
+        content.append(bullet_list(items))
+
+    build_pr_section(features, "Features")
+    build_pr_section(fixes, "Bug Fixes")
+    build_pr_section(maintenance, "Maintenance")
+    build_pr_section(other, "Other Changes")
 
     return {"type": "doc", "version": 1, "content": content}
 
 
 # ADF helper functions
 def text(value: str, bold: bool = False, code: bool = False) -> dict:
-    node = {"type": "text", "text": value}
-    marks = []
+    node: dict[str, Any] = {"type": "text", "text": value}
+    marks: list[dict[str, Any]] = []
     if bold:
         marks.append({"type": "strong"})
     if code:
@@ -260,7 +403,7 @@ def text(value: str, bold: bool = False, code: bool = False) -> dict:
 
 
 def link(label: str, url: str, bold: bool = False) -> dict:
-    marks = [{"type": "link", "attrs": {"href": url}}]
+    marks: list[dict[str, Any]] = [{"type": "link", "attrs": {"href": url}}]
     if bold:
         marks.append({"type": "strong"})
     return {"type": "text", "text": label, "marks": marks}
@@ -286,15 +429,15 @@ def bullet_list(items: list[dict]) -> dict:
     return {"type": "bulletList", "content": items}
 
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: python scripts/create_jira_release.py <version>")
-        print("Example: python scripts/create_jira_release.py v0.0.8")
-        sys.exit(1)
+def cmd_generate_notes(args: argparse.Namespace) -> int:
+    """Generate QA notes markdown for review."""
+    release = fetch_release_info(args.version)
+    print(generate_notes_markdown(release))
+    return 0
 
-    version = sys.argv[1]
-    version_name = f"ana-cli {version}"
 
+def cmd_create_release(args: argparse.Namespace) -> int:
+    """Create Jira release with reviewed notes."""
     # Check environment
     email = os.environ.get("ATLASSIAN_USER_EMAIL")
     token = os.environ.get("ATLASSIAN_API_TOKEN")
@@ -302,48 +445,53 @@ def main():
     if not email or not token:
         print("Error: ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN must be set")
         print("Create a .env file and source it, or export the variables directly.")
-        sys.exit(1)
+        return 1
+
+    # Read notes
+    if args.notes_stdin:
+        notes_content = sys.stdin.read()
+    elif args.notes_file:
+        with open(args.notes_file) as f:
+            notes_content = f.read()
+    else:
+        print("Error: Must specify --notes-file or --notes-stdin")
+        return 1
+
+    # Parse notes
+    _, pr_notes = parse_notes_markdown(notes_content)
+
+    # Fetch release info
+    release = fetch_release_info(args.version)
 
     jira = JiraClient(email, token)
 
     # Check if version already exists
-    if jira.version_exists(version_name):
-        print(f"Error: Jira version '{version_name}' already exists")
-        sys.exit(1)
-
-    # Get GitHub release
-    print(f"Fetching GitHub release {version}...")
-    release = get_github_release(version)
-    github_url = release["url"]
-
-    # Extract and process PRs
-    print("Extracting PRs from release notes...")
-    pr_numbers = extract_pr_numbers(release["body"])
-    prs = build_pr_list(pr_numbers)
+    if jira.version_exists(release.version_name):
+        print(f"Error: Jira version '{release.version_name}' already exists")
+        return 1
 
     # Create Jira version
-    print(f"Creating Jira release '{version_name}'...")
+    print(f"Creating Jira release '{release.version_name}'...")
     from datetime import date
 
     version_result = jira.create_version(
-        name=version_name,
-        description=f"GitHub Release: {github_url}",
+        name=release.version_name,
+        description=f"GitHub Release: {release.github_url}",
         release_date=date.today().isoformat(),
     )
     version_id = version_result["id"]
     print(f"  Created with ID: {version_id}")
 
     # Update Fix Version on linked Jira issues
-    jira_issues = [pr.jira_link for pr in prs if pr.jira_link]
-    for issue_key in jira_issues:
+    for issue_key in release.jira_issues:
         print(f"Updating Fix Version on {issue_key}...")
         jira.update_issue_fix_version(issue_key, version_id)
 
     # Create QA Story
     print("Creating QA testing story...")
-    qa_description = build_adf_document(github_url, prs)
+    qa_description = build_adf_from_notes(release, pr_notes)
     qa_result = jira.create_issue(
-        summary=f"QA Testing Notes for {version_name}",
+        summary=f"QA Testing Notes for {release.version_name}",
         description=qa_description,
         fix_version_id=version_id,
     )
@@ -354,9 +502,56 @@ def main():
     print("Done!")
     print(f"  Jira Release: {JIRA_BASE_URL}/projects/CLI/versions/{version_id}")
     print(f"  QA Story:     {JIRA_BASE_URL}/browse/{qa_key}")
-    if jira_issues:
-        print(f"  Updated Fix Version on: {', '.join(jira_issues)}")
+    if release.jira_issues:
+        print(f"  Updated Fix Version on: {', '.join(release.jira_issues)}")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a Jira release for ana-cli with QA testing notes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Step 1: Generate notes for review
+  %(prog)s v0.0.9 --generate-notes > qa_notes.md
+
+  # Step 2: Review and edit qa_notes.md, then create the release
+  %(prog)s v0.0.9 --notes-file qa_notes.md
+
+  # Or pipe directly:
+  cat qa_notes.md | %(prog)s v0.0.9 --notes-stdin
+""",
+    )
+    parser.add_argument("version", help="Release version (e.g., v0.0.9)")
+    parser.add_argument(
+        "--generate-notes",
+        action="store_true",
+        help="Generate QA notes markdown for review (stdout)",
+    )
+    parser.add_argument(
+        "--notes-file",
+        metavar="FILE",
+        help="Path to reviewed notes markdown file",
+    )
+    parser.add_argument(
+        "--notes-stdin",
+        action="store_true",
+        help="Read reviewed notes from stdin",
+    )
+
+    args = parser.parse_args()
+
+    if args.generate_notes:
+        return cmd_generate_notes(args)
+    elif args.notes_file or args.notes_stdin:
+        return cmd_create_release(args)
+    else:
+        parser.print_help()
+        print("\nError: Must specify --generate-notes, --notes-file, or --notes-stdin")
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This adds a new CLAUDE.md and script, which should help guide creation of Jira releases and QA testing notes from a GitHub release. You can ask the agent to e.g. "Create a release in Jira for v0.0.9" and it should find the tool and execute.

- Add Python script to automate Jira release creation when a new GitHub release is published
- Add CLAUDE.md with project documentation and release process instructions
- Add `requests` dependency to pixi.toml

## What the script does

1. Fetches GitHub release notes for the specified version
2. Creates a Jira version/release with a link to the GitHub release
3. Extracts PR numbers from release notes and checks each PR description for Jira links
4. Updates Fix Version on any linked Jira issues (e.g., CLI-408)
5. Creates a QA Story with testing notes, grouped by type (Features, Bug Fixes, Maintenance)

## Usage

```bash
source .env  # Contains ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN
pixi run python scripts/create_jira_release.py v0.0.9
```

## Test plan

- [x] Script correctly detects when a Jira version already exists
- [x] Passes all pre-commit hooks (ruff check, ruff format)
- [ ] Run on next release to verify end-to-end functionality