### PR TITLE
fix: Add id-token permission for Azure OIDC in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ jobs:
       environment: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
       skip-tests: ${{ github.event_name == 'push' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit] reusable workflows must inherit environment secrets
+    permissions:
+      contents: read   # To check out private repository
+      id-token: write  # Required for Azure OIDC authentication
 
   publish-to-anaconda-dot-org:
     name: Publish to Anaconda.org


### PR DESCRIPTION
## Summary
The release workflow was failing with a `startup_failure` because the reusable `ci.yaml` workflow requires `id-token: write` permission for Azure OIDC authentication (used for Windows binary signing), but the calling `release.yaml` workflow only granted `contents: read`.

This adds the missing `id-token: write` permission at the job level for the `ci` job, keeping the permission scoped only to where it's needed.

## Test plan
- [ ] Verify the release workflow no longer fails on push to main
- [ ] Verify Windows signing still works correctly