### PR TITLE
chore: Enable lockfile maitenance with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,5 +32,8 @@
   ],
   "gitIgnoredAuthors": [
     "devops+anaconda-bot@anaconda.com"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
     }
   ],
   "extends": [
-    "local>anaconda/renovate-config"
+    "github>anaconda/renovate-config"
   ],
   "gitIgnoredAuthors": [
     "devops+anaconda-bot@anaconda.com"


### PR DESCRIPTION
## Summary

With the current `renovate` configuration, transitive dependencies are not updated. These dependencies may contain security vulnerabilities that have already been patched upstream. Enabling lockfile maintenance will update these dependencies. `renovate` will re-create the all lock files every week and create one PR with updated dependencies in the lock file.

I also changed `extends` from `local` to `github` because of a `renovate` bug that won't allow running `renovate` locally with a `local` preset.