### PR TITLE
fix: Prevent panic when running help with subcommand arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1343,4 +1343,53 @@ mod tests {
             _ => panic!("Expected Feature Disable command"),
         }
     }
+
+    #[test]
+    fn test_build_valid_subcommand_path_with_argument() {
+        // "ana feature enable main-x --help" should resolve to "feature enable"
+        // since "main-x" is an argument, not a subcommand
+        let parts = vec!["feature", "enable", "main-x"];
+        let result = build_valid_subcommand_path(&parts);
+        assert_eq!(result, Some("feature enable".to_string()));
+    }
+
+    #[test]
+    fn test_build_valid_subcommand_path_without_argument() {
+        // "ana feature enable --help" should also resolve to "feature enable"
+        let parts = vec!["feature", "enable"];
+        let result = build_valid_subcommand_path(&parts);
+        assert_eq!(result, Some("feature enable".to_string()));
+    }
+
+    #[test]
+    fn test_help_with_feature_argument_matches_help_without() {
+        // Both "ana feature enable main-x --help" and "ana feature enable --help"
+        // should produce the same subcommand path for help
+        let with_arg = build_valid_subcommand_path(&["feature", "enable", "main-x"]);
+        let without_arg = build_valid_subcommand_path(&["feature", "enable"]);
+        assert_eq!(with_arg, without_arg);
+    }
+
+    #[test]
+    fn test_build_valid_subcommand_path_nested() {
+        // Nested subcommands like "self update" should work
+        let parts = vec!["self", "update"];
+        let result = build_valid_subcommand_path(&parts);
+        assert_eq!(result, Some("self update".to_string()));
+    }
+
+    #[test]
+    fn test_build_valid_subcommand_path_invalid_start() {
+        // Starting with a non-subcommand should return None
+        let parts = vec!["not-a-command"];
+        let result = build_valid_subcommand_path(&parts);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_build_valid_subcommand_path_empty() {
+        let parts: Vec<&str> = vec![];
+        let result = build_valid_subcommand_path(&parts);
+        assert_eq!(result, None);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -681,7 +681,10 @@ fn build_valid_subcommand_path(parts: &[&str]) -> Option<String> {
     let mut valid_parts = Vec::new();
 
     for part in parts {
-        let maybe_subcmd = cmd.get_subcommands().find(|s| s.get_name() == *part).cloned();
+        let maybe_subcmd = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == *part)
+            .cloned();
         if let Some(subcmd) = maybe_subcmd {
             valid_parts.push(*part);
             cmd = subcmd;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -670,10 +670,31 @@ pub fn parse() -> (Action, LogLevel) {
 }
 
 /// Check if a string is a valid subcommand name
-fn is_valid_subcommand(name: &str) -> bool {
-    Cli::command()
-        .get_subcommands()
-        .any(|s| s.get_name() == name)
+/// Build a valid subcommand path from args, stopping when a part is not a subcommand.
+/// Returns None if no valid subcommand path can be built.
+fn build_valid_subcommand_path(parts: &[&str]) -> Option<String> {
+    if parts.is_empty() {
+        return None;
+    }
+
+    let mut cmd = Cli::command();
+    let mut valid_parts = Vec::new();
+
+    for part in parts {
+        let maybe_subcmd = cmd.get_subcommands().find(|s| s.get_name() == *part).cloned();
+        if let Some(subcmd) = maybe_subcmd {
+            valid_parts.push(*part);
+            cmd = subcmd;
+        } else {
+            break;
+        }
+    }
+
+    if valid_parts.is_empty() {
+        None
+    } else {
+        Some(valid_parts.join(" "))
+    }
 }
 
 fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
@@ -688,8 +709,7 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
             .map(|s| s.as_str())
             .collect();
 
-        if !subcommand_parts.is_empty() && is_valid_subcommand(subcommand_parts[0]) {
-            let subcommand_path = subcommand_parts.join(" ");
+        if let Some(subcommand_path) = build_valid_subcommand_path(&subcommand_parts) {
             return (Action::ShowSubcommandHelp(subcommand_path), LogLevel::Off);
         }
         return (Action::ShowHelp, LogLevel::Off);

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,6 +339,37 @@ class TestArgumentErrors:
         assert "Unknown self command: foobar" in result.stderr
 
 
+class TestHelpWithArguments:
+    """Tests for --help when arguments are provided before the flag."""
+
+    def test_feature_enable_help_with_argument(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana feature enable main-x --help' shows help, not an error."""
+        with_arg = run_ana("feature", "enable", "main-x", "--help")
+        without_arg = run_ana("feature", "enable", "--help")
+
+        assert with_arg.returncode == 0
+        assert without_arg.returncode == 0
+        assert with_arg.stdout == without_arg.stdout
+
+    def test_feature_disable_help_with_argument(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana feature disable main-x --help' shows help, not an error."""
+        with_arg = run_ana("feature", "disable", "main-x", "--help")
+        without_arg = run_ana("feature", "disable", "--help")
+
+        assert with_arg.returncode == 0
+        assert without_arg.returncode == 0
+        assert with_arg.stdout == without_arg.stdout
+
+    def test_tool_install_help_with_argument(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana tool install some-tool --help' shows help, not an error."""
+        with_arg = run_ana("tool", "install", "some-tool", "--help")
+        without_arg = run_ana("tool", "install", "--help")
+
+        assert with_arg.returncode == 0
+        assert without_arg.returncode == 0
+        assert with_arg.stdout == without_arg.stdout
+
+
 class TestBinaryFeatures:
     """Tests for binary feature configuration."""
 


### PR DESCRIPTION
## Summary
- Fixed panic when running `ana feature enable <NAME> --help` (e.g., `ana feature enable main-x --help`)
- The CLI was treating argument values like `main-x` as subcommands, causing `get_subcommand()` to panic with "subcommand should exist"
- Replaced `is_valid_subcommand()` with `build_valid_subcommand_path()` which validates each path component and stops when it encounters a non-subcommand argument

## Test plan
- [ ] Run `ana feature enable main-x --help` - should show help for `feature enable`
- [ ] Run `ana feature enable wheels --help` - should show help for `feature enable`
- [ ] Run `ana feature enable --help` - should still work
- [ ] Run `ana feature --help` - should still work
- [ ] Run `ana self update --help` - should still work
- [ ] Run `cargo test` - all tests pass
- [ ] Run `cargo clippy` - no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)