### PR TITLE
fix: Handle KeyError when deconfiguring pip on Linux

### DIFF
--- a/src/tools/pip.rs
+++ b/src/tools/pip.rs
@@ -36,8 +36,10 @@ pub fn deconfigure() -> miette::Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // "no such key" means it wasn't configured, which is fine
-        if !stderr.contains("no such key") {
+        // "no such key" means it wasn't configured, which is fine.
+        // "KeyError" can occur on Linux when the pip.conf doesn't exist or
+        // the key was never set - also safe to ignore.
+        if !stderr.contains("no such key") && !stderr.contains("KeyError") {
             return Err(miette!("Failed to deconfigure pip: {}", stderr));
         }
     }


### PR DESCRIPTION
## Summary
On Linux, `pip config unset` raises a Python `KeyError` exception with the config file path when attempting to unset a key that doesn't exist or when `pip.conf` is missing. This differs from macOS/Windows, which returns "no such key". 

This fix extends the error handling in `deconfigure()` to treat `KeyError` as a benign condition, allowing `ana feature disable wheels --pip` to succeed when the pip config was never set or has already been removed.

## Test plan
- [ ] On Linux, run `ana feature disable wheels --pip` without first enabling the feature - should succeed silently
- [ ] On Linux, run `ana feature enable wheels --pip` then `ana feature disable wheels --pip` - should succeed
- [ ] On macOS, verify existing behavior still works

Jira: [CLI-587](https://anaconda.atlassian.net/browse/CLI-587)

🤖 Generated with [Claude Code](https://claude.ai/code)

[CLI-587]: https://anaconda.atlassian.net/browse/CLI-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ