### PR TITLE
fix: Normalize ANA_DOMAIN by stripping scheme and path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -223,12 +223,17 @@ fn default_keyring_path() -> PathBuf {
 /// e.g., "https://stage.anaconda.com/app" -> "stage.anaconda.com"
 fn normalize_domain(domain: &str) -> String {
     let domain = domain.trim();
-    // Strip scheme
-    let domain = domain
-        .strip_prefix("https://")
-        .or_else(|| domain.strip_prefix("http://"))
-        .unwrap_or(domain);
-    // Strip path (everything after first /)
+
+    // If it looks like a URL (has scheme), parse it properly
+    if domain.starts_with("http://") || domain.starts_with("https://") {
+        if let Ok(url) = url::Url::parse(domain) {
+            if let Some(host) = url.host_str() {
+                return host.to_string();
+            }
+        }
+    }
+
+    // Otherwise treat as bare domain - strip any path component
     domain.split('/').next().unwrap_or(domain).to_string()
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,9 @@ impl Default for Config {
 impl Config {
     /// Load configuration from environment variables.
     pub fn load() -> Self {
-        let domain = env::var("ANA_DOMAIN").unwrap_or_else(|_| DEFAULT_DOMAIN.to_string());
+        let domain = normalize_domain(
+            &env::var("ANA_DOMAIN").unwrap_or_else(|_| DEFAULT_DOMAIN.to_string()),
+        );
         let client_id =
             env::var("ANA_AUTH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
         let ssl_verify = parse_bool_env("ANA_SSL_VERIFY", DEFAULT_SSL_VERIFY);
@@ -215,6 +217,19 @@ impl Config {
 /// Get the default keyring path
 fn default_keyring_path() -> PathBuf {
     crate::paths::home_dir().join(".anaconda").join("keyring")
+}
+
+/// Normalize a domain by stripping scheme (http://, https://) and path components.
+/// e.g., "https://stage.anaconda.com/app" -> "stage.anaconda.com"
+fn normalize_domain(domain: &str) -> String {
+    let domain = domain.trim();
+    // Strip scheme
+    let domain = domain
+        .strip_prefix("https://")
+        .or_else(|| domain.strip_prefix("http://"))
+        .unwrap_or(domain);
+    // Strip path (everything after first /)
+    domain.split('/').next().unwrap_or(domain).to_string()
 }
 
 /// Parse a boolean from a string value.
@@ -509,6 +524,63 @@ mod tests {
         temp_env::with_var("ANA_SELF_UPDATE_URL", Some("GitHub"), || {
             let config = Config::load();
             assert_eq!(config.self_update_url, None);
+        });
+    }
+
+    #[test]
+    fn test_normalize_domain_plain() {
+        assert_eq!(normalize_domain("anaconda.com"), "anaconda.com");
+    }
+
+    #[test]
+    fn test_normalize_domain_strips_https() {
+        assert_eq!(normalize_domain("https://anaconda.com"), "anaconda.com");
+    }
+
+    #[test]
+    fn test_normalize_domain_strips_http() {
+        assert_eq!(normalize_domain("http://anaconda.com"), "anaconda.com");
+    }
+
+    #[test]
+    fn test_normalize_domain_strips_path() {
+        assert_eq!(normalize_domain("anaconda.com/app"), "anaconda.com");
+    }
+
+    #[test]
+    fn test_normalize_domain_strips_scheme_and_path() {
+        assert_eq!(
+            normalize_domain("https://stage.anaconda.com/app"),
+            "stage.anaconda.com"
+        );
+    }
+
+    #[test]
+    fn test_normalize_domain_strips_deep_path() {
+        assert_eq!(
+            normalize_domain("https://example.com/foo/bar/baz"),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn test_normalize_domain_trims_whitespace() {
+        assert_eq!(normalize_domain("  anaconda.com  "), "anaconda.com");
+    }
+
+    #[test]
+    fn test_config_load_domain_strips_path() {
+        temp_env::with_var("ANA_DOMAIN", Some("stage.anaconda.com/app"), || {
+            let config = Config::load();
+            assert_eq!(config.domain, "stage.anaconda.com");
+        });
+    }
+
+    #[test]
+    fn test_config_load_domain_strips_scheme() {
+        temp_env::with_var("ANA_DOMAIN", Some("https://stage.anaconda.com"), || {
+            let config = Config::load();
+            assert_eq!(config.domain, "stage.anaconda.com");
         });
     }
 }


### PR DESCRIPTION
## Summary
- Adds `normalize_domain()` function that strips URL scheme (http://, https://) and path components from `ANA_DOMAIN`
- Fixes cryptic HTTP errors when users accidentally include paths like `/app` in the domain value
- e.g., `ANA_DOMAIN=https://stage.anaconda.com/app` now correctly becomes `stage.anaconda.com`

## Test plan
- [x] Added unit tests for `normalize_domain()` function covering all cases
- [x] Added integration tests for `Config::load()` to verify domain normalization
- [ ] Manual test: `ANA_DOMAIN=stage.anaconda.com/app ana login` should work

Jira: [CLI-389](https://anaconda.atlassian.net/browse/CLI-389)

[CLI-389]: https://anaconda.atlassian.net/browse/CLI-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ