### PR TITLE
ci: Add secret property to anaconda.sh upload credentials

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,9 +123,9 @@ jobs:
           secretId: ${{ secrets.VAULT_ANACONDA_CLI_APPROLE_SECRET_ID }}
           url: ${{ secrets.EXT_VAULT_ADDR }}
           secrets: |
-            anaconda-cli/prod/data/anaconda-sh/token | pat ;
-            anaconda-cli/prod/data/anaconda-sh/workflow | repo ;
-            anaconda-cli/prod/data/anaconda-sh/workflow | workflow-id
+            anaconda-cli/prod/data/anaconda-sh/token pat | pat ;
+            anaconda-cli/prod/data/anaconda-sh/workflow repo | repo ;
+            anaconda-cli/prod/data/anaconda-sh/workflow workflow-id | workflow-id
 
       - name: Send deploy signal
         env:


### PR DESCRIPTION
## Summary

Add the properties that need to be obtained from the Vault paths for the `anaconda.sh` upload workflow.
