### PR TITLE
refac: Centralize `ensure_logged_in` for reusable login prompts

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -429,6 +429,27 @@ async fn login_device_flow(ctx: &CommandContext, force: bool) -> Result<(), Auth
     }
 }
 
+/// Ensure the user is logged in, prompting to login if not.
+///
+/// Returns Ok(()) if logged in (or successfully logged in after prompt).
+/// Returns Err if not logged in and user declines to login.
+pub async fn ensure_logged_in(ctx: &CommandContext) -> Result<(), AuthError> {
+    if get_api_key(&ctx.config)?.is_some() {
+        return Ok(());
+    }
+
+    status::warn(&format!(
+        "Not logged in to {}",
+        status::highlight(&ctx.config.domain)
+    ));
+
+    if !crate::input::prompt_yes_no("Login now?", true) {
+        return Err(AuthError::NotLoggedIn);
+    }
+
+    login_device_flow(ctx, false).await
+}
+
 /// Perform login - either via API key or device authorization flow.
 ///
 /// Arguments:

--- a/src/auth/errors.rs
+++ b/src/auth/errors.rs
@@ -34,7 +34,10 @@ pub enum AuthError {
     InvalidApiKey(String),
 
     #[error("Not logged in")]
-    #[diagnostic(code(ana::auth::not_logged_in), help("Run `ana login` to authenticate"))]
+    #[diagnostic(
+        code(ana::auth::not_logged_in),
+        help("Run `ana login` to authenticate")
+    )]
     NotLoggedIn,
 }
 

--- a/src/auth/errors.rs
+++ b/src/auth/errors.rs
@@ -1,29 +1,41 @@
 //! Authentication error types.
 
+use miette::Diagnostic;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum AuthError {
     #[error("HTTP request failed: {0}")]
+    #[diagnostic(code(ana::auth::request))]
     Request(#[from] reqwest::Error),
 
     #[error("HTTP middleware error: {0}")]
+    #[diagnostic(code(ana::auth::middleware))]
     Middleware(String),
 
     #[error("Authorization failed: {0}")]
+    #[diagnostic(code(ana::auth::authorization))]
     Authorization(String),
 
     #[error("Authorization timed out")]
+    #[diagnostic(code(ana::auth::timeout))]
     Timeout,
 
     #[error("Missing endpoint in OpenID configuration: {0}")]
+    #[diagnostic(code(ana::auth::missing_endpoint))]
     MissingEndpoint(String),
 
     #[error("Keyring error: {0}")]
+    #[diagnostic(code(ana::auth::keyring))]
     Keyring(String),
 
     #[error("Invalid API key: {0}")]
+    #[diagnostic(code(ana::auth::invalid_api_key))]
     InvalidApiKey(String),
+
+    #[error("Not logged in")]
+    #[diagnostic(code(ana::auth::not_logged_in), help("Run `ana login` to authenticate"))]
+    NotLoggedIn,
 }
 
 impl From<reqwest_middleware::Error> for AuthError {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -6,5 +6,5 @@ pub mod errors;
 mod keyring;
 mod responses;
 
-pub use actions::{login, logout, show_api_key, whoami};
+pub use actions::{ensure_logged_in, login, logout, show_api_key, whoami};
 pub use keyring::get_api_key;

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -188,7 +188,6 @@ pub async fn disable_main_x(_ctx: &CommandContext, force: bool) -> miette::Resul
     Ok(())
 }
 
-
 /// Run a conda config command.
 fn run_conda_config(conda_bin: &Path, args: &[&str]) -> miette::Result<()> {
     let status = Command::new(conda_bin)

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -90,7 +90,7 @@ pub async fn enable_main_x(ctx: &CommandContext, force: bool) -> miette::Result<
     status::blank_line();
 
     // Step 1: Check login status and prompt if needed
-    ensure_logged_in(ctx).await?;
+    auth::ensure_logged_in(ctx).await.into_diagnostic()?;
 
     // Step 2: Determine what changes need to be made
     let conda_bin = find_conda()?;
@@ -188,26 +188,6 @@ pub async fn disable_main_x(_ctx: &CommandContext, force: bool) -> miette::Resul
     Ok(())
 }
 
-/// Ensure the user is logged in, prompting them to login if not.
-async fn ensure_logged_in(ctx: &CommandContext) -> miette::Result<()> {
-    status::waiting("Checking authentication status...");
-
-    // Try to get API key to check if logged in
-    match auth::get_api_key(&ctx.config) {
-        Ok(Some(_)) => {
-            status::success("Already logged in");
-            Ok(())
-        }
-        Ok(None) | Err(_) => {
-            status::info("Not logged in. Starting login flow...");
-            status::blank_line();
-            auth::login(ctx, None, false, false)
-                .await
-                .map_err(|e| miette::miette!("Login failed: {}", e))?;
-            Ok(())
-        }
-    }
-}
 
 /// Run a conda config command.
 fn run_conda_config(conda_bin: &Path, args: &[&str]) -> miette::Result<()> {

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -356,4 +356,3 @@ pub async fn disable_wheels(
 
     Ok(())
 }
-

--- a/src/feature/wheels.rs
+++ b/src/feature/wheels.rs
@@ -2,6 +2,8 @@
 //!
 //! Configures pip and/or uv to use Anaconda's wheels index.
 
+use miette::IntoDiagnostic;
+
 use crate::auth;
 use crate::config::Config;
 use crate::context::CommandContext;
@@ -190,7 +192,7 @@ pub async fn enable_wheels(
     }
 
     // Step 2: Check login status and prompt if needed
-    ensure_logged_in(ctx).await?;
+    auth::ensure_logged_in(ctx).await.into_diagnostic()?;
 
     // Step 3: Show planned changes
     status::blank_line();
@@ -355,23 +357,3 @@ pub async fn disable_wheels(
     Ok(())
 }
 
-/// Ensure the user is logged in, prompting them to login if not.
-async fn ensure_logged_in(ctx: &mut CommandContext) -> miette::Result<()> {
-    status::waiting("Checking authentication status...");
-
-    let config = Config::load();
-    match auth::get_api_key(&config) {
-        Ok(Some(_)) => {
-            status::success("Already logged in");
-            Ok(())
-        }
-        Ok(None) | Err(_) => {
-            status::info("Not logged in. Starting login flow...");
-            status::blank_line();
-            auth::login(ctx, None, false, false)
-                .await
-                .map_err(|e| miette::miette!("Login failed: {}", e))?;
-            Ok(())
-        }
-    }
-}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -11,9 +11,7 @@ pub async fn api_fetch(
     data: Option<&str>,
     json: Option<&str>,
 ) -> miette::Result<()> {
-    if auth::get_api_key(&ctx.config).into_diagnostic()?.is_none() {
-        return Err(miette!("Not logged in. Run `ana login` first."));
-    }
+    auth::ensure_logged_in(ctx).await.into_diagnostic()?;
 
     let method_upper = method.to_uppercase();
     let mut request = match method_upper.as_str() {

--- a/src/tools/pip.rs
+++ b/src/tools/pip.rs
@@ -16,7 +16,7 @@ pub fn configure(config: &Config) -> miette::Result<()> {
 
     let api_key = auth::get_api_key(config)
         .into_diagnostic()?
-        .ok_or_else(|| miette!("Login required to configure pip. Run `ana login` first."))?;
+        .ok_or_else(|| miette!("Not logged in"))?;
 
     configure_pip(pip_cmd, config, &api_key)?;
 

--- a/src/tools/uv.rs
+++ b/src/tools/uv.rs
@@ -117,7 +117,7 @@ fn deconfigure_global_index() -> miette::Result<()> {
 pub fn configure(config: &Config) -> miette::Result<()> {
     let api_key = auth::get_api_key(config)
         .into_diagnostic()?
-        .ok_or_else(|| miette!("Login required to configure uv. Run `ana login` first."))?;
+        .ok_or_else(|| miette!("Not logged in"))?;
 
     // Step 1: Configure global index in uv.toml
     configure_global_index(&config.pip_index_url)?;


### PR DESCRIPTION
## Summary
- Add `auth::ensure_logged_in(ctx)` function that checks login status and prompts users to login via device flow if not authenticated
- Replace duplicate `ensure_logged_in` implementations in `wheels.rs` and `main_x.rs`
- Update `fetch.rs` to use the new centralized function
- Add `NotLoggedIn` error variant with miette diagnostic to `AuthError`

## Test plan
- [ ] Run `ana fetch GET /api/account` while logged out - should prompt to login
- [ ] Run `ana feature enable wheels` while logged out - should prompt to login
- [ ] Run `ana feature enable main-x` while logged out - should prompt to login
- [ ] Decline login prompt - should show helpful error message
- [ ] Accept login prompt - should complete device flow and continue with command

🤖 Generated with [Claude Code](https://claude.com/claude-code)