### PR TITLE
chore: Add anaconda-cli team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @anaconda/anaconda-cli


### PR DESCRIPTION
## Summary

Add [`anaconda-cli`](https://github.com/orgs/anaconda/teams/anaconda-cli) team as code owners. After this PR is merged, PRs will require approval from code owners to be merged.
