### PR TITLE
fix: Skip download when updating to same version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,7 @@ pub enum Action {
     },
     Update {
         version: Option<String>,
+        force: bool,
     },
     CheckForUpdate,
     ShowAvailableVersions,
@@ -305,8 +306,8 @@ impl Action {
             Action::Logout => Ok(auth::logout(ctx).into_diagnostic()?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx).into_diagnostic()?),
             Action::Whoami { json } => Ok(auth::whoami(ctx, json).await.into_diagnostic()?),
-            Action::Update { version } => {
-                update::run_update(ctx, VERSION, version).await;
+            Action::Update { version, force } => {
+                update::run_update(ctx, VERSION, version, force).await;
                 Ok(())
             }
             Action::CheckForUpdate => {
@@ -553,13 +554,14 @@ pub fn parse() -> (Action, LogLevel) {
                         version,
                         check,
                         list,
+                        force,
                     }) => {
                         if check {
                             Action::CheckForUpdate
                         } else if list {
                             Action::ShowAvailableVersions
                         } else {
-                            Action::Update { version }
+                            Action::Update { version, force }
                         }
                     }
                     Some(SelfCommands::UserAgent { prefix }) => Action::UserAgent { prefix },
@@ -949,12 +951,16 @@ enum SelfCommands {
         version: Option<String>,
 
         /// Check if an update is available
-        #[arg(long, conflicts_with_all = ["list", "version"])]
+        #[arg(long, conflicts_with_all = ["list", "version", "force"])]
         check: bool,
 
         /// List available versions
-        #[arg(long, conflicts_with_all = ["check", "version"])]
+        #[arg(long, conflicts_with_all = ["check", "version", "force"])]
         list: bool,
+
+        /// Force reinstall even if already on the target version
+        #[arg(long, conflicts_with_all = ["check", "list"])]
+        force: bool,
     },
 
     /// Display the user-agent string

--- a/src/update.rs
+++ b/src/update.rs
@@ -426,6 +426,7 @@ pub async fn run_update(
     ctx: &CommandContext,
     current_version: &str,
     target_version: Option<String>,
+    force: bool,
 ) {
     use crate::ui::status;
 
@@ -437,9 +438,9 @@ pub async fn run_update(
             format!("v{}", version)
         };
 
-        // Check if already on this version
+        // Check if already on this version (unless --force is used)
         let current_tag = format!("v{}", current_version);
-        if target_tag == current_tag {
+        if !force && target_tag == current_tag {
             print_up_to_date(current_version);
             return;
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -414,6 +414,14 @@ fn print_update_success(current_version: &str, new_version: &str, elapsed: std::
     eprintln!();
 }
 
+fn print_up_to_date(current_version: &str) {
+    use crate::ui::status;
+    eprintln!("  {}", status::section("UP TO DATE"));
+    eprintln!();
+    eprintln!("  {:<10} v{}", "Current:", current_version);
+    eprintln!();
+}
+
 pub async fn run_update(
     ctx: &CommandContext,
     current_version: &str,
@@ -422,7 +430,20 @@ pub async fn run_update(
     use crate::ui::status;
 
     if let Some(version) = target_version {
-        // Install specific version
+        // Normalize version tag (ensure v prefix)
+        let target_tag = if version.starts_with('v') {
+            version
+        } else {
+            format!("v{}", version)
+        };
+
+        // Check if already on this version
+        let current_tag = format!("v{}", current_version);
+        if target_tag == current_tag {
+            print_up_to_date(current_version);
+            return;
+        }
+
         let releases = match fetch_available_releases(ctx).await {
             Ok(r) => r,
             Err(e) => {
@@ -430,13 +451,6 @@ pub async fn run_update(
                 status::error(&format!("Failed to fetch releases: {}", e));
                 return;
             }
-        };
-
-        // Normalize version tag (ensure v prefix)
-        let target_tag = if version.starts_with('v') {
-            version
-        } else {
-            format!("v{}", version)
         };
 
         let release = match releases.into_iter().find(|r| r.tag_name == target_tag) {
@@ -483,10 +497,7 @@ pub async fn run_update(
                 }
             }
             UpdateCheck::AlreadyUpToDate => {
-                eprintln!("  {}", status::section("UP TO DATE"));
-                eprintln!();
-                eprintln!("  {:<10} v{}", "Current:", current_version);
-                eprintln!();
+                print_up_to_date(current_version);
             }
             UpdateCheck::NoReleases => {
                 status::warn("No releases available.");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,3 +283,11 @@ def ana_install_env_with_mock_server(
     """Provide isolated environment with mock server URL."""
     ana_install_env_isolated["ANA_BASE_URL"] = ana_binary_mock_server
     return ana_install_env_isolated
+
+
+@pytest.fixture
+def ana_version(run_ana: AnaRunner) -> str:
+    """Get the current ana version."""
+    result = run_ana("--version")
+    assert result.returncode == 0
+    return result.stdout.strip()

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -54,6 +54,13 @@ class TestSelfUpdateSameVersion:
             or "Already on version" not in result.stderr
         )
 
+    def test_update_check_still_works(self, run_ana: AnaRunner) -> None:
+        """The --check flag should still work as before."""
+        result = run_ana("self", "update", "--check")
+        assert result.returncode == 0
+        # Should show either update available or up to date
+        assert "UPDATE" in result.stderr or "UP TO DATE" in result.stderr
+
 
 class TestSelfUpdateCli:
     """Tests for self update CLI interface (no network required)."""
@@ -87,10 +94,3 @@ class TestSelfUpdateDifferentVersion:
         result = run_ana("self", "update", "v999.999.999")
         assert result.returncode == 0  # Command runs but shows error
         assert "not found" in result.stderr.lower()
-
-    def test_update_check_still_works(self, run_ana: AnaRunner) -> None:
-        """The --check flag should still work as before."""
-        result = run_ana("self", "update", "--check")
-        assert result.returncode == 0
-        # Should show either update available or up to date
-        assert "UPDATE" in result.stderr or "UP TO DATE" in result.stderr

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
+import pytest
 from helpers import AnaRunner
 
 
 class TestSelfUpdateSameVersion:
     """Tests for 'ana self update <version>' when already on that version."""
 
+    @pytest.mark.parametrize("prefix", ["v", ""])
     def test_update_to_same_version_shows_up_to_date(
-        self, run_ana: AnaRunner, ana_version: str
+        self, run_ana: AnaRunner, ana_version: str, prefix: str
     ) -> None:
         """When updating to the current version, show 'up to date' instead of downloading."""
-
-        # Try to update to the same version (with v prefix)
-        result = run_ana("self", "update", f"v{ana_version}")
+        result = run_ana("self", "update", f"{prefix}{ana_version}")
         assert result.returncode == 0
 
         # Should show "UP TO DATE" status, not "UPDATED"
@@ -23,18 +23,6 @@ class TestSelfUpdateSameVersion:
         # Should show current version
         assert ana_version in result.stderr
         # Should NOT show download progress
-        assert "Downloading" not in result.stderr
-
-    def test_update_to_same_version_without_v_prefix(
-        self, run_ana: AnaRunner, ana_version: str
-    ) -> None:
-        """Version comparison should work without 'v' prefix."""
-        # Try to update to the same version (without v prefix)
-        result = run_ana("self", "update", ana_version)
-        assert result.returncode == 0
-
-        # Should show "UP TO DATE" status
-        assert "UP TO DATE" in result.stderr
         assert "Downloading" not in result.stderr
 
     def test_update_to_same_version_with_force_flag(

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1,0 +1,63 @@
+"""Integration tests for ana self update same-version handling."""
+
+from __future__ import annotations
+
+from helpers import AnaRunner
+
+
+def get_version(run_ana: AnaRunner) -> str:
+    """Get the current ana version."""
+    result = run_ana("--version")
+    assert result.returncode == 0
+    return result.stdout.strip()
+
+
+class TestSelfUpdateSameVersion:
+    """Tests for 'ana self update <version>' when already on that version (CLI-626)."""
+
+    def test_update_to_same_version_shows_up_to_date(self, run_ana: AnaRunner) -> None:
+        """When updating to the current version, show 'up to date' instead of downloading."""
+        current_version = get_version(run_ana)
+
+        # Try to update to the same version (with v prefix)
+        result = run_ana("self", "update", f"v{current_version}")
+        assert result.returncode == 0
+
+        # Should show "UP TO DATE" status, not "UPDATED"
+        assert "UP TO DATE" in result.stderr
+        assert "UPDATED" not in result.stderr
+        # Should show current version
+        assert current_version in result.stderr
+        # Should NOT show download progress
+        assert "Downloading" not in result.stderr
+
+    def test_update_to_same_version_without_v_prefix(self, run_ana: AnaRunner) -> None:
+        """Version comparison should work without 'v' prefix."""
+        current_version = get_version(run_ana)
+
+        # Try to update to the same version (without v prefix)
+        result = run_ana("self", "update", current_version)
+        assert result.returncode == 0
+
+        # Should show "UP TO DATE" status
+        assert "UP TO DATE" in result.stderr
+        assert "Downloading" not in result.stderr
+
+
+class TestSelfUpdateDifferentVersion:
+    """Tests to ensure normal update behavior is preserved."""
+
+    def test_update_to_nonexistent_version_shows_error(
+        self, run_ana: AnaRunner
+    ) -> None:
+        """Updating to a non-existent version should show an error."""
+        result = run_ana("self", "update", "v999.999.999")
+        assert result.returncode == 0  # Command runs but shows error
+        assert "not found" in result.stderr.lower()
+
+    def test_update_check_still_works(self, run_ana: AnaRunner) -> None:
+        """The --check flag should still work as before."""
+        result = run_ana("self", "update", "--check")
+        assert result.returncode == 0
+        # Should show either update available or up to date
+        assert "UPDATE" in result.stderr or "UP TO DATE" in result.stderr

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -5,52 +5,46 @@ from __future__ import annotations
 from helpers import AnaRunner
 
 
-def get_version(run_ana: AnaRunner) -> str:
-    """Get the current ana version."""
-    result = run_ana("--version")
-    assert result.returncode == 0
-    return result.stdout.strip()
-
-
 class TestSelfUpdateSameVersion:
     """Tests for 'ana self update <version>' when already on that version."""
 
-    def test_update_to_same_version_shows_up_to_date(self, run_ana: AnaRunner) -> None:
+    def test_update_to_same_version_shows_up_to_date(
+        self, run_ana: AnaRunner, ana_version: str
+    ) -> None:
         """When updating to the current version, show 'up to date' instead of downloading."""
-        current_version = get_version(run_ana)
 
         # Try to update to the same version (with v prefix)
-        result = run_ana("self", "update", f"v{current_version}")
+        result = run_ana("self", "update", f"v{ana_version}")
         assert result.returncode == 0
 
         # Should show "UP TO DATE" status, not "UPDATED"
         assert "UP TO DATE" in result.stderr
         assert "UPDATED" not in result.stderr
         # Should show current version
-        assert current_version in result.stderr
+        assert ana_version in result.stderr
         # Should NOT show download progress
         assert "Downloading" not in result.stderr
 
-    def test_update_to_same_version_without_v_prefix(self, run_ana: AnaRunner) -> None:
+    def test_update_to_same_version_without_v_prefix(
+        self, run_ana: AnaRunner, ana_version: str
+    ) -> None:
         """Version comparison should work without 'v' prefix."""
-        current_version = get_version(run_ana)
-
         # Try to update to the same version (without v prefix)
-        result = run_ana("self", "update", current_version)
+        result = run_ana("self", "update", ana_version)
         assert result.returncode == 0
 
         # Should show "UP TO DATE" status
         assert "UP TO DATE" in result.stderr
         assert "Downloading" not in result.stderr
 
-    def test_update_to_same_version_with_force_flag(self, run_ana: AnaRunner) -> None:
+    def test_update_to_same_version_with_force_flag(
+        self, run_ana: AnaRunner, ana_version: str
+    ) -> None:
         """The --force flag should bypass the same-version check and perform update."""
-        current_version = get_version(run_ana)
-
         # Force update to the same version - this should attempt to download
         # Since we're testing locally, we check that it doesn't show "UP TO DATE"
         # and instead proceeds with the update flow
-        result = run_ana("self", "update", f"v{current_version}", "--force")
+        result = run_ana("self", "update", f"v{ana_version}", "--force")
 
         # When forcing, it should NOT show "UP TO DATE" (it proceeds to update)
         # It might fail to find the version (0.0.0 for dev builds) but that's ok -

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -43,6 +43,45 @@ class TestSelfUpdateSameVersion:
         assert "UP TO DATE" in result.stderr
         assert "Downloading" not in result.stderr
 
+    def test_update_to_same_version_with_force_flag(self, run_ana: AnaRunner) -> None:
+        """The --force flag should bypass the same-version check and perform update."""
+        current_version = get_version(run_ana)
+
+        # Force update to the same version - this should attempt to download
+        # Since we're testing locally, we check that it doesn't show "UP TO DATE"
+        # and instead proceeds with the update flow
+        result = run_ana("self", "update", f"v{current_version}", "--force")
+
+        # When forcing, it should NOT show "UP TO DATE" (it proceeds to update)
+        # It might fail to find the version (0.0.0 for dev builds) but that's ok -
+        # the point is it didn't short-circuit with "UP TO DATE"
+        assert (
+            "UP TO DATE" not in result.stderr
+            or "Already on version" not in result.stderr
+        )
+
+
+class TestSelfUpdateCli:
+    """Tests for self update CLI interface (no network required)."""
+
+    def test_force_flag_help_text(self, run_ana: AnaRunner) -> None:
+        """The --force flag should appear in help output."""
+        result = run_ana("self", "update", "--help")
+        assert result.returncode == 0
+        assert "--force" in result.stdout
+
+    def test_force_conflicts_with_check(self, run_ana: AnaRunner) -> None:
+        """The --force flag should conflict with --check."""
+        result = run_ana("self", "update", "--force", "--check")
+        assert result.returncode != 0
+        assert "cannot be used with" in result.stderr
+
+    def test_force_conflicts_with_list(self, run_ana: AnaRunner) -> None:
+        """The --force flag should conflict with --list."""
+        result = run_ana("self", "update", "--force", "--list")
+        assert result.returncode != 0
+        assert "cannot be used with" in result.stderr
+
 
 class TestSelfUpdateDifferentVersion:
     """Tests to ensure normal update behavior is preserved."""

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -13,7 +13,7 @@ def get_version(run_ana: AnaRunner) -> str:
 
 
 class TestSelfUpdateSameVersion:
-    """Tests for 'ana self update <version>' when already on that version (CLI-626)."""
+    """Tests for 'ana self update <version>' when already on that version."""
 
     def test_update_to_same_version_shows_up_to_date(self, run_ana: AnaRunner) -> None:
         """When updating to the current version, show 'up to date' instead of downloading."""


### PR DESCRIPTION
## Summary
- When running `ana self update <version>` where `<version>` matches the current version, show "UP TO DATE" instead of downloading and reinstalling unnecessarily
- Add `--force` flag to bypass the same-version check for cases where reinstallation is desired (e.g., repairing a corrupted installation)

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [ ] Run `ana self update v<current>` and verify it shows "UP TO DATE" without downloading
- [ ] Run `ana self update v<current> --force` and verify it proceeds with the download
- [ ] Run `ana self update --help` and verify `--force` flag is documented

Jira: [CLI-626](https://anaconda.atlassian.net/browse/CLI-626)

[CLI-626]: https://anaconda.atlassian.net/browse/CLI-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ