### PR TITLE
feat: Remove pre-releases and speed up push events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
   workflow_call:
+    inputs:
+      skip-tests:
+        description: Whether to skip tests
+        type: boolean
+        default: false
     secrets:
       PRIVATE_REPO_TOKEN:
         description: Token for accessing private repositories
@@ -80,6 +82,7 @@ jobs:
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e  # v0.9.4
 
       - name: Run unit tests
+        if: ${{ !inputs.skip-tests }}
         env:
           RUST_BACKTRACE: 1
         run: pixi run test-release
@@ -88,6 +91,7 @@ jobs:
         run: pixi run build-release
 
       - name: Run integration tests
+        if: ${{ !inputs.skip-tests }}
         env:
           ANA_SENTRY_ENVIRONMENT: integration-test
           # Disable Sentry for pre-merge builds (PRs, merge queue) to avoid polluting error tracking
@@ -95,7 +99,7 @@ jobs:
         run: pixi run test-integration
 
       - name: Run integration tests (PowerShell)
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ !inputs.skip-tests && runner.os == 'Windows' }}
         env:
           ANA_SENTRY_ENVIRONMENT: integration-test
           # Disable Sentry for pre-merge builds (PRs, merge queue) to avoid polluting error tracking

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,47 +21,11 @@ jobs:
       PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-  # Determine release info early so other jobs can use it
-  release-info:
-    name: Get Release Info
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.info.outputs.version }}
-      is_release: ${{ steps.info.outputs.is_release }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up ana with pixi
-        uses: anaconda/github-actions/setup-ana@fd7a6d41f5b751fe36e01155fd8eee7f1c51e598 # v0.2.0
-        with:
-          ana-version: v0.0.9
-          tools: pixi
-
-      - name: Get release info
-        id: info
-        env:
-          REF_NAME: ${{ github.ref_name }}
-          REF_TYPE: ${{ github.ref_type }}
-        run: |
-          # is_release=true for manual version tags, false for main branch pushes (prereleases)
-          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "version=${REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-            VERSION=$(pixi run python scripts/with_version.py)
-            echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
-
   publish-to-anaconda-dot-org:
     name: Publish to Anaconda.org
     environment: anaconda-org-upload
     runs-on: ubuntu-latest
-    needs: [ci, release-info]
+    needs: [ci]
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -76,15 +40,16 @@ jobs:
           token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
           owner: anaconda-cloud
           packages: packages/*/*.conda
-          labels: ${{ needs.release-info.outputs.is_release == 'true' && 'main' || 'dev' }}
+          labels: ${{ github.event_name == 'release' && 'main' || 'dev' }}
           private: true
           force: true
           verbose: true
 
   create-github-release:
     name: Upload Binaries to GitHub Release
+    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
-    needs: [ci, release-info]
+    needs: [ci]
     permissions:
       contents: write  # To create a release
     steps:
@@ -114,43 +79,10 @@ jobs:
             sha256sum "$file" > "${file}.sha256"
           done
 
-      # For prereleases (main branch pushes): create automatic prerelease
-      - name: Create automatic prerelease
-        if: needs.release-info.outputs.is_release == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.release-info.outputs.version }}
-        run: |
-          # Delete existing prerelease if it exists (prereleases are recreated each time)
-          if gh release view "$VERSION" &>/dev/null; then
-            gh release delete "$VERSION" --yes
-            git push origin ":refs/tags/$VERSION" 2>/dev/null || true
-          fi
-
-          gh release create "$VERSION" \
-            --title "$VERSION" \
-            --prerelease \
-            --generate-notes \
-            release-assets/*
-
-          # Append footer to release notes
-          CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
-          NOTES=$(cat <<EOF
-          ${CURRENT_BODY}
-
-          ---
-          *Automated prerelease from main branch.*
-          EOF
-          )
-
-          gh release edit "$VERSION" --notes "$NOTES"
-
-      # For releases: upload artifacts to existing draft release, publish it, and update latest
       - name: Publish release
-        if: needs.release-info.outputs.is_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.release-info.outputs.version }}
+          VERSION: ${{ github.ref_name }}
         run: |
           # Check if release exists (draft, prerelease, or published)
           if gh release view "$VERSION" &>/dev/null; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+*
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +18,8 @@ concurrency:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml
+    with:
+      skip-tests: ${{ github.event_name == 'push' }}
     secrets:
       PRIVATE_REPO_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
## Summary

Remove creating the pre-release for each merge. Currently, each push to `main` creates a pre-release, even if the changes are not related to the code base. This is unnecessary since artifacts are already available for each push to `main` and makes the releases page difficult to navigate. We could increase the retention time if there are concerns about accessing artifacts for a specific commit. The `conda` packages still exist as a fallback and are just a binary repack.

Additionally, I noticed that the current merging behavior runs through the CI three times:

1. During the merge group build
2. After pushing to `main`
3. When building the pre-release

While removing the pre-releases removes some of that inefficiency, the push event still contains some redundancy. To remove some of it, I decided to skip tests during push events. We still need to run the extra build to upload the `conda` package to the `dev` label because I couldn't find a way to add the upload step to the merge group while keeping the upload environment protected.