### PR TITLE
fix: Raise RLIMIT_NOFILE to prevent 'too many open files' on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "rattler_lock",
  "reqwest 0.12.28",
  "reqwest-middleware",
+ "rlimit",
  "rpassword",
  "self-replace",
  "semver",
@@ -3534,6 +3535,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+rlimit = "0.10"
 
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:59d126b4-9696-45d4-9a48-eda852591f0c",
+  "serialNumber": "urn:uuid:8e1d8ce3-9901-40c5-a2b3-32b7f2125320",
   "metadata": {
-    "timestamp": "2026-05-12T04:25:37Z",
+    "timestamp": "2026-05-13T19:42:48Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -7558,6 +7558,43 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.10.2",
+      "author": "Nugine <nugine@foxmail.com>",
+      "name": "rlimit",
+      "version": "0.10.2",
+      "description": "Resource limits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/rlimit@0.10.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/rlimit"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/Nugine/rlimit/"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.2",
       "author": "Conrad Kleinespel <conradk@conradk.com>",
       "name": "rpassword",
@@ -13463,6 +13500,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.10.2",
         "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
@@ -15450,6 +15488,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.10.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
       ]
     },
     {

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-12T04:25:37Z<br>
+Generated: 2026-05-13T19:42:48Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 432 (66 platform-specific)<br>
+Packages: 433 (67 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -266,6 +266,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.4.2 | MIT OR Apache-2.0 |  |  |
 | [retry-policies](https://crates.io/crates/retry-policies) | 0.5.2 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
+| [rlimit](https://crates.io/crates/rlimit) | 0.10.2 | MIT | linux, macos |  |
 | [rpassword](https://crates.io/crates/rpassword) | 7.5.2 | Apache-2.0 |  |  |
 | [rtoolbox](https://crates.io/crates/rtoolbox) | 0.0.5 | Apache-2.0 |  |  |
 | [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |  |
@@ -448,7 +449,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | License | Count |
 | --- | ---: |
 | MIT OR Apache-2.0 | 233 |
-| MIT | 84 |
+| MIT | 85 |
 | Apache-2.0 OR MIT | 31 |
 | Apache-2.0 | 20 |
 | BSD-3-Clause | 18 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,32 @@ fn reset_sigpipe() {
 #[cfg(not(unix))]
 fn reset_sigpipe() {}
 
+/// Attempt to raise RLIMIT_NOFILE to a value suitable for rattler installations.
+/// On macOS, respects kern.maxfilesperproc (the real hard ceiling).
+/// Logs a warning if the limit could not be raised; never fatal.
+#[cfg(unix)]
+pub fn raise_open_file_limit(target: u64) -> u64 {
+    match rlimit::increase_nofile_limit(target) {
+        Ok(n) => {
+            tracing::debug!(limit = n, "RLIMIT_NOFILE raised");
+            n
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, target, "Failed to raise RLIMIT_NOFILE");
+            0
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub fn raise_open_file_limit(_target: u64) -> u64 {
+    0
+}
+
 #[tokio::main]
 async fn main() {
     reset_sigpipe();
+    raise_open_file_limit(10240);
 
     let config = config::Config::load();
     let _diagnostics_guard = diagnostics::init(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn raise_open_file_limit(_target: u64) {}
 #[tokio::main]
 async fn main() {
     reset_sigpipe();
-    raise_open_file_limit(10240);
+    raise_open_file_limit(2048);
 
     let config = config::Config::load();
     let _diagnostics_guard = diagnostics::init(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,23 +42,15 @@ fn reset_sigpipe() {}
 /// On macOS, respects kern.maxfilesperproc (the real hard ceiling).
 /// Logs a warning if the limit could not be raised; never fatal.
 #[cfg(unix)]
-pub fn raise_open_file_limit(target: u64) -> u64 {
+fn raise_open_file_limit(target: u64) {
     match rlimit::increase_nofile_limit(target) {
-        Ok(n) => {
-            tracing::debug!(limit = n, "RLIMIT_NOFILE raised");
-            n
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, target, "Failed to raise RLIMIT_NOFILE");
-            0
-        }
+        Ok(n) => tracing::debug!(limit = n, "RLIMIT_NOFILE raised"),
+        Err(e) => tracing::warn!(error = %e, target, "Failed to raise RLIMIT_NOFILE"),
     }
 }
 
 #[cfg(not(unix))]
-pub fn raise_open_file_limit(_target: u64) -> u64 {
-    0
-}
+fn raise_open_file_limit(_target: u64) {}
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,37 +25,29 @@ mod update;
 
 pub const VERSION: &str = env!("PKG_VERSION");
 
-/// Reset SIGPIPE to default behavior so the process terminates cleanly when
-/// output is piped to commands like `head` or `grep -q`. Rust ignores SIGPIPE
-/// by default, which causes panics on broken pipe errors.
-#[cfg(unix)]
-fn reset_sigpipe() {
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+fn prepare_runtime() {
+    #[cfg(unix)]
+    {
+        // Reset SIGPIPE to default behavior so the process terminates cleanly when
+        // output is piped to commands like `head` or `grep -q`. Rust ignores SIGPIPE
+        // by default, which causes panics on broken pipe errors.
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+
+        // Raise RLIMIT_NOFILE for rattler installations. On macOS, respects
+        // kern.maxfilesperproc (the real hard ceiling).
+        match rlimit::increase_nofile_limit(2048) {
+            Ok(n) => tracing::debug!(limit = n, "RLIMIT_NOFILE raised"),
+            Err(e) => tracing::warn!(error = %e, "Failed to raise RLIMIT_NOFILE"),
+        }
     }
 }
-
-#[cfg(not(unix))]
-fn reset_sigpipe() {}
-
-/// Attempt to raise RLIMIT_NOFILE to a value suitable for rattler installations.
-/// On macOS, respects kern.maxfilesperproc (the real hard ceiling).
-/// Logs a warning if the limit could not be raised; never fatal.
-#[cfg(unix)]
-fn raise_open_file_limit(target: u64) {
-    match rlimit::increase_nofile_limit(target) {
-        Ok(n) => tracing::debug!(limit = n, "RLIMIT_NOFILE raised"),
-        Err(e) => tracing::warn!(error = %e, target, "Failed to raise RLIMIT_NOFILE"),
-    }
-}
-
-#[cfg(not(unix))]
-fn raise_open_file_limit(_target: u64) {}
 
 #[tokio::main]
 async fn main() {
-    reset_sigpipe();
-    raise_open_file_limit(2048);
+    // Apply platform-specific runtime modifications
+    prepare_runtime();
 
     let config = config::Config::load();
     let _diagnostics_guard = diagnostics::init(&config);


### PR DESCRIPTION
## Summary
Raises the soft file descriptor limit from macOS's default of 256 to 10,240 (or the hard limit, whichever is lower) before package installation begins. This prevents "too many open files" errors during rattler installations.

Uses the `rlimit` crate, which is the same approach used by pixi.

Fixes #223

## Test plan
- [ ] Run `ana tool install pixi` on macOS and verify no fd exhaustion errors
- [ ] Verify the limit is raised by running with `RUST_LOG=debug` and checking for the `RLIMIT_NOFILE raised` log message

Jira: [CLI-624](https://anaconda.atlassian.net/browse/CLI-624)

[CLI-624]: https://anaconda.atlassian.net/browse/CLI-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ