### PR TITLE
ci: Sync release assets with anaconda.sh with each release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,3 +100,42 @@ jobs:
 
           echo "Publishing release $VERSION"
           gh release edit "$VERSION" --draft=false --latest
+
+  deploy-to-anaconda-sh:
+    name: Deploy to anaconda.sh
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: [create-github-release]
+    environment: prod
+    steps:
+      - name: Obtain token
+        id: token
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          exportEnv: false
+          extraHeaders: |
+            CF-Access-Client-Id: ${{ secrets.CF_ANACONDA_CLI_CLIENT_ID }}
+            CF-Access-Client-Secret: ${{ secrets.CF_ANACONDA_CLI_CLIENT_SECRET }}
+          method: approle
+          namespace: admin
+          path: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_PATH }}
+          roleId: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_SECRET_ID }}
+          url: ${{ secrets.EXT_VAULT_ADDR }}
+          secrets: |
+            anaconda-cli/prod/data/anaconda-sh/token | pat ;
+            anaconda-cli/prod/data/anaconda-sh/workflow | repo ;
+            anaconda-cli/prod/data/anaconda-sh/workflow | workflow-id
+
+      - name: Send deploy signal
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.pat }}
+          REPO: ${{ steps.token.outputs.repo }}
+          WORKFLOW_ID: ${{ steps.token.outputs.workflow-id }}
+        run: |
+          gh api \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${REPO}/actions/workflows/${WORKFLOW_ID}/dispatches" \
+            -f "ref=main"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
     hooks:
       - id: zizmor
+        args: [--persona, auditor]
   - repo: local
     hooks:
       - id: rustfmt


### PR DESCRIPTION
## Summary

Push release assets to `anaconda.sh` with every release. Updates are currently triggered manually. This PR adds an automatic trigger to each release that will perform the update whenever a new release is on GitHub.

Jira: [CLI-630](https://anaconda.atlassian.net/browse/CLI-630)

[CLI-630]: https://anaconda.atlassian.net/browse/CLI-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ