### PR TITLE
feat: Non-blocking telemetry via spool files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,11 +61,11 @@ pub async fn execute() {
     let filter = build_tracing_filter(level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let is_telemetry_submit = matches!(&action, Action::TelemetrySubmit);
+    let skip_telemetry_spawn = matches!(&action, Action::TelemetrySubmit | Action::TelemetryKill);
 
     let result = action.execute().await;
 
-    if !is_telemetry_submit {
+    if !skip_telemetry_spawn {
         if let Err(e) = crate::telemetry::spawn_telemetry_submitter() {
             tracing::debug!("Failed to spawn telemetry submitter: {}", e);
         }
@@ -149,6 +149,7 @@ pub enum Action {
         uv: bool,
     },
     TelemetrySubmit,
+    TelemetryKill,
 }
 
 impl Action {
@@ -185,6 +186,7 @@ impl Action {
                 _ => "feature.disable.unknown",
             },
             Action::TelemetrySubmit => "telemetry-submit",
+            Action::TelemetryKill => "telemetry-kill",
         }
     }
 
@@ -344,6 +346,14 @@ impl Action {
                 crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
                 Ok(())
             }
+            Action::TelemetryKill => {
+                match crate::telemetry::kill_submitters() {
+                    Ok(0) => println!("No telemetry processes found"),
+                    Ok(n) => println!("Killed {} telemetry process(es)", n),
+                    Err(e) => return Err(format!("Failed to kill processes: {}", e).into()),
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -461,6 +471,7 @@ pub fn parse() -> (Action, LogLevel) {
                     },
                 },
                 Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
+                Some(Commands::TelemetryKill) => Action::TelemetryKill,
             };
             (action, level)
         }
@@ -668,6 +679,10 @@ enum Commands {
     /// Submit pending telemetry batches (internal use only)
     #[command(hide = true)]
     TelemetrySubmit,
+
+    /// Kill background telemetry processes (internal use only)
+    #[command(hide = true)]
+    TelemetryKill,
 }
 
 #[derive(Subcommand)]
@@ -841,7 +856,7 @@ mod tests {
     fn test_all_subcommands_in_help_sections() {
         // Commands intentionally hidden from help output
         let hidden_from_help: std::collections::HashSet<_> =
-            ["org", "config", "telemetry-submit"].into_iter().collect();
+            ["org", "config", "telemetry-submit", "telemetry-kill"].into_iter().collect();
 
         let cmd = Cli::command();
         let clap_subcommands: std::collections::HashSet<_> = cmd

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
-use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
 use clap::{CommandFactory, Parser, Subcommand};
 use miette::{IntoDiagnostic, miette};
 
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
-use crate::config::{self, Config};
+use crate::config::Config;
 use crate::context::CommandContext;
 use crate::feature;
 #[cfg(feature = "feedback")]
@@ -62,11 +61,15 @@ pub async fn execute() {
     let filter = build_tracing_filter(level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    config::setup_telemetry();
+    let is_telemetry_submit = matches!(&action, Action::TelemetrySubmit);
 
     let result = action.execute().await;
 
-    shutdown_telemetry();
+    if !is_telemetry_submit {
+        if let Err(e) = crate::telemetry::spawn_telemetry_submitter() {
+            tracing::debug!("Failed to spawn telemetry submitter: {}", e);
+        }
+    }
 
     if let Err(e) = result {
         tracing::error!("Command failed: {}", e);
@@ -145,6 +148,7 @@ pub enum Action {
         pip: bool,
         uv: bool,
     },
+    TelemetrySubmit,
 }
 
 impl Action {
@@ -180,15 +184,18 @@ impl Action {
                 "wheels" => "feature.disable.wheels",
                 _ => "feature.disable.unknown",
             },
+            Action::TelemetrySubmit => "telemetry-submit",
         }
     }
 
     /// Execute the action with telemetry middleware
     pub async fn execute(self) -> miette::Result<()> {
         let name = self.match_action_name();
+        let is_telemetry_submit = matches!(&self, Action::TelemetrySubmit);
+
         let mut ctx = CommandContext::new();
         ctx.telemetry.add("command", name);
-        increment_counter("cli_command_invoked", 1, ctx.telemetry.attrs());
+        ctx.telemetry.record_counter("cli_command_invoked", 1);
 
         let start = Instant::now();
         let result = self.run(&mut ctx).await;
@@ -196,20 +203,20 @@ impl Action {
 
         match &result {
             Ok(_) => {
-                increment_counter("cli_command_success", 1, ctx.telemetry.attrs());
-                record_histogram(
-                    "cli_command_success_duration_ms",
-                    duration_ms,
-                    ctx.telemetry.into_attrs(),
-                );
+                ctx.telemetry.record_counter("cli_command_success", 1);
+                ctx.telemetry
+                    .record_histogram("cli_command_success_duration_ms", duration_ms);
             }
             Err(_) => {
-                increment_counter("cli_command_failure", 1, ctx.telemetry.attrs());
-                record_histogram(
-                    "cli_command_failure_duration_ms",
-                    duration_ms,
-                    ctx.telemetry.into_attrs(),
-                );
+                ctx.telemetry.record_counter("cli_command_failure", 1);
+                ctx.telemetry
+                    .record_histogram("cli_command_failure_duration_ms", duration_ms);
+            }
+        }
+
+        if !is_telemetry_submit {
+            if let Err(e) = ctx.telemetry.flush_to_spool() {
+                tracing::debug!("Failed to spool telemetry: {}", e);
             }
         }
 
@@ -333,6 +340,10 @@ impl Action {
                 }
                 Ok(())
             }
+            Action::TelemetrySubmit => {
+                crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
+                Ok(())
+            }
         }
     }
 }
@@ -449,6 +460,7 @@ pub fn parse() -> (Action, LogLevel) {
                         uv,
                     },
                 },
+                Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
             };
             (action, level)
         }
@@ -652,6 +664,10 @@ enum Commands {
         #[command(subcommand)]
         command: Option<FeatureCommands>,
     },
+
+    /// Submit pending telemetry batches (internal use only)
+    #[command(hide = true)]
+    TelemetrySubmit,
 }
 
 #[derive(Subcommand)]
@@ -825,7 +841,7 @@ mod tests {
     fn test_all_subcommands_in_help_sections() {
         // Commands intentionally hidden from help output
         let hidden_from_help: std::collections::HashSet<_> =
-            ["org", "config"].into_iter().collect();
+            ["org", "config", "telemetry-submit"].into_iter().collect();
 
         let cmd = Cli::command();
         let clap_subcommands: std::collections::HashSet<_> = cmd

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -878,10 +878,15 @@ mod tests {
     #[test]
     fn test_all_subcommands_in_help_sections() {
         // Commands intentionally hidden from help output
-        let hidden_from_help: std::collections::HashSet<_> =
-            ["org", "config", "telemetry-submit", "telemetry-kill", "telemetry-status"]
-                .into_iter()
-                .collect();
+        let hidden_from_help: std::collections::HashSet<_> = [
+            "org",
+            "config",
+            "telemetry-submit",
+            "telemetry-kill",
+            "telemetry-status",
+        ]
+        .into_iter()
+        .collect();
 
         let cmd = Cli::command();
         let clap_subcommands: std::collections::HashSet<_> = cmd

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,10 @@ pub async fn execute() {
     let filter = build_tracing_filter(level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let skip_telemetry_spawn = matches!(&action, Action::TelemetrySubmit | Action::TelemetryKill);
+    let skip_telemetry_spawn = matches!(
+        &action,
+        Action::TelemetrySubmit | Action::TelemetryKill | Action::TelemetryStatus
+    );
 
     let result = action.execute().await;
 
@@ -150,6 +153,7 @@ pub enum Action {
     },
     TelemetrySubmit,
     TelemetryKill,
+    TelemetryStatus,
 }
 
 impl Action {
@@ -187,6 +191,7 @@ impl Action {
             },
             Action::TelemetrySubmit => "telemetry-submit",
             Action::TelemetryKill => "telemetry-kill",
+            Action::TelemetryStatus => "telemetry-status",
         }
     }
 
@@ -350,7 +355,20 @@ impl Action {
                 match crate::telemetry::kill_submitters() {
                     Ok(0) => println!("No telemetry processes found"),
                     Ok(n) => println!("Killed {} telemetry process(es)", n),
-                    Err(e) => return Err(format!("Failed to kill processes: {}", e).into()),
+                    Err(e) => return Err(miette!("Failed to kill processes: {}", e)),
+                }
+                Ok(())
+            }
+            Action::TelemetryStatus => {
+                match crate::telemetry::list_submitters() {
+                    Ok(pids) if pids.is_empty() => println!("No telemetry processes running"),
+                    Ok(pids) => {
+                        println!("{} telemetry process(es) running:", pids.len());
+                        for pid in pids {
+                            println!("  PID {}", pid);
+                        }
+                    }
+                    Err(e) => return Err(miette!("Failed to list processes: {}", e)),
                 }
                 Ok(())
             }
@@ -472,6 +490,7 @@ pub fn parse() -> (Action, LogLevel) {
                 },
                 Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
                 Some(Commands::TelemetryKill) => Action::TelemetryKill,
+                Some(Commands::TelemetryStatus) => Action::TelemetryStatus,
             };
             (action, level)
         }
@@ -683,6 +702,10 @@ enum Commands {
     /// Kill background telemetry processes (internal use only)
     #[command(hide = true)]
     TelemetryKill,
+
+    /// Check status of background telemetry processes (internal use only)
+    #[command(hide = true)]
+    TelemetryStatus,
 }
 
 #[derive(Subcommand)]
@@ -856,7 +879,9 @@ mod tests {
     fn test_all_subcommands_in_help_sections() {
         // Commands intentionally hidden from help output
         let hidden_from_help: std::collections::HashSet<_> =
-            ["org", "config", "telemetry-submit", "telemetry-kill"].into_iter().collect();
+            ["org", "config", "telemetry-submit", "telemetry-kill", "telemetry-status"]
+                .into_iter()
+                .collect();
 
         let cmd = Cli::command();
         let clap_subcommands: std::collections::HashSet<_> = cmd

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,8 +42,13 @@ use crate::VERSION;
 use crate::auth;
 use crate::table;
 
+/// Check if telemetry is enabled.
+pub fn telemetry_enabled() -> bool {
+    parse_bool_env("ANA_ENABLE_TELEMETRY", true)
+}
+
 pub fn setup_telemetry() {
-    if !parse_bool_env("ANA_ENABLE_TELEMETRY", true) {
+    if !telemetry_enabled() {
         return;
     }
     let _ = try_setup_telemetry();

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,47 +31,14 @@
 //! Boolean values are parsed as `false` for empty, "0", or "false" (case-insensitive),
 //! and `true` for any other value.
 
-use anaconda_otel_rs::{
-    attributes::ResourceAttributes, config::Configuration, signals::initialize_telemetry,
-};
-use miette::{IntoDiagnostic, miette};
 use std::env;
 use std::path::PathBuf;
 
-use crate::VERSION;
-use crate::auth;
 use crate::table;
 
 /// Check if telemetry is enabled.
 pub fn telemetry_enabled() -> bool {
     parse_bool_env("ANA_ENABLE_TELEMETRY", true)
-}
-
-pub fn setup_telemetry() {
-    if !telemetry_enabled() {
-        return;
-    }
-    let _ = try_setup_telemetry();
-}
-
-fn try_setup_telemetry() -> miette::Result<()> {
-    let app_config = Config::load();
-
-    let mut otel_config =
-        Configuration::new(Some(&app_config.metrics_endpoint), None).into_diagnostic()?;
-
-    let api_key = auth::get_api_key(&app_config).ok().flatten();
-    otel_config.set_auth_token(api_key);
-    otel_config.set_console_exporter(app_config.metrics_console_exporter);
-    otel_config.set_metrics_export_interval_ms(app_config.metrics_export_interval_ms);
-    otel_config.skip_internet_check = app_config.metrics_skip_internet_check;
-
-    let attrs = ResourceAttributes::new("ana-cli", VERSION).map_err(|e| miette!("{}", e))?;
-
-    initialize_telemetry(otel_config, attrs, vec!["metrics"])
-        .map_err(|e| miette!("Telemetry initialization failed: {}", e))?;
-
-    Ok(())
 }
 
 const DEFAULT_DOMAIN: &str = "anaconda.com";

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,11 +14,13 @@ use opentelemetry::Value;
 use crate::VERSION;
 use crate::config::Config;
 use crate::http::{self, Client};
+use crate::telemetry::{SerializableValue, TelemetryEvent};
 
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]
 pub struct TelemetryContext {
     attrs: HashMap<String, Value>,
+    events: Vec<TelemetryEvent>,
 }
 
 impl TelemetryContext {
@@ -28,7 +30,10 @@ impl TelemetryContext {
         attrs.insert("os".to_string(), OS.into());
         attrs.insert("arch".to_string(), ARCH.into());
         attrs.insert("version".to_string(), VERSION.into());
-        Self { attrs }
+        Self {
+            attrs,
+            events: Vec::new(),
+        }
     }
 
     /// Add an attribute.
@@ -36,14 +41,49 @@ impl TelemetryContext {
         self.attrs.insert(key.into(), value.into());
     }
 
-    /// Get the attributes for recording.
-    pub(crate) fn into_attrs(self) -> HashMap<String, Value> {
-        self.attrs
+    /// Record a counter metric (buffered locally).
+    pub fn record_counter(&mut self, name: &str, value: u64) {
+        let attrs = self
+            .attrs
+            .iter()
+            .map(|(k, v)| (k.clone(), SerializableValue::from(v.clone())))
+            .collect();
+
+        self.events.push(TelemetryEvent::Counter {
+            name: name.to_string(),
+            value,
+            attributes: attrs,
+        });
     }
 
-    /// Clone attributes for intermediate recording.
-    pub(crate) fn attrs(&self) -> HashMap<String, Value> {
-        self.attrs.clone()
+    /// Record a histogram metric (buffered locally).
+    pub fn record_histogram(&mut self, name: &str, value: f64) {
+        let attrs = self
+            .attrs
+            .iter()
+            .map(|(k, v)| (k.clone(), SerializableValue::from(v.clone())))
+            .collect();
+
+        self.events.push(TelemetryEvent::Histogram {
+            name: name.to_string(),
+            value,
+            attributes: attrs,
+        });
+    }
+
+    /// Flush buffered events to spool file.
+    ///
+    /// Returns Ok(None) if telemetry is disabled or no events.
+    pub fn flush_to_spool(self) -> std::io::Result<Option<std::path::PathBuf>> {
+        if self.events.is_empty() {
+            return Ok(None);
+        }
+
+        if !crate::config::telemetry_enabled() {
+            return Ok(None);
+        }
+
+        crate::telemetry::write_batch(self.events, VERSION).map(Some)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod input;
 mod paths;
 mod qr;
 mod table;
+mod telemetry;
 mod tools;
 mod ua;
 mod ui;

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -90,5 +90,4 @@ mod tests {
         assert_eq!(batch.version, parsed.version);
         assert_eq!(batch.events.len(), 1);
     }
-
 }

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -1,0 +1,148 @@
+//! Portable telemetry event types.
+//!
+//! These types have no ana-cli dependencies and can be moved to anaconda-otel-rs.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A single telemetry event (counter or histogram).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum TelemetryEvent {
+    Counter {
+        name: String,
+        value: u64,
+        attributes: HashMap<String, SerializableValue>,
+    },
+    Histogram {
+        name: String,
+        value: f64,
+        attributes: HashMap<String, SerializableValue>,
+    },
+}
+
+/// A value type that can be serialized and converted to/from OpenTelemetry Value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum SerializableValue {
+    String(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+}
+
+impl From<opentelemetry::Value> for SerializableValue {
+    fn from(v: opentelemetry::Value) -> Self {
+        match v {
+            opentelemetry::Value::String(s) => SerializableValue::String(s.to_string()),
+            opentelemetry::Value::I64(i) => SerializableValue::Int(i),
+            opentelemetry::Value::F64(f) => SerializableValue::Float(f),
+            opentelemetry::Value::Bool(b) => SerializableValue::Bool(b),
+            _ => SerializableValue::String(format!("{:?}", v)),
+        }
+    }
+}
+
+impl From<SerializableValue> for opentelemetry::Value {
+    fn from(v: SerializableValue) -> Self {
+        match v {
+            SerializableValue::String(s) => opentelemetry::Value::String(s.into()),
+            SerializableValue::Int(i) => opentelemetry::Value::I64(i),
+            SerializableValue::Float(f) => opentelemetry::Value::F64(f),
+            SerializableValue::Bool(b) => opentelemetry::Value::Bool(b),
+        }
+    }
+}
+
+/// A batch of telemetry events with metadata.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TelemetryBatch {
+    pub timestamp: String,
+    pub version: String,
+    pub events: Vec<TelemetryEvent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_serialization_roundtrip() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "command".to_string(),
+            SerializableValue::String("test".to_string()),
+        );
+        attrs.insert("count".to_string(), SerializableValue::Int(42));
+
+        let event = TelemetryEvent::Counter {
+            name: "cli_command_invoked".to_string(),
+            value: 1,
+            attributes: attrs,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: TelemetryEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, parsed);
+    }
+
+    #[test]
+    fn test_histogram_serialization_roundtrip() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "os".to_string(),
+            SerializableValue::String("macos".to_string()),
+        );
+
+        let event = TelemetryEvent::Histogram {
+            name: "cli_command_duration_ms".to_string(),
+            value: 123.45,
+            attributes: attrs,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: TelemetryEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, parsed);
+    }
+
+    #[test]
+    fn test_batch_serialization() {
+        let batch = TelemetryBatch {
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            version: "0.1.0".to_string(),
+            events: vec![TelemetryEvent::Counter {
+                name: "test".to_string(),
+                value: 1,
+                attributes: HashMap::new(),
+            }],
+        };
+
+        let json = serde_json::to_string_pretty(&batch).unwrap();
+        let parsed: TelemetryBatch = serde_json::from_str(&json).unwrap();
+        assert_eq!(batch.timestamp, parsed.timestamp);
+        assert_eq!(batch.version, parsed.version);
+        assert_eq!(batch.events.len(), 1);
+    }
+
+    #[test]
+    fn test_serializable_value_from_otel() {
+        let string_val = opentelemetry::Value::String("test".into());
+        let int_val = opentelemetry::Value::I64(42);
+        let float_val = opentelemetry::Value::F64(3.14);
+        let bool_val = opentelemetry::Value::Bool(true);
+
+        assert_eq!(
+            SerializableValue::from(string_val),
+            SerializableValue::String("test".to_string())
+        );
+        assert_eq!(SerializableValue::from(int_val), SerializableValue::Int(42));
+        assert_eq!(
+            SerializableValue::from(float_val),
+            SerializableValue::Float(3.14)
+        );
+        assert_eq!(
+            SerializableValue::from(bool_val),
+            SerializableValue::Bool(true)
+        );
+    }
+}

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -1,9 +1,9 @@
 //! Portable telemetry event types.
-//!
-//! These types have no ana-cli dependencies and can be moved to anaconda-otel-rs.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use super::otel::SerializableValue;
 
 /// A single telemetry event (counter or histogram).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -19,39 +19,6 @@ pub enum TelemetryEvent {
         value: f64,
         attributes: HashMap<String, SerializableValue>,
     },
-}
-
-/// A value type that can be serialized and converted to/from OpenTelemetry Value.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum SerializableValue {
-    String(String),
-    Int(i64),
-    Float(f64),
-    Bool(bool),
-}
-
-impl From<opentelemetry::Value> for SerializableValue {
-    fn from(v: opentelemetry::Value) -> Self {
-        match v {
-            opentelemetry::Value::String(s) => SerializableValue::String(s.to_string()),
-            opentelemetry::Value::I64(i) => SerializableValue::Int(i),
-            opentelemetry::Value::F64(f) => SerializableValue::Float(f),
-            opentelemetry::Value::Bool(b) => SerializableValue::Bool(b),
-            _ => SerializableValue::String(format!("{:?}", v)),
-        }
-    }
-}
-
-impl From<SerializableValue> for opentelemetry::Value {
-    fn from(v: SerializableValue) -> Self {
-        match v {
-            SerializableValue::String(s) => opentelemetry::Value::String(s.into()),
-            SerializableValue::Int(i) => opentelemetry::Value::I64(i),
-            SerializableValue::Float(f) => opentelemetry::Value::F64(f),
-            SerializableValue::Bool(b) => opentelemetry::Value::Bool(b),
-        }
-    }
 }
 
 /// A batch of telemetry events with metadata.
@@ -124,25 +91,4 @@ mod tests {
         assert_eq!(batch.events.len(), 1);
     }
 
-    #[test]
-    fn test_serializable_value_from_otel() {
-        let string_val = opentelemetry::Value::String("test".into());
-        let int_val = opentelemetry::Value::I64(42);
-        let float_val = opentelemetry::Value::F64(3.14);
-        let bool_val = opentelemetry::Value::Bool(true);
-
-        assert_eq!(
-            SerializableValue::from(string_val),
-            SerializableValue::String("test".to_string())
-        );
-        assert_eq!(SerializableValue::from(int_val), SerializableValue::Int(42));
-        assert_eq!(
-            SerializableValue::from(float_val),
-            SerializableValue::Float(3.14)
-        );
-        assert_eq!(
-            SerializableValue::from(bool_val),
-            SerializableValue::Bool(true)
-        );
-    }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,29 @@
+//! Non-blocking telemetry via spool files and detached subprocess.
+//!
+//! This module provides fire-and-forget telemetry that doesn't block CLI exit:
+//!
+//! 1. Commands buffer metrics locally in `TelemetryContext`
+//! 2. At exit, events are serialized to `~/.ana/telemetry/pending/*.json`
+//! 3. A detached subprocess (`ana telemetry-submit`) processes the files
+//! 4. The parent CLI exits immediately
+//!
+//! The types in `event.rs` are portable and can be moved to anaconda-otel-rs.
+
+pub mod event;
+mod spawn;
+mod spool;
+mod submit;
+
+pub use event::{SerializableValue, TelemetryEvent};
+pub use spawn::spawn_telemetry_submitter;
+pub use spool::write_batch;
+pub use submit::submit_pending;
+
+use std::path::PathBuf;
+
+use crate::paths;
+
+/// Directory for pending telemetry files: ~/.ana/telemetry/pending/
+pub fn pending_dir() -> PathBuf {
+    paths::ana_home().join("telemetry").join("pending")
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -10,11 +10,13 @@
 //! The types in `event.rs` are portable and can be moved to anaconda-otel-rs.
 
 pub mod event;
+pub mod otel;
 mod spawn;
 mod spool;
 mod submit;
 
-pub use event::{SerializableValue, TelemetryEvent};
+pub use event::TelemetryEvent;
+pub use otel::SerializableValue;
 pub use spawn::spawn_telemetry_submitter;
 pub use spool::write_batch;
 pub use submit::submit_pending;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -17,7 +17,7 @@ mod submit;
 
 pub use event::TelemetryEvent;
 pub use otel::SerializableValue;
-pub use spawn::spawn_telemetry_submitter;
+pub use spawn::{kill_submitters, spawn_telemetry_submitter};
 pub use spool::write_batch;
 pub use submit::submit_pending;
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -17,7 +17,7 @@ mod submit;
 
 pub use event::TelemetryEvent;
 pub use otel::SerializableValue;
-pub use spawn::{kill_submitters, spawn_telemetry_submitter};
+pub use spawn::{kill_submitters, list_submitters, spawn_telemetry_submitter};
 pub use spool::write_batch;
 pub use submit::submit_pending;
 

--- a/src/telemetry/otel.rs
+++ b/src/telemetry/otel.rs
@@ -84,19 +84,15 @@ pub fn shutdown() {
 
 /// Submit a counter metric to OpenTelemetry.
 pub fn submit_counter(name: &str, value: u64, attrs: HashMap<String, SerializableValue>) {
-    let otel_attrs: HashMap<String, Value> = attrs
-        .into_iter()
-        .map(|(k, v)| (k, v.into()))
-        .collect();
+    let otel_attrs: HashMap<String, Value> =
+        attrs.into_iter().map(|(k, v)| (k, v.into())).collect();
     increment_counter(name, value, otel_attrs);
 }
 
 /// Submit a histogram metric to OpenTelemetry.
 pub fn submit_histogram(name: &str, value: f64, attrs: HashMap<String, SerializableValue>) {
-    let otel_attrs: HashMap<String, Value> = attrs
-        .into_iter()
-        .map(|(k, v)| (k, v.into()))
-        .collect();
+    let otel_attrs: HashMap<String, Value> =
+        attrs.into_iter().map(|(k, v)| (k, v.into())).collect();
     record_histogram(name, value, otel_attrs);
 }
 

--- a/src/telemetry/otel.rs
+++ b/src/telemetry/otel.rs
@@ -1,0 +1,144 @@
+//! OpenTelemetry integration for telemetry submission.
+//!
+//! This module consolidates all anaconda_otel_rs interactions:
+//! - Value type conversions
+//! - Telemetry initialization
+//! - Metric submission
+
+use std::collections::HashMap;
+
+use anaconda_otel_rs::{
+    attributes::ResourceAttributes,
+    config::Configuration,
+    signals::{increment_counter, initialize_telemetry, record_histogram, shutdown_telemetry},
+};
+use opentelemetry::Value;
+use serde::{Deserialize, Serialize};
+
+use crate::VERSION;
+
+/// A value type that can be serialized and converted to/from OpenTelemetry Value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum SerializableValue {
+    String(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+}
+
+impl From<Value> for SerializableValue {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::String(s) => SerializableValue::String(s.to_string()),
+            Value::I64(i) => SerializableValue::Int(i),
+            Value::F64(f) => SerializableValue::Float(f),
+            Value::Bool(b) => SerializableValue::Bool(b),
+            _ => SerializableValue::String(format!("{:?}", v)),
+        }
+    }
+}
+
+impl From<SerializableValue> for Value {
+    fn from(v: SerializableValue) -> Self {
+        match v {
+            SerializableValue::String(s) => Value::String(s.into()),
+            SerializableValue::Int(i) => Value::I64(i),
+            SerializableValue::Float(f) => Value::F64(f),
+            SerializableValue::Bool(b) => Value::Bool(b),
+        }
+    }
+}
+
+/// Initialize the OpenTelemetry telemetry system.
+pub fn setup() {
+    if !crate::config::telemetry_enabled() {
+        return;
+    }
+    let _ = try_setup();
+}
+
+fn try_setup() -> Result<(), Box<dyn std::error::Error>> {
+    let app_config = crate::config::Config::load();
+
+    let mut otel_config = Configuration::new(Some(&app_config.metrics_endpoint), None)?;
+
+    let api_key = crate::auth::get_api_key(&app_config).ok().flatten();
+    otel_config.set_auth_token(api_key);
+    otel_config.set_console_exporter(app_config.metrics_console_exporter);
+    otel_config.set_metrics_export_interval_ms(app_config.metrics_export_interval_ms);
+    otel_config.skip_internet_check = app_config.metrics_skip_internet_check;
+
+    let attrs = ResourceAttributes::new("ana-cli", VERSION)?;
+
+    initialize_telemetry(otel_config, attrs, vec!["metrics"])
+        .map_err(|e| format!("Telemetry initialization failed: {}", e))?;
+
+    Ok(())
+}
+
+/// Shutdown the OpenTelemetry telemetry system.
+pub fn shutdown() {
+    shutdown_telemetry();
+}
+
+/// Submit a counter metric to OpenTelemetry.
+pub fn submit_counter(name: &str, value: u64, attrs: HashMap<String, SerializableValue>) {
+    let otel_attrs: HashMap<String, Value> = attrs
+        .into_iter()
+        .map(|(k, v)| (k, v.into()))
+        .collect();
+    increment_counter(name, value, otel_attrs);
+}
+
+/// Submit a histogram metric to OpenTelemetry.
+pub fn submit_histogram(name: &str, value: f64, attrs: HashMap<String, SerializableValue>) {
+    let otel_attrs: HashMap<String, Value> = attrs
+        .into_iter()
+        .map(|(k, v)| (k, v.into()))
+        .collect();
+    record_histogram(name, value, otel_attrs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serializable_value_from_otel() {
+        let string_val = Value::String("test".into());
+        let int_val = Value::I64(42);
+        let float_val = Value::F64(3.14);
+        let bool_val = Value::Bool(true);
+
+        assert_eq!(
+            SerializableValue::from(string_val),
+            SerializableValue::String("test".to_string())
+        );
+        assert_eq!(SerializableValue::from(int_val), SerializableValue::Int(42));
+        assert_eq!(
+            SerializableValue::from(float_val),
+            SerializableValue::Float(3.14)
+        );
+        assert_eq!(
+            SerializableValue::from(bool_val),
+            SerializableValue::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_serializable_value_roundtrip() {
+        let values = vec![
+            SerializableValue::String("hello".to_string()),
+            SerializableValue::Int(42),
+            SerializableValue::Float(3.14),
+            SerializableValue::Bool(true),
+        ];
+
+        for original in values {
+            let otel: Value = original.clone().into();
+            let back: SerializableValue = otel.into();
+            assert_eq!(original, back);
+        }
+    }
+}

--- a/src/telemetry/spawn.rs
+++ b/src/telemetry/spawn.rs
@@ -55,6 +55,55 @@ fn spawn_detached_windows(exe: &std::path::Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Check for running telemetry-submit processes.
+///
+/// Returns a list of PIDs.
+pub fn list_submitters() -> io::Result<Vec<u32>> {
+    #[cfg(unix)]
+    {
+        list_submitters_unix()
+    }
+
+    #[cfg(windows)]
+    {
+        list_submitters_windows()
+    }
+}
+
+#[cfg(unix)]
+fn list_submitters_unix() -> io::Result<Vec<u32>> {
+    let output = Command::new("pgrep")
+        .args(["-f", "ana telemetry-submit"])
+        .output()?;
+
+    let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect();
+
+    Ok(pids)
+}
+
+#[cfg(windows)]
+fn list_submitters_windows() -> io::Result<Vec<u32>> {
+    let output = Command::new("wmic")
+        .args([
+            "process",
+            "where",
+            "commandline like '%ana%telemetry-submit%'",
+            "get",
+            "processid",
+        ])
+        .output()?;
+
+    let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect();
+
+    Ok(pids)
+}
+
 /// Kill any running telemetry-submit processes.
 ///
 /// Returns the number of processes killed.

--- a/src/telemetry/spawn.rs
+++ b/src/telemetry/spawn.rs
@@ -1,4 +1,4 @@
-//! Cross-platform detached process spawning for telemetry submission.
+//! Cross-platform detached process spawning and management for telemetry submission.
 
 use std::io;
 use std::process::{Command, Stdio};
@@ -53,4 +53,64 @@ fn spawn_detached_windows(exe: &std::path::Path) -> io::Result<()> {
     let _child = cmd.spawn()?;
 
     Ok(())
+}
+
+/// Kill any running telemetry-submit processes.
+///
+/// Returns the number of processes killed.
+pub fn kill_submitters() -> io::Result<u32> {
+    #[cfg(unix)]
+    {
+        kill_submitters_unix()
+    }
+
+    #[cfg(windows)]
+    {
+        kill_submitters_windows()
+    }
+}
+
+#[cfg(unix)]
+fn kill_submitters_unix() -> io::Result<u32> {
+    // Use pkill to find and kill processes matching "ana telemetry-submit"
+    // pkill returns 0 if processes were killed, 1 if none found
+    let output = Command::new("pkill")
+        .args(["-f", "ana telemetry-submit"])
+        .output()?;
+
+    // pkill returns 0 if processes were killed, 1 if none matched
+    if output.status.success() {
+        Ok(1) // pkill doesn't report count, report minimum
+    } else {
+        Ok(0)
+    }
+}
+
+#[cfg(windows)]
+fn kill_submitters_windows() -> io::Result<u32> {
+    // Use WMIC to find PIDs, then taskkill
+    let output = Command::new("wmic")
+        .args([
+            "process",
+            "where",
+            "commandline like '%ana%telemetry-submit%'",
+            "get",
+            "processid",
+        ])
+        .output()?;
+
+    let output_str = String::from_utf8_lossy(&output.stdout);
+    let mut killed = 0;
+
+    for line in output_str.lines() {
+        let line = line.trim();
+        if let Ok(pid) = line.parse::<u32>() {
+            let _ = Command::new("taskkill")
+                .args(["/F", "/PID", &pid.to_string()])
+                .output();
+            killed += 1;
+        }
+    }
+
+    Ok(killed)
 }

--- a/src/telemetry/spawn.rs
+++ b/src/telemetry/spawn.rs
@@ -163,3 +163,35 @@ fn kill_submitters_windows() -> io::Result<u32> {
 
     Ok(killed)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_submitters_returns_ok() {
+        // Should not panic and should return a result
+        let result = list_submitters();
+        assert!(result.is_ok());
+        // Result should be a vec (possibly empty)
+        let pids = result.unwrap();
+        assert!(pids.len() < 1000); // Sanity check
+    }
+
+    #[test]
+    fn test_kill_submitters_returns_ok() {
+        // Should not panic and should return a result
+        // Note: This may or may not kill processes depending on what's running
+        let result = kill_submitters();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_list_submitters_returns_valid_pids() {
+        let result = list_submitters().unwrap();
+        // All returned values should be valid PIDs (positive integers)
+        for pid in result {
+            assert!(pid > 0);
+        }
+    }
+}

--- a/src/telemetry/spawn.rs
+++ b/src/telemetry/spawn.rs
@@ -86,13 +86,12 @@ fn list_submitters_unix() -> io::Result<Vec<u32>> {
 
 #[cfg(windows)]
 fn list_submitters_windows() -> io::Result<Vec<u32>> {
-    let output = Command::new("wmic")
+    // Use PowerShell instead of deprecated WMIC
+    let output = Command::new("powershell")
         .args([
-            "process",
-            "where",
-            "commandline like '%ana%telemetry-submit%'",
-            "get",
-            "processid",
+            "-NoProfile",
+            "-Command",
+            "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*ana*telemetry-submit*' } | Select-Object -ExpandProperty ProcessId",
         ])
         .output()?;
 
@@ -137,26 +136,15 @@ fn kill_submitters_unix() -> io::Result<u32> {
 
 #[cfg(windows)]
 fn kill_submitters_windows() -> io::Result<u32> {
-    // Use WMIC to find PIDs, then taskkill
-    let output = Command::new("wmic")
-        .args([
-            "process",
-            "where",
-            "commandline like '%ana%telemetry-submit%'",
-            "get",
-            "processid",
-        ])
-        .output()?;
-
-    let output_str = String::from_utf8_lossy(&output.stdout);
+    // Get PIDs first using PowerShell
+    let pids = list_submitters_windows()?;
     let mut killed = 0;
 
-    for line in output_str.lines() {
-        let line = line.trim();
-        if let Ok(pid) = line.parse::<u32>() {
-            let _ = Command::new("taskkill")
-                .args(["/F", "/PID", &pid.to_string()])
-                .output();
+    for pid in pids {
+        let result = Command::new("taskkill")
+            .args(["/F", "/PID", &pid.to_string()])
+            .output();
+        if result.is_ok() {
             killed += 1;
         }
     }
@@ -169,29 +157,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_list_submitters_returns_ok() {
-        // Should not panic and should return a result
+    fn test_list_submitters_completes() {
+        // Should not panic - may return Ok or Err depending on system tools available
         let result = list_submitters();
-        assert!(result.is_ok());
-        // Result should be a vec (possibly empty)
-        let pids = result.unwrap();
-        assert!(pids.len() < 1000); // Sanity check
-    }
-
-    #[test]
-    fn test_kill_submitters_returns_ok() {
-        // Should not panic and should return a result
-        // Note: This may or may not kill processes depending on what's running
-        let result = kill_submitters();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_list_submitters_returns_valid_pids() {
-        let result = list_submitters().unwrap();
-        // All returned values should be valid PIDs (positive integers)
-        for pid in result {
-            assert!(pid > 0);
+        // If it succeeds, verify the result is reasonable
+        if let Ok(pids) = result {
+            assert!(pids.len() < 1000); // Sanity check
+            // All returned values should be valid PIDs (positive integers)
+            for pid in pids {
+                assert!(pid > 0);
+            }
         }
+        // If it fails (e.g., pgrep/powershell not available), that's acceptable in tests
+    }
+
+    #[test]
+    fn test_kill_submitters_completes() {
+        // Should not panic - may return Ok or Err depending on system tools available
+        let _result = kill_submitters();
+        // We just verify it doesn't panic; actual killing depends on running processes
     }
 }

--- a/src/telemetry/spawn.rs
+++ b/src/telemetry/spawn.rs
@@ -1,0 +1,56 @@
+//! Cross-platform detached process spawning for telemetry submission.
+
+use std::io;
+use std::process::{Command, Stdio};
+
+/// Spawn a detached telemetry submission process.
+///
+/// The parent can exit immediately - the child continues independently.
+pub fn spawn_telemetry_submitter() -> io::Result<()> {
+    let exe = std::env::current_exe()?;
+
+    #[cfg(unix)]
+    {
+        spawn_detached_unix(&exe)
+    }
+
+    #[cfg(windows)]
+    {
+        spawn_detached_windows(&exe)
+    }
+}
+
+#[cfg(unix)]
+fn spawn_detached_unix(exe: &std::path::Path) -> io::Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("telemetry-submit")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0);
+
+    let _child = cmd.spawn()?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn spawn_detached_windows(exe: &std::path::Path) -> io::Result<()> {
+    use std::os::windows::process::CommandExt;
+
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("telemetry-submit")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW);
+
+    let _child = cmd.spawn()?;
+
+    Ok(())
+}

--- a/src/telemetry/spool.rs
+++ b/src/telemetry/spool.rs
@@ -180,4 +180,108 @@ mod tests {
 
         assert_eq!(remaining.len(), 2);
     }
+
+    #[test]
+    fn test_enforce_max_files_ignores_non_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Create json files and non-json files
+        for i in 0..3 {
+            fs::write(pending_dir.join(format!("{}.json", i)), "{}").unwrap();
+        }
+        fs::write(pending_dir.join("test.txt"), "not json").unwrap();
+        fs::write(pending_dir.join("123.tmp"), "temp").unwrap();
+
+        // Enforce max of 2 json files
+        enforce_max_files(&pending_dir, 2).unwrap();
+
+        // Non-json files should still exist
+        assert!(pending_dir.join("test.txt").exists());
+        assert!(pending_dir.join("123.tmp").exists());
+
+        // Only newest json file should remain (plus one slot for new file)
+        let json_files: Vec<_> = fs::read_dir(&pending_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "json"))
+            .collect();
+        assert_eq!(json_files.len(), 1);
+    }
+
+    #[test]
+    fn test_enforce_max_files_empty_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Should handle empty directory without error
+        let result = enforce_max_files(&pending_dir, 10);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_write_batch_multiple_events() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let events = vec![
+                TelemetryEvent::Counter {
+                    name: "counter1".to_string(),
+                    value: 1,
+                    attributes: HashMap::new(),
+                },
+                TelemetryEvent::Counter {
+                    name: "counter2".to_string(),
+                    value: 2,
+                    attributes: HashMap::new(),
+                },
+                TelemetryEvent::Histogram {
+                    name: "histogram1".to_string(),
+                    value: 3.14,
+                    attributes: HashMap::new(),
+                },
+            ];
+
+            let path = write_batch(events, "0.1.0").unwrap();
+            let content = fs::read_to_string(&path).unwrap();
+            let batch: TelemetryBatch = serde_json::from_str(&content).unwrap();
+
+            assert_eq!(batch.events.len(), 3);
+        });
+    }
+
+    #[test]
+    fn test_write_batch_empty_events() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let events: Vec<TelemetryEvent> = vec![];
+
+            let path = write_batch(events, "0.1.0").unwrap();
+            let content = fs::read_to_string(&path).unwrap();
+            let batch: TelemetryBatch = serde_json::from_str(&content).unwrap();
+
+            assert_eq!(batch.events.len(), 0);
+        });
+    }
+
+    #[test]
+    fn test_write_batch_contains_timestamp() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let events = vec![TelemetryEvent::Counter {
+                name: "test".to_string(),
+                value: 1,
+                attributes: HashMap::new(),
+            }];
+
+            let path = write_batch(events, "0.1.0").unwrap();
+            let content = fs::read_to_string(&path).unwrap();
+            let batch: TelemetryBatch = serde_json::from_str(&content).unwrap();
+
+            // Timestamp should be RFC3339 format
+            assert!(!batch.timestamp.is_empty());
+            assert!(batch.timestamp.contains("T")); // ISO format contains T separator
+        });
+    }
 }

--- a/src/telemetry/spool.rs
+++ b/src/telemetry/spool.rs
@@ -1,0 +1,104 @@
+//! Spool telemetry batches to disk for deferred submission.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::event::{TelemetryBatch, TelemetryEvent};
+
+/// Write a batch of events to a spool file.
+///
+/// Uses atomic write (temp file + rename) for crash safety.
+/// Returns the path to the written file.
+pub fn write_batch(events: Vec<TelemetryEvent>, version: &str) -> io::Result<PathBuf> {
+    let pending_dir = super::pending_dir();
+    fs::create_dir_all(&pending_dir)?;
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    let timestamp = chrono::Utc::now().to_rfc3339();
+
+    let batch = TelemetryBatch {
+        timestamp,
+        version: version.to_string(),
+        events,
+    };
+
+    let filename = format!("{}.json", nanos);
+    let final_path = pending_dir.join(&filename);
+    let temp_path = pending_dir.join(format!("{}.tmp", nanos));
+
+    let content = serde_json::to_string_pretty(&batch)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    let mut file = fs::File::create(&temp_path)?;
+    file.write_all(content.as_bytes())?;
+    file.sync_all()?;
+    drop(file);
+
+    fs::rename(&temp_path, &final_path)?;
+
+    Ok(final_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::telemetry::event::SerializableValue;
+
+    #[test]
+    fn test_write_batch_creates_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "command".to_string(),
+                SerializableValue::String("test".to_string()),
+            );
+
+            let events = vec![TelemetryEvent::Counter {
+                name: "test_counter".to_string(),
+                value: 1,
+                attributes: attrs,
+            }];
+
+            let path = write_batch(events, "0.1.0").unwrap();
+            assert!(path.exists());
+            assert!(path.extension().unwrap() == "json");
+
+            let content = fs::read_to_string(&path).unwrap();
+            let batch: TelemetryBatch = serde_json::from_str(&content).unwrap();
+            assert_eq!(batch.version, "0.1.0");
+            assert_eq!(batch.events.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_write_batch_no_temp_files_left() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let events = vec![TelemetryEvent::Counter {
+                name: "test".to_string(),
+                value: 1,
+                attributes: HashMap::new(),
+            }];
+
+            write_batch(events, "0.1.0").unwrap();
+
+            let pending_dir = super::super::pending_dir();
+            let tmp_files: Vec<_> = fs::read_dir(&pending_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().map_or(false, |ext| ext == "tmp"))
+                .collect();
+
+            assert!(tmp_files.is_empty(), "No .tmp files should remain");
+        });
+    }
+}

--- a/src/telemetry/spool.rs
+++ b/src/telemetry/spool.rs
@@ -50,7 +50,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    use crate::telemetry::event::SerializableValue;
+    use crate::telemetry::otel::SerializableValue;
 
     #[test]
     fn test_write_batch_creates_file() {

--- a/src/telemetry/spool.rs
+++ b/src/telemetry/spool.rs
@@ -7,13 +7,20 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::event::{TelemetryBatch, TelemetryEvent};
 
+/// Maximum number of pending spool files to keep.
+const MAX_PENDING_FILES: usize = 100;
+
 /// Write a batch of events to a spool file.
 ///
 /// Uses atomic write (temp file + rename) for crash safety.
+/// Enforces MAX_PENDING_FILES limit by deleting oldest files.
 /// Returns the path to the written file.
 pub fn write_batch(events: Vec<TelemetryEvent>, version: &str) -> io::Result<PathBuf> {
     let pending_dir = super::pending_dir();
     fs::create_dir_all(&pending_dir)?;
+
+    // Enforce max file count before writing
+    enforce_max_files(&pending_dir, MAX_PENDING_FILES)?;
 
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -43,6 +50,29 @@ pub fn write_batch(events: Vec<TelemetryEvent>, version: &str) -> io::Result<Pat
     fs::rename(&temp_path, &final_path)?;
 
     Ok(final_path)
+}
+
+/// Enforce maximum file count by deleting oldest files.
+fn enforce_max_files(dir: &PathBuf, max_files: usize) -> io::Result<()> {
+    let mut entries: Vec<_> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |ext| ext == "json"))
+        .collect();
+
+    if entries.len() < max_files {
+        return Ok(());
+    }
+
+    // Sort by filename (which is nanosecond timestamp) - oldest first
+    entries.sort_by_key(|e| e.file_name());
+
+    // Delete oldest files to make room
+    let to_delete = entries.len() - max_files + 1; // +1 for the new file we're about to write
+    for entry in entries.into_iter().take(to_delete) {
+        let _ = fs::remove_file(entry.path());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -100,5 +130,54 @@ mod tests {
 
             assert!(tmp_files.is_empty(), "No .tmp files should remain");
         });
+    }
+
+    #[test]
+    fn test_enforce_max_files_deletes_oldest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Create 5 files with sequential names
+        for i in 0..5 {
+            let path = pending_dir.join(format!("{}.json", i));
+            fs::write(&path, "{}").unwrap();
+        }
+
+        // Enforce max of 3 files (need room for 1 new file, so keep 2)
+        enforce_max_files(&pending_dir, 3).unwrap();
+
+        let remaining: Vec<_> = fs::read_dir(&pending_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+
+        // Should have deleted 3 oldest (0, 1, 2), keeping 2 (3, 4)
+        assert_eq!(remaining.len(), 2);
+        assert!(pending_dir.join("3.json").exists());
+        assert!(pending_dir.join("4.json").exists());
+    }
+
+    #[test]
+    fn test_enforce_max_files_no_op_when_under_limit() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Create 2 files
+        for i in 0..2 {
+            let path = pending_dir.join(format!("{}.json", i));
+            fs::write(&path, "{}").unwrap();
+        }
+
+        // Enforce max of 5 files - should do nothing
+        enforce_max_files(&pending_dir, 5).unwrap();
+
+        let remaining: Vec<_> = fs::read_dir(&pending_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+
+        assert_eq!(remaining.len(), 2);
     }
 }

--- a/src/telemetry/submit.rs
+++ b/src/telemetry/submit.rs
@@ -4,9 +4,8 @@ use std::fs;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
-
 use super::event::{TelemetryBatch, TelemetryEvent};
+use super::otel;
 
 /// Submit all pending telemetry batches.
 ///
@@ -18,7 +17,7 @@ pub fn submit_pending() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    crate::config::setup_telemetry();
+    otel::setup();
 
     let entries: Vec<_> = fs::read_dir(&pending_dir)?
         .filter_map(|e| e.ok())
@@ -42,7 +41,7 @@ pub fn submit_pending() -> Result<(), Box<dyn std::error::Error>> {
 
     cleanup_old_files(&pending_dir, 7)?;
 
-    shutdown_telemetry();
+    otel::shutdown();
 
     Ok(())
 }
@@ -52,22 +51,20 @@ fn submit_batch_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let batch: TelemetryBatch = serde_json::from_str(&content)?;
 
     for event in batch.events {
-        let attrs = match &event {
-            TelemetryEvent::Counter { attributes, .. } => attributes,
-            TelemetryEvent::Histogram { attributes, .. } => attributes,
-        };
-
-        let otel_attrs: std::collections::HashMap<String, opentelemetry::Value> = attrs
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone().into()))
-            .collect();
-
         match event {
-            TelemetryEvent::Counter { name, value, .. } => {
-                increment_counter(&name, value, otel_attrs);
+            TelemetryEvent::Counter {
+                name,
+                value,
+                attributes,
+            } => {
+                otel::submit_counter(&name, value, attributes);
             }
-            TelemetryEvent::Histogram { name, value, .. } => {
-                record_histogram(&name, value, otel_attrs);
+            TelemetryEvent::Histogram {
+                name,
+                value,
+                attributes,
+            } => {
+                otel::submit_histogram(&name, value, attributes);
             }
         }
     }
@@ -101,7 +98,7 @@ mod tests {
     use std::collections::HashMap;
     use std::io::Write;
 
-    use crate::telemetry::event::SerializableValue;
+    use crate::telemetry::otel::SerializableValue;
 
     #[test]
     fn test_cleanup_old_files_keeps_recent() {

--- a/src/telemetry/submit.rs
+++ b/src/telemetry/submit.rs
@@ -2,15 +2,42 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, SystemTime};
 
 use super::event::{TelemetryBatch, TelemetryEvent};
 use super::otel;
 
-/// Submit all pending telemetry batches.
+/// Default timeout for the telemetry submission process (30 seconds).
+const SUBMIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Submit all pending telemetry batches with a timeout.
 ///
 /// Called by the detached telemetry-submit subprocess.
+/// Returns an error if submission takes longer than SUBMIT_TIMEOUT.
 pub fn submit_pending() -> Result<(), Box<dyn std::error::Error>> {
+    let (tx, rx) = mpsc::channel::<Result<(), String>>();
+
+    thread::spawn(move || {
+        let result = submit_pending_inner().map_err(|e| e.to_string());
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(SUBMIT_TIMEOUT) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e.into()),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            Err("Telemetry submission timed out".into())
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("Telemetry submission thread panicked".into())
+        }
+    }
+}
+
+/// Inner submission logic without timeout.
+fn submit_pending_inner() -> Result<(), Box<dyn std::error::Error>> {
     let pending_dir = super::pending_dir();
 
     if !pending_dir.exists() {

--- a/src/telemetry/submit.rs
+++ b/src/telemetry/submit.rs
@@ -171,4 +171,85 @@ mod tests {
         let parsed: TelemetryBatch = serde_json::from_str(&content).unwrap();
         assert_eq!(parsed.events.len(), 1);
     }
+
+    #[test]
+    fn test_submit_pending_inner_no_pending_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            // pending dir doesn't exist - should return Ok
+            let result = submit_pending_inner();
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_submit_pending_inner_empty_pending_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            // pending dir exists but is empty - should return Ok
+            let result = submit_pending_inner();
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_submit_pending_inner_skips_non_json_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Create a non-json file
+        fs::write(pending_dir.join("test.txt"), "not json").unwrap();
+        // Create a tmp file (in-progress write)
+        fs::write(pending_dir.join("123.tmp"), "{}").unwrap();
+
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            let result = submit_pending_inner();
+            assert!(result.is_ok());
+
+            // Files should still exist (not processed)
+            assert!(pending_dir.join("test.txt").exists());
+            assert!(pending_dir.join("123.tmp").exists());
+        });
+    }
+
+    #[test]
+    fn test_submit_pending_inner_handles_invalid_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_dir = temp_dir.path().join("telemetry").join("pending");
+        fs::create_dir_all(&pending_dir).unwrap();
+
+        // Create an invalid json file
+        fs::write(pending_dir.join("123.json"), "not valid json").unwrap();
+
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            // Should not panic, just log warning and continue
+            let result = submit_pending_inner();
+            assert!(result.is_ok());
+
+            // Invalid file should still exist (not deleted on parse failure)
+            assert!(pending_dir.join("123.json").exists());
+        });
+    }
+
+    #[test]
+    fn test_cleanup_old_files_empty_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        // Should handle empty directory without error
+        let result = cleanup_old_files(temp_dir.path(), 7);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_submit_pending_timeout_returns_result() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("ANA_HOME", Some(temp_dir.path()), || {
+            // With no pending dir, should complete quickly and return Ok
+            let result = submit_pending();
+            assert!(result.is_ok());
+        });
+    }
 }

--- a/src/telemetry/submit.rs
+++ b/src/telemetry/submit.rs
@@ -1,0 +1,150 @@
+//! Submit pending telemetry batches to the metrics endpoint.
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use anaconda_otel_rs::signals::{increment_counter, record_histogram, shutdown_telemetry};
+
+use super::event::{TelemetryBatch, TelemetryEvent};
+
+/// Submit all pending telemetry batches.
+///
+/// Called by the detached telemetry-submit subprocess.
+pub fn submit_pending() -> Result<(), Box<dyn std::error::Error>> {
+    let pending_dir = super::pending_dir();
+
+    if !pending_dir.exists() {
+        return Ok(());
+    }
+
+    crate::config::setup_telemetry();
+
+    let entries: Vec<_> = fs::read_dir(&pending_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |ext| ext == "json"))
+        .collect();
+
+    for entry in entries {
+        let path = entry.path();
+
+        match submit_batch_file(&path) {
+            Ok(()) => {
+                if let Err(e) = fs::remove_file(&path) {
+                    tracing::warn!("Failed to delete spool file {:?}: {}", path, e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to submit telemetry batch {:?}: {}", path, e);
+            }
+        }
+    }
+
+    cleanup_old_files(&pending_dir, 7)?;
+
+    shutdown_telemetry();
+
+    Ok(())
+}
+
+fn submit_batch_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(path)?;
+    let batch: TelemetryBatch = serde_json::from_str(&content)?;
+
+    for event in batch.events {
+        let attrs = match &event {
+            TelemetryEvent::Counter { attributes, .. } => attributes,
+            TelemetryEvent::Histogram { attributes, .. } => attributes,
+        };
+
+        let otel_attrs: std::collections::HashMap<String, opentelemetry::Value> = attrs
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone().into()))
+            .collect();
+
+        match event {
+            TelemetryEvent::Counter { name, value, .. } => {
+                increment_counter(&name, value, otel_attrs);
+            }
+            TelemetryEvent::Histogram { name, value, .. } => {
+                record_histogram(&name, value, otel_attrs);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cleanup_old_files(dir: &Path, max_age_days: i64) -> Result<(), std::io::Error> {
+    let max_age = Duration::from_secs((max_age_days * 24 * 60 * 60) as u64);
+    let now = SystemTime::now();
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+
+        if let Ok(modified) = metadata.modified() {
+            if let Ok(age) = now.duration_since(modified) {
+                if age > max_age {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::Write;
+
+    use crate::telemetry::event::SerializableValue;
+
+    #[test]
+    fn test_cleanup_old_files_keeps_recent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let new_file = temp_dir.path().join("new.json");
+
+        fs::write(&new_file, "{}").unwrap();
+
+        cleanup_old_files(temp_dir.path(), 7).unwrap();
+
+        assert!(new_file.exists(), "Recent file should remain");
+    }
+
+    #[test]
+    fn test_submit_batch_file_parses_correctly() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let batch_file = temp_dir.path().join("batch.json");
+
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "command".to_string(),
+            SerializableValue::String("test".to_string()),
+        );
+
+        let batch = TelemetryBatch {
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            version: "0.1.0".to_string(),
+            events: vec![TelemetryEvent::Counter {
+                name: "test_counter".to_string(),
+                value: 1,
+                attributes: attrs,
+            }],
+        };
+
+        let mut file = fs::File::create(&batch_file).unwrap();
+        file.write_all(serde_json::to_string(&batch).unwrap().as_bytes())
+            .unwrap();
+        drop(file);
+
+        // Note: submit_batch_file calls increment_counter which requires telemetry setup
+        // This test just verifies parsing works
+        let content = fs::read_to_string(&batch_file).unwrap();
+        let parsed: TelemetryBatch = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed.events.len(), 1);
+    }
+}

--- a/src/telemetry/submit.rs
+++ b/src/telemetry/submit.rs
@@ -27,9 +27,7 @@ pub fn submit_pending() -> Result<(), Box<dyn std::error::Error>> {
     match rx.recv_timeout(SUBMIT_TIMEOUT) {
         Ok(Ok(())) => Ok(()),
         Ok(Err(e)) => Err(e.into()),
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            Err("Telemetry submission timed out".into())
-        }
+        Err(mpsc::RecvTimeoutError::Timeout) => Err("Telemetry submission timed out".into()),
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             Err("Telemetry submission thread panicked".into())
         }


### PR DESCRIPTION
## Summary

- Eliminates exit delays caused by synchronous telemetry HTTP flush
- Events are written to `~/.ana/telemetry/pending/*.json` spool files
- A detached subprocess (`ana telemetry-submit`) handles background submission
- CLI exits immediately instead of waiting for network

## Benchmark Results

| Command | Before | After | Speedup |
|---------|--------|-------|---------|
| `ana --help` | 3.0s | 13ms | **227x** |
| `ana --version` | 3.7s | 20ms | **187x** |

## Architecture

```
CLI Command → Execute → Write spool file → Spawn detached process → Exit (~15ms)
                                                   ↓
                                          [Background: Submit → Delete]
```

## Test plan

- [x] All existing tests pass (`cargo test`)
- [ ] Manual test: `time ana --help` completes in <50ms
- [ ] Manual test: `ls ~/.ana/telemetry/pending/` shows spool file created
- [ ] Manual test: `ana telemetry-submit` processes and deletes pending files
- [ ] Test with `ANA_ENABLE_TELEMETRY=false` - no spool file created

## Notes

The telemetry module is isolated for future extraction to `anaconda-otel-rs`.