### PR TITLE
fix: Detect deleted accounts in whoami and clear credentials

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -589,6 +589,26 @@ pub async fn whoami(ctx: &CommandContext, json: bool) -> Result<(), AuthError> {
 
     let data: serde_json::Value = response.json().await?;
 
+    // Check if account has been deleted/anonymized
+    // Deleted accounts have email set to "{random}@anonym.ized"
+    let profile = data.get("passport").and_then(|p| p.get("profile"));
+    let is_anonymized = profile
+        .and_then(|p| p.get("email"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|email| email.ends_with("@anonym.ized"));
+
+    if is_anonymized {
+        // Clear stored credentials for the deleted account
+        delete_api_key(&ctx.config)?;
+
+        status::error("Your account has been deleted.");
+        status::info(&format!(
+            "Run {} to authenticate with a different account.",
+            status::highlight("ana login")
+        ));
+        return Ok(());
+    }
+
     // JSON output mode
     if json {
         let pretty = serde_json::to_string_pretty(&data).unwrap_or_default();
@@ -597,9 +617,6 @@ pub async fn whoami(ctx: &CommandContext, json: bool) -> Result<(), AuthError> {
     }
 
     // Styled output mode
-    // Data is nested under passport.profile for user info
-    let profile = data.get("passport").and_then(|p| p.get("profile"));
-
     // Account section
     eprintln!("{}", status::section("account"));
 


### PR DESCRIPTION
## Summary

When an account is deleted via the UI, the backend soft-deletes by anonymizing the user data, setting the email to `{random}@anonym.ized`. This PR detects this pattern in `ana whoami`, clears the stored credentials, and shows a helpful message prompting the user to log in with a different account.

Before this fix, `ana whoami` would show the anonymized details (`anonymized anonymized` / `f09ef256ec0c4d76@anonym.ized`), and `ana login` would say "Already logged in" with a stale token.

## Test plan

- [ ] Delete an account via the UI
- [ ] Run `ana whoami` - should show "Your account has been deleted" and prompt to login
- [ ] Verify credentials are cleared (subsequent `ana whoami` shows "not logged in")
- [ ] Run `ana login` - should start fresh device flow

Jira: [CLI-534](https://anaconda.atlassian.net/browse/CLI-534)

[CLI-534]: https://anaconda.atlassian.net/browse/CLI-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ