### PR TITLE
feat: Replace feedback form with GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+      placeholder: Tell us what happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `ana ...`
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Ana version
+      description: Output of `ana --version`
+      placeholder: ana 0.1.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, logs, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? Why would it be useful?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, mockups, or examples.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,29 @@
+name: Question
+description: Ask a question about ana
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? We're happy to help!
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any relevant context about what you're trying to accomplish.
+
+  - type: input
+    id: version
+    attributes:
+      label: Ana version (if relevant)
+      description: Output of `ana --version`
+      placeholder: ana 0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "urlencoding",
  "webbrowser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ libc = "0.2"
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 default = ["feedback"]
 diagnostics = ["dep:sentry"]
-feedback = ["dep:urlencoding"]
+feedback = []
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }
@@ -44,7 +44,6 @@ toml_edit = "0.25"
 anaconda-otel-rs = { git = "https://github.com/anaconda/anaconda-otel-rs" }
 thiserror = "2"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "time", "fs", "sync"] }
-urlencoding = { version = "2", optional = true }
 webbrowser = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ libc = "0.2"
 
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
-default = ["feedback"]
+default = []
 diagnostics = ["dep:sentry"]
-feedback = []
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:bd8df030-0734-4c60-b85d-b31fa9780fb4",
+  "serialNumber": "urn:uuid:29165ed4-8da7-4057-9ac0-5a710cc284d0",
   "metadata": {
-    "timestamp": "2026-05-11T17:20:34Z",
+    "timestamp": "2026-05-11T17:51:18Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -1257,6 +1257,32 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
+      "name": "bs58",
+      "version": "0.5.1",
+      "description": "Another Base58 codec implementation.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bs58@0.5.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Nullus157/bs58-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
       "author": "Nick Fitzgerald <fitzgen@gmail.com>",
       "name": "bumpalo",
@@ -1411,16 +1437,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.2.61",
+      "version": "1.2.62",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+          "content": "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
         }
       ],
       "licenses": [
@@ -1428,7 +1454,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.2.61",
+      "purl": "pkg:cargo/cc@1.2.62",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2870,16 +2896,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "filetime",
-      "version": "0.2.27",
+      "version": "0.2.28",
       "description": "Platform-agnostic accessors of timestamps in File metadata ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+          "content": "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
         }
       ],
       "licenses": [
@@ -2887,7 +2913,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/filetime@0.2.27",
+      "purl": "pkg:cargo/filetime@0.2.28",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3910,16 +3936,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
-      "author": "Amanieu d'Antras <amanieu@gmail.com>",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
       "name": "hashbrown",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "description": "A Rust port of Google's SwissTable hash map",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+          "content": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
         }
       ],
       "licenses": [
@@ -3927,7 +3952,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/hashbrown@0.17.0",
+      "purl": "pkg:cargo/hashbrown@0.17.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -8251,16 +8276,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
       "author": "Luca Palmieri <lpalmieri@truelayer.com>",
       "name": "retry-policies",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "description": "A collection of plug-and-play retry policies for Rust projects.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+          "content": "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
         }
       ],
       "licenses": [
@@ -8268,7 +8293,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/retry-policies@0.5.1",
+      "purl": "pkg:cargo/retry-policies@0.5.2",
       "externalReferences": [
         {
           "type": "vcs",
@@ -8837,16 +8862,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-actix",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration for actix-web 4. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "168d0312e1b1741d8295a16c7b2c62c10c76302f7476a1749d6ccc14cb40663a"
+          "content": "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
         }
       ],
       "licenses": [
@@ -8854,7 +8879,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-actix@0.48.1",
+      "purl": "pkg:cargo/sentry-actix@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -8868,16 +8893,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-backtrace",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration and utilities for dealing with stacktraces. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "dc84c325ace9ca2388e510fe7d6672b5d60cd8b3bd0eb4bb4ee8314c323cd686"
+          "content": "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
         }
       ],
       "licenses": [
@@ -8885,7 +8910,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-backtrace@0.48.1",
+      "purl": "pkg:cargo/sentry-backtrace@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -8899,16 +8924,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-contexts",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration for os, device, and rust contexts. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "896c1ab62dbfe1746fb262bbf72e6feb2fb9dfb2c14709077bf71beb532e44b2"
+          "content": "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
         }
       ],
       "licenses": [
@@ -8916,7 +8941,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-contexts@0.48.1",
+      "purl": "pkg:cargo/sentry-contexts@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -8930,16 +8955,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-core",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Core Sentry library used for instrumentation and integration development. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
+          "content": "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
         }
       ],
       "licenses": [
@@ -8947,7 +8972,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-core@0.48.1",
+      "purl": "pkg:cargo/sentry-core@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -8961,16 +8986,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-debug-images",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration that adds the list of loaded libraries to events. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4b88bbe6a760d5724bb40689827e82e8db1e275947df2c59abe171bfc30bb671"
+          "content": "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
         }
       ],
       "licenses": [
@@ -8978,7 +9003,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-debug-images@0.48.1",
+      "purl": "pkg:cargo/sentry-debug-images@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -8992,16 +9017,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-panic",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration for capturing panics. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0260dcb52562b6a79ae7702312a26dba94b79fb5baee7301087529e5ca4e872e"
+          "content": "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
         }
       ],
       "licenses": [
@@ -9009,7 +9034,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-panic@0.48.1",
+      "purl": "pkg:cargo/sentry-panic@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -9023,16 +9048,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-tracing",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry integration for the tracing and tracing-subscriber crates. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a1c035f3a0a8671ae1a231c5b457abb68b71acba2bf3054dab2a09a9d4ea487e"
+          "content": "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
         }
       ],
       "licenses": [
@@ -9040,7 +9065,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-tracing@0.48.1",
+      "purl": "pkg:cargo/sentry-tracing@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -9054,16 +9079,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry-types",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Common reusable types for implementing the sentry.io protocol. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
+          "content": "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
         }
       ],
       "licenses": [
@@ -9071,7 +9096,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry-types@0.48.1",
+      "purl": "pkg:cargo/sentry-types@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -9085,16 +9110,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
       "author": "Sentry <hello@sentry.io>",
       "name": "sentry",
-      "version": "0.48.1",
+      "version": "0.48.2",
       "description": "Sentry (sentry.io) client for Rust. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
+          "content": "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
         }
       ],
       "licenses": [
@@ -9102,7 +9127,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/sentry@0.48.1",
+      "purl": "pkg:cargo/sentry@0.48.2",
       "externalReferences": [
         {
           "type": "website",
@@ -9433,16 +9458,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
       "author": "Jonas Bushart, Marcin Ka\u017amierczak",
       "name": "serde_with",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "description": "Custom de/serialization functions for Rust's serde",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+          "content": "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
         }
       ],
       "licenses": [
@@ -9450,7 +9475,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with@3.19.0",
+      "purl": "pkg:cargo/serde_with@3.20.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9464,16 +9489,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
       "author": "Jonas Bushart",
       "name": "serde_with_macros",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "description": "proc-macro library for serde_with",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+          "content": "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
         }
       ],
       "licenses": [
@@ -9481,7 +9506,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with_macros@3.19.0",
+      "purl": "pkg:cargo/serde_with_macros@3.20.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -13337,15 +13362,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
       "name": "quick-xml",
-      "version": "0.39.3",
+      "version": "0.39.4",
       "description": "High performance xml reader and writer",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+          "content": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
         }
       ],
       "licenses": [
@@ -13353,7 +13378,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/quick-xml@0.39.3",
+      "purl": "pkg:cargo/quick-xml@0.39.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -14758,7 +14783,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
@@ -14987,7 +15012,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
@@ -15124,6 +15149,12 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
       "dependsOn": []
     },
@@ -15153,7 +15184,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
@@ -15399,7 +15430,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15485,7 +15516,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -15498,7 +15529,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
@@ -15715,7 +15746,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
       "dependsOn": []
     },
     {
@@ -15821,7 +15852,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -15949,7 +15980,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -16190,7 +16221,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -16234,7 +16265,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.115",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
@@ -16554,7 +16585,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
@@ -16646,7 +16677,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
@@ -16668,7 +16699,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
@@ -16691,7 +16722,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -16747,7 +16778,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
-        "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -16981,15 +17012,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
@@ -17115,70 +17146,70 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
@@ -17192,19 +17223,19 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0"
       ]
@@ -17283,9 +17314,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
@@ -17294,12 +17326,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -17476,7 +17508,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
@@ -17488,14 +17520,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -18128,7 +18160,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },
@@ -18154,13 +18186,13 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
       ]
@@ -18203,7 +18235,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:4f5cac72-b070-4349-8343-fbe926d3c734",
+  "serialNumber": "urn:uuid:bd8df030-0734-4c60-b85d-b31fa9780fb4",
   "metadata": {
-    "timestamp": "2026-05-11T16:12:41Z",
+    "timestamp": "2026-05-11T17:20:34Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -44,6 +44,238 @@
       "version": "0.1.0",
       "scope": "required",
       "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40316fa5c05768a6d16da3b215fb50cd44835d7a69"
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-codec",
+      "version": "0.5.2",
+      "description": "Codec utilities for working with framed protocols",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-codec@0.5.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-http",
+      "version": "3.12.1",
+      "description": "HTTP types and services for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-http@3.12.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-router",
+      "version": "0.5.4",
+      "description": "Resource path matching and router",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-router@0.5.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-rt",
+      "version": "2.11.0",
+      "description": "Tokio-based single-threaded async runtime for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-rt@2.11.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>",
+      "name": "actix-server",
+      "version": "2.6.0",
+      "description": "General purpose TCP server built for the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-server@2.6.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net/tree/master/actix-server"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-service",
+      "version": "2.0.3",
+      "description": "Service trait and combinators for representing asynchronous request/response operations.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-service@2.0.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-utils",
+      "version": "3.0.1",
+      "description": "Various utilities used in the Actix ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-utils@3.0.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "actix-web",
+      "version": "4.13.0",
+      "description": "Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/actix-web@4.13.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-web"
+        }
+      ]
     },
     {
       "type": "library",
@@ -765,6 +997,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
+      "author": "RustCrypto Developers",
+      "name": "base64ct",
+      "version": "1.8.3",
+      "description": "Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of data-dependent branches/LUTs and thereby provides portable \"best effort\" constant-time operation and embedded-friendly no_std support ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/base64ct@1.8.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/base64ct"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/base64ct"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
       "author": "Ben Steadman <steadmanben1@gmail.com>",
       "name": "bisection",
@@ -990,32 +1257,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
-      "name": "bs58",
-      "version": "0.5.1",
-      "description": "Another Base58 codec implementation.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/bs58@0.5.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/Nullus157/bs58-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
       "author": "Nick Fitzgerald <fitzgen@gmail.com>",
       "name": "bumpalo",
@@ -1069,6 +1310,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/tokio-rs/bytes"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "bytestring",
+      "version": "1.5.1",
+      "description": "A UTF-8 encoded read-only string using `Bytes` as storage",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bytestring@1.5.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://actix.rs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
         }
       ]
     },
@@ -1139,16 +1411,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.2.62",
+      "version": "1.2.61",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+          "content": "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
         }
       ],
       "licenses": [
@@ -1156,7 +1428,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.2.62",
+      "purl": "pkg:cargo/cc@1.2.61",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1231,12 +1503,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/katharostech/cfg_aliases"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "linux,macos"
         }
       ]
     },
@@ -1596,6 +1862,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/console-rs/console"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "author": "rutrum <dave@rutrum.net>",
+      "name": "convert_case",
+      "version": "0.10.0",
+      "description": "Convert strings into any case",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/convert_case@0.10.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rutrum/convert-case"
         }
       ]
     },
@@ -1968,6 +2261,72 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "debugid",
+      "version": "0.8.0",
+      "description": "Common reusable types for implementing the sentry.io protocol.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/debugid@0.8.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/debugid"
+        },
+        {
+          "type": "website",
+          "url": "https://sentry.io/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/rust-debugid"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+      "author": "RustCrypto Developers",
+      "name": "der",
+      "version": "0.8.0",
+      "description": "Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with full support for heapless `no_std`/`no_alloc` targets ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/der@0.8.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/der"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "author": "Jacob Pratt <jacob@jhpratt.dev>",
       "name": "deranged",
@@ -1990,6 +2349,68 @@
         {
           "type": "vcs",
           "url": "https://github.com/jhpratt/deranged"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more-impl",
+      "version": "2.1.1",
+      "description": "Internal implementation of `derive_more` crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more-impl@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more",
+      "version": "2.1.1",
+      "description": "Adds #[derive(x)] macros for more traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
         }
       ]
     },
@@ -2208,6 +2629,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+      "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
+      "name": "encoding_rs",
+      "version": "0.8.35",
+      "description": "A Gecko-oriented implementation of the Encoding Standard",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/encoding_rs@0.8.35",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/encoding_rs/"
+        },
+        {
+          "type": "website",
+          "url": "https://docs.rs/encoding_rs/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hsivonen/encoding_rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "author": "Anton Lazarev <https://antonok.com>",
       "name": "enum_dispatch",
@@ -2414,16 +2870,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "filetime",
-      "version": "0.2.28",
+      "version": "0.2.27",
       "description": "Platform-agnostic accessors of timestamps in File metadata ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+          "content": "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
         }
       ],
       "licenses": [
@@ -2431,7 +2887,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/filetime@0.2.28",
+      "purl": "pkg:cargo/filetime@0.2.27",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2474,6 +2930,36 @@
         {
           "type": "vcs",
           "url": "https://github.com/rust-lang/cc-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+      "name": "findshlibs",
+      "version": "0.10.2",
+      "description": "Find the set of shared libraries loaded in the current process with a cross platform API",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/findshlibs@0.10.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/findshlibs"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/gimli-rs/findshlibs"
         }
       ]
     },
@@ -2571,6 +3057,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-fnv"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+      "author": "Orson Peters <orsonpeters@gmail.com>",
+      "name": "foldhash",
+      "version": "0.1.5",
+      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Zlib"
+        }
+      ],
+      "purl": "pkg:cargo/foldhash@0.1.5",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/orlp/foldhash"
         }
       ]
     },
@@ -3397,15 +3910,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
+      "author": "Amanieu d'Antras <amanieu@gmail.com>",
       "name": "hashbrown",
-      "version": "0.17.1",
+      "version": "0.17.0",
       "description": "A Rust port of Google's SwissTable hash map",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+          "content": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
         }
       ],
       "licenses": [
@@ -3413,7 +3927,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/hashbrown@0.17.1",
+      "purl": "pkg:cargo/hashbrown@0.17.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -3595,6 +4109,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+      "name": "http",
+      "version": "0.2.12",
+      "description": "A set of types for representing HTTP requests and responses. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/http@0.2.12",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/http"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/hyperium/http"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http",
@@ -3652,6 +4197,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/seanmonstar/httparse"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+      "author": "Pyfisch <pyfisch@posteo.org>",
+      "name": "httpdate",
+      "version": "1.0.3",
+      "description": "HTTP date parsing and formatting",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/httpdate@1.0.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pyfisch/httpdate"
         }
       ]
     },
@@ -4173,6 +4745,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+      "author": "Rob Ede <robjtede@icloud.com>",
+      "name": "impl-more",
+      "version": "0.1.9",
+      "description": "Concise, declarative trait implementation macros",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/impl-more@0.1.9",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/robjtede/impl-more"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "name": "indexmap",
       "version": "1.9.3",
@@ -4479,6 +5078,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+      "author": "Pyfisch <pyfisch@gmail.com>, Tpt <thomas@pellissier-tanon.fr>",
+      "name": "language-tags",
+      "version": "0.3.2",
+      "description": "Language tags for Rust",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/language-tags@0.3.2",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pyfisch/rust-language-tags"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "author": "Canop <cano.petrole@gmail.com>",
       "name": "lazy-regex-proc_macros",
@@ -4715,6 +5341,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/LukasKalbertodt/litrs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
+      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
+      "name": "local-waker",
+      "version": "0.1.4",
+      "description": "A synchronization primitive for thread-local task wakeup",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/local-waker@0.1.4",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/actix/actix-net"
         }
       ]
     },
@@ -6014,6 +6667,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+      "author": "RustCrypto Developers",
+      "name": "pem-rfc7468",
+      "version": "1.0.0",
+      "description": "PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a strict subset of the original Privacy-Enhanced Mail encoding intended specifically for use with cryptographic keys, certificates, and other messages. Provides a no_std-friendly, constant-time implementation suitable for use with cryptographic private keys. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/pem-rfc7468@1.0.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/pem-rfc7468"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
         }
       ]
     },
@@ -7373,6 +8057,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+      "name": "regex-lite",
+      "version": "0.1.9",
+      "description": "A lightweight regex engine that optimizes for binary size and compilation time. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/regex-lite@0.1.9",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/regex-lite"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/regex/tree/master/regex-lite"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/regex"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex-syntax",
@@ -7501,16 +8220,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
-      "author": "Luca Palmieri <lpalmieri@truelayer.com>",
-      "name": "retry-policies",
-      "version": "0.5.2",
-      "description": "A collection of plug-and-play retry policies for Rust projects.",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
+      "author": "Sean McArthur <sean@seanmonstar.com>",
+      "name": "reqwest",
+      "version": "0.13.3",
+      "description": "higher level HTTP client library",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+          "content": "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
         }
       ],
       "licenses": [
@@ -7518,7 +8237,38 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/retry-policies@0.5.2",
+      "purl": "pkg:cargo/reqwest@0.13.3",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/reqwest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/seanmonstar/reqwest"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "author": "Luca Palmieri <lpalmieri@truelayer.com>",
+      "name": "retry-policies",
+      "version": "0.5.1",
+      "description": "A collection of plug-and-play retry policies for Rust projects.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/retry-policies@0.5.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -8087,6 +8837,285 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-actix",
+      "version": "0.48.1",
+      "description": "Sentry integration for actix-web 4. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "168d0312e1b1741d8295a16c7b2c62c10c76302f7476a1749d6ccc14cb40663a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-actix@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-backtrace",
+      "version": "0.48.1",
+      "description": "Sentry integration and utilities for dealing with stacktraces. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dc84c325ace9ca2388e510fe7d6672b5d60cd8b3bd0eb4bb4ee8314c323cd686"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-backtrace@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-contexts",
+      "version": "0.48.1",
+      "description": "Sentry integration for os, device, and rust contexts. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "896c1ab62dbfe1746fb262bbf72e6feb2fb9dfb2c14709077bf71beb532e44b2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-contexts@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-core",
+      "version": "0.48.1",
+      "description": "Core Sentry library used for instrumentation and integration development. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-core@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-debug-images",
+      "version": "0.48.1",
+      "description": "Sentry integration that adds the list of loaded libraries to events. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b88bbe6a760d5724bb40689827e82e8db1e275947df2c59abe171bfc30bb671"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-debug-images@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-panic",
+      "version": "0.48.1",
+      "description": "Sentry integration for capturing panics. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0260dcb52562b6a79ae7702312a26dba94b79fb5baee7301087529e5ca4e872e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-panic@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-tracing",
+      "version": "0.48.1",
+      "description": "Sentry integration for the tracing and tracing-subscriber crates. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1c035f3a0a8671ae1a231c5b457abb68b71acba2bf3054dab2a09a9d4ea487e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-tracing@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry-types",
+      "version": "0.48.1",
+      "description": "Common reusable types for implementing the sentry.io protocol. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry-types@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
+      "author": "Sentry <hello@sentry.io>",
+      "name": "sentry",
+      "version": "0.48.1",
+      "description": "Sentry (sentry.io) client for Rust. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/sentry@0.48.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://sentry.io/welcome/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/getsentry/sentry-rust"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "serde-untagged",
@@ -8404,16 +9433,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
       "author": "Jonas Bushart, Marcin Ka\u017amierczak",
       "name": "serde_with",
-      "version": "3.20.0",
+      "version": "3.19.0",
       "description": "Custom de/serialization functions for Rust's serde",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+          "content": "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
         }
       ],
       "licenses": [
@@ -8421,7 +9450,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with@3.20.0",
+      "purl": "pkg:cargo/serde_with@3.19.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8435,16 +9464,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
       "author": "Jonas Bushart",
       "name": "serde_with_macros",
-      "version": "3.20.0",
+      "version": "3.19.0",
       "description": "proc-macro library for serde_with",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+          "content": "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
         }
       ],
       "licenses": [
@@ -8452,7 +9481,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with_macros@3.20.0",
+      "purl": "pkg:cargo/serde_with_macros@3.19.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8840,6 +9869,41 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-smallvec"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+      "name": "socket2",
+      "version": "0.5.10",
+      "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/socket2@0.5.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/socket2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/socket2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/socket2"
         }
       ]
     },
@@ -10595,6 +11659,47 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
+      "author": "Ignacio Corderi <icorderi@msn.com>",
+      "name": "uname",
+      "version": "0.1.1",
+      "description": "Name and information about current kernel",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/uname@0.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://icorderi.github.io/rust-uname/index.html"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/icorderi/rust-uname"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/icorderi/rust-uname"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
       "name": "unarray",
       "version": "0.1.4",
@@ -10842,6 +11947,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+      "author": "erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+      "name": "unicode-xid",
+      "version": "0.2.6",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-xid@0.2.6",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://unicode-rs.github.io/unicode-xid"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/unicode-rs/unicode-xid"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
       "name": "unit-prefix",
@@ -10958,6 +12098,60 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+      "author": "Martin Algesten <martin@algesten.se>",
+      "name": "ureq-proto",
+      "version": "0.6.0",
+      "description": "ureq support crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ureq-proto@0.6.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/ureq-proto"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
+      "author": "Martin Algesten <martin@algesten.se>, Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>",
+      "name": "ureq",
+      "version": "3.3.0",
+      "description": "Simple, safe HTTP client",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/ureq@3.3.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/ureq"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
       "author": "The rust-url developers",
       "name": "url",
@@ -11015,6 +12209,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/kornelski/rust_urlencoding"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+      "author": "Simon Sapin <simon.sapin@exyr.org>, Martin Algesten <martin@algesten.se>",
+      "name": "utf8-zero",
+      "version": "0.8.1",
+      "description": "Zero-copy, incremental UTF-8 decoding with error handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/utf8-zero@0.8.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/algesten/utf8-zero"
         }
       ]
     },
@@ -11342,6 +12563,36 @@
         {
           "type": "vcs",
           "url": "https://github.com/amodm/webbrowser-rs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7",
+      "name": "webpki-root-certs",
+      "version": "1.0.7",
+      "description": "Mozilla trusted certificate authorities in self-signed X.509 format for use with crates other than webpki",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "CDLA-Permissive-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/webpki-root-certs@1.0.7",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/rustls/webpki-roots"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rustls/webpki-roots"
         }
       ]
     },
@@ -12086,15 +13337,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
       "name": "quick-xml",
-      "version": "0.39.4",
+      "version": "0.39.3",
       "description": "High performance xml reader and writer",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+          "content": "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
         }
       ],
       "licenses": [
@@ -12102,7 +13353,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/quick-xml@0.39.4",
+      "purl": "pkg:cargo/quick-xml@0.39.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12405,6 +13656,47 @@
         {
           "type": "vcs",
           "url": "https://github.com/polyfill-rs/once_cell_polyfill"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
+      "author": "Jan Schulte <hello@unexpected-co.de>, Stanislav Tkach <stanislav.tkach@gmail.com>",
+      "name": "os_info",
+      "version": "3.14.0",
+      "description": "Detect the operating system type and version.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/os_info@3.14.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/os_info"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/stanislav-tkach/os_info"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/stanislav-tkach/os_info"
         }
       ],
       "properties": [
@@ -13466,6 +14758,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
@@ -13476,8 +14769,131 @@
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#urlencoding@2.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -13571,7 +14987,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
@@ -13670,6 +15086,10 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
       "dependsOn": []
     },
@@ -13704,18 +15124,18 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.2",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
@@ -13733,7 +15153,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
@@ -13836,6 +15256,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -13923,10 +15349,41 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1"
       ]
     },
     {
@@ -13942,7 +15399,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -13972,6 +15429,12 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
@@ -14022,7 +15485,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -14031,6 +15494,15 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
+        "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
@@ -14048,6 +15520,10 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
       "dependsOn": []
     },
     {
@@ -14239,7 +15715,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
       "dependsOn": []
     },
     {
@@ -14280,6 +15756,14 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -14288,6 +15772,10 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
       "dependsOn": []
     },
     {
@@ -14333,7 +15821,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -14446,6 +15934,10 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
@@ -14457,7 +15949,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -14506,6 +15998,10 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -14544,6 +16040,10 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
       "dependsOn": []
     },
     {
@@ -14638,6 +16138,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -14689,7 +16190,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -14733,7 +16234,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.115",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
@@ -14860,6 +16361,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3"
       ]
     },
     {
@@ -15047,7 +16554,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
@@ -15139,7 +16646,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
@@ -15161,7 +16668,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
@@ -15184,7 +16691,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -15240,7 +16747,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
-        "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
+        "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -15378,6 +16885,10 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "dependsOn": []
     },
@@ -15438,15 +16949,47 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
@@ -15572,6 +17115,101 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
@@ -15645,10 +17283,9 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.19.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
@@ -15657,12 +17294,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.19.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -15745,6 +17382,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
@@ -15832,7 +17476,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.45",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.27",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
@@ -15844,14 +17488,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -16164,6 +17808,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
@@ -16184,6 +17829,12 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
@@ -16220,6 +17871,10 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "dependsOn": []
     },
@@ -16236,6 +17891,29 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+        "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+        "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
@@ -16250,6 +17928,10 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
       "dependsOn": []
     },
@@ -16261,7 +17943,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
     {
@@ -16305,6 +17988,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1"
       ]
     },
     {
@@ -16439,7 +18128,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.61",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },
@@ -16465,13 +18154,13 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0"
       ]
@@ -16514,7 +18203,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -16526,6 +18215,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-11T16:12:41Z<br>
+Generated: 2026-05-11T17:20:34Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 432 (66 platform-specific)<br>
+Packages: 474 (67 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -10,6 +10,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | Package | Version | License | Platforms | CVEs |
 | --- | --- | --- | --- | ---: |
+| [actix-codec](https://crates.io/crates/actix-codec) | 0.5.2 | MIT OR Apache-2.0 |  |  |
+| [actix-http](https://crates.io/crates/actix-http) | 3.12.1 | MIT OR Apache-2.0 |  |  |
+| [actix-router](https://crates.io/crates/actix-router) | 0.5.4 | MIT OR Apache-2.0 |  |  |
+| [actix-rt](https://crates.io/crates/actix-rt) | 2.11.0 | MIT OR Apache-2.0 |  |  |
+| [actix-server](https://crates.io/crates/actix-server) | 2.6.0 | MIT OR Apache-2.0 |  |  |
+| [actix-service](https://crates.io/crates/actix-service) | 2.0.3 | MIT OR Apache-2.0 |  |  |
+| [actix-utils](https://crates.io/crates/actix-utils) | 3.0.1 | MIT OR Apache-2.0 |  |  |
+| [actix-web](https://crates.io/crates/actix-web) | 4.13.0 | MIT OR Apache-2.0 |  |  |
 | [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT | linux, macos |  |
 | [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |  |
 | [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |  |
@@ -36,6 +44,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |  |
 | [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
+| [base64ct](https://crates.io/crates/base64ct) | 1.8.3 | Apache-2.0 OR MIT |  |  |
 | [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
@@ -43,14 +52,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
-| [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
+| [bytestring](https://crates.io/crates/bytestring) | 1.5.1 | MIT OR Apache-2.0 |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.2.62 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.2.61 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
 | [clap](https://crates.io/crates/clap) | 4.6.1 | MIT OR Apache-2.0 |  |  |
@@ -63,6 +72,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.32 | MIT OR Apache-2.0 |  |  |
 | [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
+| [convert\_case](https://crates.io/crates/convert_case) | 0.10.0 | MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
@@ -78,7 +88,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |  |
+| [debugid](https://crates.io/crates/debugid) | 0.8.0 | Apache-2.0 |  |  |
+| [der](https://crates.io/crates/der) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
+| [derive\_more](https://crates.io/crates/derive_more) | 2.1.1 | MIT |  |  |
+| [derive\_more-impl](https://crates.io/crates/derive_more-impl) | 2.1.1 | MIT |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
@@ -87,6 +101,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
 | [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |  |
 | [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
+| [encoding\_rs](https://crates.io/crates/encoding_rs) | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause |  |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
@@ -94,11 +109,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
 | [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.3.0 | BSD-3-Clause |  |  |
-| [filetime](https://crates.io/crates/filetime) | 0.2.28 | MIT OR Apache-2.0 |  |  |
+| [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
+| [findshlibs](https://crates.io/crates/findshlibs) | 0.10.2 | MIT OR Apache-2.0 |  |  |
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
 | [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |  |
 | [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |  |
+| [foldhash](https://crates.io/crates/foldhash) | 0.1.5 | Zlib |  |  |
 | [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |  |
 | [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 | linux |  |
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
@@ -126,15 +143,17 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.17.1 | MIT OR Apache-2.0 |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.17.0 | MIT OR Apache-2.0 |  |  |
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
+| [http](https://crates.io/crates/http) | 0.2.12 | MIT OR Apache-2.0 |  |  |
 | [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |  |
 | [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
 | [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
 | [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
+| [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
 | [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.9 | Apache-2.0 OR ISC OR MIT |  |  |
@@ -151,6 +170,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |  |
 | [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.2 | Apache-2.0 OR MIT |  |  |
+| [impl-more](https://crates.io/crates/impl-more) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 2.14.0 | Apache-2.0 OR MIT |  |  |
 | [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
@@ -162,6 +182,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
+| [language-tags](https://crates.io/crates/language-tags) | 0.3.2 | MIT OR Apache-2.0 |  |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
@@ -170,6 +191,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
+| [local-waker](https://crates.io/crates/local-waker) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |  |
 | [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |  |
 | [mac\_address](https://crates.io/crates/mac_address) | 1.1.8 | MIT OR Apache-2.0 |  |  |
@@ -209,11 +231,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |  |
 | [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |  |
 | [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |  |
+| [os\_info](https://crates.io/crates/os_info) | 3.14.0 | MIT | windows |  |
 | [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |  |
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
 | [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.8 | BSD-3-Clause |  |  |
+| [pem-rfc7468](https://crates.io/crates/pem-rfc7468) | 1.0.0 | Apache-2.0 OR MIT |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |  |
@@ -233,7 +257,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.39.4 | MIT | macos |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.39.3 | MIT | macos |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.9.4 | MIT OR Apache-2.0 |  |  |
@@ -261,10 +285,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
 | [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |  |
 | [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
+| [regex-lite](https://crates.io/crates/regex-lite) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
+| [reqwest](https://crates.io/crates/reqwest) | 0.13.3 | MIT OR Apache-2.0 |  |  |
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
-| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.2 | MIT OR Apache-2.0 |  |  |
+| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
 | [rpassword](https://crates.io/crates/rpassword) | 7.5.2 | Apache-2.0 |  |  |
 | [rtoolbox](https://crates.io/crates/rtoolbox) | 0.0.5 | Apache-2.0 |  |  |
@@ -286,6 +312,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
+| [sentry](https://crates.io/crates/sentry) | 0.48.1 | MIT |  |  |
+| [sentry-actix](https://crates.io/crates/sentry-actix) | 0.48.1 | MIT |  |  |
+| [sentry-backtrace](https://crates.io/crates/sentry-backtrace) | 0.48.1 | MIT |  |  |
+| [sentry-contexts](https://crates.io/crates/sentry-contexts) | 0.48.1 | MIT |  |  |
+| [sentry-core](https://crates.io/crates/sentry-core) | 0.48.1 | MIT |  |  |
+| [sentry-debug-images](https://crates.io/crates/sentry-debug-images) | 0.48.1 | MIT |  |  |
+| [sentry-panic](https://crates.io/crates/sentry-panic) | 0.48.1 | MIT |  |  |
+| [sentry-tracing](https://crates.io/crates/sentry-tracing) | 0.48.1 | MIT |  |  |
+| [sentry-types](https://crates.io/crates/sentry-types) | 0.48.1 | MIT |  |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
 | [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
@@ -296,8 +331,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
 | [serde\_spanned](https://crates.io/crates/serde_spanned) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
-| [serde\_with](https://crates.io/crates/serde_with) | 3.20.0 | MIT OR Apache-2.0 |  |  |
-| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.20.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with](https://crates.io/crates/serde_with) | 3.19.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.19.0 | MIT OR Apache-2.0 |  |  |
 | [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |  |
 | [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
@@ -310,6 +345,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.5.10 | MIT OR Apache-2.0 |  |  |
 | [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
@@ -367,6 +403,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [typenum](https://crates.io/crates/typenum) | 1.20.0 | MIT OR Apache-2.0 |  |  |
+| [uname](https://crates.io/crates/uname) | 0.1.1 | MIT OR Apache-2.0 | linux, macos |  |
 | [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |  |
 | [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |  |
@@ -375,12 +412,16 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |  |
+| [unicode-xid](https://crates.io/crates/unicode-xid) | 0.2.6 | MIT OR Apache-2.0 |  |  |
 | [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |  |
 | [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |  |
 | [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |  |
 | [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |  |
+| [ureq](https://crates.io/crates/ureq) | 3.3.0 | MIT OR Apache-2.0 |  |  |
+| [ureq-proto](https://crates.io/crates/ureq-proto) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |  |
 | [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
+| [utf8-zero](https://crates.io/crates/utf8-zero) | 0.8.1 | MIT OR Apache-2.0 |  |  |
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
 | [uuid](https://crates.io/crates/uuid) | 1.23.1 | Apache-2.0 OR MIT |  |  |
@@ -391,6 +432,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.1 | MIT OR Apache-2.0 |  |  |
+| [webpki-root-certs](https://crates.io/crates/webpki-root-certs) | 1.0.7 | CDLA-Permissive-2.0 |  |  |
 | [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
@@ -447,19 +489,20 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 233 |
-| MIT | 84 |
-| Apache-2.0 OR MIT | 31 |
-| Apache-2.0 | 20 |
+| MIT OR Apache-2.0 | 255 |
+| MIT | 97 |
+| Apache-2.0 OR MIT | 34 |
+| Apache-2.0 | 21 |
 | BSD-3-Clause | 18 |
 | Unicode-3.0 | 18 |
 | ISC | 3 |
+| Zlib | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
 | Unlicense OR MIT | 2 |
-| Zlib | 2 |
+| (Apache-2.0 OR MIT) AND BSD-3-Clause | 1 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |
@@ -467,6 +510,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | Apache-2.0 OR BSL-1.0 | 1 |
 | BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
 | BSL-1.0 | 1 |
+| CDLA-Permissive-2.0 | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
 | MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-11T17:20:34Z<br>
+Generated: 2026-05-11T17:51:18Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 474 (67 platform-specific)<br>
+Packages: 475 (67 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -52,12 +52,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
+| [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
 | [bytestring](https://crates.io/crates/bytestring) | 1.5.1 | MIT OR Apache-2.0 |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.2.61 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.2.62 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
 | [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
@@ -109,7 +110,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
 | [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.3.0 | BSD-3-Clause |  |  |
-| [filetime](https://crates.io/crates/filetime) | 0.2.27 | MIT OR Apache-2.0 |  |  |
+| [filetime](https://crates.io/crates/filetime) | 0.2.28 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [findshlibs](https://crates.io/crates/findshlibs) | 0.10.2 | MIT OR Apache-2.0 |  |  |
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
@@ -143,7 +144,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.16.1 | MIT OR Apache-2.0 |  |  |
-| [hashbrown](https://crates.io/crates/hashbrown) | 0.17.0 | MIT OR Apache-2.0 |  |  |
+| [hashbrown](https://crates.io/crates/hashbrown) | 0.17.1 | MIT OR Apache-2.0 |  |  |
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
@@ -257,7 +258,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.39.3 | MIT | macos |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.39.4 | MIT | macos |  |
 | [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.9.4 | MIT OR Apache-2.0 |  |  |
@@ -290,7 +291,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.13.3 | MIT OR Apache-2.0 |  |  |
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
-| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.1 | MIT OR Apache-2.0 |  |  |
+| [retry-policies](https://crates.io/crates/retry-policies) | 0.5.2 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
 | [rpassword](https://crates.io/crates/rpassword) | 7.5.2 | Apache-2.0 |  |  |
 | [rtoolbox](https://crates.io/crates/rtoolbox) | 0.0.5 | Apache-2.0 |  |  |
@@ -312,15 +313,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
-| [sentry](https://crates.io/crates/sentry) | 0.48.1 | MIT |  |  |
-| [sentry-actix](https://crates.io/crates/sentry-actix) | 0.48.1 | MIT |  |  |
-| [sentry-backtrace](https://crates.io/crates/sentry-backtrace) | 0.48.1 | MIT |  |  |
-| [sentry-contexts](https://crates.io/crates/sentry-contexts) | 0.48.1 | MIT |  |  |
-| [sentry-core](https://crates.io/crates/sentry-core) | 0.48.1 | MIT |  |  |
-| [sentry-debug-images](https://crates.io/crates/sentry-debug-images) | 0.48.1 | MIT |  |  |
-| [sentry-panic](https://crates.io/crates/sentry-panic) | 0.48.1 | MIT |  |  |
-| [sentry-tracing](https://crates.io/crates/sentry-tracing) | 0.48.1 | MIT |  |  |
-| [sentry-types](https://crates.io/crates/sentry-types) | 0.48.1 | MIT |  |  |
+| [sentry](https://crates.io/crates/sentry) | 0.48.2 | MIT |  |  |
+| [sentry-actix](https://crates.io/crates/sentry-actix) | 0.48.2 | MIT |  |  |
+| [sentry-backtrace](https://crates.io/crates/sentry-backtrace) | 0.48.2 | MIT |  |  |
+| [sentry-contexts](https://crates.io/crates/sentry-contexts) | 0.48.2 | MIT |  |  |
+| [sentry-core](https://crates.io/crates/sentry-core) | 0.48.2 | MIT |  |  |
+| [sentry-debug-images](https://crates.io/crates/sentry-debug-images) | 0.48.2 | MIT |  |  |
+| [sentry-panic](https://crates.io/crates/sentry-panic) | 0.48.2 | MIT |  |  |
+| [sentry-tracing](https://crates.io/crates/sentry-tracing) | 0.48.2 | MIT |  |  |
+| [sentry-types](https://crates.io/crates/sentry-types) | 0.48.2 | MIT |  |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
 | [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
@@ -331,8 +332,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
 | [serde\_spanned](https://crates.io/crates/serde_spanned) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
-| [serde\_with](https://crates.io/crates/serde_with) | 3.19.0 | MIT OR Apache-2.0 |  |  |
-| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.19.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with](https://crates.io/crates/serde_with) | 3.20.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.20.0 | MIT OR Apache-2.0 |  |  |
 | [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |  |
 | [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
@@ -489,7 +490,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 255 |
+| MIT OR Apache-2.0 | 256 |
 | MIT | 97 |
 | Apache-2.0 OR MIT | 34 |
 | Apache-2.0 | 21 |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::context::CommandContext;
 use crate::feature;
 #[cfg(feature = "feedback")]
-use crate::feedback::{self, FeedbackType};
+use crate::feedback;
 use crate::fetch::api_fetch;
 use crate::help;
 use crate::mcp::{self, McpAction, McpCommands};
@@ -134,10 +134,7 @@ pub enum Action {
         prefix: Option<String>,
     },
     #[cfg(feature = "feedback")]
-    OpenFeedback {
-        feedback_type: Option<FeedbackType>,
-        description: Option<String>,
-    },
+    OpenFeedback,
     ToolInstall {
         name: String,
     },
@@ -197,7 +194,7 @@ impl Action {
             Action::McpRun { .. } => "mcp",
             Action::UserAgent { .. } => "user-agent",
             #[cfg(feature = "feedback")]
-            Action::OpenFeedback { .. } => "feedback",
+            Action::OpenFeedback => "feedback",
             Action::ToolInstall { .. } => "tool.install",
             Action::ToolUninstall { .. } => "tool.uninstall",
             Action::ToolList => "tool.list",
@@ -327,11 +324,8 @@ impl Action {
                 Ok(())
             }
             #[cfg(feature = "feedback")]
-            Action::OpenFeedback {
-                feedback_type,
-                description,
-            } => {
-                feedback::open_feedback(ctx, feedback_type, description);
+            Action::OpenFeedback => {
+                feedback::open_feedback();
                 Ok(())
             }
             Action::ApiFetch {
@@ -493,14 +487,7 @@ pub fn parse() -> (Action, LogLevel) {
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSubcommandHelp("self".to_string()),
                     #[cfg(feature = "feedback")]
-                    Some(SelfCommands::Feedback {
-                        bug,
-                        feature,
-                        description,
-                    }) => Action::OpenFeedback {
-                        feedback_type: feedback::parse_feedback_type(bug, feature),
-                        description,
-                    },
+                    Some(SelfCommands::Feedback) => Action::OpenFeedback,
                     Some(SelfCommands::Update {
                         version,
                         check,
@@ -891,20 +878,9 @@ enum AuthCommands {
 
 #[derive(Subcommand)]
 enum SelfCommands {
-    /// Open the feedback form
+    /// Open GitHub issues page to report bugs or request features
     #[cfg(feature = "feedback")]
-    Feedback {
-        /// Report a bug
-        #[arg(long, conflicts_with = "feature")]
-        bug: bool,
-
-        /// Request a feature
-        #[arg(long, conflicts_with = "bug")]
-        feature: bool,
-
-        /// Pre-fill the description
-        description: Option<String>,
-    },
+    Feedback,
 
     /// Manage your ana version
     Update {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,6 @@ use crate::auth;
 use crate::config::Config;
 use crate::context::CommandContext;
 use crate::feature;
-#[cfg(feature = "feedback")]
 use crate::feedback;
 use crate::fetch::api_fetch;
 use crate::help;
@@ -133,7 +132,6 @@ pub enum Action {
     UserAgent {
         prefix: Option<String>,
     },
-    #[cfg(feature = "feedback")]
     OpenFeedback,
     ToolInstall {
         name: String,
@@ -193,7 +191,6 @@ impl Action {
             Action::ObAutoConfigure { .. } => "ob.configure.auto",
             Action::McpRun { .. } => "mcp",
             Action::UserAgent { .. } => "user-agent",
-            #[cfg(feature = "feedback")]
             Action::OpenFeedback => "feedback",
             Action::ToolInstall { .. } => "tool.install",
             Action::ToolUninstall { .. } => "tool.uninstall",
@@ -323,7 +320,6 @@ impl Action {
                 println!("{}", crate::ua::user_agent());
                 Ok(())
             }
-            #[cfg(feature = "feedback")]
             Action::OpenFeedback => {
                 feedback::open_feedback();
                 Ok(())
@@ -486,7 +482,6 @@ pub fn parse() -> (Action, LogLevel) {
                 },
                 Some(Commands::Self_ { command }) => match command {
                     None => Action::ShowSubcommandHelp("self".to_string()),
-                    #[cfg(feature = "feedback")]
                     Some(SelfCommands::Feedback) => Action::OpenFeedback,
                     Some(SelfCommands::Update {
                         version,
@@ -879,7 +874,6 @@ enum AuthCommands {
 #[derive(Subcommand)]
 enum SelfCommands {
     /// Open GitHub issues page to report bugs or request features
-    #[cfg(feature = "feedback")]
     Feedback,
 
     /// Manage your ana version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1016,10 +1016,12 @@ mod tests {
     fn test_all_subcommands_in_help_sections() {
         // Commands intentionally hidden from help output
         // "ob" is conditionally hidden based on experimental feature state
+        // "bootstrap" is hidden as it's synonymous to `ana tool install anaconda-cli`
         let hidden_from_help: std::collections::HashSet<_> = [
             "org",
             "config",
             "ob",
+            "bootstrap",
             "telemetry-submit",
             "telemetry-kill",
             "telemetry-status",

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,4 +1,4 @@
-const GITHUB_ISSUES_URL: &str = "https://github.com/anaconda/ana-cli/issues";
+const GITHUB_ISSUES_URL: &str = "https://github.com/anaconda/ana-cli/issues/new/choose";
 
 pub fn open_feedback() {
     println!("Opening GitHub issues: {}", GITHUB_ISSUES_URL);

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,53 +1,8 @@
-use crate::context::CommandContext;
+const GITHUB_ISSUES_URL: &str = "https://github.com/anaconda/ana-cli/issues";
 
-const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
-
-/// Feedback type for the feedback form
-#[derive(Clone, Copy)]
-pub enum FeedbackType {
-    Bug,
-    Feature,
-}
-
-pub fn parse_feedback_type(bug: bool, feature: bool) -> Option<FeedbackType> {
-    if bug {
-        Some(FeedbackType::Bug)
-    } else if feature {
-        Some(FeedbackType::Feature)
-    } else {
-        None
-    }
-}
-
-pub fn open_feedback(
-    _ctx: &mut CommandContext,
-    feedback_type: Option<FeedbackType>,
-    description: Option<String>,
-) {
-    let mut params = vec![("usp", "pp_url".to_string())];
-
-    if let Some(ft) = feedback_type {
-        let type_value = match ft {
-            FeedbackType::Bug => "Bug",
-            FeedbackType::Feature => "Feature / Enhancement request",
-        };
-        params.push(("entry.1875536722", type_value.to_string()));
-    }
-
-    if let Some(desc) = description {
-        params.push(("entry.949440629", desc));
-    }
-
-    let query_string: String = params
-        .iter()
-        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
-        .collect::<Vec<_>>()
-        .join("&");
-
-    let url = format!("{}?{}", FEEDBACK_BASE_URL, query_string);
-
-    println!("Opening feedback form: {}", url);
-    if let Err(e) = webbrowser::open(&url) {
+pub fn open_feedback() {
+    println!("Opening GitHub issues: {}", GITHUB_ISSUES_URL);
+    if let Err(e) = webbrowser::open(GITHUB_ISSUES_URL) {
         eprintln!("Failed to open browser: {}", e);
     }
 }

--- a/src/feedback.rs
+++ b/src/feedback.rs
@@ -1,8 +1,14 @@
+use crate::ui::status;
+
 const GITHUB_ISSUES_URL: &str = "https://github.com/anaconda/ana-cli/issues/new/choose";
 
 pub fn open_feedback() {
-    println!("Opening GitHub issues: {}", GITHUB_ISSUES_URL);
+    eprintln!(
+        "{} {}",
+        status::dim("Opening"),
+        status::highlight(GITHUB_ISSUES_URL)
+    );
     if let Err(e) = webbrowser::open(GITHUB_ISSUES_URL) {
-        eprintln!("Failed to open browser: {}", e);
+        status::error(&format!("Failed to open browser: {}", e));
     }
 }

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -52,6 +52,10 @@ pub(super) fn get_main_examples() -> Vec<HelpExample> {
             command: "ana login".to_string(),
         },
         HelpExample {
+            desc: "Enable access to Anaconda's main-x (beta) channel".to_string(),
+            command: "ana feature enable main-x".to_string(),
+        },
+        HelpExample {
             desc: "Manage your ana version".to_string(),
             command: "ana self update".to_string(),
         },

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -19,10 +19,9 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
         name: "TOOLCHAIN",
         commands: &[
             "tool",
-            "bootstrap",
-            "feature",
-            "api",
-            "ob",
+            // Hiding bootstrap, as it's synonymous to `ana tool install anaconda-cli`
+            // "bootstrap",
+            "feature", "api", "ob",
             // TODO(mattkram): Hiding config from help until we fully implement CRUD
             // "config",
             "self",

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -21,7 +21,7 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
             "tool",
             // Hiding bootstrap, as it's synonymous to `ana tool install anaconda-cli`
             // "bootstrap",
-            "feature", "api", "ob",
+            "feature", "api", "mcp", "ob",
             // TODO(mattkram): Hiding config from help until we fully implement CRUD
             // "config",
             "self",
@@ -36,10 +36,6 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
     HelpSection {
         name: "ACCOUNT",
         commands: &["login", "logout", "whoami", "auth"],
-    },
-    HelpSection {
-        name: "AI",
-        commands: &["mcp"],
     },
 ];
 

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -59,6 +59,10 @@ pub(super) fn get_main_examples() -> Vec<HelpExample> {
             desc: "Manage your ana version".to_string(),
             command: "ana self update".to_string(),
         },
+        HelpExample {
+            desc: "Provide feedback or report a bug".to_string(),
+            command: "ana self feedback".to_string(),
+        },
     ]
 }
 

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -52,10 +52,6 @@ pub(super) fn get_main_examples() -> Vec<HelpExample> {
             command: "ana login".to_string(),
         },
         HelpExample {
-            desc: "Install a tool".to_string(),
-            command: "ana tool install outerbounds".to_string(),
-        },
-        HelpExample {
             desc: "Manage your ana version".to_string(),
             command: "ana self update".to_string(),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ mod context;
 mod diagnostics;
 pub mod errors;
 mod feature;
-#[cfg(feature = "feedback")]
 mod feedback;
 mod fetch;
 mod help;
@@ -25,8 +24,6 @@ mod ui;
 mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
-#[cfg(feature = "feedback")]
-pub const FEEDBACK_BASE_URL: &str = "https://docs.google.com/forms/d/e/1FAIpQLSeGd9p7pQSHvjIc6RNShjTQCGmM-5_3xkPNpNfYk102-HZB8Q/viewform";
 
 /// Reset SIGPIPE to default behavior so the process terminates cleanly when
 /// output is piped to commands like `head` or `grep -q`. Rust ignores SIGPIPE


### PR DESCRIPTION
## Summary
- Replace `ana self feedback` command to open GitHub issues instead of a Google Form
- Add GitHub issue templates for bug reports, feature requests, and questions
- Remove the `feedback` feature flag (now always enabled)
- Remove `urlencoding` dependency (no longer needed)

## Test plan
- [ ] Run `ana self feedback` and verify it opens https://github.com/anaconda/ana-cli/issues/new/choose
- [ ] Verify issue templates appear when creating a new issue on GitHub
- [ ] Run `cargo test` and `cargo clippy`

Jira: [CLI-551](https://anaconda.atlassian.net/browse/CLI-551)

[CLI-551]: https://anaconda.atlassian.net/browse/CLI-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ