### PR TITLE
chore: Replace release name with ref to distinguish between tag pushes and pushes to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

When merging a PR `main`, two events happen: a push to `main` and a push to a tag. They both have the same hash, so there is a concurrency conflict. Use the `ref` instead to distinguish between tag and branch pushes.

Note: this will only run the latest push to `main`. I think this is okay since we mostly care about the latest one. Since we always push to a tag, we do still have a per-merge resolution if a build fails. If we want every push to `main` to run, we could add the `github.sha` to the concurrency group, but I think that's wasteful.