### PR TITLE
fix: Handle broken pipe gracefully when output is piped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,26 @@ Available types:
 - `build` - Build system changes
 - `ci` - CI/CD changes
 
+### PR descriptions
+Follow this format for PR descriptions:
+
+```markdown
+## Summary
+<Brief description of changes - can be bullet points or paragraphs>
+
+## Test plan
+- [ ] <Checklist of manual testing steps>
+- [ ] <Include specific commands to run>
+
+Jira: [CLI-XXX](https://anaconda.atlassian.net/browse/CLI-XXX)
+```
+
+Notes:
+- The `## Summary` section is required
+- Include `## Test plan` with checkboxes for manual testing when applicable
+- If there's a linked Jira ticket, add it at the bottom with the format `Jira: [CLI-XXX](url)`
+- Omit the Jira line if there's no associated ticket
+
 ## Release Process
 
 When creating a new release:

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,23 @@ pub const VERSION: &str = env!("PKG_VERSION");
 #[cfg(feature = "feedback")]
 pub const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
 
+/// Reset SIGPIPE to default behavior so the process terminates cleanly when
+/// output is piped to commands like `head` or `grep -q`. Rust ignores SIGPIPE
+/// by default, which causes panics on broken pipe errors.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 #[tokio::main]
 async fn main() {
+    reset_sigpipe();
+
     let config = config::Config::load();
     let _diagnostics_guard = diagnostics::init(&config);
     cli::execute().await;


### PR DESCRIPTION
## Summary

Reset SIGPIPE to default behavior on Unix so the process terminates cleanly when output is piped to commands like `head` or `grep -q`.

Rust ignores SIGPIPE by default, which caused panics with "Broken pipe (os error 32)" when the receiving end of a pipe closed early.

## Test plan

- [ ] Run `ana tool list | head -1` - should exit cleanly with code 0
- [ ] Run `ana --help | head -1` - should exit cleanly with code 0
- [ ] Run `ana tool list | grep pixi` - should work without panic

Jira: [CLI-527](https://anaconda.atlassian.net/browse/CLI-527)

[CLI-527]: https://anaconda.atlassian.net/browse/CLI-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ