### PR TITLE
ci: Skip running integration test in Git Bash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       run:
         # Use native shells unless bash is necessary.
         # Prefer PowerShell 5 on Windows since this is the default version.
-        shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+        shell: ${{ startsWith(matrix.os, 'windows-') && 'powershell' || 'bash' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,17 +151,11 @@ jobs:
           MACOS_DEVELOPER_ID: ${{ steps.sign-notarize-macos.outputs.developer-id }}
           TEST_WINDOWS_SIGNING: 1
         run: pixi run test-integration
+        shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash -el {0}' }}
 
-      - name: Run integration tests (PowerShell)
+      - name: Run Windows SH integration tests
         if: ${{ !inputs.skip-tests && runner.os == 'Windows' }}
-        env:
-          ANA_SENTRY_ENVIRONMENT: integration-test
-          # Disable Sentry for pre-merge builds (PRs, merge queue) to avoid polluting error tracking
-          ANA_SENTRY_DISABLED: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-          # API key for tests requiring real authentication (pixi, uv, pip feature tests)
-          ANA_TEST_API_KEY: ${{ secrets.ANA_TEST_API_KEY }}
-        run: pixi run test-integration
-        shell: powershell
+        run: pixi run pytest -v test/test_sh_install_script.py
 
       - name: Build conda package
         run: pixi run build-conda

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
+    defaults:
+      run:
+        # Use native shells unless bash is necessary.
+        # Prefer PowerShell 5 on Windows since this is the default version.
+        shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,11 +156,6 @@ jobs:
           TEST_WINDOWS_SIGNING: 1
         run: pixi run test-integration
 
-      - name: Run Windows SH integration tests
-        if: ${{ !inputs.skip-tests && runner.os == 'Windows' }}
-        run: pixi run pytest -v test/test_sh_install_script.py
-        shell: bash
-
       - name: Build conda package
         run: pixi run build-conda
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,10 +39,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
-    defaults:
-      run:
-        shell: bash -el {0}
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -56,10 +52,12 @@ jobs:
           git config --global url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add url."https://x-access-token:${REPO_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
           mkdir -p ~/.cargo && echo -e '[net]\ngit-fetch-with-cli = true' >> ~/.cargo/config.toml
+        shell: bash
 
       - name: Hash SENTRY_DSN for cache key
         id: dsn-hash
         run: echo "hash=$(echo -n "$SENTRY_DSN" | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Cache Cargo registry and build
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -151,11 +149,11 @@ jobs:
           MACOS_DEVELOPER_ID: ${{ steps.sign-notarize-macos.outputs.developer-id }}
           TEST_WINDOWS_SIGNING: 1
         run: pixi run test-integration
-        shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash -el {0}' }}
 
       - name: Run Windows SH integration tests
         if: ${{ !inputs.skip-tests && runner.os == 'Windows' }}
         run: pixi run pytest -v test/test_sh_install_script.py
+        shell: bash
 
       - name: Build conda package
         run: pixi run build-conda

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -24,6 +25,16 @@ def _find_repo_root() -> Path:
 REPO_ROOT = _find_repo_root()
 
 AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def get_powershell_binary() -> str:
+    """Find the PowerShell binary installed for the system."""
+
+    if shutil.which("pwsh"):
+        return "pwsh"
+    if shutil.which("powershell"):
+        return "powershell"
+    return ""
 
 
 def assert_output_contains(text: str, *patterns: str) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,12 +28,18 @@ AnaRunner = Callable[..., subprocess.CompletedProcess[str]]
 
 
 def get_powershell_binary() -> str:
-    """Find the PowerShell binary installed for the system."""
+    """Find the PowerShell binary installed for the system.
 
-    if shutil.which("pwsh"):
-        return "pwsh"
+    Prefer `powershell`, which typically points to PowerShell 5,
+    since this is the default version on Windows. The shell used
+    in the CI should be the same - mixing will lead to missing
+    module errors.
+    """
+
     if shutil.which("powershell"):
         return "powershell"
+    if shutil.which("pwsh"):
+        return "pwsh"
     return ""
 
 

--- a/tests/test_ps1_install_script.py
+++ b/tests/test_ps1_install_script.py
@@ -13,12 +13,10 @@ from helpers import REPO_ROOT
 
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.ps1"
 
-# Prefer powershell (Windows PowerShell 5) for backwards compatibility testing
-# Fall back to pwsh (PowerShell Core) on non-Windows
-if shutil.which("powershell"):
-    PWSH = "powershell"
-elif shutil.which("pwsh"):
+if shutil.which("pwsh"):
     PWSH = "pwsh"
+elif shutil.which("powershell"):
+    PWSH = "powershell"
 else:
     pytest.skip("Tests require PowerShell.", allow_module_level=True)
 

--- a/tests/test_ps1_install_script.py
+++ b/tests/test_ps1_install_script.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -10,14 +9,11 @@ from pathlib import Path
 import pytest
 from helpers import IS_WINDOWS
 from helpers import REPO_ROOT
+from helpers import get_powershell_binary
 
 SCRIPT_PATH = REPO_ROOT / "scripts" / "install.ps1"
 
-if shutil.which("pwsh"):
-    PWSH = "pwsh"
-elif shutil.which("powershell"):
-    PWSH = "powershell"
-else:
+if not (PWSH := get_powershell_binary()):
     pytest.skip("Tests require PowerShell.", allow_module_level=True)
 
 BINARY_SUFFIX = ".exe" if IS_WINDOWS else ""

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from helpers import IS_WINDOWS
+from helpers import get_powershell_binary
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
 if not IS_WINDOWS:
     pytest.skip("Windows signing tests", allow_module_level=True)
 
+if not (PWSH := get_powershell_binary()):
+    pytest.skip("Tests require PowerShell.", allow_module_level=True)
 
 # Use environment variable as sentinel variable
 # since local builds are not expected to be signed
@@ -30,7 +33,7 @@ def get_authenticode_signature(binary_path: Path) -> dict[str, Any]:
     """Get Authenticode signature information for a Windows binary."""
     result = subprocess.run(
         [
-            "powershell",
+            PWSH,
             "-c",
             f"ConvertTo-Json (Get-AuthenticodeSignature '{binary_path}')",
         ],

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -35,7 +35,10 @@ def get_authenticode_signature(binary_path: Path) -> dict[str, Any]:
         [
             PWSH,
             "-c",
-            f"ConvertTo-Json (Get-AuthenticodeSignature '{binary_path}')",
+            # ConvertTo-Json truncates after a maximum nesting depth.
+            # In PowerShell 7, this emits a warning, which makes the
+            # output invalid JSON.
+            f"ConvertTo-Json -Depth 5 (Get-AuthenticodeSignature '{binary_path}')",
         ],
         text=True,
         check=True,


### PR DESCRIPTION
## Summary

Windows currently runs the full set of integration tests in both Git Bash and PowerShell. As pointed out in #182, this takes a long time to finish. #182 introduced parallelization of integration test, but it comes with increased code complexity.

Initially, I added the PowerShell tests to test the PowerShell installation script and kept Git Bash because I erroneously believed that the SH installation script test didn't run on PowerShell. Looking at the logs though, that appears to be false: they run and succeed inside PowerShell. So, I think there is little gain in running the full set of integration tests in both shells.

Instead, run on workflows on default shells (PowerShell on Windows and `bash` on Linux) unless `bash` is specifically required.

Supersedes #182 