### PR TITLE
feat: Refine help output formatting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -601,9 +601,16 @@ mod tests {
 
     #[test]
     fn test_all_subcommands_in_help_sections() {
+        // Commands intentionally hidden from help output
+        let hidden_from_help: std::collections::HashSet<_> =
+            ["org", "config"].into_iter().collect();
+
         let cmd = Cli::command();
-        let clap_subcommands: std::collections::HashSet<_> =
-            cmd.get_subcommands().map(|s| s.get_name()).collect();
+        let clap_subcommands: std::collections::HashSet<_> = cmd
+            .get_subcommands()
+            .map(|s| s.get_name())
+            .filter(|name| !hidden_from_help.contains(name))
+            .collect();
 
         let help_section_commands: std::collections::HashSet<_> =
             help::get_all_section_commands().into_iter().collect();

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -13,10 +13,12 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
         name: "TOOLCHAIN",
         commands: &["tool", "bootstrap", "config", "self"],
     },
-    HelpSection {
-        name: "PACKAGES",
-        commands: &["org"],
-    },
+    // TODO(mattkram): Removed PACKAGES section from help until we can comprehensively
+    //                 define the wrappers.
+    // HelpSection {
+    //     name: "PACKAGES",
+    //     commands: &["org"],
+    // },
     HelpSection {
         name: "ACCOUNT",
         commands: &["login", "logout", "whoami", "auth"],

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -11,7 +11,13 @@ pub(super) struct HelpSection {
 pub(super) const HELP_SECTIONS: &[HelpSection] = &[
     HelpSection {
         name: "TOOLCHAIN",
-        commands: &["tool", "bootstrap", "config", "self"],
+        commands: &[
+            "tool",
+            "bootstrap",
+            // TODO(mattkram): Hiding config from help until we fully implement CRUD
+            // "config",
+            "self",
+        ],
     },
     // TODO(mattkram): Removed PACKAGES section from help until we can comprehensively
     //                 define the wrappers.

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -10,16 +10,16 @@ pub(super) struct HelpSection {
 ///                 now, assuming YAGNI and asserting inclusing via unit tests.
 pub(super) const HELP_SECTIONS: &[HelpSection] = &[
     HelpSection {
-        name: "ACCOUNT",
-        commands: &["login", "logout", "whoami", "auth"],
+        name: "TOOLCHAIN",
+        commands: &["tool", "bootstrap", "config", "self"],
     },
     HelpSection {
         name: "PACKAGES",
         commands: &["org"],
     },
     HelpSection {
-        name: "TOOLCHAIN",
-        commands: &["tool", "bootstrap", "config", "self"],
+        name: "ACCOUNT",
+        commands: &["login", "logout", "whoami", "auth"],
     },
 ];
 

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -6,39 +6,55 @@ use super::data::{HELP_EXAMPLES, HELP_SECTIONS};
 use super::styles::HelpStyle;
 use crate::VERSION;
 
-/// Print a command row: "  command      description"
+const GLOBAL_INDENT: usize = 2;
+
+/// Create a string of spaces for the global left_margin
+fn left_margin() -> String {
+    " ".repeat(GLOBAL_INDENT)
+}
+
+/// Print a command row: "    command      description"
 fn print_command_row(term: &Term, name: &str, desc: &str) {
     let styled_name = HelpStyle::Command.style().apply_to(name);
     let styled_desc = HelpStyle::Desc.style().apply_to(desc);
-    let _ = term.write_line(&format!("  {styled_name:<20} {styled_desc}"));
+    let _ = term.write_line(&format!(
+        "{}  {styled_name:<20} {styled_desc}",
+        left_margin()
+    ));
 }
 
 /// Print a section header
 fn print_section(term: &Term, name: &str) {
-    let _ = term.write_line(
-        &HelpStyle::Section
-            .style()
-            .apply_to(name.to_uppercase())
-            .to_string(),
-    );
+    let _ = term.write_line(&format!(
+        "{}{}",
+        left_margin(),
+        HelpStyle::Section.style().apply_to(name.to_uppercase())
+    ));
 }
 
 /// Print the header at the top of the help output
 fn print_header(term: &Term) {
+    let ind = left_margin();
     let _ = term.write_line(&format!(
-        "{} {}",
+        "{}{} {}",
+        ind,
         HelpStyle::Command.style().apply_to("ana"),
         VERSION
     ));
     let tagline = "Manage your Anaconda toolchain and account.";
-    let _ = term.write_line(&HelpStyle::Desc.style().apply_to(tagline).to_string());
+    let _ = term.write_line(&format!(
+        "{}{}",
+        ind,
+        HelpStyle::Desc.style().apply_to(tagline)
+    ));
     let _ = term.write_line("");
-    let _ = term.write_line(
-        &HelpStyle::Desc
+    let _ = term.write_line(&format!(
+        "{}{}",
+        ind,
+        HelpStyle::Desc
             .style()
             .apply_to("Usage: ana [OPTIONS] COMMAND [ARGS]...")
-            .to_string(),
-    );
+    ));
     let _ = term.write_line("");
 }
 
@@ -46,9 +62,9 @@ fn print_header(term: &Term) {
 fn print_examples_block(term: &Term) {
     print_section(term, "EXAMPLES");
 
-    let margin = "  ";
+    let margin = left_margin();
     let inner_width: usize = 76;
-    let cmd_indent = "  "; // Indent for command lines
+    let cmd_left_margin = "  "; // Indent for command lines
     let border = HelpStyle::BoxBorder.style();
     let bg = HelpStyle::BoxDesc.style(); // For consistent background
 
@@ -76,10 +92,10 @@ fn print_examples_block(term: &Term) {
             border.apply_to("│")
         ));
 
-        // Command line (indented)
-        let cmd_with_indent = format!("{cmd_indent}{command}");
-        let padding = inner_width.saturating_sub(cmd_with_indent.len() + 1);
-        let padded_cmd = format!(" {cmd_with_indent}{}", " ".repeat(padding));
+        // Command line (left_margined)
+        let cmd_with_left_margin = format!("{cmd_left_margin}{command}");
+        let padding = inner_width.saturating_sub(cmd_with_left_margin.len() + 1);
+        let padded_cmd = format!(" {cmd_with_left_margin}{}", " ".repeat(padding));
         let _ = term.write_line(&format!(
             "{margin}{}{}{}",
             border.apply_to("│"),
@@ -137,7 +153,8 @@ fn print_options_block(term: &Term) {
 /// Print the footer at bottom of help output
 fn print_footer(term: &Term) {
     let _ = term.write_line(&format!(
-        "{} {}",
+        "{}{} {}",
+        left_margin(),
         HelpStyle::Desc
             .style()
             .apply_to("Full documentation and guides at"),
@@ -159,10 +176,11 @@ pub fn print_help(subcommands: HashMap<String, String>) {
 /// Help for a subcommand (e.g., `ana self`, `ana auth`, `ana bootstrap`)
 pub fn print_subcommand_help(cmd: &clap::Command) {
     let term = Term::stdout();
+    let ind = left_margin();
 
     // Description
     if let Some(about) = cmd.get_about() {
-        let _ = term.write_line(&about.to_string());
+        let _ = term.write_line(&format!("{}{}", ind, about));
         let _ = term.write_line("");
     }
 
@@ -173,7 +191,11 @@ pub fn print_subcommand_help(cmd: &clap::Command) {
     } else {
         usage.replacen("Usage: ", "Usage: ana ", 1)
     };
-    let _ = term.write_line(&HelpStyle::Dim.style().apply_to(usage).to_string());
+    let _ = term.write_line(&format!(
+        "{}{}",
+        ind,
+        HelpStyle::Dim.style().apply_to(usage)
+    ));
     let _ = term.write_line("");
 
     // Commands (only if there are subcommands)

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -8,6 +8,7 @@ use crate::VERSION;
 
 const GLOBAL_INDENT: usize = 2;
 const TAGLINE: &'static str = "Manage your Anaconda toolchain and account.";
+const DOCS_URL: &'static str = "https://anaconda.com/docs";
 
 /// Create a string of spaces for the global left_margin
 fn left_margin() -> String {
@@ -158,7 +159,7 @@ fn print_footer(term: &Term) {
         HelpStyle::Desc
             .style()
             .apply_to("Full documentation and guides at"),
-        HelpStyle::Section.style().apply_to("→ docs.anaconda.com"),
+        HelpStyle::Section.style().apply_to(format!("→ {DOCS_URL}")),
     ));
 }
 

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -145,8 +145,8 @@ fn print_options_block(term: &Term) {
         "-v, --verbose",
         "Increase verbosity (can be repeated)",
     );
-    print_command_row(term, "-V, --version", "Show the ana version and exit");
-    print_command_row(term, "-h, --help", "Show this message and exit");
+    print_command_row(term, "-V, --version", "Show the ana version");
+    print_command_row(term, "-h, --help", "Show this message");
     let _ = term.write_line("");
 }
 

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -7,6 +7,7 @@ use super::styles::HelpStyle;
 use crate::VERSION;
 
 const GLOBAL_INDENT: usize = 2;
+const TAGLINE: &'static str = "Manage your Anaconda toolchain and account.";
 
 /// Create a string of spaces for the global left_margin
 fn left_margin() -> String {
@@ -41,11 +42,10 @@ fn print_header(term: &Term) {
         HelpStyle::Command.style().apply_to("ana"),
         VERSION
     ));
-    let tagline = "Manage your Anaconda toolchain and account.";
     let _ = term.write_line(&format!(
         "{}{}",
         ind,
-        HelpStyle::Desc.style().apply_to(tagline)
+        HelpStyle::Desc.style().apply_to(TAGLINE)
     ));
     let _ = term.write_line("");
     let _ = term.write_line(&format!(

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -83,7 +83,7 @@ fn print_examples_block(term: &Term) {
     // Content lines
     for (i, (desc, command)) in HELP_EXAMPLES.iter().enumerate() {
         // Description line (as shell comment)
-        let comment = format!("# {desc}");
+        let comment = format!("{desc}");
         let padding = inner_width.saturating_sub(comment.len() + 1);
         let padded_desc = format!(" {comment}{}", " ".repeat(padding));
         let _ = term.write_line(&format!(

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -161,6 +161,7 @@ fn print_footer(term: &Term) {
             .apply_to("Full documentation and guides at"),
         HelpStyle::Section.style().apply_to(format!("→ {DOCS_URL}")),
     ));
+    let _ = term.write_line("");
 }
 
 /// Main help output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,9 +33,9 @@ class TestHelp:
 
     def test_help_shows_version_in_header(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")
-        # Header should be "ana {version}" on first line
+        # Header should be "ana {version}" on first line (with optional indent and dev suffix)
         first_line = result.stdout.split("\n")[0]
-        assert re.match(r"ana \d+\.\d+\.\d+", first_line)
+        assert re.match(r"\s*ana \d+\.\d+\.\d+(\.dev\d+)?", first_line)
 
     def test_help_shows_self_command(self, run_ana: AnaRunner) -> None:
         result = run_ana("--help")


### PR DESCRIPTION
## Summary
- Add consistent global indentation (2 spaces) to all help output lines
- Reorder help sections: TOOLCHAIN before ACCOUNT for better flow
- Hide incomplete subcommands (`org`, `config`) from help until fully implemented
- Extract constants for tagline and docs URL
- Clean up option descriptions (remove redundant "and exit")

The updated help output looks like this:
<img width="713" height="822" alt="image" src="https://github.com/user-attachments/assets/c3516763-21f3-42fc-a4de-b59c2a90505b" />
 

## Test plan
- [x] `make test` passes (96 tests)
- [ ] Run `ana --help` and verify formatting looks correct
- [ ] Run `ana self --help` to verify subcommand help is also indented

Jira: [CLI-525](https://anaconda.atlassian.net/browse/CLI-525)

[CLI-525]: https://anaconda.atlassian.net/browse/CLI-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ