### PR TITLE
ci: Replace private github-actions with local composite actions

### DIFF
--- a/.github/actions/setup-ana/action.yml
+++ b/.github/actions/setup-ana/action.yml
@@ -1,0 +1,63 @@
+name: Setup ana
+description: Install the ana CLI and optional tools (pixi, etc.)
+
+inputs:
+  ana-version:
+    description: Version of ana to install (e.g., "v0.1.2" or "latest")
+    required: false
+    default: latest
+  tools:
+    description: Space or comma-separated list of tools to install (e.g., "pixi" or "anaconda-cli, pixi")
+    required: false
+    default: ''
+
+outputs:
+  ana-version:
+    description: The version of ana that was installed
+    value: ${{ steps.install-ana.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install ana
+      id: install-ana
+      shell: bash
+      env:
+        ANA_VERSION: ${{ inputs.ana-version }}
+        ANA_NO_PATH_UPDATE: '1'
+        ANA_BOOTSTRAP: 'false'
+        ANA_FORCE_INSTALL: '1'
+      run: |  # zizmor: ignore[github-env]
+        curl -fsSL https://anaconda.sh/install.sh | sh
+
+        if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]] || [[ "$(uname -s)" == CYGWIN* ]]; then
+          cygpath -w "$HOME/.local/bin" >> "$GITHUB_PATH"
+          cygpath -w "$HOME/.ana/bin" >> "$GITHUB_PATH"
+        else
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.ana/bin" >> "$GITHUB_PATH"
+        fi
+
+        ANA_BIN="$HOME/.local/bin/ana"
+        if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]] || [[ "$(uname -s)" == CYGWIN* ]]; then
+          ANA_BIN="$HOME/.local/bin/ana.exe"
+        fi
+
+        VERSION=$("$ANA_BIN" --version | awk '{print $2}')
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Installed ana version: $VERSION"
+
+    - name: Install tools
+      if: inputs.tools != ''
+      shell: bash
+      env:
+        TOOLS_INPUT: ${{ inputs.tools }}
+      run: |
+        export PATH="$HOME/.local/bin:$HOME/.ana/bin:$PATH"
+
+        TOOLS=$(echo "$TOOLS_INPUT" | tr ',' ' ' | xargs)
+
+        for tool in $TOOLS; do
+          echo "Installing tool: $tool"
+          ana tool install "$tool"
+        done

--- a/.github/actions/upload-package/action.yml
+++ b/.github/actions/upload-package/action.yml
@@ -1,0 +1,84 @@
+name: Upload Package
+description: Upload conda packages to Anaconda.org
+
+inputs:
+  token:
+    description: API token for authentication
+    required: true
+  packages:
+    description: Path or glob pattern to package files (e.g., ./packages/*/*.conda)
+    required: true
+  owner:
+    description: Package owner/channel (e.g., organization name)
+    required: true
+  private:
+    description: Make package private
+    required: false
+    default: 'false'
+  labels:
+    description: Comma-separated list of labels to apply (e.g., "main,dev")
+    required: false
+  force:
+    description: Overwrite existing packages if they already exist
+    required: false
+    default: 'false'
+  verbose:
+    description: Enable verbose output
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Check for existing pixi
+      id: pixi-check
+      shell: bash
+      run: |
+        if command -v pixi >/dev/null 2>&1; then
+          echo "installed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "installed=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Setup pixi
+      if: steps.pixi-check.outputs.installed != 'true'
+      uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+      with:
+        pixi-version: v0.67.2
+
+    - name: Upload to anaconda.org
+      shell: bash
+      env:
+        ANACONDA_API_TOKEN: ${{ inputs.token }}
+        ANACONDA_CLI_FORCE_NEW: '1'
+        INPUT_VERBOSE: ${{ inputs.verbose }}
+        INPUT_FORCE: ${{ inputs.force }}
+        INPUT_PRIVATE: ${{ inputs.private }}
+        INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_OWNER: ${{ inputs.owner }}
+        INPUT_PACKAGES: ${{ inputs.packages }}
+      run: |
+        pixi global install anaconda-client
+
+        FLAGS=""
+
+        if [ "$INPUT_VERBOSE" = "true" ]; then
+          FLAGS="$FLAGS --verbose"
+        fi
+
+        if [ "$INPUT_FORCE" = "true" ]; then
+          FLAGS="$FLAGS --force"
+        fi
+
+        if [ "$INPUT_PRIVATE" = "true" ]; then
+          FLAGS="$FLAGS --private"
+        fi
+
+        if [ -n "$INPUT_LABELS" ]; then
+          IFS=',' read -ra LABELS <<< "$INPUT_LABELS"
+          for label in "${LABELS[@]}"; do
+            FLAGS="$FLAGS --label $(echo "$label" | xargs)"
+          done
+        fi
+
+        anaconda --verbose --token "$ANACONDA_API_TOKEN" upload --user "$INPUT_OWNER" $FLAGS $INPUT_PACKAGES

--- a/.github/actions/upload-package/action.yml
+++ b/.github/actions/upload-package/action.yml
@@ -30,21 +30,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check for existing pixi
-      id: pixi-check
-      shell: bash
-      run: |
-        if command -v pixi >/dev/null 2>&1; then
-          echo "installed=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "installed=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Setup pixi
-      if: steps.pixi-check.outputs.installed != 'true'
-      uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+    - name: Set up ana with anaconda-cli
+      uses: ./.github/actions/setup-ana
       with:
-        pixi-version: v0.67.2
+        tools: anaconda-cli
 
     - name: Upload to anaconda.org
       shell: bash
@@ -58,8 +47,6 @@ runs:
         INPUT_OWNER: ${{ inputs.owner }}
         INPUT_PACKAGES: ${{ inputs.packages }}
       run: |
-        pixi global install anaconda-client
-
         FLAGS=""
 
         if [ "$INPUT_VERBOSE" = "true" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,11 +73,10 @@ jobs:
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-dsn-${{ steps.dsn-hash.outputs.hash }}
 
       - name: Set up ana with pixi
-        uses: anaconda/github-actions/setup-ana@3d7b08cd24c1c5fc8a92a20caa9564bda187d7c1 # v0.2.1
+        uses: ./.github/actions/setup-ana
         with:
           ana-version: v0.1.2
           tools: pixi
-          github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
       - name: Run unit tests
         if: ${{ !inputs.skip-tests }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -35,11 +35,10 @@ jobs:
           mkdir -p ~/.cargo && echo -e '[net]\ngit-fetch-with-cli = true' >> ~/.cargo/config.toml
 
       - name: Set up ana with pixi
-        uses: anaconda/github-actions/setup-ana@3d7b08cd24c1c5fc8a92a20caa9564bda187d7c1 # v0.2.1
+        uses: ./.github/actions/setup-ana
         with:
           ana-version: v0.1.2
           tools: pixi
-          github-token: ${{ secrets.PRIVATE_REPO_TOKEN }}  # zizmor: ignore[secrets-outside-env]
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci]
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions
+
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -40,15 +46,15 @@ jobs:
           merge-multiple: true
 
       - name: Upload to anaconda.org
-        uses: anaconda/github-actions/upload-package@3d7b08cd24c1c5fc8a92a20caa9564bda187d7c1 # v0.2.1
+        uses: ./.github/actions/upload-package
         with:
           token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
           owner: anaconda-cloud
           packages: packages/*/*.conda
           labels: ${{ github.event_name == 'release' && 'main' || 'dev' }}
-          private: true
-          force: true
-          verbose: true
+          private: 'true'
+          force: 'true'
+          verbose: 'true'
 
   create-github-release:
     name: Upload Binaries to GitHub Release


### PR DESCRIPTION
## Summary
The `anaconda/github-actions` repo is internal and not accessible from this public repo. This PR replaces the remote actions with local composite actions:

- **`.github/actions/setup-ana`** - Installs ana via the public https://anaconda.sh/install.sh installer and optional tools (pixi, etc.)
- **`.github/actions/upload-package`** - Uploads conda packages to anaconda.org using anaconda-client

This removes all dependencies on the private `anaconda/github-actions` repository.

## Test plan
- [ ] CI workflows pass (setup-ana works on all platforms)
- [ ] Pre-commit workflow passes
- [ ] Release workflow can upload packages (will need to verify on a release)