### PR TITLE
fix: Output HTTP status to stderr in api fetch

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -42,7 +42,7 @@ pub async fn api_fetch(
     let response = request.send().await.into_diagnostic()?;
     let status = response.status();
     let body = response.text().await.into_diagnostic()?;
-    println!("{}", status);
+    eprintln!("{}", status);
     println!("{}", body);
     Ok(())
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from helpers import AnaRunner
+from mock_auth_server import MockAuthServer
 
 IS_WINDOWS = sys.platform == "win32"
 ANACONDA_BIN = "anaconda.exe" if IS_WINDOWS else "anaconda"
@@ -368,6 +369,39 @@ class TestHelpWithArguments:
         assert with_arg.returncode == 0
         assert without_arg.returncode == 0
         assert with_arg.stdout == without_arg.stdout
+
+
+class TestApiFetch:
+    """Tests for 'ana api fetch' subcommand."""
+
+    def test_api_fetch_outputs_json_to_stdout(
+        self,
+        run_ana: AnaRunner,
+        auth_env: dict[str, str],
+        mock_auth_server: MockAuthServer,
+    ) -> None:
+        """Test that api fetch outputs JSON to stdout and status to stderr.
+
+        This ensures the output is pipeable to tools like jq.
+        """
+        import json
+
+        # First, login to get credentials
+        login_result = run_ana(
+            "login", "--api-key", env=auth_env, input=f"{mock_auth_server.api_key}\n"
+        )
+        assert login_result.returncode == 0
+
+        # Now fetch from the whoami endpoint
+        result = run_ana("api", "fetch", "/api/auth/sessions/whoami", env=auth_env)
+
+        assert result.returncode == 0
+        # Status should be on stderr, not stdout
+        assert "200" in result.stderr
+        # stdout should be valid JSON (parseable)
+        body = json.loads(result.stdout)
+        assert "passport" in body
+        assert body["passport"]["profile"]["username"] == "testuser"
 
 
 class TestBinaryFeatures:


### PR DESCRIPTION
## Summary
The `ana api fetch` command was printing the HTTP status line (e.g., "200 OK") to stdout along with the response body, making it impossible to pipe the JSON output to tools like jq.

Before:
```bash
$ ana api fetch /api/auth/sessions/whoami | jq '.passport.profile.username'
jq: error (at <stdin>:1): Cannot index number with string "passport"
```

After:
```bash
$ ana api fetch /api/auth/sessions/whoami | jq '.passport.profile.username'
"mattkram"
```

Now the status goes to stderr and only the response body goes to stdout.

## Test plan
- [x] Added integration test that verifies JSON goes to stdout and status to stderr
- [x] Manual test: `ana api fetch /api/auth/sessions/whoami 2>/dev/null | jq '.passport.profile.username'`

Jira: [CLI-655](https://anaconda.atlassian.net/browse/CLI-655)

[CLI-655]: https://anaconda.atlassian.net/browse/CLI-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ