### PR TITLE
feat: Sign windows binaries

### DIFF
--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -36,13 +36,11 @@ runs:
         VAULT_MOUNT: ${{ inputs.vault-mount }}
       run: |
         # Validate inputs
-        if ("$env:VAULT_MOUNT" -ne "dev" -and "$env:VAULT_MOUNT" -ne "prod") {
-            Write-Host "::error::Unrecognized vault mount point `$env:VAULT_MOUNT`"
-            exit 1
+        if ($env:VAULT_MOUNT -ne "dev" -and $env:VAULT_MOUNT -ne "prod") {
+            throw "Unrecognized vault mount point: $env:VAULT_MOUNT"
         }
-        if (-not (Test-Path -Path "$env:BINARY_PATH}" -PathType Leaf)) {
-            Write-Host "::error::$env:BINARY_PATH does not exist."
-            exit 1
+        if (-not (Test-Path -Path $env:BINARY_PATH -PathType Leaf)) {
+            throw "$env:BINARY_PATH does not exist."
         }
       shell: pwsh
 

--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -27,11 +27,6 @@ inputs:
     description: URL to the HashiCorp Vault.
     required: true
 
-outputs:
-  fingerprint:
-    description: The fingerprint of the public certificate. Used for testing.
-    value: ${{ steps.certificate.outputs.fingerprint }}
-
 runs:
   using: composite
   steps:
@@ -76,7 +71,6 @@ runs:
         secrets: |
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate certificate_name | certificate-name;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate client_id | client-id ;
-          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate fingerprint | fingerprint ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate subscription_id | subscription-id ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate tenant_id | tenant-id ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate url | url

--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -36,12 +36,12 @@ runs:
         VAULT_MOUNT: ${{ inputs.vault-mount }}
       run: |
         # Validate inputs
-        if ("${env:VAULT_MOUNT}" -ne "dev" -and "${env:VAULT_MOUNT}" -ne "prod") {
-            Write-Host "::error::Unrecognized vault mount point `${env:VAULT_MOUNT}`"
+        if ("$env:VAULT_MOUNT" -ne "dev" -and "$env:VAULT_MOUNT" -ne "prod") {
+            Write-Host "::error::Unrecognized vault mount point `$env:VAULT_MOUNT`"
             exit 1
         }
-        if (-not (Test-Path -Path "${env:BINARY_PATH}" -PathType Leaf)) {
-            Write-Host "::error::${env:BINARY_PATH} does not exist."
+        if (-not (Test-Path -Path "$env:BINARY_PATH}" -PathType Leaf)) {
+            Write-Host "::error::$env:BINARY_PATH does not exist."
             exit 1
         }
       shell: pwsh

--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -87,10 +87,10 @@ runs:
         BINARY_PATH: ${{ inputs.binary-path }}
       run: |
         # Sign binary
-        AzureSignTool sign -v -kvm`
-          -kvu "${env:AZURE_URL}" `
-          -kvc "${env:AZURE_CERTIFICATE_NAME}" `
+        AzureSignTool sign -v -kvm `
+          -kvu "$env:AZURE_URL" `
+          -kvc "$env:AZURE_CERTIFICATE_NAME" `
           -tr 'http://timestamp.digicert.com' `
           -td sha512 -fd sha512 `
-          "${env:BINARY_PATH}"
+          "$env:BINARY_PATH"
       shell: pwsh

--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -1,0 +1,104 @@
+name: Sign Windows binary
+description: Signs a Windows PE file using AzureSignTool
+
+inputs:
+  binary-path:
+    description: The path to the binary to sign and notarize.
+    required: true
+  vault-approle-path:
+    description: The approle for the HashiCorp Vault namespace.
+    required: true
+  vault-cf-client-id:
+    description: CloudFlare client ID to access the HashiCorp Vault from a public GitHub runner.
+    required: true
+  vault-cf-client-secret:
+    description: CloudFlare secret to access the HashiCorp Vault from a public GitHub runner.
+    required: true
+  vault-role-id:
+    description: Role ID for the HashiCorp Vault namespace.
+    required: true
+  vault-secret-id:
+    description: Secret ID for the HashiCorp Vault namespace.
+    required: true
+  vault-mount:
+    description: HashiCorp Vault mount to retrieve secrets from (`dev` or `prod`).
+    required: true
+  vault-url:
+    description: URL to the HashiCorp Vault.
+    required: true
+
+outputs:
+  fingerprint:
+    description: The fingerprint of the public certificate. Used for testing.
+    value: ${{ steps.certificate.outputs.fingerprint }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate input
+      env:
+        BINARY_PATH: ${{ inputs.binary-path }}
+        VAULT_MOUNT: ${{ inputs.vault-mount }}
+      run: |
+        # Validate inputs
+        if ("${env:VAULT_MOUNT}" -ne "dev" -and "${env:VAULT_MOUNT}" -ne "prod") {
+            Write-Host "::error::Unrecognized vault mount point `${env:VAULT_MOUNT}`"
+            exit 1
+        }
+        if (-not (Test-Path -Path "${env:BINARY_PATH}" -PathType Leaf)) {
+            Write-Host "::error::${env:BINARY_PATH} does not exist."
+            exit 1
+        }
+      shell: pwsh
+
+    - name: Get AzureSignTool
+      run: |
+        # Get AzureSignTool
+        if (-not (Get-Command AzureSignTool -ErrorAction SilentlyContinue)) {
+            dotnet tool install --global AzureSignTool
+        }
+      shell: pwsh
+
+    - name: Get credentials
+      id: certificate
+      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      with:
+        exportEnv: false
+        extraHeaders: |
+          CF-Access-Client-Id: ${{ inputs.vault-cf-client-id }}
+          CF-Access-Client-Secret: ${{ inputs.vault-cf-client-secret }}
+        method: approle
+        namespace: admin
+        path: ${{ inputs.vault-approle-path }}
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        url: ${{ inputs.vault-url }}
+        secrets: |
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate certificate_name | certificate-name;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate client_id | client-id ;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate fingerprint | fingerprint ;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate subscription_id | subscription-id ;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate tenant_id | tenant-id ;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate url | url
+
+    - name: Log into Azure
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+      with:
+        client-id: ${{ steps.certificate.outputs.client-id }}
+        subscription-id: ${{ steps.certificate.outputs.subscription-id }}
+        tenant-id: ${{ steps.certificate.outputs.tenant-id }}
+
+    - name: Sign binary
+      env:
+        AZURE_CERTIFICATE_NAME: ${{ steps.certificate.outputs.certificate-name }}
+        AZURE_URL: ${{ steps.certificate.outputs.url }}
+        BINARY_PATH: ${{ inputs.binary-path }}
+      run: |
+        # Sign binary
+        AzureSignTool sign -v -kvm`
+          -kvu "${env:AZURE_URL}" `
+          -kvc "${env:AZURE_CERTIFICATE_NAME}" `
+          -tr 'http://timestamp.digicert.com' `
+          -td sha512 -fd sha512 `
+          "${env:BINARY_PATH}"
+      shell: pwsh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,8 @@ jobs:
     env:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     permissions:
-      contents: read  # To check out private repository
+      contents: read   # To check out private repository
+      id-token: write  # Required to authenticate with Azure via OIDC
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
           CERTIFICATE_TRUSTED: ${{ inputs.environment == 'prod' }}
           MACOS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-notarize-macos.outputs.fingerprint }}
           MACOS_DEVELOPER_ID: ${{ steps.sign-notarize-macos.outputs.developer-id }}
-          WINDOWS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-windows.outputs.fingerprint }}
+          TEST_WINDOWS_SIGNING: 1
         run: pixi run test-integration
 
       - name: Run integration tests (PowerShell)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,21 @@ jobs:
       - name: Build release binary
         run: pixi run build-release
 
+      - name: Sign binary (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        id: sign-windows
+        uses: ./.github/actions/sign-windows
+        with:
+          binary-path: target/release/ana.exe
+          vault-approle-path: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_PATH }}
+          # Created by CORE-10231
+          vault-cf-client-id: ${{ secrets.CF_ANACONDA_CLI_CLIENT_ID }}
+          vault-cf-client-secret: ${{ secrets.CF_ANACONDA_CLI_CLIENT_SECRET }}
+          vault-role-id: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_SECRET_ID }}
+          vault-mount: ${{ inputs.environment || 'dev' }}
+          vault-url: ${{ secrets.EXT_VAULT_ADDR }}
+
       - name: Sign and notarize binary (macOS)
         if: ${{ runner.os == 'macOS' }}
         id: sign-notarize-macos

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,28 @@ jobs:
           RUST_BACKTRACE: 1
         run: pixi run test-release
 
+      - name: Pre-compile shim for signing (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: pixi run build-shim
+
+      - name: Sign shim (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        id: sign-shim
+        uses: ./.github/actions/sign-windows
+        with:
+          binary-path: target/shim/shim.exe
+          vault-approle-path: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_PATH }}
+          # Created by CORE-10231
+          vault-cf-client-id: ${{ secrets.CF_ANACONDA_CLI_CLIENT_ID }}
+          vault-cf-client-secret: ${{ secrets.CF_ANACONDA_CLI_CLIENT_SECRET }}
+          vault-role-id: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_SECRET_ID }}
+          vault-mount: ${{ inputs.environment || 'dev' }}
+          vault-url: ${{ secrets.EXT_VAULT_ADDR }}
+
       - name: Build release binary
+        env:
+          WINDOWS_SHIM_PATH: ${{ runner.os == 'Windows' && 'target/shim/shim.exe' || '' }}
         run: pixi run build-release
 
       - name: Sign binary (Windows)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,9 +125,10 @@ jobs:
           ANA_SENTRY_DISABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
           # API key for tests requiring real authentication (pixi, uv, pip feature tests)
           ANA_TEST_API_KEY: ${{ secrets.ANA_TEST_API_KEY }}
+          CERTIFICATE_TRUSTED: ${{ inputs.environment == 'prod' }}
           MACOS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-notarize-macos.outputs.fingerprint }}
           MACOS_DEVELOPER_ID: ${{ steps.sign-notarize-macos.outputs.developer-id }}
-          MACOS_IS_NOTARIZED: ${{ inputs.environment == 'prod' }}
+          WINDOWS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-windows.outputs.fingerprint }}
         run: pixi run test-integration
 
       - name: Run integration tests (PowerShell)

--- a/build.rs
+++ b/build.rs
@@ -27,15 +27,24 @@ fn main() {
 #[cfg(windows)]
 fn build_shim() {
     use std::path::PathBuf;
-    use std::process::Command;
 
+    println!("cargo:rerun-if-env-changed=WINDOWS_SHIM_PATH");
     println!("cargo:rerun-if-changed=src/shim/shim.rs");
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let shim_src = PathBuf::from("src/shim/shim.rs");
     let shim_out = out_dir.join("shim.exe");
 
-    // Use rustc directly to compile the shim as a minimal binary
+    // If a pre-built shim is provided (e.g., signed), copy it instead of compiling
+    if let Ok(shim_path) = std::env::var("WINDOWS_SHIM_PATH") {
+        std::fs::copy(&shim_path, &shim_out).expect("failed to copy shim from WINDOWS_SHIM_PATH");
+        return;
+    }
+
+    // Otherwise compile it directly
+    use std::process::Command;
+
+    let shim_src = PathBuf::from("src/shim/shim.rs");
+
     let status = Command::new("rustc")
         .args([
             "--edition=2024",

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,10 @@ description = "Run pre-commit hooks on all files"
 cmd = "python scripts/with_version.py rattler-build build --recipe conda.recipe"
 description = "Build the conda package"
 
+[tasks.build-shim]
+cmd = "mkdir -p target/shim; rustc --edition=2024 -O -o target/shim/shim.exe src/shim/shim.rs"
+description = "Build the Windows shim binary"
+
 [tasks.build-debug]
 cmd = "python scripts/with_version.py cargo auditable build"
 description = "Build the standalone Rust binary in debug mode"

--- a/tests/test_macos_signing.py
+++ b/tests/test_macos_signing.py
@@ -56,10 +56,6 @@ class TestMacOSSigning:
         tmp_path: Path,
     ) -> None:
         """Verify the signing certificate matches expected fingerprint."""
-        if not (
-            expected_fingerprint := os.environ.get("MACOS_CERTIFICATE_FINGERPRINT")
-        ):
-            pytest.skip("MACOS_CERTIFICATE_FINGERPRINT not set")
         if ana_binary is None:
             pytest.skip("ana binary not found")
 
@@ -79,6 +75,7 @@ class TestMacOSSigning:
         assert fingerprint, "Fingerprint not found"
         actual_fingerprint = fingerprint.hex().upper().replace(":", "")
 
+        expected_fingerprint = os.environ.get("MACOS_CERTIFICATE_FINGERPRINT")
         assert actual_fingerprint == expected_fingerprint, (
             f"Certificate fingerprint mismatch.\n"
             f"Expected: {expected_fingerprint}\n"

--- a/tests/test_macos_signing.py
+++ b/tests/test_macos_signing.py
@@ -4,20 +4,23 @@ from __future__ import annotations
 
 import os
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from helpers import IS_MACOS
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 if not IS_MACOS:
     pytest.skip("macOS signing tests", allow_module_level=True)
 
 # Use environment variable as sentinel variable
 # since local builds are not expected to be signed
-if not os.environ.get("MACOS_DEVELOPER_ID"):
-    pytest.skip("Binary is not expected to be signed")
+if not os.environ.get("MACOS_CERTIFICATE_FINGERPRINT"):
+    pytest.skip("Binary is not expected to be signed", allow_module_level=True)
 
 
 @pytest.fixture(scope="class")
@@ -119,7 +122,7 @@ def test_notarization(ana_binary: Path | None) -> None:
     if ana_binary is None:
         pytest.skip("ana binary not found")
 
-    expected_notarized = os.environ.get("MACOS_IS_NOTARIZED", "").lower() == "true"
+    expected_notarized = os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true"
 
     result = subprocess.run(
         ["spctl", "--assess", "--type", "execute", "-v", ana_binary],

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -22,7 +22,7 @@ if not IS_WINDOWS:
 
 # Use environment variable as sentinel variable
 # since local builds are not expected to be signed
-if not os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT"):
+if not os.environ.get("TEST_WINDOWS_SIGNING"):
     pytest.skip("Binary is not expected to be signed", allow_module_level=True)
 
 
@@ -55,16 +55,6 @@ def assert_signature_valid(cert_info: dict[str, Any], name: str) -> None:
         0 if os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true" else 1
     )
     assert status == expected_status, f"{name} trust status mismatch"
-
-    certificate = cert_info.get("SignerCertificate")
-    assert certificate, f"No certificate found for {name}"
-    actual_fingerprint = certificate.get("Thumbprint", "")
-    expected_fingerprint = os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT", "")
-    assert actual_fingerprint == expected_fingerprint, (
-        f"Certificate fingerprint mismatch.\n"
-        f"Expected: {expected_fingerprint}\n"
-        f"Actual:   {actual_fingerprint}"
-    )
 
 
 def test_binary_signed(ana_binary: Path | None) -> None:

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
 
+    from helpers import AnaRunner
+
 if not IS_WINDOWS:
     pytest.skip("Windows signing tests", allow_module_level=True)
 
@@ -24,19 +26,13 @@ if not os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT"):
     pytest.skip("Binary is not expected to be signed", allow_module_level=True)
 
 
-@pytest.fixture(scope="class")
-def certificate_info(ana_binary: Path | None) -> dict[str, Any]:
-    """Get codesign information for the binary."""
-    if ana_binary is None:
-        pytest.skip(
-            "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
-        )
-
+def get_authenticode_signature(binary_path: Path) -> dict[str, Any]:
+    """Get Authenticode signature information for a Windows binary."""
     result = subprocess.run(
         [
             "powershell",
             "-c",
-            f"ConvertTo-Json (Get-AuthenticodeSignature '{ana_binary}')",
+            f"ConvertTo-Json (Get-AuthenticodeSignature '{binary_path}')",
         ],
         text=True,
         check=True,
@@ -45,34 +41,52 @@ def certificate_info(ana_binary: Path | None) -> dict[str, Any]:
     return json.loads(result.stdout)
 
 
-class TestWindowsSigning:
-    """Tests for Windows code signing verification."""
+def assert_signature_valid(cert_info: dict[str, Any], name: str) -> None:
+    """Assert that a binary is signed with the expected certificate.
 
-    def test_binary_signed(
-        self,
-        certificate_info: dict[str, Any],
-    ) -> None:
-        """Test whether the binary is signed.
+    Status codes:
+      0: Signed with a trusted certificate.
+      1: Signed with an untrusted certificate.
+      2: Not signed
+    """
+    status = cert_info.get("Status", -1)
+    assert status < 2, f"{name} is not signed"
+    expected_status = (
+        0 if os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true" else 1
+    )
+    assert status == expected_status, f"{name} trust status mismatch"
 
-        Status codes:
-          0: Signed with a trusted certificate.
-          1: Signed with an untrusted certificate.
-          2: Not signed
-        """
-        status = certificate_info.get("Status", -1)
-        assert status < 2, "Binary is not signed"
-        expected_status = (
-            0 if os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true" else 1
+    certificate = cert_info.get("SignerCertificate")
+    assert certificate, f"No certificate found for {name}"
+    actual_fingerprint = certificate.get("Thumbprint", "")
+    expected_fingerprint = os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT", "")
+    assert actual_fingerprint == expected_fingerprint, (
+        f"Certificate fingerprint mismatch.\n"
+        f"Expected: {expected_fingerprint}\n"
+        f"Actual:   {actual_fingerprint}"
+    )
+
+
+def test_binary_signed(ana_binary: Path | None) -> None:
+    """Test whether the ana binary is signed with the expected certificate."""
+    if ana_binary is None:
+        pytest.skip(
+            "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
         )
-        assert status == expected_status
+    cert_info = get_authenticode_signature(ana_binary)
+    assert_signature_valid(cert_info, "ana binary")
 
-    def test_certificate_fingerprint(
-        self,
-        certificate_info: dict[str, Any],
-    ) -> None:
-        """Verify the signature fingerprint (thumbprint)."""
 
-        certificate = certificate_info.get("SignerCertificate")
-        assert certificate, "No certificate found"
-        fingerprint = certificate.get("Thumbprint", "")
-        assert fingerprint == os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT")
+def test_shim_signed(
+    run_ana: AnaRunner,
+    fake_home: Path,
+) -> None:
+    """Test whether the installed shim is signed with the expected certificate."""
+    result = run_ana("tool", "install", "pixi")
+    assert result.returncode == 0, f"Failed to install pixi: {result.stderr}"
+
+    shim_path = fake_home / ".ana" / "bin" / "pixi.exe"
+    assert shim_path.exists(), f"Shim not found at {shim_path}"
+
+    cert_info = get_authenticode_signature(shim_path)
+    assert_signature_valid(cert_info, "pixi shim")

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -1,0 +1,78 @@
+"""Integration tests for Windows signing"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from helpers import IS_WINDOWS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+if not IS_WINDOWS:
+    pytest.skip("Windows signing tests", allow_module_level=True)
+
+
+# Use environment variable as sentinel variable
+# since local builds are not expected to be signed
+if not os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT"):
+    pytest.skip("Binary is not expected to be signed", allow_module_level=True)
+
+
+@pytest.fixture(scope="class")
+def certificate_info(ana_binary: Path | None) -> dict[str, Any]:
+    """Get codesign information for the binary."""
+    if ana_binary is None:
+        pytest.skip(
+            "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
+        )
+
+    result = subprocess.run(
+        [
+            "powershell",
+            "-c",
+            f"ConvertTo-Json (Get-AuthenticodeSignature '{ana_binary}')",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+class TestWindowsSigning:
+    """Tests for Windows code signing verification."""
+
+    def test_binary_signed(
+        self,
+        certificate_info: dict[str, Any],
+    ) -> None:
+        """Test whether the binary is signed.
+
+        Status codes:
+          0: Signed with a trusted certificate.
+          1: Signed with an untrusted certificate.
+          2: Not signed
+        """
+        status = certificate_info.get("Status", -1)
+        assert status < 2, "Binary is not signed"
+        expected_status = (
+            0 if os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true" else 1
+        )
+        assert status == expected_status
+
+    def test_certificate_fingerprint(
+        self,
+        certificate_info: dict[str, Any],
+    ) -> None:
+        """Verify the signature fingerprint (thumbprint)."""
+
+        certificate = certificate_info.get("SignerCertificate")
+        assert certificate, "No certificate found"
+        fingerprint = certificate.get("Thumbprint", "")
+        assert fingerprint == os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT")


### PR DESCRIPTION
## Summary

Sign Windows binaries using AzureSignTool. This requires a change to the way Windows binaries are compiled: since the shim is a binary executable, compiling `ana` would lead to unsigned shim binaries. Instead, the shim is compiled and signed separately and then directly included into the resulting `ana` binary.

The integration tests do not perform any thumbprint verification for now because I do not have access to the certificates directly. If I can get those before this PR is merged, I will revert https://github.com/anaconda/anaconda-cli/pull/207/commits/4527d460fbaeeaba82274aa5b04ac9c422e3b725

I also cleaned up some things in the macOS signing tests.

Jira: [CLI-367](https://anaconda.atlassian.net/browse/CLI-367)

## AI disclosure

Claude Code was used to review code and make the changes needed to `build.rs`.


[CLI-367]: https://anaconda.atlassian.net/browse/CLI-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ