### PR TITLE
fix: Improve error message when conda is not installed

### DIFF
--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -531,7 +531,7 @@ fn find_conda() -> miette::Result<std::path::PathBuf> {
     match check {
         Ok(output) if output.status.success() => Ok(conda_path),
         _ => Err(miette::miette!(
-            "conda not found. Install it with: ana tool install conda"
+            "This feature currently requires conda to be installed separately. Install it from: https://www.anaconda.com/download"
         )),
     }
 }

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -17,6 +17,7 @@ use crate::ui::status;
 const MAIN_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main";
 const MAIN_X_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main-x";
 const REPO_HOST: &str = "repo.anaconda.cloud";
+const ANACONDA_DOWNLOAD_URL: &str = "https://www.anaconda.com/download";
 
 /// Represents a channel configuration action to be executed for conda.
 enum CondaChannelAction {
@@ -531,7 +532,8 @@ fn find_conda() -> miette::Result<std::path::PathBuf> {
     match check {
         Ok(output) if output.status.success() => Ok(conda_path),
         _ => Err(miette::miette!(
-            "This feature currently requires conda to be installed separately. Install it from: https://www.anaconda.com/download"
+            "This feature currently requires conda to be installed separately. Install it from: {}",
+            status::highlight(ANACONDA_DOWNLOAD_URL)
         )),
     }
 }


### PR DESCRIPTION
## Summary
When running `ana feature enable main-x` without conda installed, the error previously suggested `ana tool install conda`, but conda is not a managed tool. This updates the message to direct users to the Anaconda download page instead.

## Test plan
- [ ] On a machine without conda installed, run `ana feature enable main-x`
- [ ] Verify the error message says: "This feature currently requires conda to be installed separately. Install it from: https://www.anaconda.com/download"

Jira: [CLI-650](https://anaconda.atlassian.net/browse/CLI-650)

[CLI-650]: https://anaconda.atlassian.net/browse/CLI-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ