### PR TITLE
fix: Only send Authorization header to allowed domains

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -50,6 +50,18 @@ impl AuthMiddleware {
     }
 }
 
+const AUTH_ALLOWED_DOMAINS: &[&str] = &["anaconda.com"];
+
+fn is_auth_allowed_domain(url: &reqwest::Url) -> bool {
+    url.host_str()
+        .map(|host| {
+            AUTH_ALLOWED_DOMAINS
+                .iter()
+                .any(|domain| host == *domain || host.ends_with(&format!(".{}", domain)))
+        })
+        .unwrap_or(false)
+}
+
 #[async_trait::async_trait]
 impl Middleware for AuthMiddleware {
     async fn handle(
@@ -58,13 +70,15 @@ impl Middleware for AuthMiddleware {
         extensions: &mut http::Extensions,
         next: Next<'_>,
     ) -> Result<Response> {
-        if let Ok(Some(api_key)) = auth::get_api_key(&self.config) {
-            if let Ok(mut value) =
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key))
-            {
-                value.set_sensitive(true);
-                req.headers_mut()
-                    .insert(reqwest::header::AUTHORIZATION, value);
+        if is_auth_allowed_domain(req.url()) {
+            if let Ok(Some(api_key)) = auth::get_api_key(&self.config) {
+                if let Ok(mut value) =
+                    reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key))
+                {
+                    value.set_sensitive(true);
+                    req.headers_mut()
+                        .insert(reqwest::header::AUTHORIZATION, value);
+                }
             }
         }
         next.run(req, extensions).await
@@ -284,6 +298,28 @@ mod tests {
 
         // Verify we can create a request
         let _request = client.get("https://example.com/test");
+    }
+
+    #[test]
+    fn test_is_auth_allowed_domain() {
+        let parse = |s| reqwest::Url::parse(s).unwrap();
+
+        // Should match anaconda.com and subdomains
+        assert!(is_auth_allowed_domain(&parse("https://anaconda.com/api")));
+        assert!(is_auth_allowed_domain(&parse(
+            "https://api.anaconda.com/v1"
+        )));
+        assert!(is_auth_allowed_domain(&parse(
+            "https://sub.api.anaconda.com/"
+        )));
+
+        // Should not match other domains
+        assert!(!is_auth_allowed_domain(&parse("https://example.com/")));
+        assert!(!is_auth_allowed_domain(&parse("https://notanaconda.com/")));
+        assert!(!is_auth_allowed_domain(&parse("https://fakeanaconda.com/")));
+        assert!(!is_auth_allowed_domain(&parse(
+            "https://anaconda.com.evil.com/"
+        )));
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -62,6 +62,10 @@ fn is_auth_allowed_domain(url: &reqwest::Url) -> bool {
         .unwrap_or(false)
 }
 
+fn is_auth_allowed(url: &reqwest::Url, base_url: &str) -> bool {
+    is_auth_allowed_domain(url) || url.as_str().starts_with(base_url)
+}
+
 #[async_trait::async_trait]
 impl Middleware for AuthMiddleware {
     async fn handle(
@@ -70,7 +74,7 @@ impl Middleware for AuthMiddleware {
         extensions: &mut http::Extensions,
         next: Next<'_>,
     ) -> Result<Response> {
-        if is_auth_allowed_domain(req.url()) {
+        if is_auth_allowed(req.url(), &self.config.base_url()) {
             if let Ok(Some(api_key)) = auth::get_api_key(&self.config) {
                 if let Ok(mut value) =
                     reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key))


### PR DESCRIPTION
## Summary
- Adds domain allowlist check to `AuthMiddleware` to only send Authorization headers to `anaconda.com` and its subdomains
- Prevents leaking API tokens when using `ana api fetch` with external URLs

## Test plan
- [ ] Run `ana api fetch GET https://httpbin.org/headers` and verify no Authorization header is sent
- [ ] Run `ana api fetch GET https://api.anaconda.com/whoami` and verify request succeeds with auth

Jira: [CLI-625](https://anaconda.atlassian.net/browse/CLI-625)

[CLI-625]: https://anaconda.atlassian.net/browse/CLI-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ