### PR TITLE
chore: Gate feature behind unstable compile flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ libc = "0.2"
 
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
+# Unstable features are hidden and disabled by default.
 default = []
 diagnostics = ["dep:sentry"]
+unstable = []
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:29165ed4-8da7-4057-9ac0-5a710cc284d0",
+  "serialNumber": "urn:uuid:59d126b4-9696-45d4-9a48-eda852591f0c",
   "metadata": {
-    "timestamp": "2026-05-11T17:51:18Z",
+    "timestamp": "2026-05-12T04:25:37Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -44,238 +44,6 @@
       "version": "0.1.0",
       "scope": "required",
       "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40316fa5c05768a6d16da3b215fb50cd44835d7a69"
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-codec",
-      "version": "0.5.2",
-      "description": "Codec utilities for working with framed protocols",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-codec@0.5.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-http",
-      "version": "3.12.1",
-      "description": "HTTP types and services for the Actix ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-http@3.12.1",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://actix.rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-web"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-router",
-      "version": "0.5.4",
-      "description": "Resource path matching and router",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-router@0.5.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-web"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-rt",
-      "version": "2.11.0",
-      "description": "Tokio-based single-threaded async runtime for the Actix ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-rt@2.11.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://actix.rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>, Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>",
-      "name": "actix-server",
-      "version": "2.6.0",
-      "description": "General purpose TCP server built for the Actix ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-server@2.6.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://actix.rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net/tree/master/actix-server"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-service",
-      "version": "2.0.3",
-      "description": "Service trait and combinators for representing asynchronous request/response operations.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-service@2.0.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-utils",
-      "version": "3.0.1",
-      "description": "Various utilities used in the Actix ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-utils@3.0.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "actix-web",
-      "version": "4.13.0",
-      "description": "Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/actix-web@4.13.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://actix.rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-web"
-        }
-      ]
     },
     {
       "type": "library",
@@ -997,41 +765,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
-      "author": "RustCrypto Developers",
-      "name": "base64ct",
-      "version": "1.8.3",
-      "description": "Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of data-dependent branches/LUTs and thereby provides portable \"best effort\" constant-time operation and embedded-friendly no_std support ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/base64ct@1.8.3",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/base64ct"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/formats/tree/master/base64ct"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/formats"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
       "author": "Ben Steadman <steadmanben1@gmail.com>",
       "name": "bisection",
@@ -1341,37 +1074,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "bytestring",
-      "version": "1.5.1",
-      "description": "A UTF-8 encoded read-only string using `Bytes` as storage",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/bytestring@1.5.1",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://actix.rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
       "name": "bzip2",
       "version": "0.6.1",
@@ -1529,6 +1231,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/katharostech/cfg_aliases"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
         }
       ]
     },
@@ -1888,33 +1596,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/console-rs/console"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
-      "author": "rutrum <dave@rutrum.net>",
-      "name": "convert_case",
-      "version": "0.10.0",
-      "description": "Convert strings into any case",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/convert_case@0.10.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/rutrum/convert-case"
         }
       ]
     },
@@ -2287,72 +1968,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "debugid",
-      "version": "0.8.0",
-      "description": "Common reusable types for implementing the sentry.io protocol.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/debugid@0.8.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/debugid"
-        },
-        {
-          "type": "website",
-          "url": "https://sentry.io/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/rust-debugid"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
-      "author": "RustCrypto Developers",
-      "name": "der",
-      "version": "0.8.0",
-      "description": "Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with full support for heapless `no_std`/`no_alloc` targets ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/der@0.8.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/formats/tree/master/der"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/formats"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "author": "Jacob Pratt <jacob@jhpratt.dev>",
       "name": "deranged",
@@ -2375,68 +1990,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/jhpratt/deranged"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
-      "author": "Jelte Fennema <github-tech@jeltef.nl>",
-      "name": "derive_more-impl",
-      "version": "2.1.1",
-      "description": "Internal implementation of `derive_more` crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/derive_more-impl@2.1.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/derive_more"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/JelteF/derive_more"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
-      "author": "Jelte Fennema <github-tech@jeltef.nl>",
-      "name": "derive_more",
-      "version": "2.1.1",
-      "description": "Adds #[derive(x)] macros for more traits",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/derive_more@2.1.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/derive_more"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/JelteF/derive_more"
         }
       ]
     },
@@ -2650,41 +2203,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/rayon-rs/either"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-      "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
-      "name": "encoding_rs",
-      "version": "0.8.35",
-      "description": "A Gecko-oriented implementation of the Encoding Standard",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
-        }
-      ],
-      "purl": "pkg:cargo/encoding_rs@0.8.35",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/encoding_rs/"
-        },
-        {
-          "type": "website",
-          "url": "https://docs.rs/encoding_rs/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/hsivonen/encoding_rs"
         }
       ]
     },
@@ -2961,36 +2479,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
-      "name": "findshlibs",
-      "version": "0.10.2",
-      "description": "Find the set of shared libraries loaded in the current process with a cross platform API",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/findshlibs@0.10.2",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/findshlibs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/gimli-rs/findshlibs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
       "author": "Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>",
       "name": "flate2",
@@ -3083,33 +2571,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-fnv"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
-      "author": "Orson Peters <orsonpeters@gmail.com>",
-      "name": "foldhash",
-      "version": "0.1.5",
-      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Zlib"
-        }
-      ],
-      "purl": "pkg:cargo/foldhash@0.1.5",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/orlp/foldhash"
         }
       ]
     },
@@ -4134,37 +3595,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
-      "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
-      "name": "http",
-      "version": "0.2.12",
-      "description": "A set of types for representing HTTP requests and responses. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/http@0.2.12",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/http"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/hyperium/http"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http",
@@ -4222,33 +3652,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/seanmonstar/httparse"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
-      "author": "Pyfisch <pyfisch@posteo.org>",
-      "name": "httpdate",
-      "version": "1.0.3",
-      "description": "HTTP date parsing and formatting",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/httpdate@1.0.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/pyfisch/httpdate"
         }
       ]
     },
@@ -4770,33 +4173,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
-      "author": "Rob Ede <robjtede@icloud.com>",
-      "name": "impl-more",
-      "version": "0.1.9",
-      "description": "Concise, declarative trait implementation macros",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/impl-more@0.1.9",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/robjtede/impl-more"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "name": "indexmap",
       "version": "1.9.3",
@@ -5103,33 +4479,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
-      "author": "Pyfisch <pyfisch@gmail.com>, Tpt <thomas@pellissier-tanon.fr>",
-      "name": "language-tags",
-      "version": "0.3.2",
-      "description": "Language tags for Rust",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/language-tags@0.3.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/pyfisch/rust-language-tags"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "author": "Canop <cano.petrole@gmail.com>",
       "name": "lazy-regex-proc_macros",
@@ -5366,33 +4715,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/LukasKalbertodt/litrs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
-      "author": "Nikolay Kim <fafhrd91@gmail.com>, Rob Ede <robjtede@icloud.com>",
-      "name": "local-waker",
-      "version": "0.1.4",
-      "description": "A synchronization primitive for thread-local task wakeup",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/local-waker@0.1.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/actix/actix-net"
         }
       ]
     },
@@ -6692,37 +6014,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/conda/rattler"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
-      "author": "RustCrypto Developers",
-      "name": "pem-rfc7468",
-      "version": "1.0.0",
-      "description": "PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a strict subset of the original Privacy-Enhanced Mail encoding intended specifically for use with cryptographic keys, certificates, and other messages. Provides a no_std-friendly, constant-time implementation suitable for use with cryptographic private keys. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/pem-rfc7468@1.0.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/formats/tree/master/pem-rfc7468"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/formats"
         }
       ]
     },
@@ -8082,41 +7373,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
-      "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
-      "name": "regex-lite",
-      "version": "0.1.9",
-      "description": "A lightweight regex engine that optimizes for binary size and compilation time. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/regex-lite@0.1.9",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/regex-lite"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/rust-lang/regex/tree/master/regex-lite"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/rust-lang/regex"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex-syntax",
@@ -8232,37 +7488,6 @@
         }
       ],
       "purl": "pkg:cargo/reqwest@0.12.28",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/reqwest"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/seanmonstar/reqwest"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
-      "author": "Sean McArthur <sean@seanmonstar.com>",
-      "name": "reqwest",
-      "version": "0.13.3",
-      "description": "higher level HTTP client library",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/reqwest@0.13.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8857,285 +8082,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/dtolnay/semver"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-actix",
-      "version": "0.48.2",
-      "description": "Sentry integration for actix-web 4. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-actix@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-backtrace",
-      "version": "0.48.2",
-      "description": "Sentry integration and utilities for dealing with stacktraces. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-backtrace@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-contexts",
-      "version": "0.48.2",
-      "description": "Sentry integration for os, device, and rust contexts. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-contexts@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-core",
-      "version": "0.48.2",
-      "description": "Core Sentry library used for instrumentation and integration development. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-core@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-debug-images",
-      "version": "0.48.2",
-      "description": "Sentry integration that adds the list of loaded libraries to events. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-debug-images@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-panic",
-      "version": "0.48.2",
-      "description": "Sentry integration for capturing panics. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-panic@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-tracing",
-      "version": "0.48.2",
-      "description": "Sentry integration for the tracing and tracing-subscriber crates. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-tracing@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry-types",
-      "version": "0.48.2",
-      "description": "Common reusable types for implementing the sentry.io protocol. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry-types@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
-      "author": "Sentry <hello@sentry.io>",
-      "name": "sentry",
-      "version": "0.48.2",
-      "description": "Sentry (sentry.io) client for Rust. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/sentry@0.48.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://sentry.io/welcome/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/getsentry/sentry-rust"
         }
       ]
     },
@@ -9894,41 +8840,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/servo/rust-smallvec"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
-      "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
-      "name": "socket2",
-      "version": "0.5.10",
-      "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/socket2@0.5.10",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/socket2"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/rust-lang/socket2"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/rust-lang/socket2"
         }
       ]
     },
@@ -11684,47 +10595,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
-      "author": "Ignacio Corderi <icorderi@msn.com>",
-      "name": "uname",
-      "version": "0.1.1",
-      "description": "Name and information about current kernel",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/uname@0.1.1",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://icorderi.github.io/rust-uname/index.html"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/icorderi/rust-uname"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/icorderi/rust-uname"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "linux,macos"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
       "name": "unarray",
       "version": "0.1.4",
@@ -11972,41 +10842,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
-      "author": "erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
-      "name": "unicode-xid",
-      "version": "0.2.6",
-      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/unicode-xid@0.2.6",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://unicode-rs.github.io/unicode-xid"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/unicode-rs/unicode-xid"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/unicode-rs/unicode-xid"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "author": "Fabio Valentini <decathorpe@gmail.com>, Benjamin Sago <ogham@bsago.me>",
       "name": "unit-prefix",
@@ -12123,60 +10958,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
-      "author": "Martin Algesten <martin@algesten.se>",
-      "name": "ureq-proto",
-      "version": "0.6.0",
-      "description": "ureq support crate",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/ureq-proto@0.6.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/algesten/ureq-proto"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
-      "author": "Martin Algesten <martin@algesten.se>, Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>",
-      "name": "ureq",
-      "version": "3.3.0",
-      "description": "Simple, safe HTTP client",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/ureq@3.3.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/algesten/ureq"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
       "author": "The rust-url developers",
       "name": "url",
@@ -12234,33 +11015,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/kornelski/rust_urlencoding"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
-      "author": "Simon Sapin <simon.sapin@exyr.org>, Martin Algesten <martin@algesten.se>",
-      "name": "utf8-zero",
-      "version": "0.8.1",
-      "description": "Zero-copy, incremental UTF-8 decoding with error handling",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/utf8-zero@0.8.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/algesten/utf8-zero"
         }
       ]
     },
@@ -12588,36 +11342,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/amodm/webbrowser-rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7",
-      "name": "webpki-root-certs",
-      "version": "1.0.7",
-      "description": "Mozilla trusted certificate authorities in self-signed X.509 format for use with crates other than webpki",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "CDLA-Permissive-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/webpki-root-certs@1.0.7",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/rustls/webpki-roots"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/rustls/webpki-roots"
         }
       ]
     },
@@ -13692,47 +12416,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
-      "author": "Jan Schulte <hello@unexpected-co.de>, Stanislav Tkach <stanislav.tkach@gmail.com>",
-      "name": "os_info",
-      "version": "3.14.0",
-      "description": "Detect the operating system type and version.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/os_info@3.14.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/os_info"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/stanislav-tkach/os_info"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/stanislav-tkach/os_info"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
       "author": "Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>",
       "name": "schannel",
@@ -14783,7 +13466,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
@@ -14795,130 +13477,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
-        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
-        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
-        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#actix-codec@0.5.2",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-router@0.5.4",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-rt@2.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-server@2.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-service@2.0.3",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-utils@3.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-        "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
-        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -15111,10 +13669,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bisection@0.1.0",
       "dependsOn": []
     },
@@ -15161,12 +13715,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
       "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytestring@1.5.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
@@ -15287,12 +13835,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -15380,41 +13922,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1"
       ]
     },
     {
@@ -15460,12 +13971,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.15.0",
       "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
@@ -15527,15 +14032,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
-        "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -15551,10 +14047,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#foldhash@0.1.5",
       "dependsOn": []
     },
     {
@@ -15787,14 +14279,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@0.2.12",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
-        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -15803,10 +14287,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
       "dependsOn": []
     },
     {
@@ -15965,10 +14445,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#impl-more@0.1.9",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.0",
@@ -16029,10 +14505,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#language-tags@0.3.2",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
@@ -16071,10 +14543,6 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#local-waker@0.1.4",
       "dependsOn": []
     },
     {
@@ -16169,7 +14637,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -16392,12 +14859,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@1.0.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.8.3"
       ]
     },
     {
@@ -16916,10 +15377,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-lite@0.1.9",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "dependsOn": []
     },
@@ -16972,38 +15429,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
-        "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
-        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
@@ -17143,101 +15568,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#actix-http@3.12.1",
-        "registry+https://github.com/rust-lang/crates.io-index#actix-web@4.13.0",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#backtrace@0.3.76",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#findshlibs@0.10.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry-types@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#debugid@0.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sentry@0.48.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
-        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.3",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-actix@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-backtrace@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-contexts@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-core@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-debug-images@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-panic@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#sentry-tracing@0.48.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
-        "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0"
       ]
     },
     {
@@ -17414,13 +15744,6 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
     },
     {
@@ -17840,7 +16163,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
@@ -17861,12 +16183,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0",
       "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#uname@0.1.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4",
@@ -17903,10 +16219,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.6",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2",
       "dependsOn": []
     },
@@ -17923,29 +16235,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ureq@3.3.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#der@0.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
-        "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
-        "registry+https://github.com/rust-lang/crates.io-index#ureq-proto@0.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
-        "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
@@ -17960,10 +16249,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8-zero@0.8.1",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
       "dependsOn": []
     },
@@ -17975,8 +16260,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
       ]
     },
     {
@@ -18020,12 +16304,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#webpki-root-certs@1.0.7",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1"
       ]
     },
     {
@@ -18247,14 +16525,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.2",
       "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#os_info@3.14.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.29",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-11T17:51:18Z<br>
+Generated: 2026-05-12T04:25:37Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 475 (67 platform-specific)<br>
+Packages: 432 (66 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -10,14 +10,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | Package | Version | License | Platforms | CVEs |
 | --- | --- | --- | --- | ---: |
-| [actix-codec](https://crates.io/crates/actix-codec) | 0.5.2 | MIT OR Apache-2.0 |  |  |
-| [actix-http](https://crates.io/crates/actix-http) | 3.12.1 | MIT OR Apache-2.0 |  |  |
-| [actix-router](https://crates.io/crates/actix-router) | 0.5.4 | MIT OR Apache-2.0 |  |  |
-| [actix-rt](https://crates.io/crates/actix-rt) | 2.11.0 | MIT OR Apache-2.0 |  |  |
-| [actix-server](https://crates.io/crates/actix-server) | 2.6.0 | MIT OR Apache-2.0 |  |  |
-| [actix-service](https://crates.io/crates/actix-service) | 2.0.3 | MIT OR Apache-2.0 |  |  |
-| [actix-utils](https://crates.io/crates/actix-utils) | 3.0.1 | MIT OR Apache-2.0 |  |  |
-| [actix-web](https://crates.io/crates/actix-web) | 4.13.0 | MIT OR Apache-2.0 |  |  |
 | [addr2line](https://crates.io/crates/addr2line) | 0.25.1 | Apache-2.0 OR MIT | linux, macos |  |
 | [adler2](https://crates.io/crates/adler2) | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |  |  |
 | [ahash](https://crates.io/crates/ahash) | 0.8.12 | MIT OR Apache-2.0 |  |  |
@@ -44,7 +36,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |  |
 | [backtrace-ext](https://crates.io/crates/backtrace-ext) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
-| [base64ct](https://crates.io/crates/base64ct) | 1.8.3 | Apache-2.0 OR MIT |  |  |
 | [bisection](https://crates.io/crates/bisection) | 0.1.0 | MIT |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
@@ -55,12 +46,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.2 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
-| [bytestring](https://crates.io/crates/bytestring) | 1.5.1 | MIT OR Apache-2.0 |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
 | [cc](https://crates.io/crates/cc) | 1.2.62 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
 | [clap](https://crates.io/crates/clap) | 4.6.1 | MIT OR Apache-2.0 |  |  |
@@ -73,7 +63,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.32 | MIT OR Apache-2.0 |  |  |
 | [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
-| [convert\_case](https://crates.io/crates/convert_case) | 0.10.0 | MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
@@ -89,11 +78,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.1.0 | MIT |  |  |
-| [debugid](https://crates.io/crates/debugid) | 0.8.0 | Apache-2.0 |  |  |
-| [der](https://crates.io/crates/der) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
-| [derive\_more](https://crates.io/crates/derive_more) | 2.1.1 | MIT |  |  |
-| [derive\_more-impl](https://crates.io/crates/derive_more-impl) | 2.1.1 | MIT |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
@@ -102,7 +87,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
 | [either](https://crates.io/crates/either) | 1.15.0 | MIT OR Apache-2.0 |  |  |
 | [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
-| [encoding\_rs](https://crates.io/crates/encoding_rs) | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause |  |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
@@ -112,11 +96,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [file\_url](https://crates.io/crates/file_url) | 0.3.0 | BSD-3-Clause |  |  |
 | [filetime](https://crates.io/crates/filetime) | 0.2.28 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
-| [findshlibs](https://crates.io/crates/findshlibs) | 0.10.2 | MIT OR Apache-2.0 |  |  |
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
 | [float-cmp](https://crates.io/crates/float-cmp) | 0.10.0 | MIT |  |  |
 | [fnv](https://crates.io/crates/fnv) | 1.0.7 | Apache-2.0  OR  MIT |  |  |
-| [foldhash](https://crates.io/crates/foldhash) | 0.1.5 | Zlib |  |  |
 | [foldhash](https://crates.io/crates/foldhash) | 0.2.0 | Zlib |  |  |
 | [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 | linux |  |
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
@@ -148,13 +130,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
-| [http](https://crates.io/crates/http) | 0.2.12 | MIT OR Apache-2.0 |  |  |
 | [http](https://crates.io/crates/http) | 1.4.0 | MIT OR Apache-2.0 |  |  |
 | [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
 | [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
 | [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
-| [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
 | [hyper](https://crates.io/crates/hyper) | 1.9.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.9 | Apache-2.0 OR ISC OR MIT |  |  |
@@ -171,7 +151,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [ident\_case](https://crates.io/crates/ident_case) | 1.0.1 | MIT OR Apache-2.0 |  |  |
 | [idna](https://crates.io/crates/idna) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.2 | Apache-2.0 OR MIT |  |  |
-| [impl-more](https://crates.io/crates/impl-more) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 2.14.0 | Apache-2.0 OR MIT |  |  |
 | [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
@@ -183,7 +162,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
-| [language-tags](https://crates.io/crates/language-tags) | 0.3.2 | MIT OR Apache-2.0 |  |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
@@ -192,7 +170,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
-| [local-waker](https://crates.io/crates/local-waker) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |  |
 | [log](https://crates.io/crates/log) | 0.4.29 | MIT OR Apache-2.0 |  |  |
 | [mac\_address](https://crates.io/crates/mac_address) | 1.1.8 | MIT OR Apache-2.0 |  |  |
@@ -232,13 +209,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [opentelemetry\_sdk](https://crates.io/crates/opentelemetry_sdk) | 0.31.0 | Apache-2.0 |  |  |
 | [option-ext](https://crates.io/crates/option-ext) | 0.2.0 | MPL-2.0 |  |  |
 | [ordered-float](https://crates.io/crates/ordered-float) | 2.10.1 | MIT |  |  |
-| [os\_info](https://crates.io/crates/os_info) | 3.14.0 | MIT | windows |  |
 | [owo-colors](https://crates.io/crates/owo-colors) | 4.3.0 | MIT |  |  |
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
 | [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.8 | BSD-3-Clause |  |  |
-| [pem-rfc7468](https://crates.io/crates/pem-rfc7468) | 1.0.0 | Apache-2.0 OR MIT |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [pep508\_rs](https://crates.io/crates/pep508_rs) | 0.9.2 | Apache-2.0 OR BSD-2-Clause |  |  |
 | [percent-encoding](https://crates.io/crates/percent-encoding) | 2.3.2 | MIT OR Apache-2.0 |  |  |
@@ -286,10 +261,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
 | [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |  |
 | [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
-| [regex-lite](https://crates.io/crates/regex-lite) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
-| [reqwest](https://crates.io/crates/reqwest) | 0.13.3 | MIT OR Apache-2.0 |  |  |
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
 | [retry-policies](https://crates.io/crates/retry-policies) | 0.5.2 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
@@ -313,15 +286,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
-| [sentry](https://crates.io/crates/sentry) | 0.48.2 | MIT |  |  |
-| [sentry-actix](https://crates.io/crates/sentry-actix) | 0.48.2 | MIT |  |  |
-| [sentry-backtrace](https://crates.io/crates/sentry-backtrace) | 0.48.2 | MIT |  |  |
-| [sentry-contexts](https://crates.io/crates/sentry-contexts) | 0.48.2 | MIT |  |  |
-| [sentry-core](https://crates.io/crates/sentry-core) | 0.48.2 | MIT |  |  |
-| [sentry-debug-images](https://crates.io/crates/sentry-debug-images) | 0.48.2 | MIT |  |  |
-| [sentry-panic](https://crates.io/crates/sentry-panic) | 0.48.2 | MIT |  |  |
-| [sentry-tracing](https://crates.io/crates/sentry-tracing) | 0.48.2 | MIT |  |  |
-| [sentry-types](https://crates.io/crates/sentry-types) | 0.48.2 | MIT |  |  |
 | [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
 | [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
@@ -346,7 +310,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |  |
-| [socket2](https://crates.io/crates/socket2) | 0.5.10 | MIT OR Apache-2.0 |  |  |
 | [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
@@ -404,7 +367,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [typenum](https://crates.io/crates/typenum) | 1.20.0 | MIT OR Apache-2.0 |  |  |
-| [uname](https://crates.io/crates/uname) | 0.1.1 | MIT OR Apache-2.0 | linux, macos |  |
 | [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |  |
 | [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |  |
@@ -413,16 +375,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |  |
-| [unicode-xid](https://crates.io/crates/unicode-xid) | 0.2.6 | MIT OR Apache-2.0 |  |  |
 | [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |  |
 | [unsafe-libyaml](https://crates.io/crates/unsafe-libyaml) | 0.2.11 | MIT |  |  |
 | [unscanny](https://crates.io/crates/unscanny) | 0.1.0 | MIT OR Apache-2.0 |  |  |
 | [untrusted](https://crates.io/crates/untrusted) | 0.9.0 | ISC |  |  |
-| [ureq](https://crates.io/crates/ureq) | 3.3.0 | MIT OR Apache-2.0 |  |  |
-| [ureq-proto](https://crates.io/crates/ureq-proto) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [url](https://crates.io/crates/url) | 2.5.8 | MIT OR Apache-2.0 |  |  |
 | [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
-| [utf8-zero](https://crates.io/crates/utf8-zero) | 0.8.1 | MIT OR Apache-2.0 |  |  |
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
 | [uuid](https://crates.io/crates/uuid) | 1.23.1 | Apache-2.0 OR MIT |  |  |
@@ -433,7 +391,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.1 | MIT OR Apache-2.0 |  |  |
-| [webpki-root-certs](https://crates.io/crates/webpki-root-certs) | 1.0.7 | CDLA-Permissive-2.0 |  |  |
 | [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
@@ -490,20 +447,19 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 256 |
-| MIT | 97 |
-| Apache-2.0 OR MIT | 34 |
-| Apache-2.0 | 21 |
+| MIT OR Apache-2.0 | 233 |
+| MIT | 84 |
+| Apache-2.0 OR MIT | 31 |
+| Apache-2.0 | 20 |
 | BSD-3-Clause | 18 |
 | Unicode-3.0 | 18 |
 | ISC | 3 |
-| Zlib | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
 | Unlicense OR MIT | 2 |
-| (Apache-2.0 OR MIT) AND BSD-3-Clause | 1 |
+| Zlib | 2 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |
@@ -511,7 +467,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | Apache-2.0 OR BSL-1.0 | 1 |
 | BSD-2-Clause OR Apache-2.0 OR MIT | 1 |
 | BSL-1.0 | 1 |
-| CDLA-Permissive-2.0 | 1 |
 | MIT OR Apache-2.0 OR Zlib | 1 |
 | MIT OR LGPL-3.0-or-later | 1 |
 | MIT OR Zlib OR Apache-2.0 | 1 |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,11 +198,13 @@ impl Action {
             Action::ApiFetch { .. } => "api.fetch",
             Action::FeatureEnable { feature, .. } => match feature.as_str() {
                 "main-x" => "feature.enable.main-x",
+                #[cfg(feature = "unstable")]
                 "wheels" => "feature.enable.wheels",
                 _ => "feature.enable.unknown",
             },
             Action::FeatureDisable { feature, .. } => match feature.as_str() {
                 "main-x" => "feature.disable.main-x",
+                #[cfg(feature = "unstable")]
                 "wheels" => "feature.disable.wheels",
                 _ => "feature.disable.unknown",
             },
@@ -341,6 +343,7 @@ impl Action {
                 )
                 .await
             }
+            #[allow(unused_variables)]
             Action::FeatureEnable {
                 feature,
                 force,
@@ -358,6 +361,7 @@ impl Action {
                             feature::enable_main_x_conda(ctx, force).await?
                         }
                     }
+                    #[cfg(feature = "unstable")]
                     "wheels" => {
                         // wheels is an experimental feature that requires the feature flag
                         // to be enabled first before configuring pip/uv
@@ -428,6 +432,7 @@ impl Action {
                 let _ = conda;
                 Ok(())
             }
+            #[allow(unused_variables)]
             Action::FeatureDisable {
                 feature,
                 force,
@@ -445,6 +450,7 @@ impl Action {
                             feature::disable_main_x_conda(ctx, force).await?
                         }
                     }
+                    #[cfg(feature = "unstable")]
                     "wheels" => {
                         // wheels is an experimental feature
                         if pip || uv {
@@ -1106,6 +1112,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_enable_wheels() {
         let cli = Cli::try_parse_from(["ana", "feature", "enable", "wheels"]).unwrap();
         match cli.command {
@@ -1129,6 +1136,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_disable_wheels() {
         let cli = Cli::try_parse_from(["ana", "feature", "disable", "wheels"]).unwrap();
         match cli.command {
@@ -1152,6 +1160,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_enable_wheels_pip_flag() {
         let cli = Cli::try_parse_from(["ana", "feature", "enable", "wheels", "--pip"]).unwrap();
         match cli.command {
@@ -1175,6 +1184,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_enable_wheels_uv_flag() {
         let cli = Cli::try_parse_from(["ana", "feature", "enable", "wheels", "--uv"]).unwrap();
         match cli.command {
@@ -1198,6 +1208,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_enable_wheels_both_flags() {
         let cli =
             Cli::try_parse_from(["ana", "feature", "enable", "wheels", "--pip", "--uv"]).unwrap();
@@ -1222,6 +1233,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_disable_wheels_pip_flag() {
         let cli = Cli::try_parse_from(["ana", "feature", "disable", "wheels", "--pip"]).unwrap();
         match cli.command {
@@ -1245,6 +1257,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_disable_wheels_uv_flag() {
         let cli = Cli::try_parse_from(["ana", "feature", "disable", "wheels", "--uv"]).unwrap();
         match cli.command {
@@ -1268,6 +1281,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn test_feature_disable_wheels_both_flags() {
         let cli =
             Cli::try_parse_from(["ana", "feature", "disable", "wheels", "--pip", "--uv"]).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -358,7 +358,51 @@ impl Action {
                             feature::enable_main_x_conda(ctx, force).await?
                         }
                     }
-                    "wheels" => feature::enable_wheels(ctx, force, pip, uv).await?,
+                    "wheels" => {
+                        // wheels is an experimental feature that requires the feature flag
+                        // to be enabled first before configuring pip/uv
+                        if pip || uv {
+                            // User wants to configure tools - check if experimental flag is enabled
+                            if !feature::is_feature_enabled("wheels") {
+                                use crate::ui::status::{blank_line, highlight, tip, warn};
+                                warn(&format!(
+                                    "The {} feature is experimental and hidden from public use.",
+                                    highlight("wheels")
+                                ));
+                                tip(&format!(
+                                    "Enable the experimental flag first with {}",
+                                    highlight("ana feature enable wheels")
+                                ));
+                                blank_line();
+                                return Err(miette!(
+                                    "Experimental feature 'wheels' is not enabled"
+                                ));
+                            }
+                            feature::enable_wheels(ctx, force, pip, uv).await?
+                        } else {
+                            // No --pip/--uv flags - treat as enabling the experimental feature
+                            crate::ui::status::warn(&format!(
+                                "The '{}' feature is experimental and may change or be removed.",
+                                "wheels"
+                            ));
+                            if !force
+                                && !crate::input::prompt_yes_no(
+                                    "Enable this experimental feature?",
+                                    false,
+                                )
+                            {
+                                return Ok(());
+                            }
+                            feature::enable_feature("wheels")?;
+                            crate::ui::status::success("Experimental feature 'wheels' enabled.");
+                            crate::ui::status::blank_line();
+                            crate::ui::status::tip(&format!(
+                                "Now configure your tools with {} or {}",
+                                crate::ui::status::highlight("ana feature enable wheels --pip"),
+                                crate::ui::status::highlight("--uv")
+                            ));
+                        }
+                    }
                     name if feature::is_valid_feature(name) => {
                         crate::ui::status::warn(&format!(
                             "The '{}' feature is experimental and may change or be removed.",
@@ -401,7 +445,17 @@ impl Action {
                             feature::disable_main_x_conda(ctx, force).await?
                         }
                     }
-                    "wheels" => feature::disable_wheels(ctx, force, pip, uv).await?,
+                    "wheels" => {
+                        // wheels is an experimental feature
+                        if pip || uv {
+                            // User wants to deconfigure tools
+                            feature::disable_wheels(ctx, force, pip, uv).await?
+                        } else {
+                            // No --pip/--uv flags - disable the experimental feature flag
+                            feature::disable_feature("wheels")?;
+                            crate::ui::status::success("Experimental feature 'wheels' disabled.");
+                        }
+                    }
                     name if feature::is_valid_feature(name) => {
                         feature::disable_feature(name)?;
                         crate::ui::status::success(&format!(
@@ -950,7 +1004,7 @@ enum ApiCommands {
 enum FeatureCommands {
     /// Enable a feature
     Enable {
-        /// Name of the feature to enable (e.g., main-x, wheels)
+        /// Name of the feature to enable (e.g., main-x)
         name: String,
 
         /// Skip confirmation prompt
@@ -958,11 +1012,11 @@ enum FeatureCommands {
         force: bool,
 
         /// Configure pip (for wheels feature)
-        #[arg(long)]
+        #[arg(long, hide = true)]
         pip: bool,
 
         /// Configure uv (for wheels feature)
-        #[arg(long)]
+        #[arg(long, hide = true)]
         uv: bool,
 
         /// Configure conda (for main-x feature, default if neither --conda nor --pixi specified)
@@ -976,7 +1030,7 @@ enum FeatureCommands {
 
     /// Disable a feature
     Disable {
-        /// Name of the feature to disable (e.g., main-x, wheels)
+        /// Name of the feature to disable (e.g., main-x)
         name: String,
 
         /// Skip confirmation prompt
@@ -984,11 +1038,11 @@ enum FeatureCommands {
         force: bool,
 
         /// Deconfigure pip (for wheels feature)
-        #[arg(long)]
+        #[arg(long, hide = true)]
         pip: bool,
 
         /// Deconfigure uv (for wheels feature)
-        #[arg(long)]
+        #[arg(long, hide = true)]
         uv: bool,
 
         /// Deconfigure conda (for main-x feature, default if neither --conda nor --pixi specified)

--- a/src/feature/experimental.rs
+++ b/src/feature/experimental.rs
@@ -15,11 +15,17 @@ use serde::{Deserialize, Serialize};
 use crate::paths::ana_home;
 
 /// Valid experimental feature names.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unstable"))]
 const VALID_FEATURES: &[&str] = &["outerbounds", "wheels"];
 
-#[cfg(windows)]
+#[cfg(all(unix, not(feature = "unstable")))]
+const VALID_FEATURES: &[&str] = &["outerbounds"];
+
+#[cfg(all(windows, feature = "unstable"))]
 const VALID_FEATURES: &[&str] = &["wheels"];
+
+#[cfg(all(windows, not(feature = "unstable")))]
+const VALID_FEATURES: &[&str] = &[];
 
 /// Root config structure for ~/.ana/config.toml
 #[derive(Default, Serialize, Deserialize)]

--- a/src/feature/experimental.rs
+++ b/src/feature/experimental.rs
@@ -16,10 +16,10 @@ use crate::paths::ana_home;
 
 /// Valid experimental feature names.
 #[cfg(unix)]
-const VALID_FEATURES: &[&str] = &["outerbounds"];
+const VALID_FEATURES: &[&str] = &["outerbounds", "wheels"];
 
 #[cfg(windows)]
-const VALID_FEATURES: &[&str] = &[];
+const VALID_FEATURES: &[&str] = &["wheels"];
 
 /// Root config structure for ~/.ana/config.toml
 #[derive(Default, Serialize, Deserialize)]

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -2,10 +2,12 @@
 
 mod experimental;
 mod main_x;
+#[cfg(feature = "unstable")]
 mod wheels;
 
 pub use experimental::{disable_feature, enable_feature, is_feature_enabled, is_valid_feature};
 pub use main_x::{
     disable_main_x_conda, disable_main_x_pixi, enable_main_x_conda, enable_main_x_pixi,
 };
+#[cfg(feature = "unstable")]
 pub use wheels::{disable_wheels, enable_wheels};

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -306,6 +306,7 @@ pub fn print_subcommand_help(cmd: &clap::Command, path: &str) {
     let option_args: Vec<_> = cmd
         .get_arguments()
         .filter(|a| !is_builtin_arg(a))
+        .filter(|a| !a.is_hide_set())
         .filter(|a| a.get_long().is_some() || a.get_short().is_some())
         .collect();
     print_section(&term, "OPTIONS");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,11 +1,14 @@
 pub mod install;
 pub mod list;
+#[cfg(feature = "unstable")]
 pub mod pip;
 mod pixi_config;
 mod run;
 pub mod tools;
 pub mod uninstall;
+#[cfg(feature = "unstable")]
 pub mod utils;
+#[cfg(feature = "unstable")]
 pub mod uv;
 
 pub use run::run_tool_binary;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -73,6 +73,7 @@ pub fn highlight(text: &str) -> String {
 }
 
 /// Return a green checkmark.
+#[cfg(feature = "unstable")]
 pub fn checkmark() -> String {
     UiColor::Green.apply_to("✓").to_string()
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,31 @@ def ana_binary() -> Path | None:
     return None
 
 
+def _binary_supports_wheels(binary_path: Path | None) -> bool:
+    """Check if the ana binary supports the wheels feature.
+
+    The wheels feature is gated behind a compile-time feature flag ('unstable').
+    This detects whether the binary was compiled with that flag enabled.
+    """
+    if binary_path is None:
+        return False
+
+    result = subprocess.run(
+        [str(binary_path), "feature", "enable", "wheels"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    return "Unknown feature: wheels" not in result.stderr
+
+
+@pytest.fixture(scope="session")
+def wheels_feature_available(ana_binary: Path | None) -> bool:
+    """Check if the wheels feature is available in the ana binary."""
+    return _binary_supports_wheels(ana_binary)
+
+
 @pytest.fixture
 def run_ana(ana_binary: Path | None, env_isolated: dict[str, str]) -> AnaRunner:
     """Provide a function to run the ana binary with isolated environment."""

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1113,6 +1113,13 @@ WHEELS_INDEX_URL = "https://repo.anaconda.cloud/repo/anaconda-wheels/simple"
 class TestWheelsPipEnable:
     """Tests for 'ana feature enable wheels --pip'."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
+
     def test_enable_wheels_pip_configures_index(
         self,
         run_ana_pip_feature: AnaRunner,
@@ -1175,6 +1182,13 @@ class TestWheelsPipEnable:
 class TestWheelsPipDisable:
     """Tests for 'ana feature disable wheels --pip'."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
+
     def test_disable_wheels_pip_removes_config(
         self,
         run_ana_pip_feature: AnaRunner,
@@ -1213,6 +1227,13 @@ class TestWheelsPipDisable:
 @requires_api_key
 class TestWheelsPipEndToEnd:
     """End-to-end tests for the wheels pip feature workflow."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
 
     def test_enable_then_disable_pip(
         self,
@@ -1350,6 +1371,13 @@ class TestWheelsPipEndToEnd:
 class TestWheelsUvEnable:
     """Tests for 'ana feature enable wheels --uv'."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
+
     def test_enable_wheels_uv_configures_index(
         self,
         run_ana_uv_feature: AnaRunner,
@@ -1413,6 +1441,13 @@ class TestWheelsUvEnable:
 class TestWheelsUvDisable:
     """Tests for 'ana feature disable wheels --uv'."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
+
     def test_disable_wheels_uv_removes_config(
         self,
         run_ana_uv_feature: AnaRunner,
@@ -1444,6 +1479,13 @@ class TestWheelsUvDisable:
 @requires_api_key
 class TestWheelsUvEndToEnd:
     """End-to-end tests for the wheels uv feature workflow."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_wheels(self, wheels_feature_available: bool) -> None:
+        if not wheels_feature_available:
+            pytest.skip(
+                "wheels feature requires binary compiled with 'unstable' feature"
+            )
 
     def test_enable_then_disable_uv(
         self,


### PR DESCRIPTION
## Summary
- Adds `unstable` Cargo feature flag to gate the wheels functionality
- When built without `--features unstable`, `ana feature enable wheels` returns "Unknown feature"
- When built with `--features unstable`, wheels feature works as before
- Gates related modules (`pip`, `uv`, `utils`) and `checkmark()` helper to avoid dead code warnings

## Test plan
- [x] `cargo test` passes (198 tests without unstable, 220 with)
- [x] `cargo clippy` passes with no unused warnings
- [x] `cargo run -- feature enable wheels` returns "Unknown feature: wheels"
- [x] `cargo run --features unstable -- feature enable wheels` prompts for experimental feature