### PR TITLE
feat: Add `ana feature list` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,6 +164,7 @@ pub enum Action {
         conda: bool,
         pixi: bool,
     },
+    FeatureList,
     TelemetrySubmit,
     TelemetryKill,
     TelemetryStatus,
@@ -206,6 +207,7 @@ impl Action {
                 "wheels" => "feature.disable.wheels",
                 _ => "feature.disable.unknown",
             },
+            Action::FeatureList => "feature.list",
             Action::TelemetrySubmit => "telemetry-submit",
             Action::TelemetryKill => "telemetry-kill",
             Action::TelemetryStatus => "telemetry-status",
@@ -415,6 +417,10 @@ impl Action {
                 let _ = conda;
                 Ok(())
             }
+            Action::FeatureList => {
+                feature::list::print_feature_list(ctx);
+                Ok(())
+            }
             Action::TelemetrySubmit => {
                 crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
                 Ok(())
@@ -589,6 +595,7 @@ pub fn parse() -> (Action, LogLevel) {
                         conda,
                         pixi,
                     },
+                    Some(FeatureCommands::List) => Action::FeatureList,
                 },
                 Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
                 Some(Commands::TelemetryKill) => Action::TelemetryKill,
@@ -948,6 +955,9 @@ enum ApiCommands {
 
 #[derive(Subcommand)]
 enum FeatureCommands {
+    /// List available features
+    List,
+
     /// Enable a feature
     Enable {
         /// Name of the feature to enable (e.g., main-x, wheels)

--- a/src/feature/list.rs
+++ b/src/feature/list.rs
@@ -14,6 +14,7 @@ pub struct FeatureInfo {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FeatureCategory {
     Stable,
+    Beta,
     Experimental,
 }
 
@@ -23,12 +24,7 @@ pub fn list_features() -> Vec<FeatureInfo> {
         FeatureInfo {
             name: "main-x",
             description: "Configure conda/pixi to use Anaconda's main-x channel",
-            category: FeatureCategory::Stable,
-        },
-        FeatureInfo {
-            name: "wheels",
-            description: "Configure pip/uv to use Anaconda's PyPI mirror",
-            category: FeatureCategory::Stable,
+            category: FeatureCategory::Beta,
         },
         #[cfg(unix)]
         FeatureInfo {
@@ -56,6 +52,10 @@ pub fn print_feature_list(_ctx: &mut CommandContext) {
         .iter()
         .filter(|f| f.category == FeatureCategory::Stable)
         .collect();
+    let beta: Vec<_> = features
+        .iter()
+        .filter(|f| f.category == FeatureCategory::Beta)
+        .collect();
     let experimental: Vec<_> = features
         .iter()
         .filter(|f| f.category == FeatureCategory::Experimental)
@@ -64,6 +64,14 @@ pub fn print_feature_list(_ctx: &mut CommandContext) {
     if !stable.is_empty() {
         eprintln!("{}", status::section("stable"));
         for feature in stable {
+            print_kv(feature.name, feature.description);
+        }
+    }
+
+    if !beta.is_empty() {
+        status::blank_line();
+        eprintln!("{}", status::section("beta"));
+        for feature in beta {
             print_kv(feature.name, feature.description);
         }
     }

--- a/src/feature/list.rs
+++ b/src/feature/list.rs
@@ -1,0 +1,78 @@
+//! List available features and their status.
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+/// Information about a feature for display.
+pub struct FeatureInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub category: FeatureCategory,
+}
+
+/// Category of a feature.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FeatureCategory {
+    Stable,
+    Experimental,
+}
+
+/// List all available features.
+pub fn list_features() -> Vec<FeatureInfo> {
+    vec![
+        FeatureInfo {
+            name: "main-x",
+            description: "Configure conda/pixi to use Anaconda's main-x channel",
+            category: FeatureCategory::Stable,
+        },
+        FeatureInfo {
+            name: "wheels",
+            description: "Configure pip/uv to use Anaconda's PyPI mirror",
+            category: FeatureCategory::Stable,
+        },
+        #[cfg(unix)]
+        FeatureInfo {
+            name: "outerbounds",
+            description: "Enable Outerbounds CLI integration (alias: ob)",
+            category: FeatureCategory::Experimental,
+        },
+    ]
+}
+
+/// Print a key-value pair with consistent formatting.
+fn print_kv(key: &str, value: &str) {
+    eprintln!(
+        "  {}{}",
+        status::dim(&format!("{:<14}", key)),
+        status::highlight(value)
+    );
+}
+
+/// Print the feature list with section headers.
+pub fn print_feature_list(_ctx: &mut CommandContext) {
+    let features = list_features();
+
+    let stable: Vec<_> = features
+        .iter()
+        .filter(|f| f.category == FeatureCategory::Stable)
+        .collect();
+    let experimental: Vec<_> = features
+        .iter()
+        .filter(|f| f.category == FeatureCategory::Experimental)
+        .collect();
+
+    if !stable.is_empty() {
+        eprintln!("{}", status::section("stable"));
+        for feature in stable {
+            print_kv(feature.name, feature.description);
+        }
+    }
+
+    if !experimental.is_empty() {
+        status::blank_line();
+        eprintln!("{}", status::section("experimental"));
+        for feature in experimental {
+            print_kv(feature.name, feature.description);
+        }
+    }
+}

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -1,6 +1,7 @@
 //! Feature commands for Anaconda services.
 
 mod experimental;
+pub mod list;
 mod main_x;
 mod wheels;
 


### PR DESCRIPTION
## Summary
- Adds `ana feature list` command to display all available features
- Groups features into "Stable", "Beta", and "Experimental" sections
- Uses the same styling as `whoami` (section headers, key-value formatting)

Example output:
```
BETA
  main-x        Configure conda/pixi to use Anaconda's main-x channel

EXPERIMENTAL
  outerbounds   Enable Outerbounds CLI integration (alias: ob)
```

## Test plan
- [ ] Run `ana feature list` and verify output matches expected format
- [ ] Run `ana feature --help` and verify `list` appears in subcommands

Jira: [CLI-582](https://anaconda.atlassian.net/browse/CLI-582)

[CLI-582]: https://anaconda.atlassian.net/browse/CLI-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ