### PR TITLE
fix: Support file input for -j flag to fix PowerShell compatibility

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1013,7 +1013,7 @@ enum ApiCommands {
         #[arg(short = 'd', long, conflicts_with = "json")]
         data: Option<String>,
 
-        /// JSON request body
+        /// JSON request body (use @file.json to read from file, or - for stdin)
         #[arg(short = 'j', long, conflicts_with = "data")]
         json: Option<String>,
     },

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,7 +1,31 @@
+use std::io::{self, Read as _};
+
 use miette::{Context, IntoDiagnostic, miette};
 
 use crate::auth;
 use crate::context::CommandContext;
+
+/// Read JSON input, supporting:
+/// - Direct JSON string: `{"foo":"bar"}`
+/// - Read from file: `@filename.json`
+/// - Read from stdin: `-` or `@-`
+fn read_json_input(input: &str) -> miette::Result<String> {
+    let input = input.trim();
+    if input == "-" || input == "@-" {
+        let mut buffer = String::new();
+        io::stdin()
+            .read_to_string(&mut buffer)
+            .into_diagnostic()
+            .context("Failed to read JSON from stdin")?;
+        Ok(buffer)
+    } else if let Some(path) = input.strip_prefix('@') {
+        std::fs::read_to_string(path)
+            .into_diagnostic()
+            .context(format!("Failed to read JSON from file: {}", path))
+    } else {
+        Ok(input.to_string())
+    }
+}
 
 pub async fn api_fetch(
     ctx: &CommandContext,
@@ -34,7 +58,8 @@ pub async fn api_fetch(
         request = request.body(body.to_string());
     }
     if let Some(body) = json {
-        let parsed: serde_json::Value = serde_json::from_str(body)
+        let json_content = read_json_input(body)?;
+        let parsed: serde_json::Value = serde_json::from_str(&json_content)
             .into_diagnostic()
             .context("Invalid JSON")?;
         request = request.json(&parsed);
@@ -45,4 +70,40 @@ pub async fn api_fetch(
     println!("{}", status);
     println!("{}", body);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_json_input_direct_string() {
+        let result = read_json_input(r#"{"foo":"bar"}"#).unwrap();
+        assert_eq!(result, r#"{"foo":"bar"}"#);
+    }
+
+    #[test]
+    fn test_read_json_input_trims_whitespace() {
+        let result = read_json_input("  {\"foo\":\"bar\"}  ").unwrap();
+        assert_eq!(result, r#"{"foo":"bar"}"#);
+    }
+
+    #[test]
+    fn test_read_json_input_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.json");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        writeln!(file, r#"{{"test": "value"}}"#).unwrap();
+
+        let input = format!("@{}", file_path.display());
+        let result = read_json_input(&input).unwrap();
+        assert!(result.contains(r#""test": "value""#));
+    }
+
+    #[test]
+    fn test_read_json_input_file_not_found() {
+        let result = read_json_input("@nonexistent_file.json");
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- PowerShell handles single-quoted JSON strings differently from bash, causing `ana api fetch -j '{"foo":"bar"}'` to fail with "Invalid JSON" on Windows
- Added support for reading JSON from files using `@file.json` syntax (following curl's convention)
- Added support for reading JSON from stdin using `-` or `@-`
- Existing direct JSON string input continues to work unchanged

## Test plan
- [x] `cargo test` passes (202 tests)
- [x] `cargo clippy` passes
- [ ] On Windows PowerShell: `echo '{"foo":"bar"}' > body.json && ana api fetch /api/test --method POST -j @body.json`
- [ ] On bash/zsh: `ana api fetch /api/test --method POST -j '{"foo":"bar"}'` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)