### PR TITLE
feat: Polish wheels config terminal output

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -272,7 +272,7 @@ async fn login_with_api_key(
             return Ok(());
         }
 
-        if !crate::input::prompt_yes_no("Overwrite existing credentials?") {
+        if !crate::input::prompt_yes_no("Overwrite existing credentials?", false) {
             return Ok(());
         }
     }
@@ -312,7 +312,7 @@ async fn login_device_flow(config: &Config, force: bool) -> Result<(), AuthError
             "Already logged in to {}",
             status::highlight(&config.domain)
         ));
-        if !crate::input::prompt_yes_no("Login again?") {
+        if !crate::input::prompt_yes_no("Login again?", true) {
             // Return early if user declines to log in again
             return Ok(());
         }

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -114,7 +114,7 @@ pub async fn enable_main_x(ctx: &mut CommandContext, force: bool) -> miette::Res
     status::blank_line();
 
     // Step 4: Prompt for confirmation unless --force
-    if !force && !prompt_yes_no("Proceed?") {
+    if !force && !prompt_yes_no("Proceed?", true) {
         eprintln!("Aborted.");
         return Ok(());
     }
@@ -171,7 +171,7 @@ pub async fn disable_main_x(_ctx: &mut CommandContext, force: bool) -> miette::R
     status::blank_line();
 
     // Prompt for confirmation unless --force
-    if !force && !prompt_yes_no("Proceed?") {
+    if !force && !prompt_yes_no("Proceed?", true) {
         eprintln!("Aborted.");
         return Ok(());
     }

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -6,7 +6,7 @@ use crate::auth;
 use crate::config::Config;
 use crate::context::CommandContext;
 use crate::input::prompt_yes_no;
-use crate::tools::utils::{command_exists, find_pip};
+use crate::tools::utils::{command_exists, find_pip, which};
 use crate::ui::status;
 
 /// Represents a tool configuration action to be executed.
@@ -87,10 +87,12 @@ fn discover_tools(enable: bool) -> miette::Result<Vec<ConfigAction>> {
 
     status::info("Detected package managers:");
     if let Some(cmd) = pip_cmd {
-        eprintln!("  {} {} (pip)", status::checkmark(), cmd);
+        let path = which(cmd).unwrap_or_else(|| cmd.to_string());
+        eprintln!("  {} pip ({})", status::checkmark(), status::dim(&path));
     }
     if uv_available {
-        eprintln!("  {} uv", status::checkmark());
+        let path = which("uv").unwrap_or_else(|| "uv".to_string());
+        eprintln!("  {} uv ({})", status::checkmark(), status::dim(&path));
     }
     status::blank_line();
 

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -87,10 +87,10 @@ fn discover_tools(enable: bool) -> miette::Result<Vec<ConfigAction>> {
 
     status::info("Detected package managers:");
     if let Some(cmd) = pip_cmd {
-        eprintln!("  {} {} (pip)", status::highlight("✓"), cmd);
+        eprintln!("  {} {} (pip)", status::checkmark(), cmd);
     }
     if uv_available {
-        eprintln!("  {} uv", status::highlight("✓"));
+        eprintln!("  {} uv", status::checkmark());
     }
     status::blank_line();
 

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -161,7 +161,7 @@ pub async fn enable_wheels(
 
     // Show tip about flags if multiple tools detected and no explicit flags
     if !pip && !uv && actions.len() > 1 {
-        status::info("Tip: Use --pip or --uv to configure only one tool.");
+        status::tip("Use --pip or --uv to configure only one tool.");
         status::blank_line();
     }
 
@@ -274,7 +274,7 @@ pub async fn disable_wheels(
 
     // Show tip about flags if multiple tools detected and no explicit flags
     if !pip && !uv && actions.len() > 1 {
-        status::info("Tip: Use --pip or --uv to deconfigure only one tool.");
+        status::tip("Use --pip or --uv to deconfigure only one tool.");
         status::blank_line();
     }
 

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -203,7 +203,7 @@ pub async fn enable_wheels(
     status::blank_line();
 
     // Step 4: Prompt for confirmation unless --force
-    if !force && !prompt_yes_no("Proceed?") {
+    if !force && !prompt_yes_no("Proceed?", true) {
         eprintln!("Aborted.");
         return Ok(());
     }
@@ -312,7 +312,7 @@ pub async fn disable_wheels(
     status::blank_line();
 
     // Step 3: Prompt for confirmation unless --force
-    if !force && !prompt_yes_no("Proceed?") {
+    if !force && !prompt_yes_no("Proceed?", true) {
         eprintln!("Aborted.");
         return Ok(());
     }

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -73,9 +73,9 @@ fn get_uv_config_path() -> String {
         .unwrap_or_else(|| "~/.config/uv/uv.toml".to_string())
 }
 
-/// Discover available tools and prompt the user for each one.
+/// Discover available tools and return actions for all of them.
 /// Returns the list of actions to perform.
-fn discover_and_prompt_tools(enable: bool, force: bool) -> miette::Result<Vec<ConfigAction>> {
+fn discover_tools(enable: bool) -> miette::Result<Vec<ConfigAction>> {
     let pip_cmd = find_pip();
     let uv_available = command_exists("uv");
 
@@ -97,32 +97,18 @@ fn discover_and_prompt_tools(enable: bool, force: bool) -> miette::Result<Vec<Co
     let mut actions = Vec::new();
 
     if pip_cmd.is_some() {
-        let prompt = if enable {
-            "Configure pip to use Anaconda's wheels index?"
+        if enable {
+            actions.push(ConfigAction::ConfigurePip);
         } else {
-            "Remove pip configuration for Anaconda's wheels index?"
-        };
-        if force || prompt_yes_no(prompt) {
-            if enable {
-                actions.push(ConfigAction::ConfigurePip);
-            } else {
-                actions.push(ConfigAction::DeconfigurePip);
-            }
+            actions.push(ConfigAction::DeconfigurePip);
         }
     }
 
     if uv_available {
-        let prompt = if enable {
-            "Configure uv to use Anaconda's wheels index?"
+        if enable {
+            actions.push(ConfigAction::ConfigureUv);
         } else {
-            "Remove uv configuration for Anaconda's wheels index?"
-        };
-        if force || prompt_yes_no(prompt) {
-            if enable {
-                actions.push(ConfigAction::ConfigureUv);
-            } else {
-                actions.push(ConfigAction::DeconfigureUv);
-            }
+            actions.push(ConfigAction::DeconfigureUv);
         }
     }
 
@@ -164,13 +150,19 @@ pub async fn enable_wheels(
         }
         actions
     } else {
-        // No flags - auto-detect and prompt for each available tool
-        discover_and_prompt_tools(true, force)?
+        // No flags - auto-detect all available tools
+        discover_tools(true)?
     };
 
     if actions.is_empty() {
         status::info("No tools selected for configuration.");
         return Ok(());
+    }
+
+    // Show tip about flags if multiple tools detected and no explicit flags
+    if !pip && !uv && actions.len() > 1 {
+        status::info("Tip: Use --pip or --uv to configure only one tool.");
+        status::blank_line();
     }
 
     // Step 2: Check login status and prompt if needed
@@ -271,13 +263,19 @@ pub async fn disable_wheels(
         }
         actions
     } else {
-        // No flags - auto-detect and prompt for each available tool
-        discover_and_prompt_tools(false, force)?
+        // No flags - auto-detect all available tools
+        discover_tools(false)?
     };
 
     if actions.is_empty() {
         status::info("No tools selected for deconfiguration.");
         return Ok(());
+    }
+
+    // Show tip about flags if multiple tools detected and no explicit flags
+    if !pip && !uv && actions.len() > 1 {
+        status::info("Tip: Use --pip or --uv to deconfigure only one tool.");
+        status::blank_line();
     }
 
     // Step 2: Show planned changes

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -25,34 +25,56 @@ impl ConfigAction {
         }
     }
 
-    fn command_descriptions(&self, config: &Config) -> Vec<String> {
+    fn planned_changes(&self, config: &Config) -> Vec<PlannedChange> {
         match self {
             ConfigAction::ConfigurePip => {
                 let pip_cmd = find_pip().unwrap_or("pip");
-                vec![format!(
+                vec![PlannedChange::Command(format!(
                     "{} config set global.index-url {}",
                     pip_cmd, config.pip_index_url
-                )]
+                ))]
             }
             ConfigAction::DeconfigurePip => {
                 let pip_cmd = find_pip().unwrap_or("pip");
-                vec![format!("{} config unset global.index-url", pip_cmd)]
+                vec![PlannedChange::Command(format!(
+                    "{} config unset global.index-url",
+                    pip_cmd
+                ))]
             }
             ConfigAction::ConfigureUv => {
                 let base_url = get_uv_base_url(&config.pip_index_url);
                 let config_path = get_uv_config_path();
                 vec![
-                    format!("Set default index in {}", config_path),
-                    format!("uv auth login {}", base_url),
+                    PlannedChange::FileChange("Set default index in".to_string(), config_path),
+                    PlannedChange::Command(format!("uv auth login {}", base_url)),
                 ]
             }
             ConfigAction::DeconfigureUv => {
                 let base_url = get_uv_base_url(&config.pip_index_url);
                 let config_path = get_uv_config_path();
                 vec![
-                    format!("Remove default index from {}", config_path),
-                    format!("uv auth logout {}", base_url),
+                    PlannedChange::FileChange("Remove default index from".to_string(), config_path),
+                    PlannedChange::Command(format!("uv auth logout {}", base_url)),
                 ]
+            }
+        }
+    }
+}
+
+/// Represents a planned change to display to the user.
+enum PlannedChange {
+    Command(String),
+    FileChange(String, String),
+}
+
+impl PlannedChange {
+    fn display(&self) -> String {
+        match self {
+            PlannedChange::Command(cmd) => {
+                format!("Run: {}", status::highlight(cmd))
+            }
+            PlannedChange::FileChange(description, path) => {
+                format!("{}: {}", description, status::highlight(path))
             }
         }
     }
@@ -174,8 +196,8 @@ pub async fn enable_wheels(
     status::blank_line();
     status::info("The following changes will be made:");
     for action in &actions {
-        for desc in action.command_descriptions(&ctx.config) {
-            eprintln!("  {}", status::highlight(&desc));
+        for change in action.planned_changes(&ctx.config) {
+            eprintln!("  {}", change.display());
         }
     }
     status::blank_line();
@@ -283,8 +305,8 @@ pub async fn disable_wheels(
     // Step 2: Show planned changes
     status::info("The following changes will be made:");
     for action in &actions {
-        for desc in action.command_descriptions(&ctx.config) {
-            eprintln!("  {}", status::highlight(&desc));
+        for change in action.planned_changes(&ctx.config) {
+            eprintln!("  {}", change.display());
         }
     }
     status::blank_line();

--- a/src/input.rs
+++ b/src/input.rs
@@ -77,22 +77,41 @@ impl KeyListener {
 
 /// Prompt the user for yes/no confirmation.
 ///
-/// Displays `message` followed by `[y/N]` and waits for input.
-/// Returns `true` only if the user enters "y" or "yes" (case-insensitive).
-/// Returns `false` on empty input, "n", "no", or any read error.
+/// Displays `message` followed by `[Y/n]` or `[y/N]` depending on the default.
+/// The default choice is highlighted and used when the user presses Enter.
 ///
 /// This uses line-based input, so Ctrl+C is handled normally by the terminal.
-pub fn prompt_yes_no(message: &str) -> bool {
+pub fn prompt_yes_no(message: &str, default: bool) -> bool {
+    use crate::ui::status;
     use std::io::Write;
-    print!("{} [y/N] ", message);
+
+    let prompt = if default {
+        status::highlight("Y/n")
+    } else {
+        status::highlight("y/N")
+    };
+    print!("{} [{}] ", message, prompt);
     std::io::stdout().flush().unwrap();
 
     let mut input = String::new();
     if std::io::stdin().read_line(&mut input).is_err() {
-        return false;
+        return default;
     }
 
-    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+    parse_yes_no(&input, default)
+}
+
+/// Parse a yes/no response string.
+///
+/// Returns `true` for "y" or "yes" (case-insensitive).
+/// Returns `false` for "n" or "no" (case-insensitive).
+/// Returns the default for empty input or unrecognized values.
+fn parse_yes_no(input: &str, default: bool) -> bool {
+    match input.trim().to_lowercase().as_str() {
+        "y" | "yes" => true,
+        "n" | "no" => false,
+        _ => default,
+    }
 }
 
 /// RAII guard for terminal state restoration.
@@ -144,5 +163,81 @@ struct TerminalGuard;
 impl TerminalGuard {
     fn new() -> Option<Self> {
         Some(Self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod parse_yes_no {
+        use super::*;
+
+        #[test]
+        fn yes_inputs_return_true() {
+            assert!(parse_yes_no("y", false));
+            assert!(parse_yes_no("Y", false));
+            assert!(parse_yes_no("yes", false));
+            assert!(parse_yes_no("YES", false));
+            assert!(parse_yes_no("Yes", false));
+            assert!(parse_yes_no("yEs", false));
+        }
+
+        #[test]
+        fn no_inputs_return_false() {
+            assert!(!parse_yes_no("n", true));
+            assert!(!parse_yes_no("N", true));
+            assert!(!parse_yes_no("no", true));
+            assert!(!parse_yes_no("NO", true));
+            assert!(!parse_yes_no("No", true));
+            assert!(!parse_yes_no("nO", true));
+        }
+
+        #[test]
+        fn empty_input_returns_default() {
+            assert!(parse_yes_no("", true));
+            assert!(!parse_yes_no("", false));
+        }
+
+        #[test]
+        fn whitespace_only_returns_default() {
+            assert!(parse_yes_no("   ", true));
+            assert!(!parse_yes_no("   ", false));
+            assert!(parse_yes_no("\t", true));
+            assert!(!parse_yes_no("\t", false));
+            assert!(parse_yes_no("\n", true));
+            assert!(!parse_yes_no("\n", false));
+        }
+
+        #[test]
+        fn input_with_surrounding_whitespace_is_trimmed() {
+            assert!(parse_yes_no("  y  ", false));
+            assert!(parse_yes_no("\ty\n", false));
+            assert!(parse_yes_no("  yes  ", false));
+            assert!(!parse_yes_no("  n  ", true));
+            assert!(!parse_yes_no("\tno\n", true));
+        }
+
+        #[test]
+        fn unrecognized_input_returns_default() {
+            assert!(parse_yes_no("yeah", true));
+            assert!(!parse_yes_no("yeah", false));
+            assert!(parse_yes_no("nope", true));
+            assert!(!parse_yes_no("nope", false));
+            assert!(parse_yes_no("maybe", true));
+            assert!(!parse_yes_no("maybe", false));
+            assert!(parse_yes_no("1", true));
+            assert!(!parse_yes_no("0", false));
+        }
+
+        #[test]
+        fn partial_matches_return_default() {
+            // "ye" is not "yes"
+            assert!(parse_yes_no("ye", true));
+            assert!(!parse_yes_no("ye", false));
+            // "yess" is not "yes"
+            assert!(parse_yes_no("yess", true));
+            assert!(!parse_yes_no("yess", false));
+        }
     }
 }

--- a/src/tools/pixi_config.rs
+++ b/src/tools/pixi_config.rs
@@ -40,7 +40,7 @@ pub fn configure_default_channels(pixi_bin: &Path) -> miette::Result<()> {
         );
         eprintln!();
 
-        if !prompt_yes_no("   Update default channels?") {
+        if !prompt_yes_no("   Update default channels?", true) {
             eprintln!("   Keeping existing channel configuration.");
             return Ok(());
         }

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -52,7 +52,7 @@ pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miet
     eprintln!();
 
     // Prompt for confirmation unless --force was passed
-    if !force && !prompt_yes_no("Proceed with uninstall?") {
+    if !force && !prompt_yes_no("Proceed with uninstall?", false) {
         eprintln!("Aborted.");
         return Ok(());
     }

--- a/src/tools/utils.rs
+++ b/src/tools/utils.rs
@@ -9,6 +9,18 @@ pub fn command_exists(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Find the full path to a command using `which`.
+/// Returns None if the command is not found.
+pub fn which(cmd: &str) -> Option<String> {
+    Command::new("which")
+        .arg(cmd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
 /// Find the pip command (pip or pip3).
 /// Returns the command name if found, None otherwise.
 pub fn find_pip() -> Option<&'static str> {

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -58,6 +58,11 @@ pub fn highlight(text: &str) -> String {
     UiColor::Blue.apply_to(text).to_string()
 }
 
+/// Return a green checkmark.
+pub fn checkmark() -> String {
+    UiColor::Green.apply_to("✓").to_string()
+}
+
 /// Return text styled as dim.
 ///
 /// Use this for secondary information, hints.

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -51,6 +51,13 @@ pub fn waiting(msg: &str) {
     eprintln!("{}", UiColor::Dim.apply_to(msg));
 }
 
+/// Print a tip in dim text.
+///
+/// Example output: `Tip: Use --pip or --uv to configure only one tool.`
+pub fn tip(msg: &str) {
+    eprintln!("{}", UiColor::Dim.apply_to(&format!("Tip: {}", msg)));
+}
+
 /// Return text styled as highlighted (blue).
 ///
 /// Use this for values like usernames, emails, commands.

--- a/src/update.rs
+++ b/src/update.rs
@@ -289,7 +289,7 @@ pub async fn run_update(_ctx: &mut CommandContext, current_version: &str, force:
         UpdateCheck::Available(release) => {
             if !force {
                 let message = format!("Update {} -> {}?", current_version, release.tag_name);
-                if !prompt_yes_no(&message) {
+                if !prompt_yes_no(&message, true) {
                     println!("Update cancelled.");
                     return;
                 }


### PR DESCRIPTION
## Summary

I've made some relatively small stylistic changes to polish the output. This PR targets #145.

After we merge, then assuming we are aligned, the other PR is ready to go!

The primary functional change is we've collapsed confirmation into a single prompt, with a tip instead to show the explicit way:
<img width="800" height="403" alt="image" src="https://github.com/user-attachments/assets/a9a4b0c0-90a6-47b2-ac38-4393ce156986" />
