### PR TITLE
chore: Improve workflow security and efficiency

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -8,12 +8,13 @@ on:
       - opened
       - edited
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # required to create PRs
     steps:
       - name: Apply conventional commit label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -10,8 +10,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
+    name: Add label to PR
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # required to create PRs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure git for private repos
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Configure git for private repos

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   merge_group:
   workflow_call:
     secrets:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Configure git for private repos

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,11 @@ jobs:
           persist-credentials: false
 
       - name: Configure git for private repos
+        env:
+          REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
         run: |
-          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
           mkdir -p ~/.cargo && echo -e '[net]\ngit-fetch-with-cli = true' >> ~/.cargo/config.toml
 
       - name: Set up Rust

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+    permissions:
+      contents: read  # To check out private repository
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,6 @@ jobs:
           git config --global --add url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
           mkdir -p ~/.cargo && echo -e '[net]\ngit-fetch-with-cli = true' >> ~/.cargo/config.toml
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
       - name: Hash SENTRY_DSN for cache key
         id: dsn-hash
         run: echo "hash=$(echo -n "$SENTRY_DSN" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -14,12 +14,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
+permissions:
+  contents: read  # To check out private repository
+
 jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    permissions:
-      contents: read  # To check out private repository
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -15,18 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
 permissions:
-  contents: read  # To check out private repository
+  pull-requests: read  # To access pull requests
 
 jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Validate PR Title
         if: github.event_name != 'merge_group'
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate PR Title
         if: github.event_name != 'merge_group'

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -18,6 +18,8 @@ jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # To check out private repository
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   pre-commit:
-    name: Run pre-commit and push fixes
+    name: pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Configure git for private repos
         env:
-          REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}  # zizmor: ignore[secrets-outside-env]
         run: |
           git config --global url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
@@ -49,7 +49,7 @@ jobs:
         with:
           ana-version: v0.0.9
           tools: pixi
-          github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}  # zizmor: ignore[secrets-outside-env]
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,8 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read  # To check out private repository
+permissions: {}
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -36,9 +36,11 @@ jobs:
           token: ${{ secrets.ANACONDA_BOT_TOKEN }}
 
       - name: Configure git for private repos
+        env:
+          REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
         run: |
-          git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
           mkdir -p ~/.cargo && echo -e '[net]\ngit-fetch-with-cli = true' >> ~/.cargo/config.toml
 
       - name: Set up ana with pixi

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on:
       labels:
         - ubuntu-latest
+    permissions:
+      contents: read  # To check out private repository
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   pre-commit:
+    name: Run pre-commit and push fixes
     runs-on: ubuntu-latest
     permissions:
       contents: read  # To check out private repository
@@ -33,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ secrets.ANACONDA_BOT_TOKEN }}
+          token: ${{ secrets.ANACONDA_BOT_TOKEN }}  # zizmor: ignore[secrets-outside-env]
 
       - name: Configure git for private repos
         env:
@@ -60,7 +61,7 @@ jobs:
         run: |
           pixi run pre-commit || :
           if git status --porcelain | grep -q .; then
-            echo "changed=1" >>$GITHUB_OUTPUT
+            echo "changed=1" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Commit and fail if changes occurred

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -31,8 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.ANACONDA_BOT_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.ANACONDA_BOT_TOKEN }}
 
       - name: Configure git for private repos
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,9 +25,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on:
-      labels:
-        - ubuntu-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read  # To check out private repository
     steps:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,15 +8,6 @@ on:
       - main
   merge_group:
   pull_request:
-    # Default is [opened, reopened, synchronize]. Since we want to run pre-commit on "ready to review",
-    # we add that one. Since lists are overwritten, not merged, we add all four.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-    # for documentation of the default behaviour
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 # Cancel a previous job if the same workflow is triggers on the same PR or commit.
 concurrency:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.ANACONDA_BOT_TOKEN }}  # zizmor: ignore[secrets-outside-env]
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -65,9 +65,11 @@ jobs:
 
       - name: Commit and fail if changes occurred
         if: steps.updates.outputs.changed == 1
+        env:
+          REF: ${{ github.head_ref }}
         run: |
-          git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
-          git checkout ${{ github.head_ref }}
+          git fetch origin "refs/heads/${REF}:refs/remotes/origin/${REF}"
+          git checkout "${REF}"
 
           git config user.name "Anaconda Bot"
           git config user.email "devops+anaconda-bot@anaconda.com"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,12 +23,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # To check out private repository
+
 jobs:
   pre-commit:
     name: Run pre-commit and push fixes
     runs-on: ubuntu-latest
-    permissions:
-      contents: read  # To check out private repository
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,7 @@ jobs:
 
   publish-to-anaconda-dot-org:
     name: Publish to Anaconda.org
+    environment: anaconda-org-upload
     runs-on: ubuntu-latest
     needs: [ci, release-info]
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up ana with pixi
         uses: anaconda/github-actions/setup-ana@fd7a6d41f5b751fe36e01155fd8eee7f1c51e598 # v0.2.0
@@ -85,6 +86,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Download binaries
@@ -168,9 +167,6 @@ jobs:
             gh release delete latest --yes
             git push origin :refs/tags/latest 2>/dev/null || true
           fi
-
-          # Delete local tag if it exists (from fetch-depth: 0)
-          git tag -d latest 2>/dev/null || true
 
           NOTES=$(cat <<EOF
           This release always points to the most recent build.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,14 @@ jobs:
 
       - name: Get release info
         id: info
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           # is_release=true for manual version tags, false for main branch pushes (prereleases)
-          if [[ "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "version=${REF_NAME}" >> "$GITHUB_OUTPUT"
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             VERSION=$(pixi run python scripts/with_version.py)
@@ -113,9 +116,8 @@ jobs:
         if: needs.release-info.outputs.is_release == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.release-info.outputs.version }}
         run: |
-          VERSION="${{ needs.release-info.outputs.version }}"
-
           # Delete existing prerelease if it exists (prereleases are recreated each time)
           if gh release view "$VERSION" &>/dev/null; then
             gh release delete "$VERSION" --yes
@@ -145,9 +147,8 @@ jobs:
         if: needs.release-info.outputs.is_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.release-info.outputs.version }}
         run: |
-          VERSION="${{ needs.release-info.outputs.version }}"
-
           # Check if release exists (draft, prerelease, or published)
           if gh release view "$VERSION" &>/dev/null; then
             echo "Uploading assets to existing release $VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: read
+  contents: read  # To check out private repository
 
 on:
   push:
@@ -12,8 +12,6 @@ on:
 
 jobs:
   ci:
-    permissions:
-      contents: read
     uses: ./.github/workflows/ci.yaml
     secrets:
       PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
@@ -83,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci, release-info]
     permissions:
-      contents: write
+      contents: write  # To create a release
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,10 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
+    hooks:
+      - id: zizmor
   - repo: local
     hooks:
       - id: rustfmt


### PR DESCRIPTION
## Summary

Improve the security and efficiency of our workflows by linting them with [zizmor](https://github.com/zizmorcore/zizmor). I performed the following changes:

* Added the `zizmor` pre-commit hook
* Replaced template expansion with environment variables
* Explicitly set permissions and commented on write permissions for our tokens
* Added concurrency groups
* Created a protected environment for the anaconda.org upload token secret. The remaining secret warnings are ignored because they are org-wide tokens or temporary tokens while the repository is private

Additionally, I changed:

* The fetch depth in all jobs that do not access the tag history.
* Remove the checkout check for linting the PR title since it only requires reading the pull request, not the repository.
* Removed the `ready_for_review` trigger. Marking a pull request as ready for review does not result in any code changes, making a re-run of the build and lint process redundant.