### PR TITLE
fix: Remove build-release dependency from conda package task

### DIFF
--- a/.github/actions/sign-notarize-macos/action.yaml
+++ b/.github/actions/sign-notarize-macos/action.yaml
@@ -92,8 +92,8 @@ runs:
 
         # import certificate to keychain
         APPLICATION_CERTIFICATE_PATH="${RUNNER_TEMP}/application_certificate.p12"
-        echo -n "${APPLICATION_CERTIFICATE_BASE64}" | \
-          base64 --d -o "${APPLICATION_CERTIFICATE_PATH}"
+        echo "${APPLICATION_CERTIFICATE_BASE64}" | \
+          base64 -d -o "${APPLICATION_CERTIFICATE_PATH}"
 
         security import "${APPLICATION_CERTIFICATE_PATH}" \
           -P "${APPLICATION_CERTIFICATE_PASSWORD}" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up ana with pixi
         uses: anaconda/github-actions/setup-ana@3d7b08cd24c1c5fc8a92a20caa9564bda187d7c1 # v0.2.1
         with:
-          ana-version: v0.2.0
+          ana-version: v0.1.2
           tools: pixi
           github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up ana with pixi
         uses: anaconda/github-actions/setup-ana@3d7b08cd24c1c5fc8a92a20caa9564bda187d7c1 # v0.2.1
         with:
-          ana-version: v0.2.0
+          ana-version: v0.1.2
           tools: pixi
           github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}  # zizmor: ignore[secrets-outside-env]
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,4 +92,4 @@ jobs:
           gh release upload "$VERSION" "${GITHUB_WORKSPACE}/scripts/install.ps1"
 
           echo "Publishing release $VERSION"
-          gh release edit "$VERSION" --draft=false
+          gh release edit "$VERSION" --draft=false --latest

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,7 +29,6 @@ description = "Run pre-commit hooks on all files"
 
 [tasks.build-conda]
 cmd = "python scripts/with_version.py rattler-build build --recipe conda.recipe"
-depends-on = ["build-release"]
 description = "Build the conda package"
 
 [tasks.build-debug]

--- a/scripts/create_self_signed_certificate_macos.sh
+++ b/scripts/create_self_signed_certificate_macos.sh
@@ -25,7 +25,7 @@ openssl genrsa -out "${keyfile}" 2048
 openssl req -x509 -new -key "${keyfile}"\
     -out "${crtfile}"\
     -sha256\
-    -days 1\
+    -days 36500\
     -subj "/C=XX/ST=State/L=City/O=Company/OU=Org/CN=${commonname}/emailAddress=somebody@somewhere.com"\
     -addext "basicConstraints=critical,CA:FALSE"\
     -addext "extendedKeyUsage=critical,${keyusage}"\


### PR DESCRIPTION
## Summary

Remove the `build-release` prerequisite from the `build-conda` task. The macOS binaries that were uploaded to [v0.3.0](https://github.com/anaconda/ana-cli/releases/tag/v0.3.0) are not signed and notarized despite passing all integration tests. This is because before uploaded, the `conda` package build task recompiled `ana` and overwrites the signed binary. For local testing, that binary will have to be compiled now before running the task.

I also found that the release was not set as `latest` automatically, probably because prior releases had been manually set, so I re-added that flag to the `gh` call.
