### PR TITLE
fix: Preserve main channel when disabling main-x for pixi

### DIFF
--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -56,7 +56,9 @@ impl CondaChannelAction {
 enum PixiChannelAction {
     AddMain,
     AddMainX,
-    RemoveMainX,
+    /// Remove main-x while preserving other channels (especially main).
+    /// Contains the list of channels to keep after removal.
+    RemoveMainX(Vec<String>),
 }
 
 impl PixiChannelAction {
@@ -74,8 +76,8 @@ impl PixiChannelAction {
                     MAIN_X_CHANNEL
                 )
             }
-            PixiChannelAction::RemoveMainX => {
-                "pixi config unset --global default-channels".to_string()
+            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+                format_pixi_remove_main_x_command(channels_to_keep)
             }
         }
     }
@@ -96,13 +98,47 @@ impl PixiChannelAction {
                     &["prepend", "--global", "default-channels", MAIN_X_CHANNEL],
                 )?;
             }
-            PixiChannelAction::RemoveMainX => {
-                run_pixi_config(pixi_bin, &["unset", "--global", "default-channels"])?;
+            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+                execute_pixi_remove_main_x(pixi_bin, channels_to_keep)?;
             }
         }
         status::finish_running(&format!("Ran {}", status::highlight(&cmd)));
         Ok(())
     }
+}
+
+/// Format the display command for removing main-x from pixi while preserving other channels.
+fn format_pixi_remove_main_x_command(channels_to_keep: &[String]) -> String {
+    if channels_to_keep.is_empty() {
+        "pixi config unset --global default-channels".to_string()
+    } else {
+        format!(
+            "pixi config set --global default-channels [{}]",
+            format_pixi_channels_json(channels_to_keep)
+        )
+    }
+}
+
+/// Execute the pixi config command to remove main-x while preserving other channels.
+fn execute_pixi_remove_main_x(pixi_bin: &Path, channels_to_keep: &[String]) -> miette::Result<()> {
+    if channels_to_keep.is_empty() {
+        run_pixi_config(pixi_bin, &["unset", "--global", "default-channels"])
+    } else {
+        let channels_json = format!("[{}]", format_pixi_channels_json(channels_to_keep));
+        run_pixi_config(
+            pixi_bin,
+            &["set", "--global", "default-channels", &channels_json],
+        )
+    }
+}
+
+/// Format channels as a JSON-style string for pixi config (e.g., `"chan1", "chan2"`).
+fn format_pixi_channels_json(channels: &[String]) -> String {
+    channels
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Configure pixi auth for repo.anaconda.cloud.
@@ -209,10 +245,18 @@ fn plan_pixi_enable_actions(current_channels: &[String]) -> Vec<PixiChannelActio
 }
 
 /// Plan the actions needed to disable main-x channel for pixi.
+///
+/// Removes main-x from the channel list while preserving all other channels.
+/// If main-x is the only channel, the result will unset default-channels entirely.
 fn plan_pixi_disable_actions(current_channels: &[String]) -> Vec<PixiChannelAction> {
     let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
     if has_main_x {
-        vec![PixiChannelAction::RemoveMainX]
+        let channels_to_keep: Vec<String> = current_channels
+            .iter()
+            .filter(|c| *c != MAIN_X_CHANNEL)
+            .cloned()
+            .collect();
+        vec![PixiChannelAction::RemoveMainX(channels_to_keep)]
     } else {
         vec![]
     }
@@ -873,10 +917,80 @@ mod tests {
     }
 
     #[test]
-    fn test_pixi_channel_action_remove_main_x_display() {
-        let action = PixiChannelAction::RemoveMainX;
+    fn test_pixi_channel_action_remove_main_x_display_empty() {
+        let action = PixiChannelAction::RemoveMainX(vec![]);
         let cmd = action.command_display();
 
         assert!(cmd.contains("pixi config unset"));
+    }
+
+    #[test]
+    fn test_pixi_channel_action_remove_main_x_display_with_channels() {
+        let action = PixiChannelAction::RemoveMainX(vec![MAIN_CHANNEL.to_string()]);
+        let cmd = action.command_display();
+
+        assert!(cmd.contains("pixi config set"));
+        assert!(cmd.contains(MAIN_CHANNEL));
+    }
+
+    // ========================================================================
+    // plan_pixi_disable_actions tests
+    // ========================================================================
+
+    #[test]
+    fn test_plan_pixi_disable_actions_main_and_main_x() {
+        let current_channels = vec![MAIN_CHANNEL.to_string(), MAIN_X_CHANNEL.to_string()];
+        let actions = plan_pixi_disable_actions(&current_channels);
+
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+                assert_eq!(channels_to_keep, &vec![MAIN_CHANNEL.to_string()]);
+            }
+            _ => panic!("Expected RemoveMainX action"),
+        }
+    }
+
+    #[test]
+    fn test_plan_pixi_disable_actions_main_x_only() {
+        let current_channels = vec![MAIN_X_CHANNEL.to_string()];
+        let actions = plan_pixi_disable_actions(&current_channels);
+
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+                assert!(channels_to_keep.is_empty());
+            }
+            _ => panic!("Expected RemoveMainX action"),
+        }
+    }
+
+    #[test]
+    fn test_plan_pixi_disable_actions_no_main_x() {
+        let current_channels = vec![MAIN_CHANNEL.to_string()];
+        let actions = plan_pixi_disable_actions(&current_channels);
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_plan_pixi_disable_actions_preserves_other_channels() {
+        let current_channels = vec![
+            MAIN_CHANNEL.to_string(),
+            MAIN_X_CHANNEL.to_string(),
+            "conda-forge".to_string(),
+        ];
+        let actions = plan_pixi_disable_actions(&current_channels);
+
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+                assert_eq!(
+                    channels_to_keep,
+                    &vec![MAIN_CHANNEL.to_string(), "conda-forge".to_string()]
+                );
+            }
+            _ => panic!("Expected RemoveMainX action"),
+        }
     }
 }

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -957,7 +957,14 @@ class TestMainXPixiDisable:
         """Disabling main-x --pixi should preserve the main channel (not wipe all channels)."""
         # Pre-configure both main and main-x channels (as enable would do)
         subprocess.run(
-            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_X_CHANNEL],
+            [
+                "pixi",
+                "config",
+                "prepend",
+                "--global",
+                "default-channels",
+                MAIN_X_CHANNEL,
+            ],
             env=pixi_feature_env,
             check=True,
         )
@@ -989,12 +996,26 @@ class TestMainXPixiDisable:
         """Disabling main-x --pixi should preserve all other configured channels."""
         # Pre-configure main, main-x, and conda-forge channels
         subprocess.run(
-            ["pixi", "config", "prepend", "--global", "default-channels", "conda-forge"],
+            [
+                "pixi",
+                "config",
+                "prepend",
+                "--global",
+                "default-channels",
+                "conda-forge",
+            ],
             env=pixi_feature_env,
             check=True,
         )
         subprocess.run(
-            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_X_CHANNEL],
+            [
+                "pixi",
+                "config",
+                "prepend",
+                "--global",
+                "default-channels",
+                MAIN_X_CHANNEL,
+            ],
             env=pixi_feature_env,
             check=True,
         )

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -949,6 +949,77 @@ class TestMainXPixiDisable:
         assert result.returncode == 0
         assert "not enabled" in result.stderr.lower()
 
+    def test_disable_main_x_pixi_preserves_main_channel(
+        self,
+        run_ana_pixi_feature: AnaRunner,
+        pixi_feature_env: dict[str, str],
+    ) -> None:
+        """Disabling main-x --pixi should preserve the main channel (not wipe all channels)."""
+        # Pre-configure both main and main-x channels (as enable would do)
+        subprocess.run(
+            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_X_CHANNEL],
+            env=pixi_feature_env,
+            check=True,
+        )
+        subprocess.run(
+            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_CHANNEL],
+            env=pixi_feature_env,
+            check=True,
+        )
+
+        # Verify both channels are configured
+        initial_channels = get_pixi_channels(pixi_feature_env)
+        assert MAIN_CHANNEL in initial_channels
+        assert MAIN_X_CHANNEL in initial_channels
+
+        # Disable main-x
+        result = run_ana_pixi_feature("feature", "disable", "main-x", "--pixi", "-f")
+        assert result.returncode == 0, f"Disable failed: {result.stderr}"
+
+        # Verify main-x was removed but main is preserved
+        final_channels = get_pixi_channels(pixi_feature_env)
+        assert MAIN_X_CHANNEL not in final_channels, "main-x should be removed"
+        assert MAIN_CHANNEL in final_channels, "main channel should be preserved"
+
+    def test_disable_main_x_pixi_preserves_other_channels(
+        self,
+        run_ana_pixi_feature: AnaRunner,
+        pixi_feature_env: dict[str, str],
+    ) -> None:
+        """Disabling main-x --pixi should preserve all other configured channels."""
+        # Pre-configure main, main-x, and conda-forge channels
+        subprocess.run(
+            ["pixi", "config", "prepend", "--global", "default-channels", "conda-forge"],
+            env=pixi_feature_env,
+            check=True,
+        )
+        subprocess.run(
+            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_X_CHANNEL],
+            env=pixi_feature_env,
+            check=True,
+        )
+        subprocess.run(
+            ["pixi", "config", "prepend", "--global", "default-channels", MAIN_CHANNEL],
+            env=pixi_feature_env,
+            check=True,
+        )
+
+        # Verify all channels are configured
+        initial_channels = get_pixi_channels(pixi_feature_env)
+        assert MAIN_CHANNEL in initial_channels
+        assert MAIN_X_CHANNEL in initial_channels
+        assert "conda-forge" in initial_channels
+
+        # Disable main-x
+        result = run_ana_pixi_feature("feature", "disable", "main-x", "--pixi", "-f")
+        assert result.returncode == 0, f"Disable failed: {result.stderr}"
+
+        # Verify main-x was removed but others are preserved
+        final_channels = get_pixi_channels(pixi_feature_env)
+        assert MAIN_X_CHANNEL not in final_channels, "main-x should be removed"
+        assert MAIN_CHANNEL in final_channels, "main channel should be preserved"
+        assert "conda-forge" in final_channels, "conda-forge should be preserved"
+
 
 @requires_pixi
 @requires_api_key


### PR DESCRIPTION
## Summary
- Fixed `ana feature disable main-x --pixi` removing ALL global channels instead of just main-x
- The disable command now uses `pixi config set` to preserve remaining channels (especially main) rather than `pixi config unset` which wiped everything
- Added tests for the new disable behavior

Previously, disabling main-x caused pixi to fall back to conda-forge since the config was emptied. Now it correctly restores the main channel.

## Test plan
- [ ] Run `ana feature enable main-x --pixi` and verify channels are set
- [ ] Run `ana feature disable main-x --pixi` and verify main channel is preserved in `~/.pixi/config.toml`
- [ ] Verify `pixi init test && pixi add numpy` pulls from Anaconda main, not conda-forge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Jira: [CLI-657](https://anaconda.atlassian.net/browse/CLI-657)

[CLI-657]: https://anaconda.atlassian.net/browse/CLI-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ