### PR TITLE
chore: Add fingerprint test for Windows certificates

### DIFF
--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -27,6 +27,11 @@ inputs:
     description: URL to the HashiCorp Vault.
     required: true
 
+outputs:
+  fingerprint:
+    description: The fingerprint of the public certificate. Used for testing.
+    value: ${{ steps.certificate.outputs.thumbprint }}
+
 runs:
   using: composite
   steps:
@@ -71,6 +76,7 @@ runs:
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate client_id | client-id ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate subscription_id | subscription-id ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate tenant_id | tenant-id ;
+          anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate thumbprint | thumbprint ;
           anaconda-cli/${{ inputs.vault-mount }}/data/windows/certificate url | url
 
     - name: Log into Azure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
           CERTIFICATE_TRUSTED: ${{ inputs.environment == 'prod' }}
           MACOS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-notarize-macos.outputs.fingerprint }}
           MACOS_DEVELOPER_ID: ${{ steps.sign-notarize-macos.outputs.developer-id }}
-          TEST_WINDOWS_SIGNING: 1
+          WINDOWS_CERTIFICATE_FINGERPRINT: ${{ steps.sign-windows.outputs.fingerprint }}
         run: pixi run test-integration
 
       - name: Run integration tests (PowerShell)

--- a/tests/test_windows_signing.py
+++ b/tests/test_windows_signing.py
@@ -22,7 +22,7 @@ if not IS_WINDOWS:
 
 # Use environment variable as sentinel variable
 # since local builds are not expected to be signed
-if not os.environ.get("TEST_WINDOWS_SIGNING"):
+if not os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT"):
     pytest.skip("Binary is not expected to be signed", allow_module_level=True)
 
 
@@ -55,6 +55,15 @@ def assert_signature_valid(cert_info: dict[str, Any], name: str) -> None:
         0 if os.environ.get("CERTIFICATE_TRUSTED", "").lower() == "true" else 1
     )
     assert status == expected_status, f"{name} trust status mismatch"
+    certificate = cert_info.get("SignerCertificate")
+    assert certificate, f"No certificate found for {name}"
+    actual_fingerprint = certificate.get("Thumbprint", "")
+    expected_fingerprint = os.environ.get("WINDOWS_CERTIFICATE_FINGERPRINT", "")
+    assert actual_fingerprint == expected_fingerprint, (
+        f"Certificate fingerprint mismatch.\n"
+        f"Expected: {expected_fingerprint}\n"
+        f"Actual:   {actual_fingerprint}"
+    )
 
 
 def test_binary_signed(ana_binary: Path | None) -> None:


### PR DESCRIPTION
## Summary

Verify the signature thumbprint in Windows integration tests. Windows signing was introduced in #207, but lacked fingerprint verification the macOS signing tests had. Now that the thumbprints are available in the Vault, we can test the fingerprint the same way.