### PR TITLE
feat: Add `api fetch` command for making HTTP requests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,9 +10,9 @@ use crate::auth;
 use crate::config::{self, Config};
 use crate::context::CommandContext;
 use crate::feature;
-use crate::fetch::api_fetch;
 #[cfg(feature = "feedback")]
 use crate::feedback::{self, FeedbackType};
+use crate::fetch::api_fetch;
 use crate::help;
 use crate::tools;
 use crate::update;
@@ -780,5 +780,4 @@ mod tests {
             missing
         );
     }
-
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -509,9 +509,9 @@ async fn api_fetch(
         request = request.body(body.to_string());
     }
     if let Some(body) = json {
-        request = request
-            .header("Content-Type", "application/json")
-            .body(body.to_string());
+        let parsed: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| format!("Invalid JSON: {}", e))?;
+        request = request.json(&parsed);
     }
     let response = request.send().await?;
     let status = response.status();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,13 @@ pub enum Action {
         force: bool,
     },
     ToolList,
+    ApiFetch {
+        method: String,
+        url: String,
+        query_args: Option<String>,
+        data: Option<String>,
+        json: Option<String>,
+    },
 }
 
 impl Action {
@@ -147,6 +154,7 @@ impl Action {
             Action::ToolInstall { .. } => "tool.install",
             Action::ToolUninstall { .. } => "tool.uninstall",
             Action::ToolList => "tool.list",
+            Action::ApiFetch { .. } => "api.fetch",
         }
     }
 
@@ -251,6 +259,23 @@ impl Action {
                 feedback::open_feedback(ctx, feedback_type, description);
                 Ok(())
             }
+            Action::ApiFetch {
+                method,
+                url,
+                query_args,
+                data,
+                json,
+            } => {
+                api_fetch(
+                    ctx,
+                    &method,
+                    &url,
+                    query_args.as_deref(),
+                    data.as_deref(),
+                    json.as_deref(),
+                )
+                .await
+            }
         }
     }
 }
@@ -321,6 +346,22 @@ pub fn parse() -> (Action, LogLevel) {
                     Some(ToolCommands::Uninstall { name, force }) => {
                         Action::ToolUninstall { name, force }
                     }
+                },
+                Some(Commands::Api { command }) => match command {
+                    None => Action::ShowSubcommandHelp("api".to_string()),
+                    Some(ApiCommands::Fetch {
+                        method,
+                        url,
+                        query_args,
+                        data,
+                        json,
+                    }) => Action::ApiFetch {
+                        method,
+                        url,
+                        query_args,
+                        data,
+                        json,
+                    },
                 },
             };
             (action, level)
@@ -396,6 +437,46 @@ fn get_subcommand(name: &str) -> clap::Command {
         .find(|s| s.get_name() == name)
         .cloned()
         .expect("subcommand should exist")
+}
+
+async fn api_fetch(
+    ctx: &mut CommandContext,
+    method: &str,
+    url: &str,
+    query_args: Option<&str>,
+    data: Option<&str>,
+    json: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let method_upper = method.to_uppercase();
+    let mut request = match method_upper.as_str() {
+        "GET" => ctx.client.get(url),
+        "POST" => ctx.client.post(url),
+        "PUT" => ctx.client.put(url),
+        "PATCH" => ctx.client.patch(url),
+        "DELETE" => ctx.client.delete(url),
+        _ => return Err(format!("Unsupported HTTP method: {}", method).into()),
+    };
+    if let Some(args) = query_args {
+        let pairs: Vec<(&str, &str)> = args
+            .split(',')
+            .filter_map(|pair| pair.split_once('='))
+            .collect();
+        request = request.query(&pairs);
+    }
+    if let Some(body) = data {
+        request = request.body(body.to_string());
+    }
+    if let Some(body) = json {
+        request = request
+            .header("Content-Type", "application/json")
+            .body(body.to_string());
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+    println!("{}", status);
+    println!("{}", body);
+    Ok(())
 }
 
 #[derive(Parser)]
@@ -493,6 +574,17 @@ enum Commands {
         #[command(subcommand)]
         command: Option<ToolCommands>,
     },
+
+    /// API commands
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana api <command> [options]"
+    )]
+    Api {
+        #[command(subcommand)]
+        command: Option<ApiCommands>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -585,6 +677,31 @@ enum ToolCommands {
         /// Skip confirmation prompt
         #[arg(short = 'y', long = "yes")]
         force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum ApiCommands {
+    /// Fetch data from the API
+    Fetch {
+        /// API path (e.g., /api/auth/passport)
+        url: String,
+
+        /// HTTP method to use
+        #[arg(long, default_value = "GET")]
+        method: String,
+
+        /// Comma-separated query arguments (e.g., key=value,key2=value2)
+        #[arg(short = 'q', long = "query-args")]
+        query_args: Option<String>,
+
+        /// Request body data
+        #[arg(short = 'd', long, conflicts_with = "json")]
+        data: Option<String>,
+
+        /// JSON request body
+        #[arg(short = 'j', long, conflicts_with = "data")]
+        json: Option<String>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -736,4 +736,11 @@ mod tests {
             missing
         );
     }
+
+    #[tokio::test]
+    async fn test_api_healthcheck() {
+        let mut ctx = CommandContext::new();
+        let result = api_fetch(&mut ctx, "GET", "/api/auth/healthcheck", None, None, None).await;
+        assert!(result.is_ok());
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ use crate::auth;
 use crate::config::{self, Config};
 use crate::context::CommandContext;
 use crate::feature;
+use crate::fetch::api_fetch;
 #[cfg(feature = "feedback")]
 use crate::feedback::{self, FeedbackType};
 use crate::help;
@@ -481,46 +482,6 @@ fn get_subcommand(name: &str) -> clap::Command {
         .expect("subcommand should exist")
 }
 
-async fn api_fetch(
-    ctx: &mut CommandContext,
-    method: &str,
-    url: &str,
-    query_args: Option<&str>,
-    data: Option<&str>,
-    json: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let method_upper = method.to_uppercase();
-    let mut request = match method_upper.as_str() {
-        "GET" => ctx.client.get(url),
-        "POST" => ctx.client.post(url),
-        "PUT" => ctx.client.put(url),
-        "PATCH" => ctx.client.patch(url),
-        "DELETE" => ctx.client.delete(url),
-        _ => return Err(format!("Unsupported HTTP method: {}", method).into()),
-    };
-    if let Some(args) = query_args {
-        let pairs: Vec<(&str, &str)> = args
-            .split(',')
-            .filter_map(|pair| pair.split_once('='))
-            .collect();
-        request = request.query(&pairs);
-    }
-    if let Some(body) = data {
-        request = request.body(body.to_string());
-    }
-    if let Some(body) = json {
-        let parsed: serde_json::Value =
-            serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
-        request = request.json(&parsed);
-    }
-    let response = request.send().await?;
-    let status = response.status();
-    let body = response.text().await?;
-    println!("{}", status);
-    println!("{}", body);
-    Ok(())
-}
-
 #[derive(Parser)]
 #[command(
     name = "ana",
@@ -820,10 +781,4 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_api_healthcheck() {
-        let mut ctx = CommandContext::new();
-        let result = api_fetch(&mut ctx, "GET", "/api/auth/healthcheck", None, None, None).await;
-        assert!(result.is_ok());
-    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -509,8 +509,8 @@ async fn api_fetch(
         request = request.body(body.to_string());
     }
     if let Some(body) = json {
-        let parsed: serde_json::Value = serde_json::from_str(body)
-            .map_err(|e| format!("Invalid JSON: {}", e))?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
         request = request.json(&parsed);
     }
     let response = request.send().await?;

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,10 +8,10 @@ use std::env::consts::{ARCH, OS};
 
 use opentelemetry::Value;
 
+use crate::VERSION;
 use crate::auth;
 use crate::config::Config;
-use crate::http::{bearer_header, Client};
-use crate::VERSION;
+use crate::http::{Client, bearer_header};
 
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]
@@ -61,8 +61,7 @@ impl CommandContext {
         if let Ok(Some(api_key)) = auth::get_api_key(&config) {
             builder = builder.default_headers(bearer_header(&api_key));
         }
-        let client = Client::new(builder, config.base_url())
-            .expect("failed to create HTTP client");
+        let client = Client::new(builder, config.base_url()).expect("failed to create HTTP client");
         Self {
             telemetry: TelemetryContext::new(),
             client,

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,9 +8,9 @@ use std::env::consts::{ARCH, OS};
 
 use opentelemetry::Value;
 
+use crate::VERSION;
 use crate::config::Config;
 use crate::http::Client;
-use crate::VERSION;
 
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,9 +9,7 @@ use std::env::consts::{ARCH, OS};
 use opentelemetry::Value;
 
 use crate::VERSION;
-use crate::auth;
-use crate::config::Config;
-use crate::http::{Client, bearer_header};
+use crate::http::Client;
 
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]
@@ -56,12 +54,7 @@ pub struct CommandContext {
 impl CommandContext {
     /// Create a new command context.
     pub fn new() -> Self {
-        let config = Config::load();
-        let mut builder = reqwest::Client::builder();
-        if let Ok(Some(api_key)) = auth::get_api_key(&config) {
-            builder = builder.default_headers(bearer_header(&api_key));
-        }
-        let client = Client::new(builder, config.base_url()).expect("failed to create HTTP client");
+        let client = Client::from_config().expect("failed to create HTTP client");
         Self {
             telemetry: TelemetryContext::new(),
             client,

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,8 @@ use std::env::consts::{ARCH, OS};
 
 use opentelemetry::Value;
 
+use crate::config::Config;
+use crate::http::Client;
 use crate::VERSION;
 
 /// Telemetry context for collecting command-specific attributes.
@@ -43,17 +45,22 @@ impl TelemetryContext {
 }
 
 /// Command execution context passed through the call stack.
-#[derive(Debug)]
 pub struct CommandContext {
     /// Telemetry attributes collector.
     pub telemetry: TelemetryContext,
+    /// HTTP client for API requests.
+    pub client: Client,
 }
 
 impl CommandContext {
     /// Create a new command context.
     pub fn new() -> Self {
+        let config = Config::load();
+        let client = Client::new(reqwest::Client::builder(), config.base_url())
+            .expect("failed to create HTTP client");
         Self {
             telemetry: TelemetryContext::new(),
+            client,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,9 +8,10 @@ use std::env::consts::{ARCH, OS};
 
 use opentelemetry::Value;
 
-use crate::VERSION;
+use crate::auth;
 use crate::config::Config;
-use crate::http::Client;
+use crate::http::{bearer_header, Client};
+use crate::VERSION;
 
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]
@@ -56,7 +57,11 @@ impl CommandContext {
     /// Create a new command context.
     pub fn new() -> Self {
         let config = Config::load();
-        let client = Client::new(reqwest::Client::builder(), config.base_url())
+        let mut builder = reqwest::Client::builder();
+        if let Ok(Some(api_key)) = auth::get_api_key(&config) {
+            builder = builder.default_headers(bearer_header(&api_key));
+        }
+        let client = Client::new(builder, config.base_url())
             .expect("failed to create HTTP client");
         Self {
             telemetry: TelemetryContext::new(),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,60 @@
+use crate::auth;
+use crate::config::Config;
+use crate::context::CommandContext;
+
+pub async fn api_fetch(
+    ctx: &mut CommandContext,
+    method: &str,
+    url: &str,
+    query_args: Option<&str>,
+    data: Option<&str>,
+    json: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load();
+    if auth::get_api_key(&config)?.is_none() {
+        return Err("Not logged in. Run `ana login` first.".into());
+    }
+
+    let method_upper = method.to_uppercase();
+    let mut request = match method_upper.as_str() {
+        "GET" => ctx.client.get(url),
+        "POST" => ctx.client.post(url),
+        "PUT" => ctx.client.put(url),
+        "PATCH" => ctx.client.patch(url),
+        "DELETE" => ctx.client.delete(url),
+        _ => return Err(format!("Unsupported HTTP method: {}", method).into()),
+    };
+    if let Some(args) = query_args {
+        let pairs: Vec<(&str, &str)> = args
+            .split(',')
+            .filter_map(|pair| pair.split_once('='))
+            .collect();
+        request = request.query(&pairs);
+    }
+    if let Some(body) = data {
+        request = request.body(body.to_string());
+    }
+    if let Some(body) = json {
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+        request = request.json(&parsed);
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+    println!("{}", status);
+    println!("{}", body);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_api_healthcheck() {
+        let mut ctx = CommandContext::new();
+        let result = api_fetch(&mut ctx, "GET", "/api/auth/healthcheck", None, None, None).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -48,14 +48,3 @@ pub async fn api_fetch(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_api_healthcheck() {
-        let mut ctx = CommandContext::new();
-        let result = api_fetch(&mut ctx, "GET", "/api/auth/healthcheck", None, None, None).await;
-        assert!(result.is_ok());
-    }
-}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -24,6 +24,7 @@ pub async fn api_fetch(
         "DELETE" => ctx.client.delete(url),
         _ => return Err(format!("Unsupported HTTP method: {}", method).into()),
     };
+    request = request.header("X-Ana-Raw-Request", "true");
     if let Some(args) = query_args {
         let pairs: Vec<(&str, &str)> = args
             .split(',')

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -47,4 +47,3 @@ pub async fn api_fetch(
     println!("{}", body);
     Ok(())
 }
-

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -21,6 +21,10 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
         name: "TOOLCHAIN",
         commands: &["tool", "bootstrap", "config", "self"],
     },
+    HelpSection {
+        name: "API",
+        commands: &["api"],
+    },
 ];
 
 /// Examples for the help output (using real commands)

--- a/src/http.rs
+++ b/src/http.rs
@@ -3,6 +3,9 @@
 use reqwest::{Request, Response};
 use reqwest_middleware::{Middleware, Next, Result};
 
+use crate::auth;
+use crate::config::Config;
+
 /// Middleware that logs HTTP requests and responses.
 pub struct LoggingMiddleware;
 
@@ -54,6 +57,16 @@ impl Client {
             inner,
             base_url: base_url.into(),
         })
+    }
+
+    /// Create a client from config with optional auth headers.
+    pub fn from_config() -> std::result::Result<Self, reqwest::Error> {
+        let config = Config::load();
+        let mut builder = reqwest::Client::builder();
+        if let Ok(Some(api_key)) = auth::get_api_key(&config) {
+            builder = builder.default_headers(bearer_header(&api_key));
+        }
+        Self::new(builder, config.base_url())
     }
 
     /// Resolve a URL - prepends base_url for relative paths, passes through full URLs.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ mod config;
 mod context;
 mod diagnostics;
 mod feature;
-mod fetch;
 #[cfg(feature = "feedback")]
 mod feedback;
+mod fetch;
 mod help;
 mod http;
 mod input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod context;
 mod diagnostics;
 mod feature;
+mod fetch;
 #[cfg(feature = "feedback")]
 mod feedback;
 mod help;


### PR DESCRIPTION
## Summary
- Adds new `ana api fetch` command for making HTTP requests to the configured API base URL
- Supports multiple HTTP methods (GET, POST, PUT, PATCH, DELETE)
- Includes options for query params (`-q`), raw body (`-d`), and JSON body (`-j`)
- Adds HTTP client to `CommandContext` for shared use across commands

## Test plan
- [ ] Run `ana api fetch /api/iam/whoami` - should make GET request
- [ ] Run `ana api fetch /api/test --method POST -j '{"foo":"bar"}'` - should POST with JSON body
- [ ] Run `ana api fetch /api/test -q key=value,other=123` - should include query params
- [ ] Verify `--data` and `--json` flags conflict with each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)