### PR TITLE
fix: Validate API key against server before storing

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -180,30 +180,34 @@ fn prompt_api_key_hidden() -> Result<String, AuthError> {
 
 /// Validate an API key by making a request to the account endpoint.
 /// Returns the user's email if valid, or an error if invalid.
-async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> Result<String, AuthError> {
+async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> miette::Result<String> {
     let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
 
     let response = client
         .get("/api/account")
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
-        .await?;
+        .await
+        .map_err(|e| miette::miette!("Failed to validate API key: {}", e))?;
 
     if !response.status().is_success() {
-        return Err(AuthError::InvalidApiKey(format!(
+        return Err(miette::miette!(
             "API key rejected by server ({})",
             response.status()
-        )));
+        ));
     }
 
-    let account: AccountResponse = response.json().await?;
+    let account: AccountResponse = response
+        .json()
+        .await
+        .map_err(|e| miette::miette!("Failed to parse account response: {}", e))?;
 
     let email = account
         .user
         .as_ref()
         .and_then(|u| u.email.clone())
         .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
-        .ok_or_else(|| AuthError::InvalidApiKey("API key is not associated with a user".into()))?;
+        .ok_or_else(|| miette::miette!("API key is not associated with a user"))?;
 
     Ok(email)
 }
@@ -245,7 +249,9 @@ async fn login_with_api_key(
     }
 
     // Validate the API key against the server before saving
-    let email = validate_api_key(ctx, &api_key).await?;
+    let email = validate_api_key(ctx, &api_key)
+        .await
+        .map_err(|e| AuthError::InvalidApiKey(e.to_string()))?;
 
     // Save to keyring
     save_api_key(&ctx.config, &api_key)?;

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -182,10 +182,9 @@ fn prompt_api_key_hidden() -> Result<String, AuthError> {
 /// Returns the user's email if valid, or an error if invalid.
 async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> Result<String, AuthError> {
     let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
-    let url = format!("{}/api/account", ctx.config.base_url());
 
     let response = client
-        .get(&url)
+        .get("/api/account")
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
         .await?;
@@ -301,7 +300,7 @@ async fn login_device_flow(ctx: &CommandContext, force: bool) -> Result<(), Auth
 
     // Fetch OpenID configuration
     let openid_config: OpenIdConfig = client
-        .get(ctx.config.well_known_url())
+        .get(&ctx.config.well_known_url())
         .send()
         .await?
         .json()
@@ -440,7 +439,7 @@ async fn login_device_flow(ctx: &CommandContext, force: bool) -> Result<(), Auth
             status::success("Authentication complete");
 
             // Create API key
-            let api_key = create_api_key(&client, &ctx.config, &token.access_token).await?;
+            let api_key = create_api_key(client, &token.access_token).await?;
 
             return save_and_display_login(ctx, &api_key).await;
         }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -178,13 +178,44 @@ fn prompt_api_key_hidden() -> Result<String, AuthError> {
     Ok(api_key.trim().to_string())
 }
 
+/// Validate an API key by making a request to the account endpoint.
+/// Returns the user's email if valid, or an error if invalid.
+async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> Result<String, AuthError> {
+    let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
+    let url = format!("{}/api/account", ctx.config.base_url());
+
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(AuthError::InvalidApiKey(format!(
+            "API key rejected by server ({})",
+            response.status()
+        )));
+    }
+
+    let account: AccountResponse = response.json().await?;
+
+    let email = account
+        .user
+        .as_ref()
+        .and_then(|u| u.email.clone())
+        .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
+        .ok_or_else(|| AuthError::InvalidApiKey("API key is not associated with a user".into()))?;
+
+    Ok(email)
+}
+
 /// Login with a provided API key (bypassing device flow).
 async fn login_with_api_key(
     ctx: &CommandContext,
     api_key: String,
     force: bool,
 ) -> Result<(), AuthError> {
-    use super::api_keys::is_valid_api_key;
+    use super::api_keys::{get_expiration, is_valid_api_key};
 
     // Validate the API key format
     if !is_valid_api_key(&api_key) {
@@ -214,7 +245,20 @@ async fn login_with_api_key(
         }
     }
 
-    save_and_display_login(ctx, &api_key).await
+    // Validate the API key against the server before saving
+    let email = validate_api_key(ctx, &api_key).await?;
+
+    // Save to keyring
+    save_api_key(&ctx.config, &api_key)?;
+    status::success("API key stored in keyring");
+
+    // Display login success
+    print_logged_in_status(&email);
+    if let Some(expires_at) = get_expiration(&api_key) {
+        print_token_expiration(&expires_at);
+    }
+
+    Ok(())
 }
 
 /// Try to read API key from stdin if data is available.

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -100,46 +100,29 @@ fn print_token_expiration(expires_at: &str) {
     }
 }
 
-/// Save API key and display login success information.
+/// Validate, save API key, and display login success information.
 ///
 /// This is the common "finalize login" logic shared by both device flow and direct API key login.
+/// Validates the key against the server before saving to catch invalid or cross-environment tokens.
 async fn save_and_display_login(ctx: &CommandContext, api_key: &str) -> Result<(), AuthError> {
     use super::api_keys::get_expiration;
+
+    // Validate the API key against the server before saving
+    let email = validate_api_key(ctx, api_key)
+        .await
+        .map_err(|e| AuthError::InvalidApiKey(e.to_string()))?;
 
     // Save to keyring
     save_api_key(&ctx.config, api_key)?;
     status::success("API key stored in keyring");
 
-    // Fetch and display user info (ctx.client() will pick up the newly saved key via middleware)
-    if let Ok(login_info) = fetch_login_info(ctx).await {
-        print_logged_in_status(&login_info.email);
-        if let Some(expires_at) = get_expiration(api_key) {
-            print_token_expiration(&expires_at);
-        }
+    // Display login success
+    print_logged_in_status(&email);
+    if let Some(expires_at) = get_expiration(api_key) {
+        print_token_expiration(&expires_at);
     }
 
     Ok(())
-}
-
-/// Combined login information for display.
-struct LoginInfo {
-    email: String,
-}
-
-/// Fetch login info for display after login.
-async fn fetch_login_info(ctx: &CommandContext) -> Result<LoginInfo, AuthError> {
-    // Auth middleware will add the API key from keyring automatically
-    let account_response = ctx.client().get("/api/account").send().await?;
-    let account: AccountResponse = account_response.json().await?;
-
-    let email = account
-        .user
-        .as_ref()
-        .and_then(|u| u.email.clone())
-        .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
-        .unwrap_or_else(|| "unknown".to_string());
-
-    Ok(LoginInfo { email })
 }
 
 /// Check if stdin is a pipe (non-TTY).
@@ -218,7 +201,7 @@ async fn login_with_api_key(
     api_key: String,
     force: bool,
 ) -> Result<(), AuthError> {
-    use super::api_keys::{get_expiration, is_valid_api_key};
+    use super::api_keys::is_valid_api_key;
 
     // Validate the API key format
     if !is_valid_api_key(&api_key) {
@@ -248,22 +231,7 @@ async fn login_with_api_key(
         }
     }
 
-    // Validate the API key against the server before saving
-    let email = validate_api_key(ctx, &api_key)
-        .await
-        .map_err(|e| AuthError::InvalidApiKey(e.to_string()))?;
-
-    // Save to keyring
-    save_api_key(&ctx.config, &api_key)?;
-    status::success("API key stored in keyring");
-
-    // Display login success
-    print_logged_in_status(&email);
-    if let Some(expires_at) = get_expiration(&api_key) {
-        print_token_expiration(&expires_at);
-    }
-
-    Ok(())
+    save_and_display_login(ctx, &api_key).await
 }
 
 /// Try to read API key from stdin if data is available.

--- a/src/auth/api_keys.rs
+++ b/src/auth/api_keys.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::errors::AuthError;
 use crate::VERSION;
-use crate::config::Config;
+use crate::http::Client;
 
 /// Request body for creating an API key.
 #[derive(Debug, Serialize)]
@@ -60,12 +60,7 @@ pub fn is_valid_api_key(api_key: &str) -> bool {
 }
 
 /// Create a new API key using the access token.
-pub async fn create_api_key(
-    client: &reqwest_middleware::ClientWithMiddleware,
-    config: &Config,
-    access_token: &str,
-) -> Result<String, AuthError> {
-    let url = format!("{}/api/auth/api-keys", config.base_url());
+pub async fn create_api_key(client: &Client, access_token: &str) -> Result<String, AuthError> {
     let payload = CreateApiKeyRequest {
         scopes: vec![
             "cloud:read".to_string(),
@@ -76,7 +71,7 @@ pub async fn create_api_key(
     };
 
     let response = client
-        .post(&url)
+        .post("/api/auth/api-keys")
         .bearer_auth(access_token)
         .json(&payload)
         .send()

--- a/src/context.rs
+++ b/src/context.rs
@@ -100,7 +100,7 @@ pub struct CommandContext {
     /// Download client (lazy initialized).
     download_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Unauthenticated client (lazy initialized).
-    unauthenticated_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
+    unauthenticated_client: OnceLock<Client>,
 }
 
 impl CommandContext {
@@ -153,13 +153,13 @@ impl CommandContext {
 
     /// Get or create an unauthenticated client with a timeout.
     /// Used for login flows where the user isn't authenticated yet.
-    pub fn unauthenticated_client(
-        &self,
-        timeout: Duration,
-    ) -> &reqwest_middleware::ClientWithMiddleware {
+    pub fn unauthenticated_client(&self, timeout: Duration) -> &Client {
         self.unauthenticated_client.get_or_init(|| {
-            http::build_client(reqwest::Client::builder().timeout(timeout))
-                .expect("failed to create unauthenticated client")
+            Client::new(
+                reqwest::Client::builder().timeout(timeout),
+                self.config.base_url(),
+            )
+            .expect("failed to create unauthenticated client")
         })
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -125,7 +125,6 @@ impl Client {
     }
 
     /// POST request.
-    #[allow(dead_code)]
     pub fn post(&self, url: &str) -> reqwest_middleware::RequestBuilder {
         self.inner.post(self.resolve_url(url))
     }

--- a/src/outerbounds/configure.rs
+++ b/src/outerbounds/configure.rs
@@ -32,7 +32,7 @@ async fn get_jwt_via_device_flow(ctx: &CommandContext) -> miette::Result<String>
 
     // Fetch OpenID configuration
     let openid_config: OpenIdConfig = client
-        .get(ctx.config.well_known_url())
+        .get(&ctx.config.well_known_url())
         .send()
         .await
         .map_err(|e| miette!("Failed to fetch OpenID config: {}", e))?


### PR DESCRIPTION
## Summary

When using `ana login --api-key`, validate the key by making a request to `/api/account` before saving it to the keyring. This prevents storing invalid or cross-environment tokens that would later show "Logged in as unknown".

Before this fix, any valid JWT format would be accepted and stored, even if it was from a different environment or otherwise invalid for the target server.

## Test plan

- [ ] Run `ana login --api-key` with a valid API key - should succeed and show user email
- [ ] Run `ana login --api-key` with an invalid JWT - should show "API key rejected by server (4xx)"
- [ ] Run `ana login --api-key` with a key from a different environment - should show rejection error
- [ ] Pipe an invalid key: `echo "invalid.jwt.token" | ana login --force` - should show rejection error

Jira: [CLI-549](https://anaconda.atlassian.net/browse/CLI-549)

[CLI-549]: https://anaconda.atlassian.net/browse/CLI-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ