### PR TITLE
fix: Cache user_id in keyring

### DIFF
--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -7,9 +7,7 @@ use tokio::time::sleep;
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
 use super::keyring::{delete_api_key, get_api_key, save_credential};
-use super::responses::{
-    AccountResponse, DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse,
-};
+use super::responses::{DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse};
 use crate::context::CommandContext;
 use crate::input::KeyListener;
 use crate::ui::status;
@@ -107,13 +105,10 @@ fn print_token_expiration(expires_at: &str) {
 async fn save_and_display_login(ctx: &CommandContext, api_key: &str) -> Result<(), AuthError> {
     use super::api_keys::get_expiration;
 
-    // Validate the API key against the server before saving
-    let email = validate_api_key(ctx, api_key)
+    // Validate the API key and get user info (email + user_id) in a single request
+    let (email, user_id) = validate_api_key(ctx, api_key)
         .await
         .map_err(|e| AuthError::InvalidApiKey(e.to_string()))?;
-
-    // Fetch user_id for telemetry (best-effort, don't fail login if this fails)
-    let user_id = fetch_user_id(ctx, api_key).await;
 
     // Save to keyring (including user_id if available)
     save_credential(&ctx.config, api_key, user_id.as_deref())?;
@@ -164,38 +159,16 @@ fn prompt_api_key_hidden() -> Result<String, AuthError> {
     Ok(api_key.trim().to_string())
 }
 
-/// Fetch user_id from the whoami endpoint.
-/// Returns None if the request fails or user_id is not found.
-async fn fetch_user_id(ctx: &CommandContext, api_key: &str) -> Option<String> {
+/// Validate an API key by making a request to the whoami endpoint.
+/// Returns (email, Option<user_id>) if valid, or an error if invalid.
+async fn validate_api_key(
+    ctx: &CommandContext,
+    api_key: &str,
+) -> miette::Result<(String, Option<String>)> {
     let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
 
     let response = client
         .get("/api/auth/sessions/whoami")
-        .header("Authorization", format!("Bearer {}", api_key))
-        .send()
-        .await
-        .ok()?;
-
-    if !response.status().is_success() {
-        return None;
-    }
-
-    let data: serde_json::Value = response.json().await.ok()?;
-
-    data.get("passport")
-        .and_then(|p| p.get("profile"))
-        .and_then(|p| p.get("user_id"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-}
-
-/// Validate an API key by making a request to the account endpoint.
-/// Returns the user's email if valid, or an error if invalid.
-async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> miette::Result<String> {
-    let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
-
-    let response = client
-        .get("/api/account")
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
         .await
@@ -208,19 +181,31 @@ async fn validate_api_key(ctx: &CommandContext, api_key: &str) -> miette::Result
         ));
     }
 
-    let account: AccountResponse = response
+    let data: serde_json::Value = response
         .json()
         .await
-        .map_err(|e| miette::miette!("Failed to parse account response: {}", e))?;
+        .map_err(|e| miette::miette!("Failed to parse whoami response: {}", e))?;
 
-    let email = account
-        .user
-        .as_ref()
-        .and_then(|u| u.email.clone())
-        .or_else(|| account.user.as_ref().and_then(|u| u.username.clone()))
+    let profile = data.get("passport").and_then(|p| p.get("profile"));
+
+    let email = profile
+        .and_then(|p| p.get("email"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            profile
+                .and_then(|p| p.get("username"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
         .ok_or_else(|| miette::miette!("API key is not associated with a user"))?;
 
-    Ok(email)
+    let user_id = profile
+        .and_then(|p| p.get("user_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok((email, user_id))
 }
 
 /// Login with a provided API key (bypassing device flow).

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -7,7 +7,9 @@ use tokio::time::sleep;
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
 use super::keyring::{delete_api_key, get_api_key, save_credential};
-use super::responses::{DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse};
+use super::responses::{
+    DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse, WhoamiResponse,
+};
 use crate::context::CommandContext;
 use crate::input::KeyListener;
 use crate::ui::status;
@@ -181,30 +183,20 @@ async fn validate_api_key(
         ));
     }
 
-    let data: serde_json::Value = response
+    let data: WhoamiResponse = response
         .json()
         .await
         .map_err(|e| miette::miette!("Failed to parse whoami response: {}", e))?;
 
-    let profile = data.get("passport").and_then(|p| p.get("profile"));
-
-    let email = profile
-        .and_then(|p| p.get("email"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .or_else(|| {
-            profile
-                .and_then(|p| p.get("username"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-        })
+    let email = data
+        .passport
+        .profile
+        .email
+        .or(data.passport.profile.username)
         .ok_or_else(|| miette::miette!("API key is not associated with a user"))?;
 
-    // Some user types (service accounts) may not have a `user_id`, so it is `Option<String>`
-    let user_id = profile
-        .and_then(|p| p.get("user_id"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    // Service accounts may not have a user_id
+    let user_id = data.passport.user_id;
 
     Ok((email, user_id))
 }

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -200,6 +200,7 @@ async fn validate_api_key(
         })
         .ok_or_else(|| miette::miette!("API key is not associated with a user"))?;
 
+    // Some user types (service accounts) may not have a `user_id`, so it is `Option<String>`
     let user_id = profile
         .and_then(|p| p.get("user_id"))
         .and_then(|v| v.as_str())

--- a/src/auth/actions.rs
+++ b/src/auth/actions.rs
@@ -6,7 +6,7 @@ use tokio::time::sleep;
 
 use super::api_keys::create_api_key;
 use super::errors::AuthError;
-use super::keyring::{delete_api_key, get_api_key, save_api_key};
+use super::keyring::{delete_api_key, get_api_key, save_credential};
 use super::responses::{
     AccountResponse, DeviceAuthResponse, OpenIdConfig, TokenErrorResponse, TokenResponse,
 };
@@ -112,8 +112,11 @@ async fn save_and_display_login(ctx: &CommandContext, api_key: &str) -> Result<(
         .await
         .map_err(|e| AuthError::InvalidApiKey(e.to_string()))?;
 
-    // Save to keyring
-    save_api_key(&ctx.config, api_key)?;
+    // Fetch user_id for telemetry (best-effort, don't fail login if this fails)
+    let user_id = fetch_user_id(ctx, api_key).await;
+
+    // Save to keyring (including user_id if available)
+    save_credential(&ctx.config, api_key, user_id.as_deref())?;
     status::success("API key stored in keyring");
 
     // Display login success
@@ -159,6 +162,31 @@ fn prompt_api_key_hidden() -> Result<String, AuthError> {
     eprintln!("{} {}", status::dim("API key:"), status::dim(&mask));
 
     Ok(api_key.trim().to_string())
+}
+
+/// Fetch user_id from the whoami endpoint.
+/// Returns None if the request fails or user_id is not found.
+async fn fetch_user_id(ctx: &CommandContext, api_key: &str) -> Option<String> {
+    let client = ctx.unauthenticated_client(REQUEST_TIMEOUT);
+
+    let response = client
+        .get("/api/auth/sessions/whoami")
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .ok()?;
+
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let data: serde_json::Value = response.json().await.ok()?;
+
+    data.get("passport")
+        .and_then(|p| p.get("profile"))
+        .and_then(|p| p.get("user_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 /// Validate an API key by making a request to the account endpoint.

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -442,7 +442,10 @@ mod tests {
         };
 
         let json = serde_json::to_string(&credential).unwrap();
-        assert!(!json.contains("user_id"), "user_id should not appear in JSON when None");
+        assert!(
+            !json.contains("user_id"),
+            "user_id should not appear in JSON when None"
+        );
     }
 
     #[test]

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -28,10 +28,22 @@ struct Credential {
     api_key: String,
     repo_tokens: Vec<String>,
     version: u32,
+    #[serde(default)]
+    user_id: Option<String>,
 }
 
-/// Save an API key to the keyring file.
-pub fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
+/// Save an API key to the keyring file (without user_id).
+#[cfg(test)]
+fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
+    save_credential(config, api_key, None)
+}
+
+/// Save an API key and optional user_id to the keyring file.
+pub(super) fn save_credential(
+    config: &Config,
+    api_key: &str,
+    user_id: Option<&str>,
+) -> Result<(), AuthError> {
     let path = &config.keyring_path;
 
     // Create parent directories if they don't exist
@@ -50,6 +62,7 @@ pub fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
         api_key: api_key.to_string(),
         repo_tokens: vec![],
         version: CREDENTIAL_VERSION,
+        user_id: user_id.map(|s| s.to_string()),
     };
     let credential_json =
         serde_json::to_string(&credential).map_err(|e| AuthError::Keyring(e.to_string()))?;
@@ -71,6 +84,16 @@ pub fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
 
 /// Get the API key from the keyring file.
 pub fn get_api_key(config: &Config) -> Result<Option<String>, AuthError> {
+    Ok(get_credential(config)?.map(|c| c.api_key))
+}
+
+/// Get the user_id from the keyring file.
+pub fn get_user_id(config: &Config) -> Result<Option<String>, AuthError> {
+    Ok(get_credential(config)?.and_then(|c| c.user_id))
+}
+
+/// Get the full credential from the keyring file.
+fn get_credential(config: &Config) -> Result<Option<Credential>, AuthError> {
     let keyring = load_keyring(config)?;
 
     let Some(domains) = keyring.get(KEYRING_KEY) else {
@@ -88,7 +111,7 @@ pub fn get_api_key(config: &Config) -> Result<Option<String>, AuthError> {
     let credential: Credential = serde_json::from_slice(&decoded)
         .map_err(|e| AuthError::Keyring(format!("Failed to parse credential: {}", e)))?;
 
-    Ok(Some(credential.api_key))
+    Ok(Some(credential))
 }
 
 /// Delete the API key from the keyring file.
@@ -388,12 +411,53 @@ mod tests {
             api_key: "ak-123".to_string(),
             repo_tokens: vec![],
             version: 2,
+            user_id: Some("user-123".to_string()),
         };
 
         let json = serde_json::to_string(&credential).unwrap();
         let parsed: Credential = serde_json::from_str(&json).unwrap();
 
         assert_eq!(credential, parsed);
+    }
+
+    #[test]
+    fn test_credential_without_user_id() {
+        // Test backwards compatibility - old credentials without user_id should still parse
+        let json = r#"{"domain":"test.com","api_key":"ak-123","repo_tokens":[],"version":2}"#;
+        let credential: Credential = serde_json::from_str(json).unwrap();
+
+        assert_eq!(credential.domain, "test.com");
+        assert_eq!(credential.api_key, "ak-123");
+        assert_eq!(credential.user_id, None);
+    }
+
+    #[test]
+    fn test_save_and_get_user_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config_with_keyring(keyring_path, "test.com");
+
+        // Save credential with user_id
+        save_credential(&config, "test-api-key", Some("user-456")).unwrap();
+
+        // Retrieve user_id
+        assert_eq!(
+            get_user_id(&config).unwrap(),
+            Some("user-456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_user_id_returns_none_when_not_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config_with_keyring(keyring_path, "test.com");
+
+        // Save credential without user_id
+        save_credential(&config, "test-api-key", None).unwrap();
+
+        // user_id should be None
+        assert_eq!(get_user_id(&config).unwrap(), None);
     }
 
     #[cfg(unix)]

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -28,14 +28,8 @@ struct Credential {
     api_key: String,
     repo_tokens: Vec<String>,
     version: u32,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     user_id: Option<String>,
-}
-
-/// Save an API key to the keyring file (without user_id).
-#[cfg(test)]
-fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
-    save_credential(config, api_key, None)
 }
 
 /// Save an API key and optional user_id to the keyring file.
@@ -243,6 +237,11 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Test helper to save an API key without user_id.
+    fn save_api_key(config: &Config, api_key: &str) -> Result<(), AuthError> {
+        save_credential(config, api_key, None)
+    }
+
     fn test_config_with_keyring(path: PathBuf, domain: &str) -> Config {
         Config {
             domain: domain.to_string(),
@@ -429,6 +428,21 @@ mod tests {
         assert_eq!(credential.domain, "test.com");
         assert_eq!(credential.api_key, "ak-123");
         assert_eq!(credential.user_id, None);
+    }
+
+    #[test]
+    fn test_credential_none_user_id_not_serialized() {
+        // Verify that None user_id is omitted from JSON (not serialized as null)
+        let credential = Credential {
+            domain: "test.com".to_string(),
+            api_key: "ak-123".to_string(),
+            repo_tokens: vec![],
+            version: 2,
+            user_id: None,
+        };
+
+        let json = serde_json::to_string(&credential).unwrap();
+        assert!(!json.contains("user_id"), "user_id should not appear in JSON when None");
     }
 
     #[test]

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -441,10 +441,7 @@ mod tests {
         save_credential(&config, "test-api-key", Some("user-456")).unwrap();
 
         // Retrieve user_id
-        assert_eq!(
-            get_user_id(&config).unwrap(),
-            Some("user-456".to_string())
-        );
+        assert_eq!(get_user_id(&config).unwrap(), Some("user-456".to_string()));
     }
 
     #[test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -7,4 +7,4 @@ mod keyring;
 pub mod responses;
 
 pub use actions::{ensure_logged_in, login, logout, show_api_key, whoami};
-pub use keyring::get_api_key;
+pub use keyring::{get_api_key, get_user_id};

--- a/src/auth/responses.rs
+++ b/src/auth/responses.rs
@@ -32,3 +32,23 @@ pub struct TokenErrorResponse {
     pub error: String,
     pub error_description: Option<String>,
 }
+
+/// Response from the whoami endpoint.
+#[derive(Debug, Deserialize)]
+pub struct WhoamiResponse {
+    pub passport: WhoamiPassport,
+}
+
+/// Passport section of the whoami response.
+#[derive(Debug, Deserialize)]
+pub struct WhoamiPassport {
+    pub user_id: Option<String>,
+    pub profile: WhoamiProfile,
+}
+
+/// Profile section of the whoami response.
+#[derive(Debug, Deserialize)]
+pub struct WhoamiProfile {
+    pub email: Option<String>,
+    pub username: Option<String>,
+}

--- a/src/auth/responses.rs
+++ b/src/auth/responses.rs
@@ -32,16 +32,3 @@ pub struct TokenErrorResponse {
     pub error: String,
     pub error_description: Option<String>,
 }
-
-/// Account information from the API.
-#[derive(Debug, Deserialize)]
-pub struct AccountResponse {
-    pub user: Option<UserInfo>,
-}
-
-/// User information nested in account response.
-#[derive(Debug, Deserialize)]
-pub struct UserInfo {
-    pub username: Option<String>,
-    pub email: Option<String>,
-}

--- a/src/context.rs
+++ b/src/context.rs
@@ -106,9 +106,17 @@ pub struct CommandContext {
 impl CommandContext {
     /// Create a new command context.
     pub fn new() -> Self {
+        let config = Config::load();
+        let mut telemetry = TelemetryContext::new();
+
+        // Add cached user_id to telemetry if available
+        if let Ok(Some(user_id)) = crate::auth::get_user_id(&config) {
+            telemetry.add("user_id", user_id);
+        }
+
         Self {
-            telemetry: TelemetryContext::new(),
-            config: Config::load(),
+            telemetry,
+            config,
             client: OnceLock::new(),
             github_client: OnceLock::new(),
             download_client: OnceLock::new(),


### PR DESCRIPTION
## Summary
- After login, fetch `user_id` from `/api/auth/sessions/whoami` and store it in the keyring alongside the API key
- On subsequent command runs, load the cached `user_id` and add it as a telemetry attribute
- The `user_id` is cleared on logout (since the entire credential entry is removed)
- Backwards compatible with existing keyrings via `#[serde(default)]`

## Test plan
- [ ] `ana login` → verify user_id is fetched and stored (check keyring file)
- [ ] Run any command → verify `user_id` appears in telemetry spool files
- [ ] `ana logout` → verify credential (including user_id) is cleared
- [ ] Test with existing keyring without user_id → should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)