### PR TITLE
ci: Place --verbose flag before upload subcommand in upload-package action

### DIFF
--- a/.github/actions/upload-package/action.yml
+++ b/.github/actions/upload-package/action.yml
@@ -47,11 +47,12 @@ runs:
         INPUT_OWNER: ${{ inputs.owner }}
         INPUT_PACKAGES: ${{ inputs.packages }}
       run: |
-        FLAGS=""
-
+        VERBOSE_FLAG=""
         if [ "$INPUT_VERBOSE" = "true" ]; then
-          FLAGS="$FLAGS --verbose"
+          VERBOSE_FLAG="--verbose"
         fi
+
+        FLAGS=""
 
         if [ "$INPUT_FORCE" = "true" ]; then
           FLAGS="$FLAGS --force"
@@ -68,4 +69,4 @@ runs:
           done
         fi
 
-        anaconda --verbose --token "$ANACONDA_API_TOKEN" upload --user "$INPUT_OWNER" $FLAGS $INPUT_PACKAGES
+        anaconda $VERBOSE_FLAG --token "$ANACONDA_API_TOKEN" upload --user "$INPUT_OWNER" $FLAGS $INPUT_PACKAGES


### PR DESCRIPTION
## Summary
- Fixes the upload-package action where `--verbose` was being added to `FLAGS` which comes after the `upload` subcommand
- The anaconda CLI expects `--verbose` before the subcommand, not after
- This was causing `--verbose` to be interpreted as a file argument, resulting in: `BinstarError: File "--verbose" does not exist`

## Test plan
- [ ] Merge and verify the release workflow completes successfully