### PR TITLE
fix!: Remove `anaconda` symlink to avoid shadowing in conda's base environment

### DIFF
--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,13 +1,9 @@
-use std::process::Command;
-
 use crate::context::CommandContext;
 use crate::paths;
 use crate::tools;
 
 pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
-    let anaconda_bin = paths::bin_path("anaconda");
-
-    if anaconda_bin.exists() {
+    if paths::tool_prefix("anaconda-cli").exists() {
         eprintln!("anaconda-cli is already installed");
         return Ok(());
     }
@@ -26,36 +22,7 @@ pub fn run_subcommand(
     subcommand: &str,
     args: &[String],
 ) -> Result<(), String> {
-    let anaconda_bin = paths::bin_path("anaconda");
-
-    if !anaconda_bin.exists() {
-        let msg = format!(
-            "anaconda not found at {}. Run `ana bootstrap` first.",
-            anaconda_bin.display()
-        );
-        tracing::error!("{}", msg);
-        return Err(msg);
-    }
-
-    run_anaconda_command(&anaconda_bin, subcommand, args)
-}
-
-fn run_anaconda_command(
-    anaconda_bin: &std::path::Path,
-    subcommand: &str,
-    args: &[String],
-) -> Result<(), String> {
-    let status = Command::new(anaconda_bin)
-        .arg(subcommand)
-        .args(args)
-        .status()
-        .map_err(|e| format!("Failed to run anaconda: {}", e))?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        let msg = format!("anaconda exited with code {}", status.code().unwrap_or(1));
-        tracing::error!("{}", msg);
-        Err(msg)
-    }
+    let mut full_args = vec![subcommand.to_string()];
+    full_args.extend(args.iter().cloned());
+    tools::run_tool_binary("anaconda-cli", "anaconda", &full_args).map_err(|e| format!("{:?}", e))
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -520,7 +520,7 @@ pub fn parse() -> (Action, LogLevel) {
 
     let cli = match Cli::from_arg_matches(&matches) {
         Ok(c) => c,
-        Err(e) => return handle_parse_error(e.into()),
+        Err(e) => return handle_parse_error(e),
     };
 
     let level: LogLevel = cli.verbose.into();

--- a/src/mcp/run.rs
+++ b/src/mcp/run.rs
@@ -6,7 +6,7 @@ use crate::ui::status;
 /// Run the `anaconda mcp` command with the given arguments.
 /// Auto-installs anaconda-cli if not present.
 pub async fn run(ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
-    if !paths::bin_path("anaconda").exists() {
+    if !paths::tool_prefix("anaconda-cli").exists() {
         status::info("Installing anaconda-cli...");
         tools::install::install_tool(ctx, "anaconda-cli").await?;
         status::blank_line();

--- a/src/telemetry/otel.rs
+++ b/src/telemetry/otel.rs
@@ -113,7 +113,7 @@ mod tests {
     fn test_serializable_value_from_otel() {
         let string_val = Value::String("test".into());
         let int_val = Value::I64(42);
-        let float_val = Value::F64(3.14);
+        let float_val = Value::F64(2.72);
         let bool_val = Value::Bool(true);
 
         assert_eq!(
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(SerializableValue::from(int_val), SerializableValue::Int(42));
         assert_eq!(
             SerializableValue::from(float_val),
-            SerializableValue::Float(3.14)
+            SerializableValue::Float(2.72)
         );
         assert_eq!(
             SerializableValue::from(bool_val),
@@ -136,7 +136,7 @@ mod tests {
         let values = vec![
             SerializableValue::String("hello".to_string()),
             SerializableValue::Int(42),
-            SerializableValue::Float(3.14),
+            SerializableValue::Float(2.72),
             SerializableValue::Bool(true),
         ];
 

--- a/src/telemetry/spool.rs
+++ b/src/telemetry/spool.rs
@@ -125,7 +125,7 @@ mod tests {
             let tmp_files: Vec<_> = fs::read_dir(&pending_dir)
                 .unwrap()
                 .filter_map(|e| e.ok())
-                .filter(|e| e.path().extension().map_or(false, |ext| ext == "tmp"))
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "tmp"))
                 .collect();
 
             assert!(tmp_files.is_empty(), "No .tmp files should remain");
@@ -238,7 +238,7 @@ mod tests {
                 },
                 TelemetryEvent::Histogram {
                     name: "histogram1".to_string(),
-                    value: 3.14,
+                    value: 2.72,
                     attributes: HashMap::new(),
                 },
             ];

--- a/src/tools/specs.rs
+++ b/src/tools/specs.rs
@@ -16,11 +16,9 @@ const TOOLS: &[Tool] = &[
     Tool {
         name: "anaconda-cli",
         lockfile: include_str!("../../tool-specs/anaconda-cli/pixi.lock"),
-        binaries: if cfg![unix] {
-            &[&["bin", "anaconda"]]
-        } else {
-            &[&["Scripts", "anaconda"]]
-        },
+        // No symlink - anaconda-cli is only accessed via ana subcommands (e.g., ana mcp)
+        // to avoid shadowing users' existing anaconda command from anaconda-auth
+        binaries: &[],
         experimental: None,
     },
     #[cfg(unix)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,27 +267,20 @@ class TestBootstrap:
         assert tool_dir.exists(), f"Tool directory not found: {tool_dir}"
         assert tool_dir.is_dir()
 
-    def test_bootstrap_creates_symlinked_binary(
+    def test_bootstrap_does_not_create_symlink(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
-        """Test that bootstrap creates a symlinked anaconda binary in ~/.ana/bin."""
+        """Test that bootstrap does NOT create an anaconda symlink in ~/.ana/bin.
+
+        anaconda-cli is only accessible via ana subcommands to avoid shadowing
+        the user's existing anaconda command from anaconda-auth.
+        """
         result = run_ana("bootstrap")
         assert result.returncode == 0
 
-        # Verify the symlinked binary exists
+        # Verify NO symlink is created
         bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
-        assert bin_path.exists(), f"Binary not found: {bin_path}"
-        tools_dir = fake_home / ".ana" / "tools"
-        if IS_WINDOWS:
-            shim_cfg = tools_dir / "shims.cfg"
-            assert (
-                "anaconda=anaconda-cli\\Scripts\\anaconda.exe\r\n"
-                in shim_cfg.read_text(newline="")
-            )
-        else:
-            src_file = tools_dir / "anaconda-cli" / "bin" / "anaconda"
-            assert bin_path.is_symlink(), f"Binary is not a symlink: {bin_path}"
-            assert bin_path.samefile(src_file)
+        assert not bin_path.exists(), f"Symlink should not be created: {bin_path}"
 
     def test_bootstrap_already_installed(
         self, run_ana: AnaRunner, fake_home: Path
@@ -297,9 +290,9 @@ class TestBootstrap:
         first_result = run_ana("bootstrap")
         assert first_result.returncode == 0
 
-        # Verify installation exists
-        bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
-        assert bin_path.exists()
+        # Verify tool prefix exists
+        tool_dir = fake_home / ".ana" / "tools" / "anaconda-cli"
+        assert tool_dir.exists()
 
         # Second run should indicate already installed
         second_result = run_ana("bootstrap")
@@ -309,13 +302,25 @@ class TestBootstrap:
     def test_bootstrap_anaconda_binary_runs(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:
-        """Test that the installed anaconda binary runs and outputs help."""
+        """Test that the installed anaconda binary runs from the tool prefix."""
         result = run_ana("bootstrap")
         assert result.returncode == 0
 
-        # Run the installed anaconda binary
-        bin_path = fake_home / ".ana" / "bin" / ANACONDA_BIN
-        assert bin_path.exists()
+        # Run the anaconda binary directly from the tool prefix
+        if IS_WINDOWS:
+            bin_path = (
+                fake_home
+                / ".ana"
+                / "tools"
+                / "anaconda-cli"
+                / "Scripts"
+                / "anaconda.exe"
+            )
+        else:
+            bin_path = (
+                fake_home / ".ana" / "tools" / "anaconda-cli" / "bin" / "anaconda"
+            )
+        assert bin_path.exists(), f"Binary not found: {bin_path}"
 
         proc = subprocess.run(
             [str(bin_path), "--help"],


### PR DESCRIPTION
## Summary
Installing `anaconda-cli` via ana created `~/.ana/bin/anaconda`, which shadowed users' existing `anaconda` command from `anaconda-auth`. This caused issues with `anaconda token` commands.

This PR removes the anaconda symlink entirely. `anaconda-cli` functionality is now only accessible through ana subcommands (e.g., `ana mcp`, `ana org`) rather than a standalone `anaconda` or `anaconda-cli` command.

Changes:
- Set `binaries: &[]` for anaconda-cli in specs.rs (no symlink created)
- Simplified anaconda_cli.rs to use run_tool_binary directly
- Updated mcp/run.rs to check tool_prefix instead of bin_path
- Updated tests to verify no symlink is created

## Test plan
- [ ] Run `ana bootstrap` and verify NO symlink is created in `~/.ana/bin/`
- [ ] Verify `ana mcp` still works (installs and runs anaconda-cli)
- [ ] Verify existing `anaconda` command (from anaconda-auth) is not shadowed