### PR TITLE
chore: Bump anaconda-mcp

### DIFF
--- a/tool-specs/anaconda-cli/pixi.lock
+++ b/tool-specs/anaconda-cli/pixi.lock
@@ -1,19 +1,17 @@
-version: 7
-platforms:
-- name: linux-64
-- name: linux-aarch64
-- name: osx-arm64
-- name: win-64
+version: 6
 environments:
   default:
     channels:
     - url: https://repo.anaconda.com/pkgs/main/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-52_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
@@ -25,6 +23,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
@@ -39,12 +38,14 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.7-py313h04fe016_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
@@ -74,6 +75,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
@@ -149,6 +151,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
@@ -157,6 +160,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.13.4-py313h06a4308_0.conda
@@ -198,6 +202,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.52.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
@@ -207,6 +212,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.7.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
@@ -233,20 +239,12 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-h47b2149_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       linux-aarch64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-52_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
@@ -258,6 +256,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
@@ -272,12 +271,14 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.7-py313haa502f6_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
@@ -307,6 +308,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
@@ -382,6 +384,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
@@ -390,6 +393,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.13.4-py313hd43f75c_0.conda
@@ -431,6 +435,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.52.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
@@ -440,6 +445,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.7.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
@@ -466,26 +472,10 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h27118de_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
@@ -497,6 +487,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
@@ -511,11 +502,13 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.7-py313hae07363_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
@@ -615,6 +608,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
@@ -622,6 +616,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.13.4-py313hca03da5_0.conda
@@ -664,6 +659,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.52.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
@@ -673,6 +669,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.7.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
@@ -690,16 +687,9 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
@@ -711,6 +701,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
@@ -726,11 +717,13 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.7-py313hbfe00f4_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
@@ -812,6 +805,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
@@ -819,6 +813,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.13.4-py313haa95532_0.conda
@@ -860,6 +855,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.52.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
@@ -869,6 +865,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.7.0-py313haa95532_0.conda
@@ -895,6 +892,12 @@ packages:
   md5: c3473ff8bdb3d124ed5ff11ec380d6f9
   size: 3473
   timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
+  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
+  md5: b272288d02db5520249ca7870c2287b4
+  license: None
+  size: 2491
+  timestamp: 1617219512888
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-52_gnu.conda
   build_number: 52
   sha256: 2f2c16a33f51ba032e8d4929b4d2e9173d81931d8d280a4a4a85a2412e8bdaf0
@@ -903,6 +906,14 @@ packages:
   license_family: BSD
   size: 6672
   timestamp: 1779131107752
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-52_gnu.conda
+  build_number: 52
+  sha256: a565f285cdcb14894ba4e8a081fcec0ce7a3b9636d3fe7be709c849438b08b79
+  md5: f367f6af1c675137019bcded877b4a59
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6626
+  timestamp: 1779131108070
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
   sha256: a7d0c79a1946344c8878079b89d7c054d71e4ff4b5cea04ec392b24ec785cd93
   md5: c2c8e35353fa943fa74108dd431a7b9f
@@ -913,6 +924,36 @@ packages:
   license_family: Apache
   size: 35419
   timestamp: 1773069249301
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
+  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
+  md5: 6327e33161b8e0ae8b501af0b07ee435
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35447
+  timestamp: 1773069243126
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
+  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
+  md5: 1784bef0a518f47b0cb442e02b75ce84
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35320
+  timestamp: 1773069152139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
+  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
+  md5: c62bd3bff5cb11570247115c1ab81225
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35318
+  timestamp: 1773069363087
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
   sha256: 22acee4a47176055648cbe19f0ca8d9ee29ac8dec54d7279e0b4572bb00bffd2
   md5: 68ae0d156d8f42f20253ab6936a58180
@@ -937,6 +978,89 @@ packages:
   license_family: BSD
   size: 117028
   timestamp: 1773844617250
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
+  md5: a8de75045d038d62c3553bdb1a2bf2b3
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - langchain-openai >=0.2.8
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116895
+  timestamp: 1773844596952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
+  md5: 88dc2eae5116b824692db6bb9b443eed
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  - langchain-openai >=0.2.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116841
+  timestamp: 1773844602363
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
+  md5: c486692f9df9720276afb556abff5361
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - mcp >=1.26
+  - pydantic-ai >=1.50
+  - langchain-openai >=0.2.8
+  - llm >=0.22
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116690
+  timestamp: 1773844804490
+- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
+  md5: c78d47374611a8e86f7a9817f3768160
+  depends:
+  - python >=3.8
+  constrains:
+  - conda >=23.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19864
+  timestamp: 1774907942644
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
   sha256: c52fe534ed3a4e6cf09289d60bf6c458c7150f82c0bd00c791a02985dc1f2c98
   md5: 7c9db0780c2764d1b9a8965b58d07d99
@@ -962,6 +1086,81 @@ packages:
   license_family: BSD
   size: 127651
   timestamp: 1777996211774
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
+  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
+  md5: cc86d0a53de1c9d4559f84313d92f08d
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda-token >=0.7.0
+  - conda >=23.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127355
+  timestamp: 1777996210212
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
+  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
+  md5: be96323ace383458edf5ef71f8e72654
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127712
+  timestamp: 1777996231900
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
+  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
+  md5: 5f4b80f4355b922b23fdd3456c6d4001
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152577
+  timestamp: 1777996277515
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
   sha256: 6ea3ced350e4d3f744774ba3bc5aa6a5eff3751d0ddd39ac6496868efbd78226
   md5: a256fa8ae4cf05d1cfb990cfee0b7976
@@ -985,6 +1184,75 @@ packages:
   license_family: BSD
   size: 62178
   timestamp: 1775469271573
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
+  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
+  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62286
+  timestamp: 1775469252673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
+  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
+  md5: 52656bda190a7f2bec974f508a9f35f2
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-auth >=0.12.0
+  - anaconda-client >=1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62048
+  timestamp: 1775469312642
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
+  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
+  md5: 5717d515db735fe7167bd3b5ea7bdc50
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86912
+  timestamp: 1775469436561
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
   sha256: 4a979bb0b48ad2712884695a3056453fbc5208acfc6a250aa3ed049831263f5e
   md5: 7233ba45150b5530456f5da5b9054d48
@@ -1013,6 +1281,90 @@ packages:
   license_family: BSD
   size: 845691
   timestamp: 1772491237524
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
+  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
+  md5: 0b644ecae935ac975164247e9f4d981d
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 845333
+  timestamp: 1772491214305
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
+  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
+  md5: c2a25adb6831401a65a5cdb63f88ba27
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 846994
+  timestamp: 1772491115479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
+  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
+  md5: e10dea7c74568841ed1cd5d8ec12ca92
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 870768
+  timestamp: 1772491405834
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-conda-0.1.11-py313h06a4308_0.conda
   sha256: acca75e8798b376e92646a8b5d7b262b215ec947e01dae4742c212b23d44abcc
   md5: af3167e083aefe1a08c832819e9256e7
@@ -1033,6 +1385,66 @@ packages:
   license_family: Other
   size: 160999
   timestamp: 1773935004052
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
+  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
+  md5: bfb5d8d4df085842d8c0b2e056b9257f
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161380
+  timestamp: 1773934997584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
+  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
+  md5: ed7020be4e2288dff58f60f7bf106fa9
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 162438
+  timestamp: 1773935019675
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
+  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
+  md5: 643c72f55e9de9926eabd069edbf2322
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161935
+  timestamp: 1773935085468
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-core-0.1.11-py313h06a4308_0.conda
   sha256: 683e0c239c7efa04fb6bc7523dd61a2005278d6eee3c9c084708075c27c10b77
   md5: 73c3d30b01b18ada722168b8a163afb3
@@ -1049,6 +1461,54 @@ packages:
   license_family: Other
   size: 169433
   timestamp: 1773871645177
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
+  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
+  md5: 7112210d85ff777ac172307690b79f45
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 168446
+  timestamp: 1773871519885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
+  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
+  md5: a9010a6c725f4a11001406492d49f35e
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 169752
+  timestamp: 1773871547623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
+  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
+  md5: c2ebc9fa966f6b08ea187fa807641415
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 226857
+  timestamp: 1773871887979
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-utilities-0.1.11-py313h06a4308_0.conda
   sha256: 9d64a3304c848ba7e5639ad99e3d513b3390ce38c1ae7d9371a4f09d9fc0564c
   md5: 9e0c6279430723e71d9b46aa80c1a66f
@@ -1065,6 +1525,54 @@ packages:
   license_family: Proprietary
   size: 161158
   timestamp: 1773868125336
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
+  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
+  md5: 213c7a858140be70244c210c31e4da04
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160774
+  timestamp: 1773868123073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
+  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
+  md5: eeca273b542009d5cd4e022bd2cb827d
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 162392
+  timestamp: 1773868150264
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
+  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
+  md5: 6f2969069844333afb09ed91b701abe0
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160509
+  timestamp: 1773868198156
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.1-py313h06a4308_0.conda
   sha256: e5110723ad643d2aa1f35eab1262a36140dcd031fef0aed5e218148e0051b70d
   md5: 0135828396adb3cb229ca6a6ef7ccaa7
@@ -1084,6 +1592,63 @@ packages:
   license_family: BSD
   size: 75075
   timestamp: 1780062413079
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.1-py313hd43f75c_0.conda
+  sha256: 645c82048a8a88715654fe12ceb8129a3b7e32b92b77f99b9506cf2970d0fa4b
+  md5: d6e0121611b5f2b607243474e4d5b059
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75772
+  timestamp: 1780062412357
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.1-py313hca03da5_0.conda
+  sha256: 7ab3e15eac10410c126524599e5990a28f379c37a3da4ecf27d88278cfd8b4c2
+  md5: 112d00c441d60f4398011c37b74547d5
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75917
+  timestamp: 1780062437196
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.1-py313haa95532_0.conda
+  sha256: 54ebcbd61bc8d9028e36fa707d19ed6761dab7f3d3376912c2d884a0aab6715b
+  md5: ccd17efbcd4b3ef56b09a7a129088c97
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100193
+  timestamp: 1780062496652
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
   sha256: 0cd6732f7a3f8c4f2911c6bc963a5d5fcd6aeb061a408842d5b6207a6a20aa77
   md5: d8c5512c00cfaa0c16b6b2c51d866378
@@ -1104,6 +1669,66 @@ packages:
   license_family: APACHE
   size: 82788
   timestamp: 1776808534361
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
+  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
+  md5: aab07c0ab08553546780a3a40f8f2cec
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82829
+  timestamp: 1776808540195
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
+  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
+  md5: 9916fa1108527ee314251aec8a0c7353
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 83086
+  timestamp: 1776808490341
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
+  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
+  md5: 8d4b877231bde39bd3ef1270fb015389
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82692
+  timestamp: 1776808693739
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
   sha256: 436b89319aa90a7338c308e0779c595276ae01430febf7968e8f40c5ae17a456
   md5: 6ceee906e5cc1dae03776e7c64e56877
@@ -1114,6 +1739,36 @@ packages:
   license_family: MIT
   size: 11432
   timestamp: 1763372671839
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
+  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
+  md5: 37fbf9726b0439b29bba0e1cf52ae35c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11421
+  timestamp: 1763372675300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
+  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
+  md5: f39857a71feb6e39da9739228f340a78
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11405
+  timestamp: 1763372676418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
+  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
+  md5: 250197e0edb4f89e9d3199c32fcecd5d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11465
+  timestamp: 1763372717011
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
   sha256: 382f07779f01e3a6621b963ebd8f01b1759fd71c64cb8d47b4b1da17451e07a4
   md5: 3d0213cea41b88c15fdf1ed04eba799c
@@ -1124,6 +1779,36 @@ packages:
   license_family: MIT
   size: 26097
   timestamp: 1761744946758
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
+  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
+  md5: 108a8bcd136312e83793f5cda2f350fb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26012
+  timestamp: 1761744922996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
+  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
+  md5: c0c2fb9483677bb657eda6d491e5f29c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 25909
+  timestamp: 1761744968164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
+  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
+  md5: 2c7171d6d58b9364b4406ab1c85ee50b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26185
+  timestamp: 1761745147069
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
   sha256: f14560ae804db5d9289a4ddec171cbbacf78dd49b4a640f21fd0829ee55b333f
   md5: fcc4b2673d3d0b0a203bf1496a694ec3
@@ -1137,6 +1822,53 @@ packages:
   license_family: MIT
   size: 317979
   timestamp: 1773134446379
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
+  md5: 910687ebf7746e8562300e8f1996edc6
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318118
+  timestamp: 1773134422321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
+  md5: 7e400853597f6d7237e927baa6706aa7
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1773134435123
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
+  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318164
+  timestamp: 1773134551978
+- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
+  md5: c0ad195970a65c174b997011ac13f2f8
+  depends:
+  - python >=3.7
+  license: MIT OR Apache-2.0
+  size: 49261
+  timestamp: 1758125010311
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
   sha256: 0c54f6998dfa0ce079af488624d12f1541ae5e4c77eadbb728f01c89d24a419e
   md5: 7abefd1bcc7f971ebe2e905b54d3d9af
@@ -1147,6 +1879,36 @@ packages:
   license_family: MIT
   size: 180870
   timestamp: 1774959670748
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
+  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
+  md5: 711f61b5492b94625605422dd8e326ed
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180516
+  timestamp: 1774959654156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
+  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
+  md5: bafc36567bd5432aea186b203ccbe80d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180639
+  timestamp: 1774959652662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
+  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
+  md5: 2a3be388a9418ec78c921662e816d826
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 181026
+  timestamp: 1774959795526
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
   sha256: eca5799ea6fe42c404d575fe3e6a1296ab4a77477338e4844e3ce55cfb92d51e
   md5: 8b691d36a48bb3b11af5acca7ef5f3b7
@@ -1161,6 +1923,48 @@ packages:
   license_family: BSD
   size: 446172
   timestamp: 1775206363270
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
+  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
+  md5: 3bee8eb5a01e45d657bc7edc508dcde4
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 445207
+  timestamp: 1775206365399
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
+  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
+  md5: a76eeaf70ce3bead86b2c5da38121a69
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446875
+  timestamp: 1775206378569
+- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
+  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
+  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 448508
+  timestamp: 1775206412930
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
   sha256: 12e6857595968ad28911cf185f7696365ff92eaa4a9ad9cead223a7332a3a6bb
   md5: 468a6120b4db27b9d6de4aa86e6c6a45
@@ -1171,6 +1975,36 @@ packages:
   license_family: MIT
   size: 1486546
   timestamp: 1772489320625
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
+  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
+  md5: 63457f5636c2230e585b265ea721c2f8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1484918
+  timestamp: 1772489319478
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
+  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
+  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488689
+  timestamp: 1772489325506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
+  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
+  md5: f38f1b967e522121f347c6e53e50386e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488599
+  timestamp: 1772489378490
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/boltons-25.0.0-py313h06a4308_0.conda
   sha256: 248e6cb425de676a39915d1c241e0434d9ec8b19d27771f7132907519f7fbc77
   md5: afd30cc40ab0edf4e246b901c8eca725
@@ -1181,6 +2015,36 @@ packages:
   license_family: BSD
   size: 522428
   timestamp: 1751383912748
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
+  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
+  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 522348
+  timestamp: 1751383856268
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
+  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
+  md5: a5b55c281bf03fadccc2b9fb5e6c567d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 524228
+  timestamp: 1751383887927
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
+  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
+  md5: 78e0f7a51d811d64b0d0fa4e886458f2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523882
+  timestamp: 1751383878776
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
   sha256: 1d13694da029eb587dcdce691e4a6a1590ac5de65f0cde234fff849fd7985168
   md5: d309f82c145a73fedf7bc6930f689dba
@@ -1195,6 +2059,47 @@ packages:
   license_family: MIT
   size: 381299
   timestamp: 1764961365931
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
+  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
+  md5: 9dd92861bec232ccdf7869b0b05b453b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 385446
+  timestamp: 1764961345156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
+  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
+  md5: 4f002093422042d948885e06821f150b
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17.0
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375456
+  timestamp: 1764961201718
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
+  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
+  md5: 964620a4cb8353969963fbb7b045b01c
+  depends:
+  - cffi >=1.17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 355904
+  timestamp: 1764961470388
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
   sha256: 235f266d5f9c3c61748bb1af0eff21bc7ed2a2a356b97ff28d9c1135039b08b0
   md5: f21a3ff51c1b271977f53ce956a69297
@@ -1204,6 +2109,32 @@ packages:
   license_family: BSD
   size: 268384
   timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
+  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
+  md5: f580b2013db742598b2d59875bccf774
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 215406
+  timestamp: 1714510578082
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
+  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
+  md5: 27a1ffbd30ff6427c112a733410e2f57
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 132212
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
+  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
+  md5: 33e784123d565c38e68945f07b461282
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 91870
+  timestamp: 1714511182837
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.34.6-hd44998d_0.conda
   sha256: a5bdd98c8c2ef2bbe52b0fb018ddda3e62f91b2f96089e66e903052e1e91498e
   md5: e16f3bb02771b2e37ea421a3f8ee1ebb
@@ -1215,6 +2146,38 @@ packages:
   license_family: MIT
   size: 206586
   timestamp: 1769077678178
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
+  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
+  md5: 6e3e5f38a8efcb439d36f091baa23034
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 217449
+  timestamp: 1769077676509
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
+  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
+  md5: ceb5c473b56eb1b79fd079f6b0d029df
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 177571
+  timestamp: 1769077680758
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
+  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
+  md5: f6f293f1ec437a5a362252af20d31e50
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 203491
+  timestamp: 1769077840032
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.5.14-h06a4308_0.conda
   sha256: 5950470e038010db93938a18891cacf9878e2b0929396754529b01485213f9aa
   md5: 16c8384e6e546a181720f7f2f2da717b
@@ -1222,6 +2185,27 @@ packages:
   license_family: Other
   size: 109982
   timestamp: 1779369544071
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.5.14-hd43f75c_0.conda
+  sha256: 1952de6b37c0a04ff26b9e719e842742fd20d3d90cff7e6ae71d59f6eacd8b35
+  md5: 53fbdd199058951543bd02ea5f55290c
+  license: MPL-2.0
+  license_family: Other
+  size: 109983
+  timestamp: 1779369526496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.5.14-hca03da5_0.conda
+  sha256: fbec6b4a50724693297bc99d16b5f455267d24d10780dee40214d11822d6a3b3
+  md5: 4fc63c7213f26bca8f8e1a561b08df0e
+  license: MPL-2.0
+  license_family: Other
+  size: 110299
+  timestamp: 1779369421717
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.5.14-haa95532_0.conda
+  sha256: cd677eba8e5005c16d6c0926b3a6ee54e4a0a466bb1ae8071e6fc49cbd65ad29
+  md5: 120259e1e9fba21a245cfe2a632332c0
+  license: MPL-2.0
+  license_family: Other
+  size: 110063
+  timestamp: 1779369808140
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-6.2.2-py313h06a4308_0.conda
   sha256: 1f940a1c17e8fec366dfeee42f16adb2226caee1fc7a14cffa9ba69f024b3d72
   md5: fff0be0678af050cf070caf6112afb73
@@ -1232,6 +2216,36 @@ packages:
   license_family: MIT
   size: 41231
   timestamp: 1764867398576
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
+  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
+  md5: 1d25e042eebc783ff4804fc9c42852d2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41563
+  timestamp: 1764867403876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
+  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
+  md5: bb47e0b8fa0f637b245c34b5b357a5d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41149
+  timestamp: 1764867366355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
+  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
+  md5: 9ce972c71a87d4d90534a24d77e99cb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41594
+  timestamp: 1764867445911
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.5.20-py313h06a4308_0.conda
   sha256: 3139ce7e371fed80ff4185cb2bfd742e6b06162057100210d3a80e6c001304ef
   md5: 47167ed1d781ecd386dac1a51c1617a8
@@ -1242,6 +2256,36 @@ packages:
   license_family: Other
   size: 134466
   timestamp: 1779370435067
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.5.20-py313hd43f75c_0.conda
+  sha256: ad0482b93275e69f0992fce82aa568a364bcd508ed5cf89a8147d60b17ddb5e2
+  md5: 06ec246514aaf39ce1b2962db79f2c69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134424
+  timestamp: 1779370393603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.5.20-py313hca03da5_0.conda
+  sha256: 22ceda465617efdfe3648420c9ae89c786148e955c3fc88643eae95dddf90df0
+  md5: 93a7a1245eb7e35a665f0d84ca941feb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134103
+  timestamp: 1779370319413
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.5.20-py313haa95532_0.conda
+  sha256: c00dca94da0cba08243b42c58fe5f896b7661095febcda0d4fe5fb9757e1b9a7
+  md5: 080f8f5683481a20991f10dc4ea654a6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134382
+  timestamp: 1779370678439
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
   sha256: a16eafa37a73eb521aef93e9760f44be8f0180f9ff3e5bccbf2de8f6e762e9a0
   md5: 48989473c291f70b074ba57b48d4eda5
@@ -1256,6 +2300,47 @@ packages:
   license_family: MIT
   size: 295376
   timestamp: 1761832800589
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
+  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
+  md5: d010d105070e615750bbb51b8f2b17f5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 317809
+  timestamp: 1761832800132
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
+  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
+  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
+  depends:
+  - __osx >=12.1
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 288576
+  timestamp: 1761832806745
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
+  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
+  md5: d1e9e395ff8688288d67b89e896c2b6c
+  depends:
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 299121
+  timestamp: 1761832847099
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
   sha256: d84312b64791eac1dad798c86110a0ac53e7d980d6d4c5d32f60ebbb82e4eb4b
   md5: 36134f1eb9574beab525f137faa53cd7
@@ -1266,6 +2351,36 @@ packages:
   license_family: MIT
   size: 100520
   timestamp: 1761744847216
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
+  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
+  md5: c89d95c43d07b658088bb12631ce9132
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100336
+  timestamp: 1761744908393
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
+  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
+  md5: 6301ec890b186cbe5d8243254450651e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100213
+  timestamp: 1761744861372
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
+  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
+  md5: 9e4732d3d22b2cf01fc408696e8ebd41
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 124770
+  timestamp: 1761745054105
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
   sha256: c743088f34421989511925c4fd47bd2d1627e0d47a9ce17ac522971456559dbf
   md5: cd0c96b38e17a2b268d15d0b22da55b3
@@ -1276,6 +2391,47 @@ packages:
   license_family: BSD
   size: 327716
   timestamp: 1764332274729
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
+  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
+  md5: 7813f91a66f3a442e803469cf76e3e1c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328923
+  timestamp: 1764332280328
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
+  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
+  md5: 7ac45ddb190136a57ad9b02e7e365ec0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328813
+  timestamp: 1764332257562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
+  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
+  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
+  depends:
+  - colorama
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328826
+  timestamp: 1764332409785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
+  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
+  md5: b73ebc8eb01ba1e79ad34303e2975694
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55002
+  timestamp: 1729036609433
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
   sha256: 7fa70086625233a494e92418fb58591f43e2c6309cb4c082e3fd778a0280c506
   md5: c47ffd5c56a75b1b62855a3c8e430889
@@ -1311,6 +2467,126 @@ packages:
   license_family: BSD
   size: 1273463
   timestamp: 1771402226765
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
+  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
+  md5: efb9dc33b510e1c882b597d994f6ab3d
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-env >=2.6
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1270780
+  timestamp: 1771402352584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
+  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
+  md5: 1fbe06ba53189032094abfe761e965ce
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-env >=2.6
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275763
+  timestamp: 1771402227023
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
+  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
+  md5: 301f7c7830bdf835d4fcf93e0122da7a
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-env >=2.6
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275313
+  timestamp: 1771402340575
+- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
+  sha256: 10f62f9acf24c5abff2b172d90c65e5e6fbdfd5d228014969282ce180de30c3d
+  md5: 4a5e3c023bdfc52f653d8ecd03daafd2
+  depends:
+  - boltons >=23.0.0
+  - conda >=26.1
+  - libmambapy >=2
+  - msgpack-python >=1.1.1
+  - python >=3.10
+  - requests >=2.28.0,<3.0.0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58289
+  timestamp: 1778687024589
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
   sha256: d1e652dbd4390b12bcf938ece3e85636c12ab54d91a25de7dd1ac8ca84b1b8b1
   md5: 8df01d8631f16021fe6e7f0093de07db
@@ -1323,6 +2599,42 @@ packages:
   license_family: BSD
   size: 284840
   timestamp: 1762366426064
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
+  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
+  md5: 6577f526b527308e4bf66a7bdef0e7fe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285635
+  timestamp: 1762366425854
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
+  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
+  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285376
+  timestamp: 1762366427916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
+  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
+  md5: 0bf62b2027e8a656a86e1c4a7e71142c
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 309759
+  timestamp: 1762366569467
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
   sha256: 8d1ff42b4560986c9d46ef2114cd77ae791ec4400a5ba4eb9a4b22ad540466c1
   md5: 56c2a9c6a706a12193c0b98ef951b4b6
@@ -1335,6 +2647,42 @@ packages:
   license_family: BSD
   size: 38518
   timestamp: 1762361653472
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
+  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
+  md5: 313fca7b4d867f8b06df3140548f9440
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38256
+  timestamp: 1762361650200
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
+  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
+  md5: 01a0bc32a49fd331d514dfd64446fb1e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38499
+  timestamp: 1762361650835
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
+  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
+  md5: d9081bd54908ac92135e6fb20d0aade2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38102
+  timestamp: 1762361726254
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
   sha256: 8718137ba3afc2eb8eb986e17442968aec45b32bbd746b64bc239c3019ec7216
   md5: 3a195bcf47b691adb4a635a8b7f396f7
@@ -1345,6 +2693,35 @@ packages:
   license_family: CC
   size: 132687
   timestamp: 1734039334436
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
+  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
+  md5: 06c2848c6311674e19391d4b81b3188a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: CC0-1.0
+  license_family: CC
+  size: 132686
+  timestamp: 1734039347698
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
+  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
+  md5: 9a83af67c17d1c760cd7aff545ef7e0f
+  depends:
+  - libcxx >=14.0.6
+  license: CC0-1.0
+  license_family: CC
+  size: 134133
+  timestamp: 1734039345192
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
+  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
+  md5: 67a55401db50a1d6bde2b153a74bcb07
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: CC0-1.0
+  license_family: CC
+  size: 133944
+  timestamp: 1734039396266
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.7-py313h04fe016_0.conda
   sha256: 75204f831ba33196179fc03b036ef28e5a7692fcade74340280553bca86aaecc
   md5: 317e0398d4abaeac3831ebf9031bfb56
@@ -1361,6 +2738,54 @@ packages:
   license_family: OTHER
   size: 1704316
   timestamp: 1775672149374
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.7-py313haa502f6_0.conda
+  sha256: 3ed601727cd363adb4659bcf6d1355f089ab03c51316b0cd9b44878689691797
+  md5: 6278e4fbbb0c256dba21cf6d8786a1ba
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=2.0.0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1684534
+  timestamp: 1775672140512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.7-py313hae07363_0.conda
+  sha256: a8a8c9a21c602dc4b5e165e763cd91a93c0a0c26cafaa3449cd2b71f1153cf24
+  md5: 2ed446dca3be7460703b133a979a88e5
+  depends:
+  - __osx >=12.1
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1585026
+  timestamp: 1775672122040
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.7-py313hbfe00f4_0.conda
+  sha256: 6ef8d801080710183ab192071940fed2d81c468bb25352a7cf69acc554053268
+  md5: 437bbfadf68c247ade554ede99116d43
+  depends:
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1480593
+  timestamp: 1775672660391
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
   sha256: ae53fd9454d789e5d815340cf2fc2dc08890e7d49a5709c3b990c923a58e8c05
   md5: 470893a428fe943c25311711c34b8912
@@ -1375,6 +2800,48 @@ packages:
   license_family: Apache
   size: 392859
   timestamp: 1772065044827
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
+  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
+  md5: 8f3083bd30c06eace150fbf4ff5acd33
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392308
+  timestamp: 1772065019547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
+  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
+  md5: 85c2e5e0e00bcd63d85871b80f060b1b
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392115
+  timestamp: 1772064911124
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
+  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
+  md5: db173ac83b3843bec70a8b2070881460
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 448738
+  timestamp: 1772065243755
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
   sha256: ff936d58ce18451f18cba16a8ade9365199a6321d4eb1c60c1eb1d8e3932c65b
   md5: 4c4aef417b613e7111d90cf2348b231a
@@ -1388,6 +2855,27 @@ packages:
   license_family: GPL
   size: 1259937
   timestamp: 1756144852972
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
+  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
+  depends:
+  - expat >=2.7.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1275876
+  timestamp: 1756144876643
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
+  md5: d912068b0729930972adcaac338882c0
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 23826
+  timestamp: 1615228158573
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
   sha256: 57e25d204f2e891ab2f68a776b9e21cc681adfe089ea35a18aa05e5aa950a4c7
   md5: 1fd7ab065e9958e7bbd4d3fbf175742b
@@ -1398,6 +2886,36 @@ packages:
   license_family: Apache
   size: 37917
   timestamp: 1728396132498
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
+  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
+  md5: 77f95d4b0a5bf1b775dda3372544dbeb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37699
+  timestamp: 1728480059192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
+  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
+  md5: 5e948f3d746f13d209bd09a9d2fb7758
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38129
+  timestamp: 1728591870413
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
+  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
+  md5: 9a502db95e7e272d1b7ed53f03dafab2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63476
+  timestamp: 1729059201537
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
   sha256: 76ed0f399394a99c99f89ea8525b89f50412a75d0230d99b07137f6f9bdc117f
   md5: d9d17b8c0998984fbde4103a0113fb34
@@ -1416,6 +2934,61 @@ packages:
   license_family: OTHER
   size: 665462
   timestamp: 1763718275784
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
+  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
+  md5: 23079a69d0ac19cf9f264cfc36dfaf67
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  license: ISC
+  license_family: OTHER
+  size: 666622
+  timestamp: 1763718283404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
+  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
+  md5: 83b6045550ea3f3984ad063b58c44f83
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpx >=0.28.0
+  - httpcore >=1.0.0
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 667571
+  timestamp: 1763718279384
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
+  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
+  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  - trio >=0.30
+  - idna >=3.10
+  - wmi >=1.5.1
+  - cryptography >=45
+  - h2 >=4.2.0
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 666555
+  timestamp: 1763718371551
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
   sha256: 4b99a2d38d4324cff99f21bcf1b938e25f178e5f22615b0dc8b6a7c6f17a0774
   md5: be1740cddc233f9ab333989a30091afb
@@ -1426,6 +2999,36 @@ packages:
   license_family: MIT
   size: 96105
   timestamp: 1766163640372
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
+  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
+  md5: 3a916231ebb779a7c2d5230fca7a2792
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96633
+  timestamp: 1766163709520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
+  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
+  md5: 84ceb2792085acb3459abeedb47f888d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96396
+  timestamp: 1766163600127
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
+  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
+  md5: 6c03175c12338ebc8273659a72c462ce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96782
+  timestamp: 1766163871411
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docutils-0.21.2-py313h06a4308_1.conda
   sha256: f07ce74ab05c47d99351bf2a8f40721f8211c3cc33a4db95f5f9d946b0ba3584
   md5: e9073a661561fdcd74f47e5e1116d686
@@ -1436,6 +3039,36 @@ packages:
   license_family: Other
   size: 938474
   timestamp: 1761746639546
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
+  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
+  md5: c73024412ae68d6afa90b3bfca1a3b28
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 939239
+  timestamp: 1761746641765
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
+  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
+  md5: 54a125d07b398d692c81bcad8c0fc6df
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 940136
+  timestamp: 1761746670106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
+  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
+  md5: bbfbf4a353f2adbd724998ab6083802f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 1014370
+  timestamp: 1761746691814
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/email-validator-2.3.0-py313h06a4308_0.conda
   sha256: e9010e12bc5ec063fada7c7f93908ebaee19f8c00fbcb42a6293e9854a92f54b
   md5: 147defdb8eb1d949155ba6dfcd33dfb7
@@ -1448,6 +3081,42 @@ packages:
   license_family: OTHER
   size: 66155
   timestamp: 1758610271322
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
+  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
+  md5: 4f6a93a269938d34f89e6c56b07905a1
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 65683
+  timestamp: 1758610280179
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
+  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
+  md5: c1112f1321fda31b8b182c011bd25f39
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 66105
+  timestamp: 1758610134265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
+  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
+  md5: 0aec5daa5284e9e3967c95a79f775012
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 90963
+  timestamp: 1758610340546
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.7-py313h06a4308_0.conda
   sha256: 34a464a65059b8878aca3cbc996597285cee847cd5ded1a121951126b2d30706
   md5: 919252a39e7e6b88c0d2f10af26c81e0
@@ -1472,6 +3141,78 @@ packages:
   license_family: BSD
   size: 66976
   timestamp: 1779916005740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
+  sha256: 4d498a91280bc6dc6d9d0108f1f7fbf3cc732014b522621ee0ce2ee1dea24b8e
+  md5: d2c9e173a97f6bbc2bc18c77796c5a6f
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66788
+  timestamp: 1779915955594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
+  sha256: 9ef08d154b7f88a5e232804d55aff2ff14c57693d4de856fdb6840ea97937034
+  md5: 2644ebe94b48d6c7e0b179c30807dfbd
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67101
+  timestamp: 1779916082564
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
+  sha256: fb3ce799f193bcb6e33061ad6f975654b06f3342c3c10a72664f9cfb23ac5c4d
+  md5: b7b2eed90ced3af325d06a98dfa4c4b0
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91692
+  timestamp: 1779916032565
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/environs-11.2.1-py313h06a4308_0.conda
   sha256: 3f42e89e9e231d76b622db947fe92ea894610c0b47dc05c672248a3de542e70d
   md5: 44df1fdd5286369932065aa827ed55cd
@@ -1484,6 +3225,42 @@ packages:
   license_family: MIT
   size: 37166
   timestamp: 1774388511813
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
+  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
+  md5: b34fd0d10946da439f9b357e3d42e1f5
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37088
+  timestamp: 1774388461266
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
+  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
+  md5: a1db257019eb3930e461aa5626be2c0e
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37392
+  timestamp: 1774388481869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
+  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
+  md5: f61420d4421c1f5c8ecb2d0cac6a910c
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37648
+  timestamp: 1774388523034
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py313h06a4308_0.conda
   sha256: ce30b8b076188b90cca5b053884631f7c9ecd669b023bdbe77b0b4aae4df3192
   md5: ca4915b2c8f67574d512d40f117617a1
@@ -1494,6 +3271,36 @@ packages:
   license_family: MIT
   size: 48909
   timestamp: 1761560358064
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
+  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
+  md5: 23b284ce11d60c82ef766dbfc024277c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49018
+  timestamp: 1761560361917
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
+  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
+  md5: cd68188eea25cf618d3ed80a746e34cd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 48744
+  timestamp: 1761560378218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
+  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
+  md5: be5485351f1313fc4628d30117e0fdd5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49233
+  timestamp: 1761560536661
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.8.1-h7354ed3_0.conda
   sha256: e878cbb8688295d31fbae7980505e404fc93dda7da53b83272b0252d461f4338
   md5: 45f62162756790fa5fc2ccb7b4efa1ad
@@ -1506,6 +3313,18 @@ packages:
   license_family: MIT
   size: 24824
   timestamp: 1779874385684
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.8.1-h5b11e9f_0.conda
+  sha256: 3e40b271ec47e077ca4d204cbf65a2240a33ec163c4860cc350d0f268af30915
+  md5: 774839ce2af756baca243ee77e2b04d5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libexpat 2.8.1 h5b11e9f_0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 25948
+  timestamp: 1779874409953
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.135.4-py313h06a4308_0.conda
   sha256: 5e2374da4a5adc8b3c7dc7d403dffcace21af420bf1a1c807559c2b0b4c9f86e
   md5: 48955966edbdf46f308f52aa594d0394
@@ -1534,6 +3353,90 @@ packages:
   license_family: MIT
   size: 212566
   timestamp: 1779213502962
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.135.4-py313hd43f75c_0.conda
+  sha256: a554a080bc41268cc230f109343d1e5463162f067d1b43be38262d722e5f1e23
+  md5: 8356bfc6cd2e6e10ee94e5c728bd12b2
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - pydantic-settings >=2.0.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - fastapi-cli >=0.0.8
+  - uvicorn-standard >=0.12.0
+  - pydantic-extra-types >=2.0.0
+  - itsdangerous >=1.1.0
+  - orjson >=3.2.1
+  - jinja2 >=3.1.5
+  - httpx >=0.23.0,<1.0.0
+  - python-multipart >=0.0.18
+  - email-validator >=2.0.0
+  - pyyaml >=5.3.1
+  license: MIT
+  license_family: MIT
+  size: 213160
+  timestamp: 1779213485286
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.135.4-py313hca03da5_0.conda
+  sha256: 1b9e6662b9cfd28296990a27bba731fdaf168e0c7eaf5018cb55755b3b97a15d
+  md5: 5c3422f980014c560b2dda3a93c3fc18
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - jinja2 >=3.1.5
+  - email-validator >=2.0.0
+  - fastapi-cli >=0.0.8
+  - itsdangerous >=1.1.0
+  - python-multipart >=0.0.18
+  - uvicorn-standard >=0.12.0
+  - pyyaml >=5.3.1
+  - pydantic-extra-types >=2.0.0
+  - httpx >=0.23.0,<1.0.0
+  - orjson >=3.2.1
+  - pydantic-settings >=2.0.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  license: MIT
+  license_family: MIT
+  size: 213782
+  timestamp: 1779213508607
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.135.4-py313haa95532_0.conda
+  sha256: 6991d1ff653f28d473c3faa78b56dddbe7484e97a8d08533c4b0b6210b73f5d1
+  md5: 08d621ddb70b614c33a8847c48b30cad
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - pydantic-settings >=2.0.0
+  - itsdangerous >=1.1.0
+  - python-multipart >=0.0.18
+  - email-validator >=2.0.0
+  - uvicorn-standard >=0.12.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - pyyaml >=5.3.1
+  - httpx >=0.23.0,<1.0.0
+  - fastapi-cli >=0.0.8
+  - orjson >=3.2.1
+  - jinja2 >=3.1.5
+  - pydantic-extra-types >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 270617
+  timestamp: 1779213555162
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastmcp-3.1.1-py313h06a4308_0.conda
   sha256: a7a9431f336fd35f1002ece0009ebd72bce46618c4cc1a488205ee8ab8ec6516
   md5: 715ed31b021b666ddf86d091f58d455e
@@ -1578,2880 +3481,6 @@ packages:
   license_family: Apache
   size: 1060147
   timestamp: 1774377863253
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-12.1.0-h44f220b_0.conda
-  sha256: 75206a86cdcdb0752db803e8ab8b27589d376413f16f8b280f8864b27702636d
-  md5: dd4be9ab91074ac1e2bc78719cf51496
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 196493
-  timestamp: 1772639967801
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
-  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
-  md5: 26dfe875df9973e0e98ec5add063e00e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39148
-  timestamp: 1761750688493
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
-  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
-  md5: df53b928c3a9dd53c7f4e87cc03e03d2
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h6a67909_0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libasprintf-devel 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libgettextpo-devel 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 535333
-  timestamp: 1772045309664
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
-  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
-  md5: ac944526cc2d27ffa3c44a42cd86f46d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3777431
-  timestamp: 1772045279414
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
-  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
-  md5: 91b9170766e7040dedc182d913a7ff89
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171370
-  timestamp: 1770382383126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
-  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
-  md5: 9b8c1795cc878775116cd01cea2ddad8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 h79c45ec_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 877844
-  timestamp: 1770755209168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
-  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
-  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64750
-  timestamp: 1761931277052
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
-  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
-  md5: 77016551f9607c23c6243632bf100507
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127896
-  timestamp: 1748526107673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
-  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
-  md5: 4b7c5319a6df6513319768f73969098c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 101585
-  timestamp: 1763634777574
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
-  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
-  md5: d25af3a5cbefe54951cb3dc369b945bb
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=8.0.0,<9.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - zstandard >=0.18.0
-  - socksio >=1.0.0,<2.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217558
-  timestamp: 1760447364823
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.3-py313h06a4308_0.conda
-  sha256: 2839f29be1c271227df948b1afec5fd344e90a69a52f3c2500f5cbcf5c5e6089
-  md5: d935fe60ceefba9d9ef09f9da74f318e
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23252
-  timestamp: 1779705422223
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-78.3-h84d19a5_0.conda
-  sha256: b4a4f7bbc3722e658cd1d21c37c4d7b4c7e89a48233bc2b90d430c9ce4a65859
-  md5: b3cca90607d3b176e49048756e89296e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 24357919
-  timestamp: 1777922220477
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
-  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
-  md5: c8b25d0fe19ba1a7319a0221e7615265
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 202882
-  timestamp: 1761911998666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
-  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
-  md5: e3d3dc1bd7e26bef582f874fbb4c543c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71396
-  timestamp: 1772097118324
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.15.0-hbcba0ee_0.conda
-  sha256: f00270fce560124e2ac09e83130d0128b510d4bfb7143fd85ea70bea6b828d86
-  md5: fa3f5a347af7dc8c8db48c54fe5a2ae2
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 66361
-  timestamp: 1779458360191
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
-  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
-  md5: c4ea3f7208a811b569bbeae8c42c5b2d
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19952
-  timestamp: 1755516354462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
-  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
-  md5: 54a430923247a921a5c57e330e04549f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17104
-  timestamp: 1769477866762
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
-  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
-  md5: 9572b85d5f84049bc36867f49d498520
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23712
-  timestamp: 1768389384997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
-  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
-  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 304593
-  timestamp: 1762897374551
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
-  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
-  md5: 8cb4b1755a4a8fd6a57883863236ef2b
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36479
-  timestamp: 1728399618377
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
-  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
-  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18979
-  timestamp: 1774432898196
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
-  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
-  md5: 259205480d74c969b6bbd3c48662291e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30490
-  timestamp: 1774283018435
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
-  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
-  md5: 7125606e211300f51b43b14c7039c163
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198245
-  timestamp: 1767955393666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
-  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
-  md5: dea8a1c280fb8cb391be3b459d8dfac1
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52614
-  timestamp: 1772640999029
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
-  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
-  md5: 2dbc150b61f12b744cf873c285f4a418
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17079
-  timestamp: 1762788451045
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
-  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
-  md5: 292a4c15bbd54feba358997e6d1b35db
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96597
-  timestamp: 1764588298747
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
-  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
-  md5: 6d505a62b565ff3d80d5a6662a83d54a
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-mypy >=1.0.1
-  - shtab >=1.1.0
-  - pytest-enabler >=3.4
-  - pytest-checkdocs >=2.4
-  license: MIT
-  license_family: MIT
-  size: 82797
-  timestamp: 1763637203264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
-  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
-  md5: c563bb71f4df90fc3b92cde204827564
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 742162
-  timestamp: 1773255564362
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
-  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
-  md5: 569d92e1732a69adff57813342a9c316
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - libabseil-static =20260107.0=cxx17*
-  - abseil-cpp =20260107.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384532
-  timestamp: 1770384636226
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.7-hb3cce40_0.conda
-  sha256: b53751f828019d420954c263c600f18658990cdb70808db407d710a26d5fb697
-  md5: 6c2434e636c663e6cd532d44143588d0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.5.6,<4.0a0
-  - xz >=5.8.2,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 887782
-  timestamp: 1777386329226
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
-  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
-  md5: 9fe17fea3f12a5dcc483b89f48e361da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52393
-  timestamp: 1772045241614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
-  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
-  md5: 114f7a7ae6d01b7f5d568439769857f7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33684
-  timestamp: 1772045249959
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
-  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
-  md5: cdc0bbfec0c99b30d435b22341a716b0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78282
-  timestamp: 1762363571278
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
-  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
-  md5: 7cad8348df1c96bf2f0a697806d1b3b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 33634
-  timestamp: 1762363575967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
-  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
-  md5: 854af1d6af8b3565fa8c7edb2141a2de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 279951
-  timestamp: 1762363583050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.20.0-hd8fa685_1.conda
-  sha256: 558a029dd317c9610f257fd73a210917c76c6d6ec5de1471ae3d432d6f3fc277
-  md5: 0bce5ed9e5696f46b16b074cf643265e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.69.0,<1.70.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 502712
-  timestamp: 1777909373160
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
-  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
-  md5: 5065620db4393fb549f30114a33897d1
-  depends:
-  - libgcc-ng >=7.5.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 114011
-  timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.8.1-h7354ed3_0.conda
-  sha256: 57a21ae2dba96d6418a06c0631d36ba16d290840bed8fade3b5feeb527cfc3d2
-  md5: b9cac11f36e352a3c78662310d88ee91
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.8.1.*
-  license: MIT
-  license_family: MIT
-  size: 126462
-  timestamp: 1779874382476
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.8-hc5d346e_2.conda
-  sha256: e3fbc1100922e09b9e472ae1e92d0b83438e559f4817a55da34288890e56a087
-  md5: f87fb1388f53485d805e355356566519
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 139680
-  timestamp: 1777296450587
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_8.conda
-  sha256: 10fbca6e0cc0da1018f82f3c92e3841e734e704dbfee5df88ae652a49d8b402f
-  md5: 44a53b93cf0953bde4b0f4e610cef1c3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex * *_gnu
-  constrains:
-  - libgomp 15.2.0 h4751f2c_8
-  - libgcc-ng ==15.2.0=*_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 822224
-  timestamp: 1779212817826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_8.conda
-  sha256: 3b4b734309a58b3ded42e01aecfbb91b029ad22d768a4c9f0f4f0006a3172203
-  md5: b3f01816cd1e046648fff257be7b0248
-  depends:
-  - libgcc 15.2.0 h69a1729_8
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28452
-  timestamp: 1779212820023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
-  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
-  md5: 775a5698ec2a0aa6e2435b86418b563f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 190134
-  timestamp: 1772045245717
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
-  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
-  md5: 5766eead346251db288d5b13c3dffd6f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36248
-  timestamp: 1772045253856
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
-  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
-  md5: 91b626db75392fc7254aaad8dc9a9850
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7252351
-  timestamp: 1770755115633
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
-  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
-  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 789520
-  timestamp: 1771491869505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
-  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
-  md5: 7ab70b332bb2df9ce90a1567126b5d2a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 82352
-  timestamp: 1760364378431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
-  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
-  md5: 3fd122ff074ed6bed89994053feb1fe3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 804625
-  timestamp: 1775137912599
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-he97f470_3.conda
-  sha256: 516dd619e0f1ea8b5563c9bbe2ca77bb37b08b06ee2803f6b7a4354766f52c45
-  md5: 717a40340cf56728dedb6ae3d76afe64
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=12.1.0,<13.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libgcc >=14
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx >=14
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.5.6,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.9.0,<0.10.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2231146
-  timestamp: 1779881576781
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313heb26620_3.conda
-  sha256: d63244b197b8c19b88ad8f489853c9b8012e7086ec7867c49c9138b62769ceac
-  md5: f927b2cc31e8c82f17ef4bab5d7c9bdf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=12.1.0,<13.0a0
-  - libgcc >=14
-  - libmamba 2.3.2 he97f470_3
-  - libstdcxx >=14
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 697719
-  timestamp: 1779881653608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
-  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
-  md5: feb10f42b1a7b523acbf85461be41a3e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 88085
-  timestamp: 1726088449399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.69.0-hc59f8b6_0.conda
-  sha256: ef1003b384126778b7d8b88178cf420b2cf15b55e0d9a55ef07166d7a60d48cb
-  md5: 20413e902c09e4d6ecb5ee6a3d27daf5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.6,<2.0a0
-  - jansson >=2.14,<3.0a0
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 663027
-  timestamp: 1777386823667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
-  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
-  md5: 0801fbfd982d1a0de5cc895fed83a19c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3703875
-  timestamp: 1770634775371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
-  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
-  md5: 0767b8ade520f4927ff9d5866d783f6b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210465
-  timestamp: 1770390434417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
-  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
-  md5: 0d547d53349f3fcf4a20c9a207c08a3b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 465860
-  timestamp: 1760357067289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
-  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
-  md5: dd68c24355431c0543339dda1404129d
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 315187
-  timestamp: 1732891131339
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_8.conda
-  sha256: 30b7a96c0f1f527d16ec9ec7f80404f34d4b916332cca0634111ed077d7fc870
-  md5: 157776d72d1eba48854127f461b729cc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 h69a1729_8
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3902423
-  timestamp: 1779212830666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_8.conda
-  sha256: 35c3aff92b054a79655da09d4435faefcd7b23303d225b327065db9d263766ed
-  md5: 1b632358fe0c3badbd77b81ac05a48c2
-  depends:
-  - libstdcxx 15.2.0 h39759b7_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28504
-  timestamp: 1779212854288
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
-  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
-  md5: e79c628574f0ed3b60bd63e6d78501a1
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 671850
-  timestamp: 1777465777755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
-  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
-  md5: 4a6a2354414c9080327274aa514e5299
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28110
-  timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
-  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
-  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 901634
-  timestamp: 1772644974924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
-  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
-  md5: fdf0d380fa3809a301e2dbc0d5183883
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 440690
-  timestamp: 1746022211479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.14.6-hf2a51f9_1.conda
-  sha256: 459abeddcd64df95b09e2d9d2d92bbe980ad20ef7294a36928977d94742a93ec
-  md5: dffa9db432bf2a7be752498a5d4fa1ac
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=78.3,<79.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.8.2,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 660718
-  timestamp: 1778673166461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-h47b2149_1.conda
-  sha256: 45de7095ec747c8d0e3e47af6f74ff9cbb208473f42b940a284e1998c248b173
-  md5: 7623ef4b77936f7670f6f906c6af4f3a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 60093
-  timestamp: 1776974326015
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
-  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
-  md5: 1468bc20414b0fa8eb1b18d3a916039f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 480121
-  timestamp: 1754999718088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
-  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
-  md5: 6f3445d61b923a4e22a50b4ede3c1865
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 377746
-  timestamp: 1775637820996
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
-  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
-  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 150496
-  timestamp: 1775657630843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
-  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
-  md5: 2ee58861f2b92b868ce761abb831819d
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 159495
-  timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_2.conda
-  sha256: eb345067b96b14e79c4a1edd4acee63c4b175d1818bb9de1c5ca373a6985cd5a
-  md5: d6250f9e480b12792b75ae296c165286
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - panflute >=2.3,<2.4
-  - mistletoe >=1.0,<2.0
-  - commonmark >=0.9,<0.10
-  - mdit-py-plugins >=0.5.0
-  - sphinx-book-theme >=1,<2
-  - mistune >=3.0,<4.0
-  - markdown >=3.4,<4
-  - linkify-it-py >=1,<3
-  license: MIT
-  license_family: MIT
-  size: 243237
-  timestamp: 1777540569559
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
-  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
-  md5: 28351e7fd716ee4b3baef571be119b98
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151241
-  timestamp: 1728403996163
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
-  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
-  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - python-dotenv >=1.0.0
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 428184
-  timestamp: 1771960075711
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
-  sha256: b6ca5bd3f708610801723deb09a29941cb47061832659de55b414f0496bab3b6
-  md5: e909ab91f515181fff72f312cbe1dcb1
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  - opentelemetry-api >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 346906
-  timestamp: 1779919393059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
-  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
-  md5: 39da6986b50a3eb3cbf60c9883f4b92e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26871
-  timestamp: 1758552191170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
-  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
-  md5: 3c19869ee69743cd3e6ed44610f7b845
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257750
-  timestamp: 1765382387320
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-11.0.2-py313h06a4308_0.conda
-  sha256: 772cd3c79506ee5060cb6c75db0a4ccdd0cb2ca2364992d0549f0ffabcabb210
-  md5: 1edd221e035f78818555abc20b080edc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 173312
-  timestamp: 1775819413675
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
-  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
-  md5: b1fb5c763a2d3e15e633e84bccf52ce4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 123032
-  timestamp: 1750958840666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
-  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
-  md5: b9ee8adce00b801f3767671675300a6f
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 154942
-  timestamp: 1728385601732
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
-  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
-  md5: 0abfc090299da4bb031b84c64309757b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1137647
-  timestamp: 1753947487644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
-  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
-  md5: 36890f7abd98066b607211b1773e6343
-  license: MIT
-  license_family: MIT
-  size: 127326
-  timestamp: 1680082329609
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.30.0-py313h06a4308_0.conda
-  sha256: 114e4cceb46e0feaa33113a4fe0c8db5b1879e7c23f91464bbe9cb65bc221cda
-  md5: c73e4d5b5823c880b21b545ac12fbacb
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - httpx_aiohttp >=0.1.9
-  - sounddevice >=0.5.1
-  - websockets >=13,<16
-  - pandas-stubs >=1.1.0.11
-  - pandas >=1.2.3
-  license: Apache-2.0
-  license_family: Apache
-  size: 1116233
-  timestamp: 1777459702066
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
-  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
-  md5: d842c01c08579c4398dc5b15a0bd875d
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79899
-  timestamp: 1763721155768
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.6-h1b28b03_0.conda
-  sha256: 2ab27b5fe0a8d348262386d36a17c50bb688dc83a8443fe39ef561ea5fc09a7d
-  md5: 5341b8a62a122529fc2083c6ed4174f6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 5918095
-  timestamp: 1775749314567
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
-  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
-  md5: 8310c25ce1847aee276a9e2617388f46
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101271
-  timestamp: 1763996098531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
-  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
-  md5: ea9c98e0799195320c546768f562f351
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37782
-  timestamp: 1764236782492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
-  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
-  md5: 4c6786f5a20a0d5705c77a18d97eebec
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43650
-  timestamp: 1764254904983
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
-  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
-  md5: de2d09e81412c0288e94586569f8276c
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33381
-  timestamp: 1764254429958
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
-  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
-  md5: a9aa9b02edaa6e129374ae281b4ace66
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 58002
-  timestamp: 1764084155711
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
-  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
-  md5: e36ceb40f2e628e2b6d4bb62032539a1
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57320
-  timestamp: 1764164412130
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
-  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
-  md5: 2a77251102af2651654e23f12c0e58c6
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 274299
-  timestamp: 1764073186249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
-  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
-  md5: e794cf7621bbe67d177b7e279cd6d610
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 179330
-  timestamp: 1764062875253
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
-  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
-  md5: 76bffd8af6e6a162a1e7af69b9b800d7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 337138
-  timestamp: 1771945983540
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
-  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
-  md5: 0f7d4f61c3851a0d436b96e9cb02c393
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200822
-  timestamp: 1775004135549
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
-  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
-  md5: da78932ffefe7e3f780f75672b3f8b36
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51265
-  timestamp: 1772567686795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
-  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
-  md5: 49c2031dcebd085e49c3aff84479e314
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1289658
-  timestamp: 1759825800150
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
-  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
-  md5: a1e79da30a6c62c6398e9bb990ee9ed6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9162
-  timestamp: 1728388115083
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
-  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
-  md5: e1705a98bf3338281b413e1fc8484a12
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54729
-  timestamp: 1773652981831
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
-  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
-  md5: 5c71fdece7639940072a849417bff8da
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47969
-  timestamp: 1776972936162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
-  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
-  md5: 7664f08981772ba49fef33294a096a18
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170398
-  timestamp: 1772733409298
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
-  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
-  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 570052
-  timestamp: 1770660764829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
-  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
-  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550941
-  timestamp: 1761896477134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
-  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
-  md5: 973a642312d2a28927aaf5b477c67250
-  depends:
-  - libgcc-ng >=7.2.0
-  license: MIT
-  license_family: MIT
-  size: 5360
-  timestamp: 1505733967605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_1.conda
-  sha256: a69af6a08868bc24fc1981a22e1e29c20416f150695a31b4ce78dae833140e57
-  md5: 802842f437b616ba517bbe8ab59ed2dd
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - types-aiobotocore-s3 >=2.16.0
-  - valkey-glide >=2.1.0
-  - pydantic >=2.11.9
-  - hvac >=2.3.0
-  - diskcache >=5.0.0
-  - dbus-python >=1.4.0
-  - pytz >=2025.2
-  - python-duckdb >=1.1.1
-  - aiohttp>=3.12
-  - asyncpg >=0.30.0
-  - aiomcache >=0.8.0
-  - pathvalidate >=3.3.1
-  - pymongo >=4.0.0
-  - cachetools >=5.0.0
-  - anyio >=4.4.0
-  - redis-py >=4.3.0
-  - cryptography >=45.0.0
-  - types-hvac >=2.3.0
-  - elasticsearch >=8.0.0
-  - aioboto3 >=13.3.0
-  - rocksdict >=0.3.24
-  - types-aiobotocore-dynamodb >=2.16.0
-  - aiofile >=3.9.0
-  - keyring >=25.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 295896
-  timestamp: 1779978190992
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
-  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
-  md5: 60ea7416e08d78563e31d16c333bd57f
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 93055
-  timestamp: 1736868559715
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
-  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
-  md5: 3b8ea90c558c424f123c1fc6069c9fa6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155521
-  timestamp: 1774959763398
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.13.4-py313h06a4308_0.conda
-  sha256: a95fbf7a462cc0d0510a702f13993f2ae026b0373d788cfd475716aac955a124
-  md5: b669824f2ec61c956ab114143eccf3bd
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.46.4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1128169
-  timestamp: 1778683891285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.46.4-py313h6e1b9ff_0.conda
-  sha256: 05b763ee21064331e6fbfb20135e801f71fda761556b07c93938cbac6e4b7d6f
-  md5: 1583c5469605cea15689ec0b9ede1bc3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1885652
-  timestamp: 1778677122534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
-  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
-  md5: 52b991b3676ad69221ac4efe952ea622
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - google-cloud-secret-manager>=2.23.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  - pyyaml >=6.0.1
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  license: MIT
-  license_family: MIT
-  size: 151041
-  timestamp: 1764165180924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
-  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
-  md5: ccea3f7c3ca8da985a55fbc042ad8d82
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4943174
-  timestamp: 1775127040649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
-  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
-  md5: 3cbe7080967f615cd88efd025391b662
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 102773
-  timestamp: 1773773809562
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
-  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
-  md5: 41e5a9f1fb430fad7e10a9db74000502
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26218
-  timestamp: 1773985120703
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
-  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
-  md5: e1ab9ffa1588856f0bdbb204322568c4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35801
-  timestamp: 1761753024312
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.13-hb7b561f_100_cp313.conda
-  build_number: 100
-  sha256: e43d4697c40efbeaddbe332ead42e50847310fe6169792a3f59ee7f667dc26b3
-  md5: f89a334358da4df35098ca9deba1fbd6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.35.1
-  - libexpat >=2.7.5,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.8.2,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 33153832
-  timestamp: 1776148532010
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
-  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
-  md5: a844b3df0b11b33f4742841d25146b6c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313830
-  timestamp: 1728385377316
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
-  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
-  md5: 6aa550906f91d13d1371c07e9cb5c5c3
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51623
-  timestamp: 1768559707638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
-  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
-  md5: 213fed7b509c30119154cf77a958aa7d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253447
-  timestamp: 1763718602538
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.29-py313h06a4308_0.conda
-  sha256: 38518c171929d43aebd14d5b3a4ae07ca8fc1e3c5b559d93d2c7d1fdfd474ac5
-  md5: f6da44f1a0c19701204d3814cd8f5a00
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 70371
-  timestamp: 1779889654398
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
-  md5: 5af1bf885def2fa779b0bb002e53651b
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6157
-  timestamp: 1764349599777
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
-  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
-  md5: f700a9cc4e35fd699b4df403f8f14148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 224571
-  timestamp: 1773043070463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
-  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
-  md5: 2384f037ab798b6ce6097c717a8758dc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 253759
-  timestamp: 1763465523432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
-  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
-  md5: 631d76b2ec86efd85d6266113f7b20d5
-  depends:
-  - libre2-11 2025.11.05 h3356fce_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26001
-  timestamp: 1770390441796
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
-  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
-  md5: 33b7455bfa1462c42bbc9a0535070313
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19959
-  timestamp: 1760613452708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
-  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
-  md5: 8578e006d4ef5cb98a6cda232b3490f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 481826
-  timestamp: 1754485653893
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
-  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
-  md5: ce6e467c7e671a9214bc5d118b8e24a7
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82123
-  timestamp: 1762536905383
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.7-h7bdf020_0.conda
-  sha256: afcc50a102a20a62df24c7fc24633890890af7cf64d9c08ca2286bccf8eec5c7
-  md5: 6457711c539cd20f56d9fa5e6ae5a5f5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 33172
-  timestamp: 1779874661488
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.7-h7bdf020_0.conda
-  sha256: 9120848526b0a8e31e77203b49a55fbee85cf76ce660271681725520abb0b93f
-  md5: cd9ab66296f9984949c0435f41e72b55
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - reproc 14.2.7 h7bdf020_0
-  license: MIT
-  license_family: MIT
-  size: 24820
-  timestamp: 1779874672388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
-  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
-  md5: 120fcdc3014753b33a63db5930b7a085
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170579
-  timestamp: 1775066095969
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
-  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
-  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88122
-  timestamp: 1728411680534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-15.0.0-py313h06a4308_0.conda
-  sha256: e6056b611316c3f7a8b4b6f0cd6ed38275f825c3598303e783a07614539158f7
-  md5: 78f44153bae9a28238cf140f78cef7be
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 626259
-  timestamp: 1778860811865
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
-  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
-  md5: 42d308b4487e6a58261a971eb689044b
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33936
-  timestamp: 1771961295227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
-  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
-  md5: 9630d019be2bb127699a375157124a0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 346701
-  timestamp: 1762366536075
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
-  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
-  md5: dc961556c7bbe4e2aa959e36ab816dcd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271868
-  timestamp: 1762535994695
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
-  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
-  md5: dad8d758af9c2b4369776c601407d9bd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 136835
-  timestamp: 1762530306911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
-  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
-  md5: 6ce9737188317c940d461c09c18d0ab3
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31382
-  timestamp: 1775127026347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
-  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
-  md5: 985226bbcb23ebc859128ca676ad6321
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45387
-  timestamp: 1761903210853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
-  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
-  md5: 08038e054ee9e8419ea6aa3fd04455ea
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1665385
-  timestamp: 1775048728528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
-  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
-  md5: 843241073919fc2c912f6ed85d14681d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23136
-  timestamp: 1761912223128
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
-  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
-  md5: 7b2a4b5be590071e1b4dce77b413d26a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 264262
-  timestamp: 1734048099531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
-  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
-  md5: 648ce63d75b826e85fb8801c8b4b4e44
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37483
-  timestamp: 1744271525796
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
-  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
-  md5: face17589cf2b386d76cc870234dfe6e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17447
-  timestamp: 1764329206740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
-  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
-  md5: c7b847a43363d2d77724b9ea04881088
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1265119
-  timestamp: 1773313781324
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
-  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
-  md5: 1fb18f68f15d21748310b2a09ea2f923
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21821
-  timestamp: 1745413175232
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.52.1-py313h06a4308_0.conda
-  sha256: 205f2efa8f24e445fdd2efc879eb43fd19885a77d5f72f86ba29ab1e09c5b154
-  md5: d9137689e3d1e45fee0613c791807ca6
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 179416
-  timestamp: 1773935038245
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
-  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
-  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3610181
-  timestamp: 1755243907117
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
-  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
-  md5: 782987d420694bdc4a207a16db446a56
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82730
-  timestamp: 1768296500871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
-  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
-  md5: d625085e004f964c54b88a3c6c5e8d7e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189342
-  timestamp: 1762896696002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
-  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
-  md5: 17b9f23e939b55ab9cab471b694a79d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 161112
-  timestamp: 1771398721582
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.15.0-py313h06a4308_0.conda
-  sha256: 274c0ad0b14fca0b3a3d2d5fff8804d2d99ca660ac338b30224f2824005b1c40
-  md5: 93dd7d3739aa3e9a0b3ce910b5c91d5c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216754
-  timestamp: 1778743205283
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.4-py313h06a4308_0.conda
-  sha256: b69555753dd28bdecf8c6a94f879d8315127f04f4c7a9acd6785f41d5e193edf
-  md5: f8e8226a4e9b6c4c7676c78022f8d003
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 50225
-  timestamp: 1778600084355
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.25.1-py313h06a4308_0.conda
-  sha256: 477ede6c19edc3ec9ac08684e3fc2c3d863cfc1d71042f50ba60f094df177450
-  md5: b524467d0bb8751ea35a55fa87ba71bc
-  depends:
-  - annotated-doc >=0.0.2
-  - click >=8.2.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.8.0
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  size: 210715
-  timestamp: 1778701935356
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
-  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
-  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313h06a4308_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11238
-  timestamp: 1756280930223
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
-  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
-  md5: b5ea08882d6d5cca3e38a27a3575e85c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32310
-  timestamp: 1760614182019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
-  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
-  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 104756
-  timestamp: 1756280924315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
-  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
-  md5: ad4d17d499c69cca7e35518f53419f5c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24140
-  timestamp: 1774276104417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.7.0-py313h06a4308_0.conda
-  sha256: 02cfb9c30d1cf750a42523f273398edd5d8fcb31df0d0da07cf47c94891381c8
-  md5: b5fd092add49ea41b474bc98a75af1da
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - backports.zstd >=1.0.0
-  - h2 >=4,<5
-  license: MIT
-  license_family: MIT
-  size: 358018
-  timestamp: 1778536210174
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
-  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
-  md5: 302fdbeea413b0dc179b3ea16886718e
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141937
-  timestamp: 1768226450635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
-  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
-  md5: 2e099756135a2ef67be288cb2d8c3119
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313h06a4308_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39548
-  timestamp: 1768226455792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
-  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
-  md5: c28e5468c6d8844e76d22ac7baea58e4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 665707
-  timestamp: 1762175545430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.2.0-py313h6e1b9ff_0.conda
-  sha256: 9c64211b9730f97994f85e74d8c0ce9e75d40e76e77143437e073aaf32118529
-  md5: 7e4c16f4508a618af7b3757139e75c00
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 423560
-  timestamp: 1780040674043
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
-  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
-  md5: 946018cc418258ab8d35ed63099a3181
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 361630
-  timestamp: 1751974452259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
-  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
-  md5: 6730c94b00e7d802f421acd3a435af84
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70377
-  timestamp: 1769450261731
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
-  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
-  md5: 446fbd19ad7929dd70635f0303c5047b
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67121
-  timestamp: 1736540936116
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
-  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
-  md5: 8d5b22b094b6802334d7c8316c4091ce
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23000
-  timestamp: 1771372478643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
-  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
-  md5: 7a684ffa744044240b3061ad28531930
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 58122
-  timestamp: 1746171563556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
-  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
-  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26341
-  timestamp: 1746172168013
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
-  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
-  md5: 6298b27afae6f49f03765b2a03df2fcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 916212
-  timestamp: 1746110020649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
-  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
-  md5: a8005a9f6eb903e113cd5363e8a11459
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 13582
-  timestamp: 1745958707989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
-  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
-  md5: c284a09ddfba81d9c4e740110f09ea06
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19260
-  timestamp: 1745992279492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
-  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
-  md5: d810521a7b4a177fb3d1152cf84a778d
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 49889
-  timestamp: 1746169291297
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
-  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
-  md5: d95e8903fc0067086f153d04b8cbe578
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 95151
-  timestamp: 1746431898579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
-  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
-  md5: 79d7d6794c6adbc537fc98f94e204270
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 409903
-  timestamp: 1746172685149
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
-  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
-  md5: 412a0d97a7a51d23326e57226189da92
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-xextproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-renderproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 594175
-  timestamp: 1746046234466
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
-  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
-  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 635646
-  timestamp: 1772548381644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
-  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
-  md5: 39fdbf4db769e494ffb06d95680c83d8
-  depends:
-  - libgcc-ng >=7.3.0
-  license: MIT
-  size: 76992
-  timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.9.0-he852c71_0.conda
-  sha256: 9881d22ff3a472b6d424ef885baa619b31dd27f2f0a7c3f6dbbace71aa1a5603
-  md5: 7e0c8c5e43d4065f5bb3cb40de4126aa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 234370
-  timestamp: 1779458140041
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
-  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
-  md5: 0c22474f16e65bd9b52fd3b8d60a0372
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32106
-  timestamp: 1763977880529
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-h47b2149_1.conda
-  sha256: a31e7df4e55a0040e533095c09275a9d58747fb19e5cf9825820af20d4d55c02
-  md5: b987e8069100421df3350e8662d6a96a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib 1.3.1 h47b2149_1
-  license: Zlib
-  license_family: OTHER
-  size: 91138
-  timestamp: 1776974327859
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
-  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
-  md5: 78685aca3b481cf213b92abfbe0b2b21
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 422402
-  timestamp: 1758189113863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
-  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
-  md5: 93b0e546434bfb874aeefd6bb6cf40bb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 622604
-  timestamp: 1758039176606
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
-  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
-  md5: b272288d02db5520249ca7870c2287b4
-  license: None
-  size: 2491
-  timestamp: 1617219512888
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-52_gnu.conda
-  build_number: 52
-  sha256: a565f285cdcb14894ba4e8a081fcec0ce7a3b9636d3fe7be709c849438b08b79
-  md5: f367f6af1c675137019bcded877b4a59
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6626
-  timestamp: 1779131108070
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
-  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
-  md5: 6327e33161b8e0ae8b501af0b07ee435
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35447
-  timestamp: 1773069243126
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
-  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
-  md5: a8de75045d038d62c3553bdb1a2bf2b3
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - langchain-openai >=0.2.8
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116895
-  timestamp: 1773844596952
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
-  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
-  md5: cc86d0a53de1c9d4559f84313d92f08d
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda-token >=0.7.0
-  - conda >=23.9.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127355
-  timestamp: 1777996210212
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
-  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
-  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62286
-  timestamp: 1775469252673
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
-  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
-  md5: 0b644ecae935ac975164247e9f4d981d
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 845333
-  timestamp: 1772491214305
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
-  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
-  md5: bfb5d8d4df085842d8c0b2e056b9257f
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161380
-  timestamp: 1773934997584
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
-  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
-  md5: 7112210d85ff777ac172307690b79f45
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 168446
-  timestamp: 1773871519885
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
-  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
-  md5: 213c7a858140be70244c210c31e4da04
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160774
-  timestamp: 1773868123073
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.1-py313hd43f75c_0.conda
-  sha256: 645c82048a8a88715654fe12ceb8129a3b7e32b92b77f99b9506cf2970d0fa4b
-  md5: d6e0121611b5f2b607243474e4d5b059
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 75772
-  timestamp: 1780062412357
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
-  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
-  md5: aab07c0ab08553546780a3a40f8f2cec
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82829
-  timestamp: 1776808540195
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
-  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
-  md5: 37fbf9726b0439b29bba0e1cf52ae35c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11421
-  timestamp: 1763372675300
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
-  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
-  md5: 108a8bcd136312e83793f5cda2f350fb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26012
-  timestamp: 1761744922996
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
-  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
-  md5: 910687ebf7746e8562300e8f1996edc6
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318118
-  timestamp: 1773134422321
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
-  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
-  md5: 711f61b5492b94625605422dd8e326ed
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180516
-  timestamp: 1774959654156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
-  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
-  md5: 3bee8eb5a01e45d657bc7edc508dcde4
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 445207
-  timestamp: 1775206365399
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
-  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
-  md5: 63457f5636c2230e585b265ea721c2f8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1484918
-  timestamp: 1772489319478
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
-  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
-  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 522348
-  timestamp: 1751383856268
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
-  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
-  md5: 9dd92861bec232ccdf7869b0b05b453b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17.0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 385446
-  timestamp: 1764961345156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
-  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
-  md5: f580b2013db742598b2d59875bccf774
-  depends:
-  - libgcc-ng >=11.2.0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 215406
-  timestamp: 1714510578082
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
-  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
-  md5: 6e3e5f38a8efcb439d36f091baa23034
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 217449
-  timestamp: 1769077676509
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.5.14-hd43f75c_0.conda
-  sha256: 1952de6b37c0a04ff26b9e719e842742fd20d3d90cff7e6ae71d59f6eacd8b35
-  md5: 53fbdd199058951543bd02ea5f55290c
-  license: MPL-2.0
-  license_family: Other
-  size: 109983
-  timestamp: 1779369526496
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
-  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
-  md5: 1d25e042eebc783ff4804fc9c42852d2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41563
-  timestamp: 1764867403876
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.5.20-py313hd43f75c_0.conda
-  sha256: ad0482b93275e69f0992fce82aa568a364bcd508ed5cf89a8147d60b17ddb5e2
-  md5: 06ec246514aaf39ce1b2962db79f2c69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 134424
-  timestamp: 1779370393603
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
-  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
-  md5: d010d105070e615750bbb51b8f2b17f5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 317809
-  timestamp: 1761832800132
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
-  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
-  md5: c89d95c43d07b658088bb12631ce9132
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100336
-  timestamp: 1761744908393
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
-  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
-  md5: 7813f91a66f3a442e803469cf76e3e1c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328923
-  timestamp: 1764332280328
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
-  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
-  md5: efb9dc33b510e1c882b597d994f6ab3d
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-env >=2.6
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1270780
-  timestamp: 1771402352584
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
-  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
-  md5: 6577f526b527308e4bf66a7bdef0e7fe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285635
-  timestamp: 1762366425854
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
-  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
-  md5: 313fca7b4d867f8b06df3140548f9440
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38256
-  timestamp: 1762361650200
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
-  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
-  md5: 06c2848c6311674e19391d4b81b3188a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: CC0-1.0
-  license_family: CC
-  size: 132686
-  timestamp: 1734039347698
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.7-py313haa502f6_0.conda
-  sha256: 3ed601727cd363adb4659bcf6d1355f089ab03c51316b0cd9b44878689691797
-  md5: 6278e4fbbb0c256dba21cf6d8786a1ba
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=2.0.0
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1684534
-  timestamp: 1775672140512
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
-  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
-  md5: 8f3083bd30c06eace150fbf4ff5acd33
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392308
-  timestamp: 1772065019547
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
-  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
-  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
-  depends:
-  - expat >=2.7.1,<3.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1275876
-  timestamp: 1756144876643
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
-  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
-  md5: 77f95d4b0a5bf1b775dda3372544dbeb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37699
-  timestamp: 1728480059192
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
-  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
-  md5: 23079a69d0ac19cf9f264cfc36dfaf67
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  license: ISC
-  license_family: OTHER
-  size: 666622
-  timestamp: 1763718283404
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
-  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
-  md5: 3a916231ebb779a7c2d5230fca7a2792
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96633
-  timestamp: 1766163709520
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
-  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
-  md5: c73024412ae68d6afa90b3bfca1a3b28
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 939239
-  timestamp: 1761746641765
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
-  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
-  md5: 4f6a93a269938d34f89e6c56b07905a1
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 65683
-  timestamp: 1758610280179
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
-  sha256: 4d498a91280bc6dc6d9d0108f1f7fbf3cc732014b522621ee0ce2ee1dea24b8e
-  md5: d2c9e173a97f6bbc2bc18c77796c5a6f
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 66788
-  timestamp: 1779915955594
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
-  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
-  md5: b34fd0d10946da439f9b357e3d42e1f5
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37088
-  timestamp: 1774388461266
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
-  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
-  md5: 23b284ce11d60c82ef766dbfc024277c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49018
-  timestamp: 1761560361917
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.8.1-h5b11e9f_0.conda
-  sha256: 3e40b271ec47e077ca4d204cbf65a2240a33ec163c4860cc350d0f268af30915
-  md5: 774839ce2af756baca243ee77e2b04d5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libexpat 2.8.1 h5b11e9f_0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 25948
-  timestamp: 1779874409953
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.135.4-py313hd43f75c_0.conda
-  sha256: a554a080bc41268cc230f109343d1e5463162f067d1b43be38262d722e5f1e23
-  md5: 8356bfc6cd2e6e10ee94e5c728bd12b2
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.46.0
-  - typing-extensions >=4.8.0
-  - typing-inspection >=0.4.2
-  constrains:
-  - pydantic-settings >=2.0.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - fastapi-cli >=0.0.8
-  - uvicorn-standard >=0.12.0
-  - pydantic-extra-types >=2.0.0
-  - itsdangerous >=1.1.0
-  - orjson >=3.2.1
-  - jinja2 >=3.1.5
-  - httpx >=0.23.0,<1.0.0
-  - python-multipart >=0.0.18
-  - email-validator >=2.0.0
-  - pyyaml >=5.3.1
-  license: MIT
-  license_family: MIT
-  size: 213160
-  timestamp: 1779213485286
 - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastmcp-3.1.1-py313hd43f75c_0.conda
   sha256: 25541e8c2d463538a366efe3768a9bc2c410d9d7b62c78023bedd113d05244ae
   md5: 890b979716890bda333d2b8da4e9df67
@@ -4496,2917 +3525,6 @@ packages:
   license_family: Apache
   size: 1057392
   timestamp: 1774377861488
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-12.1.0-h8e5a627_0.conda
-  sha256: aa7b58e9c755e962d12389a5c8ca40360f23e8acbcc4f40b7d71eacd5def830d
-  md5: 4f7d44864ddd9385f19d54f6bd1c16c9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 195404
-  timestamp: 1772639972853
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
-  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
-  md5: 8d10823536cc83aca7475e92af48e733
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 38822
-  timestamp: 1761750688451
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
-  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
-  md5: 29ce6f4467466ef1155fd8485c41b52c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h304d29d_0
-  - libasprintf 0.25.1 h8121631_0
-  - libasprintf-devel 0.25.1 h8121631_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libgettextpo-devel 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 529353
-  timestamp: 1772045298146
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
-  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
-  md5: c0f5a28ad7e3facdc8181ef762970499
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3969299
-  timestamp: 1772045273194
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
-  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
-  md5: 5a519fab2daa903499d90bef420c0c8b
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 170581
-  timestamp: 1770382377233
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
-  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
-  md5: 4648b65bcb134c3764a9e64f6e6953d8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 hec5afc2_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 831478
-  timestamp: 1770755033862
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
-  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
-  md5: 4786f45bc40fd0fb4b60c05d19e32179
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64484
-  timestamp: 1761931284057
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
-  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
-  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127463
-  timestamp: 1748526158318
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
-  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
-  md5: e4fc275a391afef3d78ec4149d5ad589
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 98508
-  timestamp: 1763634792733
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
-  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
-  md5: 63a3ec07509610236d9ad578a3b625aa
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - zstandard >=0.18.0
-  - click >=8.0.0,<9.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216526
-  timestamp: 1760447362829
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.3-py313hd43f75c_0.conda
-  sha256: 32f20f7e8b5835ab651597744fc608b9bcbd77638bd6937854ecb13e92ab2a15
-  md5: bb6b82c3e0c456cbcc0aec5dfbcc3afc
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23420
-  timestamp: 1779705412194
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-78.3-h184064b_0.conda
-  sha256: a8bbd0804c4ea74a6de8231f27a913a730b3a5e9cf65664d46b9ad5f6cc59fe2
-  md5: 0da5f35ada86b8ac25eb864edd8189ff
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 24630174
-  timestamp: 1777922213958
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
-  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
-  md5: 93b126011717941f140fd04b6dd6d37b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203848
-  timestamp: 1761912000622
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
-  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
-  md5: 465aead5c1e7b7a585ebb676781545a1
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71748
-  timestamp: 1772097105461
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.15.0-h588a716_0.conda
-  sha256: bc4f597d0a8c76d0ceffb22028757f45ab551149ed9700d1eb58449f774df3c7
-  md5: 732df9ad011a787c27b4ad59698a68eb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 69453
-  timestamp: 1779458327726
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
-  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
-  md5: 281677614ab4b309ddb5afd24c80cd26
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19436
-  timestamp: 1755516386420
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
-  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
-  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17035
-  timestamp: 1769477854229
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
-  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
-  md5: 3fc0a300184c6cfbbb48735e637b6f00
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23679
-  timestamp: 1768389385039
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
-  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
-  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 298136
-  timestamp: 1762897357507
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
-  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
-  md5: 9930fc2e22ba90d25992765ac140be02
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36927
-  timestamp: 1728480664723
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
-  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
-  md5: 793eb8901926bede7a6eebdce28cf6a0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19083
-  timestamp: 1774432919346
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
-  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
-  md5: 4660f274a8ff963e92cb29db01b37c91
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30439
-  timestamp: 1774283011961
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
-  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
-  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198026
-  timestamp: 1767955403846
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
-  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
-  md5: 022e69a93795b21be36f997e24f2b341
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52583
-  timestamp: 1772640996503
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
-  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
-  md5: da59899cde4411bae19ae5f15aebe373
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 16920
-  timestamp: 1762788449938
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
-  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
-  md5: f303bbea09244d08acd0fad083bbd6eb
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96552
-  timestamp: 1764588304837
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
-  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
-  md5: c96025bac150402baa006c878d604992
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-mypy >=1.0.1
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  license: MIT
-  license_family: MIT
-  size: 82677
-  timestamp: 1763637208740
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
-  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
-  md5: 833bdaaca975deb8a858597241ecd5c9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-aarch64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 783012
-  timestamp: 1773255553164
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
-  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
-  md5: 50deebc10eb4d612f1bb35aa92538797
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1402413
-  timestamp: 1770384640911
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.7-h7866cb9_0.conda
-  sha256: 3916a720df2f472c3a953bd8a4f97f9e61e4d21c44f79036f8aa3beca9edd0c5
-  md5: dae6a149f7aab01e0db2b27a7efd6c98
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.5.6,<4.0a0
-  - xz >=5.8.2,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 946062
-  timestamp: 1777386313184
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
-  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
-  md5: 898dd823b7a53a708a69d86847903b0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52342
-  timestamp: 1772045233389
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
-  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
-  md5: 7b561a37cd2af9c7c194c2090e419ee3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 h8121631_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33644
-  timestamp: 1772045246611
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
-  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
-  md5: 607b0beebe5e0c3643f2fceee006d15e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78099
-  timestamp: 1762363467361
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
-  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
-  md5: 805855f8193938731ccba31427eaa37c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 31209
-  timestamp: 1762363472701
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
-  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
-  md5: bfc1f2cb23c1f160079289f797e97756
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 286206
-  timestamp: 1762363480172
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.20.0-h7563a4b_1.conda
-  sha256: 1f602c45ac9a23c025ab7d4cabaa9a700d4290030d3b6a3a0d895e45f2b37bdb
-  md5: 30adc3614fcd17e672ee6edb8ad7f4c6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.69.0,<1.70.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 519428
-  timestamp: 1777909391095
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
-  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
-  md5: 230e8093b929e64244f2c7e181705802
-  depends:
-  - libgcc-ng >=10.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 115539
-  timestamp: 1619012635485
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.8.1-h5b11e9f_0.conda
-  sha256: a08e2c5d1229d1dde5bd6ef44fa933b61fef6f33a7b1fd1b7a346e46244537f7
-  md5: 2b2a39542506c31ba21df82aafee564d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.8.1.*
-  license: MIT
-  license_family: MIT
-  size: 120742
-  timestamp: 1779874407783
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.8-h89d793c_2.conda
-  sha256: 56ee541a21e585e93f12656207573904360862a3833f4cfdaa421926fe9eb165
-  md5: dd2e20b9a0d36cf7ac77f33519a92d43
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 135199
-  timestamp: 1777296435963
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_8.conda
-  sha256: 71fc8b5195cb0724371da87c77c45c0428ae6686f5735709315eb54e9948f64b
-  md5: d7b72fca6c8e51b78b9a278a48535717
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex * *_gnu
-  constrains:
-  - libgcc-ng ==15.2.0=*_8
-  - libgomp 15.2.0 hf47c802_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 511167
-  timestamp: 1779212371593
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_8.conda
-  sha256: fc466a301a5e41ca638920f241b0732c00bf503f466dc0504ea8fb8ecf5bc6e3
-  md5: 09df5fac4dec4376d90942c40dede152
-  depends:
-  - libgcc 15.2.0 hc18542e_8
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28472
-  timestamp: 1779212373309
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
-  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
-  md5: 3c39fd72e5a005e81c78cefe0f4b0464
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 214938
-  timestamp: 1772045240107
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
-  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
-  md5: 60521b8fbf132abc3846a700f33374cf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36215
-  timestamp: 1772045253063
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
-  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
-  md5: eb5839753b2b8904f6d7107d6240ef23
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6933116
-  timestamp: 1770754985299
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
-  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
-  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 778215
-  timestamp: 1771491870922
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
-  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
-  md5: 5bd529c1efa0251f0cebe7f84a504f69
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 119389
-  timestamp: 1760364375350
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
-  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
-  md5: 690464725d117c8ec5194f57b56525b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 845865
-  timestamp: 1775137916299
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-h5c8e501_3.conda
-  sha256: f99628f2f7381393808e658ef50a733d1d0197650c7cd788ce89c75a68232b28
-  md5: 46b52c2baac20d3c83becdb333d4fb80
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=12.1.0,<13.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libgcc >=14
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx >=14
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.5.6,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.9.0,<0.10.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2083126
-  timestamp: 1779881585683
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h8125cf1_3.conda
-  sha256: b177e5d4df46b07196442175e38c7be1bbff0a0a0d70c6936f36b21338721553
-  md5: 62a7292bd6ed424c0b0d05dcf9786b17
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=12.1.0,<13.0a0
-  - libgcc >=14
-  - libmamba 2.3.2 h5c8e501_3
-  - libstdcxx >=14
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 597015
-  timestamp: 1779881686575
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
-  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
-  md5: 8bd7f4c495a81af4914c899949e52542
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 125873
-  timestamp: 1726088467322
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.69.0-h2dcec1c_0.conda
-  sha256: 73c5d4b23aef0612d4a473363fec915c892998787b64e58dc29f910e904dd0e4
-  md5: 6f4ab95ca13542c93cd2de03cdc058da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.6,<2.0a0
-  - jansson >=2.14,<3.0a0
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 677342
-  timestamp: 1777386816636
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
-  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
-  md5: aa2d494311b59791b542ceedfc12ff2e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3507714
-  timestamp: 1770634686006
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
-  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
-  md5: 2d6e1172997c845d903d346b97494c07
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203733
-  timestamp: 1770390557525
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
-  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
-  md5: 40c52830df19329c37dd2f093eb944de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 471404
-  timestamp: 1760357069476
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
-  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
-  md5: a88e620d4eafd7f199a0502433e5e0c0
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 332414
-  timestamp: 1732891127645
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_8.conda
-  sha256: 95b8d1cb433ee7351351e613e3e255967d517eb0eeaedec340818aa6aa90c6e4
-  md5: ad52ae62540e04578c90125eebafa228
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 hc18542e_8
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3830999
-  timestamp: 1779212383079
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_8.conda
-  sha256: 56fed649a8357e75320a12f5dc69f8d463ac38f62a808b032d784db913df30b6
-  md5: cece8ba0b16cc5921d56a6b2c808f8ed
-  depends:
-  - libstdcxx 15.2.0 h9538471_8
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28510
-  timestamp: 1779212405030
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
-  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
-  md5: a99663395dab887607b2e5a854389721
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 676495
-  timestamp: 1777465771156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
-  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
-  md5: 59cd225a7659291aa716c6cdae7e1363
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 30035
-  timestamp: 1668082742967
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
-  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
-  md5: 52b484c9618823592d2c26632724dafd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 594684
-  timestamp: 1772644989262
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
-  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
-  md5: 28e00a696fd74b7550b7d1b8698e10af
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 443363
-  timestamp: 1746022227484
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.14.6-hfdc530d_1.conda
-  sha256: 8a5b4ebdb32935b5be251cb82c2754bd83a9eeecbacd6df11091793be65351a3
-  md5: fffd28c6e7836b329aae76a4da1ddecf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=78.3,<79.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.8.2,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 655891
-  timestamp: 1778673050392
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h27118de_1.conda
-  sha256: ed2d5f9f5ad9efa6b28163dd79c89f65dacc3cba874921feef961ff06203c809
-  md5: fc57a6ca6d0f766b9d8a96a883afed16
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 59675
-  timestamp: 1776974322337
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
-  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
-  md5: ff7911a6103418a2c907d8c0262dd7f2
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 414985
-  timestamp: 1754999724928
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
-  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
-  md5: 77eab2a2d275f56e722b1aad11532fd3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 376687
-  timestamp: 1775637816376
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
-  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
-  md5: 8a1c323359558fc4a4df9191aa6d00fa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 143384
-  timestamp: 1775657550865
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
-  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
-  md5: 70c4ab9462183ac4af60852d2a79fbf6
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 185496
-  timestamp: 1714510593467
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_2.conda
-  sha256: f59fa96e5ecb50a3725d890dda7c8a576b3b1bb51cf468d7718033ad29e99c24
-  md5: 52dfa03cd4fc6fcdf6def4692c07af7e
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - linkify-it-py >=1,<3
-  - sphinx-book-theme >=1,<2
-  - panflute >=2.3,<2.4
-  - mistune >=3.0,<4.0
-  - mdit-py-plugins >=0.5.0
-  - mistletoe >=1.0,<2.0
-  - commonmark >=0.9,<0.10
-  - markdown >=3.4,<4
-  license: MIT
-  license_family: MIT
-  size: 242575
-  timestamp: 1777540565819
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
-  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
-  md5: 1225f726844496e3564e4b2d6c539763
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151130
-  timestamp: 1728498536715
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
-  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
-  md5: b7268fc357df1edc377e4a02b5c5c115
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  - python-dotenv >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 430285
-  timestamp: 1771960065247
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
-  sha256: 830eba7a3d482bf580428ca3df9e79092d6e84525916de57e8a71ba188401ad7
-  md5: 500ea279af0692936f7d51b378eb25ba
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  - opentelemetry-api >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 347389
-  timestamp: 1779919403644
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
-  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
-  md5: 5ab5b1fc729b44eb2872d740d95c495d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26724
-  timestamp: 1758552208116
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
-  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
-  md5: 0514a2f7425fe0559d98b6593f8c936d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257086
-  timestamp: 1765382393281
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-11.0.2-py313hd43f75c_0.conda
-  sha256: e75b4464d1ba7a1658257980adccee29bbb066c63ca63a7374e32a7874d5565b
-  md5: 1399d3c4c6c2554a5c66960f096ed13d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 174008
-  timestamp: 1775819410873
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
-  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
-  md5: 90c7270744a7c8abdf51b5fecf7a9c14
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 120613
-  timestamp: 1750958715349
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
-  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
-  md5: 4d635e1fed6b6841ae3db1e0377a7712
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 153354
-  timestamp: 1728405954288
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
-  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
-  md5: 7a1863281d1b73c33d04a3709fda9bda
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1203577
-  timestamp: 1753947513381
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
-  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
-  md5: 9e9d478b40d0e254cd3b448f92f47e8c
-  license: MIT
-  license_family: MIT
-  size: 127337
-  timestamp: 1680082426492
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.30.0-py313hd43f75c_0.conda
-  sha256: cd055bc3fe872e2481f9e719bcfd586769a9f4153de8e94ca4c72b8cfc8545f7
-  md5: 88160661ed57dd988dddb7985feb0670
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - sounddevice >=0.5.1
-  - websockets >=13,<16
-  - httpx_aiohttp >=0.1.9
-  - pandas >=1.2.3
-  - pandas-stubs >=1.1.0.11
-  license: Apache-2.0
-  license_family: Apache
-  size: 1113065
-  timestamp: 1777459700855
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
-  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
-  md5: 583ab7940537e3387afa8c18b28eeb1c
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79849
-  timestamp: 1763721155450
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.6-h39c9139_0.conda
-  sha256: 1a8c2aa57cbef6576d04a2889da51cef641adbfbea56c66577b90772c0964a98
-  md5: 1fea8b1c8a9858054c8ea4ef0a0f0ce4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 6541356
-  timestamp: 1775749241503
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
-  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
-  md5: 85b624fe49b39de9fbe86b79144cb7c4
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 100915
-  timestamp: 1763996095398
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
-  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
-  md5: fab7d6c7cd4ebefb06eada5bee45916c
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37829
-  timestamp: 1764236793947
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
-  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
-  md5: 211d4704424ad214a215cf0378e685cf
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43410
-  timestamp: 1764254906556
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
-  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
-  md5: 928d47e0634131263d53b97b8359431f
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33553
-  timestamp: 1764254406341
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
-  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
-  md5: aae5f23a1a4a2c152ee68f16d380ff15
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57805
-  timestamp: 1764084154068
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
-  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
-  md5: a93dfba7f5563c3430eb842ff88b7cb7
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57059
-  timestamp: 1764164411916
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
-  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
-  md5: 0ce00548bf7f2bc4d0cca918a84a3989
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275046
-  timestamp: 1764073129503
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
-  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
-  md5: f14b38ac757bcb80c206d16fb2e55592
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 177920
-  timestamp: 1764062882890
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
-  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
-  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 334755
-  timestamp: 1771945967596
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
-  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
-  md5: ba91769862d81cb2c29f4918aae1a245
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 198468
-  timestamp: 1775004133206
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
-  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
-  md5: 730f7454d70a81d991ac05e09c699166
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51488
-  timestamp: 1772567675008
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
-  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
-  md5: d2a1b973881c8c0493bf1fd7b62a2918
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1177858
-  timestamp: 1759825801409
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
-  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
-  md5: ed391ccc6d6caaccedd5250fdeb48807
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9176
-  timestamp: 1728408515784
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
-  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
-  md5: cdff168e8e1d6bbfced0f9ce18a6534a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54735
-  timestamp: 1773652976404
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
-  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
-  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47904
-  timestamp: 1776972854196
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
-  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
-  md5: 08a8181515e8bdce86ee017bb1153d69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170028
-  timestamp: 1772733403459
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
-  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
-  md5: c65088b4df85204138e7899b7bb677c5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 579494
-  timestamp: 1770660753322
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
-  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
-  md5: 55e55bb476470a157cf4b81f44283436
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550478
-  timestamp: 1761896485773
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
-  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
-  md5: bd26b7e13996984230e8ec67f3ebd4c7
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  license_family: MIT
-  size: 7035
-  timestamp: 1615912729649
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_1.conda
-  sha256: c3528eaf21b37206af878506da663e604e17be51fb37510459515baa2283c61a
-  md5: 2f3a131bd072f4e2cbee3ad28f540dc2
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - aiofile >=3.9.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - types-aiobotocore-s3 >=2.16.0
-  - cachetools >=5.0.0
-  - aioboto3 >=13.3.0
-  - keyring >=25.6.0
-  - pydantic >=2.11.9
-  - hvac >=2.3.0
-  - types-hvac >=2.3.0
-  - anyio >=4.4.0
-  - pymongo >=4.0.0
-  - valkey-glide >=2.1.0
-  - cryptography >=45.0.0
-  - asyncpg >=0.30.0
-  - pathvalidate >=3.3.1
-  - diskcache >=5.0.0
-  - rocksdict >=0.3.24
-  - dbus-python >=1.4.0
-  - redis-py >=4.3.0
-  - aiomcache >=0.8.0
-  - python-duckdb >=1.1.1
-  - pytz >=2025.2
-  - aiohttp>=3.12
-  - elasticsearch >=8.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 295816
-  timestamp: 1779978081175
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
-  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
-  md5: 574f6176492ab5f26a379307c7377a30
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92719
-  timestamp: 1736868553560
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
-  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
-  md5: 03fd00dba51a683e8d01f74ec63a1fec
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 156035
-  timestamp: 1774959750947
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.13.4-py313hd43f75c_0.conda
-  sha256: 92bc3c7526782aa5bf6491a01db155aa4e29d79e5dc170d359341345d8317f3d
-  md5: ef8d3ac799e68017710c0e673f12d38d
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.46.4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1126826
-  timestamp: 1778683886054
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.46.4-py313hef68074_0.conda
-  sha256: 0d91bcec560dccda2733745b3d5df70c57398172e1c5ffcd05317eb354dd4b86
-  md5: f8de87b7f9d4079e54a3b9d95d01db99
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1735370
-  timestamp: 1778677068356
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
-  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
-  md5: 8bcdca4304da9f754bfb1f5839f796dc
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - azure-identity >=1.16.0
-  - tomli >=2.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - pyyaml >=6.0.1
-  - google-cloud-secret-manager>=2.23.1
-  license: MIT
-  license_family: MIT
-  size: 150714
-  timestamp: 1764165157426
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
-  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
-  md5: 1e4f8926de2d91ff108ecf1f8d30371f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4941418
-  timestamp: 1775127034860
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
-  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
-  md5: 9f01b187aede17a6e8b192f35472b652
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103005
-  timestamp: 1773773803703
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
-  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
-  md5: 90a46389b262fac93bd471f2fc0ea5ff
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25832
-  timestamp: 1773985116510
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
-  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
-  md5: 43da0d039f7b195466a8be650fa38424
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35803
-  timestamp: 1761753028895
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.13-h0f2f12d_100_cp313.conda
-  build_number: 100
-  sha256: 00215d7abb904516605d67082c7186b60b6e2484f97b2cb419b401066d105d89
-  md5: 207a787e47fa9bf2a1c0c2c8ac812e08
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.35.1
-  - libexpat >=2.7.5,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.8.2,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 31837743
-  timestamp: 1776148804346
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
-  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
-  md5: 061428165f4369719796769975341cf7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 315827
-  timestamp: 1728405669914
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
-  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
-  md5: e07c79278a8a508e83e42d176ab595be
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51868
-  timestamp: 1768559706782
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
-  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
-  md5: b8dc8f719d9a94474d335a89ff1ab0a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253530
-  timestamp: 1763718606784
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.29-py313hd43f75c_0.conda
-  sha256: c54c6f208047bc8c94bae5cdb295cafdce0072b0fef525735ecedbc50fa462a8
-  md5: 06a1d96bd36a9a13fd00b5855cea64c0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 70879
-  timestamp: 1779889663325
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
-  md5: fb2966848729243e63cc897cb90f1eda
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6101
-  timestamp: 1764349598421
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
-  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
-  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 223054
-  timestamp: 1773043038462
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
-  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
-  md5: a9b067a53f219bf9ed2a4583154facf9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 245388
-  timestamp: 1763465541517
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
-  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
-  md5: bb43fdeb5e1bc6595d63be00f22eaf00
-  depends:
-  - libre2-11 2025.11.05 h1b0d54c_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25969
-  timestamp: 1770390562916
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
-  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
-  md5: d2228764ccb4ad95813f44effcaaa38a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19961
-  timestamp: 1760613342830
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
-  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
-  md5: f04b3cb7ab28e886ceb012e4e9626e82
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 509455
-  timestamp: 1754485781954
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
-  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
-  md5: f1cd02f5cac4c78dd00805f81f7b66d8
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82590
-  timestamp: 1762536906694
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.7-h301ae1c_0.conda
-  sha256: ac4f8229d2aa423275f34dc53516f464d80fe3627412ee7ef2c1f8f00e823b8a
-  md5: 3543296e743c9cb365f2d1dee9cb6e71
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 35011
-  timestamp: 1779874676017
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.7-h301ae1c_0.conda
-  sha256: 6aabc3074e7c0195de04f8bfafbbd9ba40c34e7598f91837cb835b1da9abe1bf
-  md5: 0798f80fc7bef933ba09c8f4ddba5555
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - reproc 14.2.7 h301ae1c_0
-  license: MIT
-  license_family: MIT
-  size: 24782
-  timestamp: 1779874688284
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
-  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
-  md5: a7bcec6c82277f3990f35708bd05d660
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 171420
-  timestamp: 1775066082442
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
-  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
-  md5: 3f4000830e7a25be1df38114d361b976
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88285
-  timestamp: 1728500408740
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-15.0.0-py313hd43f75c_0.conda
-  sha256: 39e74971e59b4d9d2c9a6ad5638108eb9511ca7d137990e308dea7ca77567af5
-  md5: bff53525066be213bbde1a5bb3a1f0c7
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 628546
-  timestamp: 1778860800445
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
-  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
-  md5: 167fe8ee5af593667148b74a02090717
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33721
-  timestamp: 1771961162662
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
-  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
-  md5: 7f93cb69d835d6256cc68d0c22843159
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 335795
-  timestamp: 1762366544737
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
-  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
-  md5: 28b23d252e0d230044637b0f8f88cca6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271533
-  timestamp: 1762535980215
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
-  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
-  md5: 26960af9de364b5745c254d1a6890c45
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 127958
-  timestamp: 1762530151153
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
-  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
-  md5: 529575cd8e6b7becb44a50d0d35009f0
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31316
-  timestamp: 1775127025036
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
-  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
-  md5: c9d0d757b916ddfd019821dbbc02a0d9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45447
-  timestamp: 1761903130898
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
-  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
-  md5: 10081f3addefc88e8127e68448bf9f6d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1666759
-  timestamp: 1775048722771
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
-  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
-  md5: d32e4a1ec001c6cef1aae68c11480c55
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23120
-  timestamp: 1761912222490
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
-  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
-  md5: 0cefa22396b339a17597faad550d9582
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 226027
-  timestamp: 1734048100065
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
-  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
-  md5: 626970a8b8398716c9b9f9025eafd307
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37500
-  timestamp: 1744271573927
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
-  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
-  md5: 219c67c8ff19787a64b06c2517d063e9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17506
-  timestamp: 1764329173905
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
-  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
-  md5: 55600c8be72a7624ebd63e54ed72cbe0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1281272
-  timestamp: 1773313781654
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
-  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
-  md5: 1596a495a1f3def74862ce0efcc8281e
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21754
-  timestamp: 1745413132458
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.52.1-py313hd43f75c_0.conda
-  sha256: 13d68b3a88d81c4379d44d65d3d269c34a6752dd6869553a934f7a93a696409c
-  md5: 57f468854fad649b203e90595c14129b
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 178961
-  timestamp: 1773935043775
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
-  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
-  md5: 6a7f42565108e00d27f68f4ae5751c53
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3717438
-  timestamp: 1755243976411
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
-  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
-  md5: d5ba67844244cfccfa37b1b23ec83b23
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82633
-  timestamp: 1768296495852
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
-  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
-  md5: 8949c7ff2861d1b903cee84c0607eacf
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 188584
-  timestamp: 1762896685732
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
-  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
-  md5: 54a2c4b9c33935687b977159f85bb4cb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160713
-  timestamp: 1771398718073
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.15.0-py313hd43f75c_0.conda
-  sha256: 36d3dcc1fcf349d492bc1fc183f99102f1ad504ea5910e318cbc18e62114d64b
-  md5: 127cf9452aabe77ff4daea094120dcb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 218385
-  timestamp: 1778743205817
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.4-py313hd43f75c_0.conda
-  sha256: 07d7707d700d3ddda46216c4cce3eb8c39b3ab4244ef2600e950a9fdf3352893
-  md5: 9c2d1e8c9740dca79f9281eff9f431fb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 50345
-  timestamp: 1778600086391
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.25.1-py313hd43f75c_0.conda
-  sha256: 62ce86e20a16502f21f9d6b19ec878354695c7d2e016f5491d9dca1ea1f9262c
-  md5: c9e278b2ba623fa3634302a105cff672
-  depends:
-  - annotated-doc >=0.0.2
-  - click >=8.2.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.8.0
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  size: 210065
-  timestamp: 1778701931511
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
-  md5: 055d37ff4e41c9b9e33d2bb8919c263b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hd43f75c_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11203
-  timestamp: 1756280951293
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
-  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
-  md5: ff4e707bcf34fee0e2065cf2487e2103
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32401
-  timestamp: 1760614185275
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
-  md5: 017a18fc16caf581ce26bac0ad6f9efb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 101647
-  timestamp: 1756280944673
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
-  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
-  md5: e857fd0d00de0e82669ff9e06d27f6dd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24215
-  timestamp: 1774276085005
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.7.0-py313hd43f75c_0.conda
-  sha256: 2f429e9acc04a010d2b78629fda1d3c4f31da97de071c876f8a09739a6694e3d
-  md5: 12fbb02050f301302859c818d3f1e396
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - backports.zstd >=1.0.0
-  - h2 >=4,<5
-  license: MIT
-  license_family: MIT
-  size: 357165
-  timestamp: 1778536199781
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
-  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
-  md5: ebabc185d4b18349d7bf0d9f5c3d2901
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140643
-  timestamp: 1768226452652
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
-  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
-  md5: cb02ecced70ccf3114a942f060eb4f66
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hd43f75c_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39602
-  timestamp: 1768226458187
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
-  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
-  md5: 27e470f3b095fe3116358db877c2a2ea
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 612267
-  timestamp: 1762175558240
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.2.0-py313hef68074_0.conda
-  sha256: 0d31c70736b4c3a16f846659e66afa8b8e1444719170f0bc234912935cca8d0c
-  md5: 6a287602e1f2e6b342b2d8106bdbf2e5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 413654
-  timestamp: 1780040646077
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
-  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
-  md5: d6b2c092cb970c634a4b1376a8c212b6
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 368295
-  timestamp: 1751974662854
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
-  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
-  md5: caf0597b40222d6f17f745bd54636cea
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70703
-  timestamp: 1769450262181
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
-  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
-  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67625
-  timestamp: 1736540966215
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
-  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
-  md5: 750a7b171e663c39f6ecc0771452514a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23909
-  timestamp: 1771372468468
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
-  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
-  md5: 4f190efcbddae546e15d54f3f0314b96
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 59357
-  timestamp: 1746171572210
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
-  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
-  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26965
-  timestamp: 1746172174098
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
-  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
-  md5: e87565f2b050d575ee056f472d062383
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 950329
-  timestamp: 1746110056137
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
-  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
-  md5: 96f0df92ef31ad0aaf27b6b373e4f510
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 14118
-  timestamp: 1745958715370
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
-  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
-  md5: 5bfda69ee113cfc8e38e0214c078ef4e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19895
-  timestamp: 1745992295156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
-  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
-  md5: 607d46e3586e0c7b93a4495e0fe52db2
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 50277
-  timestamp: 1746169296094
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
-  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
-  md5: f5e59a8d2737934ac40c9bf645a75c52
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 100170
-  timestamp: 1746431911997
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
-  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
-  md5: c4b133535086cbaaf2403b18dc377e4a
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 417862
-  timestamp: 1746172689660
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
-  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
-  md5: 46b530510556e0b1830c40b5ac625f0e
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-renderproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-xextproto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 595620
-  timestamp: 1746046239552
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
-  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
-  md5: 0d2e76f65075404a9c26010882e7a786
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 643308
-  timestamp: 1772548369777
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
-  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
-  md5: 588d487b103786708d10c1800d048fd4
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  size: 77652
-  timestamp: 1619009841594
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.9.0-hcd08bf0_0.conda
-  sha256: 65852665efa9433cf9add0ea2b46bf409663af4528f17d120410371c6d4731c4
-  md5: 80b96527a03b6186e574059d6af883e2
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 222186
-  timestamp: 1779458144514
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
-  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
-  md5: 89dedf7658549815d9e8d5456231932b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32299
-  timestamp: 1763977879242
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h27118de_1.conda
-  sha256: dcec75ae492e5c0149f4b2d3e8d70d3bf4a892fe0e38f9e8231004e762533a8f
-  md5: 08ed08b247f3fc6c4a5bd14875419365
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib 1.3.1 h27118de_1
-  license: Zlib
-  license_family: OTHER
-  size: 88075
-  timestamp: 1776974324319
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
-  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
-  md5: 8d4a8433cf437f7ecc5aafa9874c2012
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 396870
-  timestamp: 1758189118512
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
-  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
-  md5: abc05ce4daceeb1fa321b365cb847975
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 594707
-  timestamp: 1758039173244
-- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
-  md5: c78d47374611a8e86f7a9817f3768160
-  depends:
-  - python >=3.8
-  constrains:
-  - conda >=23.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19864
-  timestamp: 1774907942644
-- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
-  md5: c0ad195970a65c174b997011ac13f2f8
-  depends:
-  - python >=3.7
-  license: MIT OR Apache-2.0
-  size: 49261
-  timestamp: 1758125010311
-- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
-  sha256: 10f62f9acf24c5abff2b172d90c65e5e6fbdfd5d228014969282ce180de30c3d
-  md5: 4a5e3c023bdfc52f653d8ecd03daafd2
-  depends:
-  - boltons >=23.0.0
-  - conda >=26.1
-  - libmambapy >=2
-  - msgpack-python >=1.1.1
-  - python >=3.10
-  - requests >=2.28.0,<3.0.0
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 58289
-  timestamp: 1778687024589
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
-  md5: d912068b0729930972adcaac338882c0
-  depends:
-  - python
-  license: PSF 2.0
-  license_family: PSF
-  size: 23826
-  timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
-  md5: f115ef0af90b59f35ef56743955979a4
-  depends:
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 39004
-  timestamp: 1627537099507
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
-  sha256: f54190680c16948ec7a2e37ea3a7b149dce90bd6360b0d3f5d855fcd875f77c4
-  md5: a9301655a0e91570c28b9470d0613946
-  depends:
-  - python >=3.9,<3.14.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 1197837
-  timestamp: 1780008991949
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
-  md5: 7f0df6639fdf60ccd3045ee6faedd32f
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14215
-  timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
-  md5: cda05f5f6d8509529d1a2743288d197a
-  depends:
-  - python >=2.7
-  license: MIT
-  license_family: MIT
-  size: 20302
-  timestamp: 1616166645426
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
-  sha256: 88f1c183adaf24df340d03ef5df510447973b0e80641ab1538e2d66db689c34b
-  md5: 805dd0dbe5ecde428f3c6c1afb6d94e2
-  license: CC-PDDC OR BSD-3-Clause
-  license_family: BSD
-  size: 120718
-  timestamp: 1779900350004
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
-  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
-  md5: 1784bef0a518f47b0cb442e02b75ce84
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35320
-  timestamp: 1773069152139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
-  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
-  md5: 88dc2eae5116b824692db6bb9b443eed
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  - langchain-openai >=0.2.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116841
-  timestamp: 1773844602363
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
-  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
-  md5: be96323ace383458edf5ef71f8e72654
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127712
-  timestamp: 1777996231900
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
-  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
-  md5: 52656bda190a7f2bec974f508a9f35f2
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-auth >=0.12.0
-  - anaconda-client >=1.13.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62048
-  timestamp: 1775469312642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
-  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
-  md5: c2a25adb6831401a65a5cdb63f88ba27
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 846994
-  timestamp: 1772491115479
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
-  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
-  md5: ed7020be4e2288dff58f60f7bf106fa9
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 162438
-  timestamp: 1773935019675
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
-  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
-  md5: a9010a6c725f4a11001406492d49f35e
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 169752
-  timestamp: 1773871547623
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
-  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
-  md5: eeca273b542009d5cd4e022bd2cb827d
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 162392
-  timestamp: 1773868150264
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.1-py313hca03da5_0.conda
-  sha256: 7ab3e15eac10410c126524599e5990a28f379c37a3da4ecf27d88278cfd8b4c2
-  md5: 112d00c441d60f4398011c37b74547d5
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 75917
-  timestamp: 1780062437196
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
-  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
-  md5: 9916fa1108527ee314251aec8a0c7353
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 83086
-  timestamp: 1776808490341
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
-  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
-  md5: f39857a71feb6e39da9739228f340a78
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11405
-  timestamp: 1763372676418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
-  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
-  md5: c0c2fb9483677bb657eda6d491e5f29c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 25909
-  timestamp: 1761744968164
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
-  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
-  md5: 7e400853597f6d7237e927baa6706aa7
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 317912
-  timestamp: 1773134435123
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
-  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
-  md5: bafc36567bd5432aea186b203ccbe80d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180639
-  timestamp: 1774959652662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
-  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
-  md5: a76eeaf70ce3bead86b2c5da38121a69
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 446875
-  timestamp: 1775206378569
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
-  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
-  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488689
-  timestamp: 1772489325506
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
-  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
-  md5: a5b55c281bf03fadccc2b9fb5e6c567d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 524228
-  timestamp: 1751383887927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
-  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
-  md5: 4f002093422042d948885e06821f150b
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17.0
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 375456
-  timestamp: 1764961201718
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
-  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
-  md5: 27a1ffbd30ff6427c112a733410e2f57
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 132212
-  timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
-  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
-  md5: ceb5c473b56eb1b79fd079f6b0d029df
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 177571
-  timestamp: 1769077680758
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.5.14-hca03da5_0.conda
-  sha256: fbec6b4a50724693297bc99d16b5f455267d24d10780dee40214d11822d6a3b3
-  md5: 4fc63c7213f26bca8f8e1a561b08df0e
-  license: MPL-2.0
-  license_family: Other
-  size: 110299
-  timestamp: 1779369421717
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
-  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
-  md5: bb47e0b8fa0f637b245c34b5b357a5d4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41149
-  timestamp: 1764867366355
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.5.20-py313hca03da5_0.conda
-  sha256: 22ceda465617efdfe3648420c9ae89c786148e955c3fc88643eae95dddf90df0
-  md5: 93a7a1245eb7e35a665f0d84ca941feb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 134103
-  timestamp: 1779370319413
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
-  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
-  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
-  depends:
-  - __osx >=12.1
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 288576
-  timestamp: 1761832806745
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
-  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
-  md5: 6301ec890b186cbe5d8243254450651e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100213
-  timestamp: 1761744861372
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
-  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
-  md5: 7ac45ddb190136a57ad9b02e7e365ec0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328813
-  timestamp: 1764332257562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
-  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
-  md5: 1fbe06ba53189032094abfe761e965ce
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-env >=2.6
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275763
-  timestamp: 1771402227023
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
-  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
-  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285376
-  timestamp: 1762366427916
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
-  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
-  md5: 01a0bc32a49fd331d514dfd64446fb1e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38499
-  timestamp: 1762361650835
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
-  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
-  md5: 9a83af67c17d1c760cd7aff545ef7e0f
-  depends:
-  - libcxx >=14.0.6
-  license: CC0-1.0
-  license_family: CC
-  size: 134133
-  timestamp: 1734039345192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.7-py313hae07363_0.conda
-  sha256: a8a8c9a21c602dc4b5e165e763cd91a93c0a0c26cafaa3449cd2b71f1153cf24
-  md5: 2ed446dca3be7460703b133a979a88e5
-  depends:
-  - __osx >=12.1
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1585026
-  timestamp: 1775672122040
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
-  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
-  md5: 85c2e5e0e00bcd63d85871b80f060b1b
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392115
-  timestamp: 1772064911124
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
-  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
-  md5: 5e948f3d746f13d209bd09a9d2fb7758
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38129
-  timestamp: 1728591870413
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
-  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
-  md5: 83b6045550ea3f3984ad063b58c44f83
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpx >=0.28.0
-  - httpcore >=1.0.0
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 667571
-  timestamp: 1763718279384
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
-  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
-  md5: 84ceb2792085acb3459abeedb47f888d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96396
-  timestamp: 1766163600127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
-  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
-  md5: 54a125d07b398d692c81bcad8c0fc6df
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 940136
-  timestamp: 1761746670106
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
-  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
-  md5: c1112f1321fda31b8b182c011bd25f39
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 66105
-  timestamp: 1758610134265
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
-  sha256: 9ef08d154b7f88a5e232804d55aff2ff14c57693d4de856fdb6840ea97937034
-  md5: 2644ebe94b48d6c7e0b179c30807dfbd
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 67101
-  timestamp: 1779916082564
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
-  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
-  md5: a1db257019eb3930e461aa5626be2c0e
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37392
-  timestamp: 1774388481869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
-  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
-  md5: cd68188eea25cf618d3ed80a746e34cd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 48744
-  timestamp: 1761560378218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.135.4-py313hca03da5_0.conda
-  sha256: 1b9e6662b9cfd28296990a27bba731fdaf168e0c7eaf5018cb55755b3b97a15d
-  md5: 5c3422f980014c560b2dda3a93c3fc18
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.46.0
-  - typing-extensions >=4.8.0
-  - typing-inspection >=0.4.2
-  constrains:
-  - jinja2 >=3.1.5
-  - email-validator >=2.0.0
-  - fastapi-cli >=0.0.8
-  - itsdangerous >=1.1.0
-  - python-multipart >=0.0.18
-  - uvicorn-standard >=0.12.0
-  - pyyaml >=5.3.1
-  - pydantic-extra-types >=2.0.0
-  - httpx >=0.23.0,<1.0.0
-  - orjson >=3.2.1
-  - pydantic-settings >=2.0.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  license: MIT
-  license_family: MIT
-  size: 213782
-  timestamp: 1779213508607
 - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastmcp-3.1.1-py313hca03da5_0.conda
   sha256: fcdac29589ed776f311b521b563f41b81553bf176cd7c3489c7dd62e84f98721
   md5: 306acc6065d62af1f39051a6a4457fab
@@ -7451,2599 +3569,6 @@ packages:
   license_family: Apache
   size: 1062410
   timestamp: 1774377883971
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-12.1.0-hc20ec9e_0.conda
-  sha256: 2eef880a6cc5d890b18714f4cdf533d291d35c45670921fd99d62e8413b585a1
-  md5: 4222bb0bb9d851b64a8163104f07d8b8
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 178313
-  timestamp: 1772640095208
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
-  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
-  md5: 662529f545d783dc4148ad30f1110b51
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39679
-  timestamp: 1761750693438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h50c8ec2_0.conda
-  sha256: 40d943c93b3530d872e0d984fe79570debae6cb8f6b8b715a83043fd349f9815
-  md5: 019e4c074d5db31938a582141e0d8af1
-  depends:
-  - __osx >=12.1
-  - gettext-tools 0.25.1 h61de102_0
-  - libasprintf 0.25.1 h7b764f5_0
-  - libasprintf-devel 0.25.1 h7b764f5_0
-  - libcxx >=20
-  - libgettextpo 0.25.1 h7b764f5_0
-  - libgettextpo-devel 0.25.1 h7b764f5_0
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h7b764f5_0
-  - libintl-devel 0.25.1 h7b764f5_0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 540523
-  timestamp: 1772045399083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h61de102_0.conda
-  sha256: d32649817c09e50b6fac1fe0ff33423e62e72603548486a31e4b4a4bcf21a62e
-  md5: 114bc0088ee0fb1bc617315c0cc35682
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h7b764f5_0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3473993
-  timestamp: 1772045376052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
-  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
-  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171931
-  timestamp: 1770382381497
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
-  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
-  md5: db94ba50dcc724b61f6f51982822577b
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libgrpc 1.78.0 h7694377_0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 761674
-  timestamp: 1770754627213
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
-  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
-  md5: 38e110c2ae2fb67d3ef1abfc786498f9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64806
-  timestamp: 1761931279662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
-  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
-  md5: 6d33385bdc014731d4369f0d0e09af73
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 129364
-  timestamp: 1748526183257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
-  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
-  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92280
-  timestamp: 1763634775883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
-  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
-  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pygments >=2.0.0,<3.0.0a0
-  - zstandard >=0.18.0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  - click >=8.0.0,<9.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217168
-  timestamp: 1760447208891
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.3-py313hca03da5_0.conda
-  sha256: 6c02369fd41c73a1bf806c52d32fa3733786872f81580b25fe034a020b5bc947
-  md5: 318fe0ce85ba910b160151492742c849
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23465
-  timestamp: 1779705367664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
-  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
-  md5: 48dcf4bb007f44e187fe29b1120e0ef9
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 23865757
-  timestamp: 1777922195678
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
-  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
-  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203509
-  timestamp: 1761912023966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
-  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
-  md5: 711d5bcfff34a45210902f5ef91c3ec6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 72439
-  timestamp: 1772099900987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.15.0-h9db958f_0.conda
-  sha256: c71158d76a0575cded1b6d698245b06b48cd9d6d50556c32e64d405a01c69b5c
-  md5: 618eef6415d2646740fe6b59538585c9
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 60223
-  timestamp: 1779458360360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
-  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
-  md5: f4e4bcf521aa18ee57d0607ad48f284c
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 21271
-  timestamp: 1755516531252
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
-  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
-  md5: 0a89e92618b4328787ef72b0d94d8808
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17072
-  timestamp: 1769477856721
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
-  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
-  md5: 7174017dd1ce6c709a2b1d87156deb56
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24174
-  timestamp: 1768389389007
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
-  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
-  md5: ef1c78fa12751c0d455245582d1cb49b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 268149
-  timestamp: 1762897357212
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
-  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
-  md5: 9e1af96e93b8278ec9029f1bd38f4517
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 37185
-  timestamp: 1728594571279
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
-  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
-  md5: 552bd935bf55a9099c7d2910a8d56391
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19004
-  timestamp: 1774432907812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
-  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
-  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30409
-  timestamp: 1774283033815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
-  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
-  md5: 0be71be35e5503bdecfebf75f1fa55c0
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198501
-  timestamp: 1767955687618
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
-  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
-  md5: bd5d17c69a377489445f1cac4b1390e7
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52745
-  timestamp: 1772641022505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
-  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
-  md5: 6cfee2660e901231d2fe274f02afeaf8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17167
-  timestamp: 1762788437806
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
-  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
-  md5: a691a010a6df73533294e436b2edb780
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 97019
-  timestamp: 1764588302845
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
-  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
-  md5: d19d185ec9fd87908b74303c8e38893f
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  - pytest-mypy >=1.0.1
-  license: MIT
-  license_family: MIT
-  size: 83253
-  timestamp: 1763637330760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
-  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
-  md5: 112093c65f205a89992cf9cfc7120f41
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1224935
-  timestamp: 1770384634202
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
-  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
-  md5: 9368c8128813db74810effc28a6d0de2
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.8.2,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 783208
-  timestamp: 1777387020815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-h7b764f5_0.conda
-  sha256: a3295db57bc22c78f922c0ee121ac8dbb0c8dae55a190d248e053075700ce902
-  md5: 6003a1343b04c750a86f6efa2f572aed
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: LGPL-2.1-or-later
-  size: 50271
-  timestamp: 1772045324221
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-h7b764f5_0.conda
-  sha256: 0aae2a9792cc32bab39ddac313c2af30276f95065ea98b6451d500ac72e5c46b
-  md5: 31af545e511849b35da42d6fb49795e6
-  depends:
-  - __osx >=12.1
-  - libasprintf 0.25.1 h7b764f5_0
-  license: LGPL-2.1-or-later
-  size: 33878
-  timestamp: 1772045335253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.conda
-  sha256: 6384ef4189390c3831c74d7c370947c0dcb130bbede2c2f384cf831fd8050254
-  md5: 9f83d2c2497e71ef4b3578fbd78bc673
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 77225
-  timestamp: 1762363445823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.conda
-  sha256: 9db56cd97049b73274301c2b9fc8ddb5e103f8c68b3b2a4c04d245c4e5b6fef5
-  md5: 8d41fd7da1d9d44b9ba39ab833f66605
-  depends:
-  - __osx >=12.1
-  - libbrotlicommon 1.2.0 hbd7815e_0
-  license: MIT
-  license_family: MIT
-  size: 27444
-  timestamp: 1762363457191
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.conda
-  sha256: 4c70015a24a73ce6559c98b59c35d960661326e6fd218e5aa3d074b9ab34441f
-  md5: ae2005cd80e3d845fe71ab43f4dadd73
-  depends:
-  - __osx >=12.1
-  - libbrotlicommon 1.2.0 hbd7815e_0
-  license: MIT
-  license_family: MIT
-  size: 294292
-  timestamp: 1762363468368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.20.0-h033922a_1.conda
-  sha256: 326fbb0c80960cbc989eb48910ea7e5a4376f709e3737279c21df80b0780c634
-  md5: f8cb177ffaea62f25e41174bf7ee97ba
-  depends:
-  - __osx >=12.1
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.69.0,<1.70.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 405787
-  timestamp: 1777909422116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
-  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
-  md5: 344e08f75d799c1e5b57441a2a4c357d
-  depends:
-  - __osx >=12.1
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 316282
-  timestamp: 1775479658335
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
-  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
-  md5: 00cac99189c361c3b2cbf506ae6cc718
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106490
-  timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.8.1-h50f4ffc_0.conda
-  sha256: 9ebbfa7b71762954befc42968df4b7728845ab7add2dcb5a8bf4ab033950eb71
-  md5: c21c46d2abc33b9cdc13d8154df31e39
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - expat 2.8.1.*
-  license: MIT
-  license_family: MIT
-  size: 112959
-  timestamp: 1779874356035
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.8-hcfc0b96_2.conda
-  sha256: 2cb0390c3c0ef4078230cfd95030013a59d3f48ace554b7406ee50fd85cfbf4c
-  md5: a491d121dadb72e44774af37f9737e96
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 118699
-  timestamp: 1777296337593
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-h7b764f5_0.conda
-  sha256: 990d09632f566d8fa499d67fe53c307ca451065997ef2f0028534608fffa26cc
-  md5: ff87319dec2259db334819119e4a3c2c
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h7b764f5_0
-  license: GPL-3.0-or-later
-  size: 177749
-  timestamp: 1772045341415
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-h7b764f5_0.conda
-  sha256: 21e809a6b0499e783e55e7cfe36a2df5863c3b7dfed70e73234c38dfc334a235
-  md5: 0b6fe86a04c739e37aa3306bc2ed653e
-  depends:
-  - __osx >=12.1
-  - libgettextpo 0.25.1 h7b764f5_0
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h7b764f5_0
-  license: GPL-3.0-or-later
-  size: 36532
-  timestamp: 1772045351234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
-  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
-  md5: 39336ad943dcc5f88ad31e32f1c4c66a
-  depends:
-  - __osx >=12.1
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4848994
-  timestamp: 1770754583246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
-  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
-  md5: efcf143adafc878192a4ab5252f4cacb
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-only
-  size: 749113
-  timestamp: 1771491894949
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
-  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
-  md5: 4caba2988c52534c6ba5e88afebba106
-  depends:
-  - __osx >=12.1
-  - gettext >=0.21.0,<1.0a0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 114873
-  timestamp: 1760364408172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h7b764f5_0.conda
-  sha256: 3ac68c21c6ef9200dcb2d66f33d9164197876f0107cac807c9f3fc4ab644cde8
-  md5: 71d922b1c84b98246a9990d29cba6e92
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 84499
-  timestamp: 1772045330319
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h7b764f5_0.conda
-  sha256: c7a27dcec6a9b8aa4d24345e201dfd9c9b8c857e08bf3b7173431ff8795dbdcb
-  md5: bc68d80a543744b8b36a957ca8a7f024
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h7b764f5_0
-  license: LGPL-2.1-or-later
-  size: 39263
-  timestamp: 1772045346385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkrb5-1.22.1-hbbdc3aa_1.conda
-  sha256: 8132c7e25e35deaa37898f358c8517d1ba76ab914dd6e440f439fa8d2ff3a796
-  md5: a7963ec6f60d80d694f71d78d026c7a0
-  depends:
-  - __osx >=12.1
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 666710
-  timestamp: 1775137965346
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-h4b9b42c_3.conda
-  sha256: 4bbf9f6b7921815c2a660f02d944c0f07077eda8147afd6103efda6bb3fd18f6
-  md5: ef5038993841784a4d2d26d2fd432b0b
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=12.1.0,<13.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libcxx >=19
-  - libsolv >=0.7.30,<0.8.0a0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.5.6,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.9.0,<0.10.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1468057
-  timestamp: 1779881399341
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_3.conda
-  sha256: 7cd815d87112dcb2035d3f3c98991d13252ad6512215a3befb194717fc3ebd76
-  md5: 639e171bd0fb549293a84769c65cb9fa
-  depends:
-  - __osx >=12.1
-  - fmt >=12.1.0,<13.0a0
-  - libcxx >=19
-  - libmamba 2.3.2 h4b9b42c_3
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 587635
-  timestamp: 1779881457155
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
-  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
-  md5: 7b01d2d5e276a24dd44e7846406656ed
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 70527
-  timestamp: 1726088461517
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.69.0-he427349_0.conda
-  sha256: 661509c2dc7db71bef7dac380aab53739fd13e3843af17931d70b284d8c5692f
-  md5: f448ad808be344b2991d1da2d2f2fe84
-  depends:
-  - __osx >=12.1
-  - c-ares >=1.34.6,<2.0a0
-  - jansson >=2.14,<3.0a0
-  - libcxx >=20
-  - libev >=4.33,<4.34.0a0
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 563791
-  timestamp: 1777387060041
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
-  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
-  md5: d45781f34f4b8e74d5b279e2e5d82c25
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2735206
-  timestamp: 1770634426661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
-  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
-  md5: 44b6b0d291189d289f38fa7bba97d117
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 164100
-  timestamp: 1770390432249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
-  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
-  md5: f39e89f9206a2366089b09a7cd209cf5
-  depends:
-  - __osx >=12.1
-  - libcxx >=17
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 383544
-  timestamp: 1760357075048
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
-  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
-  md5: b5aa2854a5872c57538743b4a85a731d
-  depends:
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 298763
-  timestamp: 1732891144732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
-  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
-  md5: c457b6d1695d1b5b054632d2d5895517
-  depends:
-  - __osx >=12.1
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 644497
-  timestamp: 1777466299217
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
-  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
-  md5: 5b151376f98c09831d6bd730ca7794c8
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 418963
-  timestamp: 1772645021860
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.6-h1ea6aa3_1.conda
-  sha256: 4cd7a61c92db1c7a436d33416d6e139baee110b322bb49046ee06381e5ac8c1d
-  md5: b9abad7050cac8a791658fa62882650a
-  depends:
-  - __osx >=12.1
-  - icu >=78.3,<79.0a0
-  - libiconv >=1.16,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.8.2,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 557652
-  timestamp: 1778673082116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-hb4cf58c_1.conda
-  sha256: 39df4501327dc21f6ddfd129db23c9ee6cda4c737c1f1a91e700aa965f8febb6
-  md5: 6cdcab9318862201eb86f27e7efcb7e8
-  depends:
-  - __osx >=12.1
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 44567
-  timestamp: 1776974334576
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lmdb-0.9.31-h79febb2_0.conda
-  sha256: 30f28b8d1eebf4c7bf9600c7fcf4147bdd2b40d0be80326a5994270d6de5f0a0
-  md5: f64afc713eac7e8bf402173915c58ccf
-  depends:
-  - __osx >=11.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 205738
-  timestamp: 1754999716617
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
-  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
-  md5: e535d29ea97147f0f6fb78a5a40c389e
-  depends:
-  - __osx >=12.1
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 374612
-  timestamp: 1775637687250
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
-  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
-  md5: 8b33a63dd414c362bc478d44fa6cad6b
-  depends:
-  - __osx >=12.1
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 122459
-  timestamp: 1775657525476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
-  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
-  md5: 82202ff2e94bc301fd9c790556506bb7
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 160308
-  timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_2.conda
-  sha256: 235bd34b21d4599827b3927ca325d34c1a36fe36a9b91014f3aab6e932206949
-  md5: 185560a1e60a38d87b687b47f672ff67
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - commonmark >=0.9,<0.10
-  - mistune >=3.0,<4.0
-  - mdit-py-plugins >=0.5.0
-  - linkify-it-py >=1,<3
-  - markdown >=3.4,<4
-  - mistletoe >=1.0,<2.0
-  - sphinx-book-theme >=1,<2
-  - panflute >=2.3,<2.4
-  license: MIT
-  license_family: MIT
-  size: 243450
-  timestamp: 1777540586959
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
-  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
-  md5: 4c3e970508e6cb3ad65579fb6b576143
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 149478
-  timestamp: 1728598048738
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
-  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
-  md5: 04ba8f0bfa78cef0456aeff11cfd1308
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - python-dotenv >=1.0.0
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 432541
-  timestamp: 1771960072114
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
-  sha256: 7dcb7ab7f6c3c0fd9301a4c760120e6bacd48762aee3269f304bea64e569ce91
-  md5: 9cd2d7945fcb775737365c00913343e4
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-api >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 347924
-  timestamp: 1779919417576
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
-  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
-  md5: cc0fbba5b4ee07d4f979149d050c864a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26834
-  timestamp: 1758552196391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
-  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
-  md5: e5a706e1b73efa80d1ec1f23256e3b86
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257932
-  timestamp: 1765382400100
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-11.0.2-py313hca03da5_0.conda
-  sha256: 496025e41f2694702ea58dfd61a922160698b8220766e8e85e74fbd81ec8734a
-  md5: b66a233a8bd8472e809494d0fd8aa4d3
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 172229
-  timestamp: 1775819430257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
-  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
-  md5: 58664c7ab05f2559e22bc3030c90bd2a
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 113263
-  timestamp: 1750958887102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
-  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
-  md5: 98737e4835cef677dbf6fa0d9d364968
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155808
-  timestamp: 1728586024156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
-  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
-  md5: d8a28b593d36653bec90bd2d78c7538b
-  depends:
-  - __osx >=11.1
-  license: MIT AND X11
-  license_family: MIT
-  size: 906808
-  timestamp: 1753947535285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
-  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
-  md5: 5cc48a403acb53596382724e41f99a6b
-  license: MIT
-  license_family: MIT
-  size: 128547
-  timestamp: 1680082112201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.30.0-py313hca03da5_0.conda
-  sha256: 111c4c5bc4bfa8441b6148a3a9b788a882e6925b216f4693f2a269327f68dfbf
-  md5: 04b819788d8761511073a2c2ef231ed6
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - pandas-stubs >=1.1.0.11
-  - httpx_aiohttp >=0.1.9
-  - pandas >=1.2.3
-  - websockets >=13,<16
-  - sounddevice >=0.5.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1123473
-  timestamp: 1777459710818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
-  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
-  md5: b2bded54c66346cf90e89ea7e65d80f6
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 80685
-  timestamp: 1763721157221
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.6-ha0b305a_0.conda
-  sha256: fc8e5c30740d42407ab194012329f9f8820832554593821e48fc919d582689a1
-  md5: 58bcf6e120ab49b90438bc8b199dcbc1
-  depends:
-  - __osx >=12.1
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 4817235
-  timestamp: 1775749200193
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
-  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
-  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101534
-  timestamp: 1763996094518
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
-  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
-  md5: dd551f29b6694f41a405d347e5b7641e
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38099
-  timestamp: 1764236649957
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
-  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
-  md5: 9b13a4cb589d5fc73e302f66b526c922
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43323
-  timestamp: 1764254973641
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
-  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
-  md5: e65ca1299e5e4ca5f515faa509bd23ae
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33433
-  timestamp: 1764254395627
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
-  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
-  md5: 59267a3e2c335ee1d45d703dfaee30f7
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57708
-  timestamp: 1764084154910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
-  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
-  md5: c2f0aecc8a2ea835b91a7897ab121f5c
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57335
-  timestamp: 1764164412952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
-  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
-  md5: c5fda39e599753e09a32115eb8330bac
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275773
-  timestamp: 1764073043306
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
-  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
-  md5: 677be6639bad152b927832a09d639b72
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 180260
-  timestamp: 1764062877653
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
-  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
-  md5: 304016a5b391759778800af9f24e1332
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 305477
-  timestamp: 1771946048520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
-  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
-  md5: 16eee0ba12a1721ab94eb4f87517b5e2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200339
-  timestamp: 1775004034672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
-  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
-  md5: edb4dc7d24225792e537e7db178ab7a5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51842
-  timestamp: 1772567682290
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
-  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
-  md5: dc957a9fa85669b0f6ce65ea9343fd8f
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 901944
-  timestamp: 1759825795666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
-  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
-  md5: 5c6344029e52293764fd4f88d6216c07
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9307
-  timestamp: 1728592695690
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
-  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
-  md5: f9e7cc4e6d37a4efe63452519464e148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54951
-  timestamp: 1773653001076
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
-  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
-  md5: 3550efa655956e28eb7282c3210bb015
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47964
-  timestamp: 1776972833748
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
-  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
-  md5: f686d9126128ed3d50046833a1b555a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170595
-  timestamp: 1772733427973
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
-  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
-  md5: 70879a51504dda5aff5034450b11a84a
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 461761
-  timestamp: 1770660566466
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
-  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
-  md5: 6bc6a220a229abae6afa80ccf4c3b06b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 561023
-  timestamp: 1761896362276
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_1.conda
-  sha256: ed21b11c3840d2b1dfcd5595672a36ed71a1b10f12839fba86e52308714f734c
-  md5: 3f09888d38880126245060ae0dd6ec38
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - elasticsearch >=8.0.0
-  - aiomcache >=0.8.0
-  - anyio >=4.4.0
-  - cachetools >=5.0.0
-  - types-aiobotocore-s3 >=2.16.0
-  - asyncpg >=0.30.0
-  - valkey-glide >=2.1.0
-  - redis-py >=4.3.0
-  - aioboto3 >=13.3.0
-  - pathvalidate >=3.3.1
-  - python-duckdb >=1.1.1
-  - pydantic >=2.11.9
-  - diskcache >=5.0.0
-  - dbus-python >=1.4.0
-  - rocksdict >=0.3.24
-  - pytz >=2025.2
-  - aiofile >=3.9.0
-  - hvac >=2.3.0
-  - aiohttp>=3.12
-  - keyring >=25.6.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - pymongo >=4.0.0
-  - cryptography >=45.0.0
-  - types-hvac >=2.3.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 296892
-  timestamp: 1779978100099
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
-  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
-  md5: 2ee55b934de679d2f73bd0f3840f1dfd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 90639
-  timestamp: 1736868507679
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
-  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
-  md5: 63924165d4c0b49b018d6c6c742d5666
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140335
-  timestamp: 1774959697268
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.13.4-py313hca03da5_0.conda
-  sha256: 0fc797970a04dd9485e75ccc37c3bf6b93af0886ebb23d196633fde3a3686395
-  md5: 063dbd636d74525f473fbc88dae48124
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.46.4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1129564
-  timestamp: 1778683904286
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.46.4-py313h3983f12_0.conda
-  sha256: ba6b2306d45414884172e8ace37e2ce597a056a51c0667e78564321634709159
-  md5: a6a603da37240ebd3428202bda1eca84
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1679830
-  timestamp: 1778677032197
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
-  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
-  md5: 4bc0da3d9e06af7ce644b3901790c1ee
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  - google-cloud-secret-manager>=2.23.1
-  - pyyaml >=6.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  license: MIT
-  license_family: MIT
-  size: 150650
-  timestamp: 1764165172452
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
-  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
-  md5: 1a096beb854aaa14d863b4da60533f79
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4967892
-  timestamp: 1775127065874
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
-  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
-  md5: 208f064869aaa98b2340cc60eb64c58b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103272
-  timestamp: 1773773829773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
-  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
-  md5: c7bc813891134328cf9262beac3465db
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 479484
-  timestamp: 1763629905351
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
-  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
-  md5: fd8423aa2c161f1355d9eb5e53958096
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 377280
-  timestamp: 1763651408167
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
-  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
-  md5: 505cfc77c635faa08a4a889e1c6c8a10
-  depends:
-  - pyobjc-framework-cocoa
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26139
-  timestamp: 1773985028336
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
-  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
-  md5: 16bf831da5d9b80789ca8c06f958ae2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 36057
-  timestamp: 1761753032083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.13-ha8cd034_100_cp313.conda
-  build_number: 100
-  sha256: 845ba4ef73057e2b0abeda829750e605b8dff2b9ddac63315fa7e9846a44c40c
-  md5: 5766ed009ee359deae79be0c731f9d48
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.5,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.8.2,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 13578757
-  timestamp: 1776147629054
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
-  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
-  md5: 2ac600a5ed014f3b8fe2996b213a68e6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313686
-  timestamp: 1728585595371
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
-  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
-  md5: 69ed706ac95df59f56b448091f4c40fa
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51905
-  timestamp: 1768559713789
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
-  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
-  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253652
-  timestamp: 1763718722391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.29-py313hca03da5_0.conda
-  sha256: 290dee7525f088cf979065df63cad60fbf82c0e02c1f1773be0163513529add2
-  md5: eefc93dc9958b1a4450bbe1c66a95b5c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 71167
-  timestamp: 1779889676641
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
-  md5: 12e362aabff119a51f51ac3c0f3d0a84
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6010
-  timestamp: 1764349560639
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
-  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
-  md5: 7faf2150ef3d3493e3554582fec52fcb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 226666
-  timestamp: 1773042949673
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
-  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
-  md5: 5ea183aac23f4bbe41412f200a70d09d
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 237854
-  timestamp: 1763465528485
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
-  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
-  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
-  depends:
-  - libre2-11 2025.11.05 hce96306_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26013
-  timestamp: 1770390441654
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
-  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
-  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 20018
-  timestamp: 1760613321490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
-  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
-  md5: fed853901ec41684b9e08b0c7ee4d7f0
-  depends:
-  - __osx >=11.1
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 475276
-  timestamp: 1754485689285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
-  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
-  md5: 3fa52decbfabf965e84fd38bfb2e268f
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82518
-  timestamp: 1762536906534
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.7-h279499b_0.conda
-  sha256: 15f2f9b90cacb20e84d4ca7870b15ae0226113910f070f12036228a185ee9617
-  md5: c7e057a695cfc78b1d4c785ddec6a37f
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 30651
-  timestamp: 1779874778017
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.7-h279499b_0.conda
-  sha256: 061c07d08829138f34c19aa3053402e0bf6f925906a7d7578a1635c7e3932dda
-  md5: a80f5d41ad365f36f785e6e322299762
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  - reproc 14.2.7 h279499b_0
-  license: MIT
-  license_family: MIT
-  size: 23644
-  timestamp: 1779874801900
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
-  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
-  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170039
-  timestamp: 1775066216803
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
-  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
-  md5: 85f9714b8bf50cf6f9c75deb5441bba8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88498
-  timestamp: 1731721373383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
-  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
-  md5: ffc0d1741d0d0dbff07518323feb64d8
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 603836
-  timestamp: 1760375502207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
-  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
-  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33777
-  timestamp: 1771961170073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
-  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
-  md5: 150c83ebdcae2067ae5c34a05c1da4ed
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 311962
-  timestamp: 1762366565780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
-  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
-  md5: b292e4688f8ac6f1c97f1f3e895f5cff
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271430
-  timestamp: 1762535976251
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
-  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
-  md5: ca9e7978a1057363f0c36d975b764dcb
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 114492
-  timestamp: 1762530107760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
-  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
-  md5: 8b4a9bf142beac7513382b0a84ce51f5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45786
-  timestamp: 1761903046636
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
-  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
-  md5: c396551324d88dfb8c688affa5226c2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1669346
-  timestamp: 1775048820327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
-  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
-  md5: 58fe2f1c6896f6e26cea231b74e3888c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 22962
-  timestamp: 1761912224859
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
-  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
-  md5: 443db5b88521ce0e2aaeb77bcf8fb488
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 220407
-  timestamp: 1734048107599
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
-  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
-  md5: 4af6f9244bd475289f3410b1c8880ed9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 39474
-  timestamp: 1744271575294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
-  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
-  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17410
-  timestamp: 1764329171349
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
-  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
-  md5: cf083b0b25fff8ddab995ac001076f38
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1182590
-  timestamp: 1773314600429
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
-  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
-  md5: 685d7b964cfdfd152fb5ddc0951b16d2
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 23284
-  timestamp: 1745413263670
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.52.1-py313hca03da5_0.conda
-  sha256: 8c8698c7ef19c251efad29aa3373b9b0254e6fb33a62dc92ef31682e00c6de57
-  md5: 3f457d26bf49537f9afbf846ef1e84f7
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 179700
-  timestamp: 1773935049678
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
-  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
-  md5: d1329e6c7292f448cdeed21290dd1035
-  depends:
-  - __osx >=11.1
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3448719
-  timestamp: 1755244020166
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
-  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
-  md5: 65d4e75c4c995d35de71b4e16174828c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82474
-  timestamp: 1768297453889
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
-  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
-  md5: 9199e3c9a0451d04eff558d461dd1b2c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189601
-  timestamp: 1762896659686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
-  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
-  md5: af4d88d628ea31190ed1432bba93b9c2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160792
-  timestamp: 1771398721170
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.15.0-py313hca03da5_0.conda
-  sha256: 3e4e87649ffd0483f6bf8cffe8098106679cd83ca56f3aadd9b18bb183515dbb
-  md5: 17ac336b222db9cf45b6d74890371e12
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217925
-  timestamp: 1778743224108
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.4-py313hca03da5_0.conda
-  sha256: 23f924b06f0fcf96757fcce25b5de1c35674da2e9fc8f8157fb7174442b73772
-  md5: c9caedd05a758f1f9df3c49b6225fa37
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 50313
-  timestamp: 1778600098786
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.25.1-py313hca03da5_0.conda
-  sha256: 7c2efb472fd099419f690ff8e5ef42a44c44ad0d06cae1271ad42a75f4fdee65
-  md5: bd9e935bfa0c48ef639e5ccf2cc96dc4
-  depends:
-  - annotated-doc >=0.0.2
-  - click >=8.2.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.8.0
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  size: 210811
-  timestamp: 1778701946808
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
-  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
-  md5: 22b46f0e6d389d4199ffaa317e9c9a05
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hca03da5_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 12434
-  timestamp: 1756281597870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
-  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
-  md5: 1398c39b86119164f19498b6fbcfdb69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32465
-  timestamp: 1760614190333
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
-  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
-  md5: 3c37609330dd4baeb0f4842f02cb783e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 106009
-  timestamp: 1756281579411
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
-  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
-  md5: 7c281290dab4999400a1e12be880c3a2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24287
-  timestamp: 1774276373831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.7.0-py313hca03da5_0.conda
-  sha256: 1663c484954fe3a1c2e6f656ad29dd4a6e31c99635617cc4bc67a583f35c2cac
-  md5: 523fd5bb78899f64e2e04c1b15bd4041
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - h2 >=4,<5
-  - backports.zstd >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 358132
-  timestamp: 1778536217975
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
-  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
-  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 142181
-  timestamp: 1768226456487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
-  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
-  md5: eea1461696459cc24a16b5a689281400
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hca03da5_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39438
-  timestamp: 1768226463310
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
-  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
-  md5: 62098dfc2ae82083a56bfd7bc319cf0e
-  depends:
-  - __osx >=12.1
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 545986
-  timestamp: 1762175544791
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.2.0-py313h3983f12_0.conda
-  sha256: ba19385d58257bd8c07b4de8d3b82cef3399e290497df616267735dd96b27121
-  md5: 983bdbc82459b93df85c889fa64e55d4
-  depends:
-  - __osx >=12.1
-  - anyio >=3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 368365
-  timestamp: 1780040586935
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
-  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
-  md5: ec80386b367f09af4b44b3824e29acce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 363811
-  timestamp: 1751974819165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
-  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
-  md5: 0d4dafde912fdee412dadf279d688eb5
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70617
-  timestamp: 1769450358672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
-  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
-  md5: d75550f3641901250eaa43ed71dc40d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 65365
-  timestamp: 1736541780222
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
-  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
-  md5: bc7f39bd763f6957ec91046f0e67a9f3
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 269216
-  timestamp: 1772548381049
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
-  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
-  md5: 23a9bda10db68f27fac5c379466c98b7
-  license: MIT
-  size: 73088
-  timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.9.0-h9fe17f6_0.conda
-  sha256: d519dc160c79bc40da9ca424a1daed5441d08c58d940516dc387ca25151a3a3a
-  md5: 80f60a3e6c45cddd8e956c50649639a5
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 131238
-  timestamp: 1779458127666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
-  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
-  md5: 1b87c5130b5fd6d1738e28799f8b8236
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32097
-  timestamp: 1763977879589
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-hb4cf58c_1.conda
-  sha256: 46ea11a239f326ff410d148a882b9c1daf5a26f4811cf8929e06b5ffb7907e27
-  md5: af4b715d560a4a8c11223309f733d433
-  depends:
-  - __osx >=12.1
-  - libzlib 1.3.1 hb4cf58c_1
-  license: Zlib
-  license_family: OTHER
-  size: 76072
-  timestamp: 1776974337144
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
-  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
-  md5: b282b2aecb718102ee0bb3848514689a
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 349977
-  timestamp: 1758189118260
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
-  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
-  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 471230
-  timestamp: 1758039171969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
-  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
-  md5: c62bd3bff5cb11570247115c1ab81225
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35318
-  timestamp: 1773069363087
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
-  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
-  md5: c486692f9df9720276afb556abff5361
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - mcp >=1.26
-  - pydantic-ai >=1.50
-  - langchain-openai >=0.2.8
-  - llm >=0.22
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116690
-  timestamp: 1773844804490
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
-  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
-  md5: 5f4b80f4355b922b23fdd3456c6d4001
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 152577
-  timestamp: 1777996277515
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
-  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
-  md5: 5717d515db735fe7167bd3b5ea7bdc50
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  - anaconda-cloud-cli >=0.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86912
-  timestamp: 1775469436561
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
-  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
-  md5: e10dea7c74568841ed1cd5d8ec12ca92
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 870768
-  timestamp: 1772491405834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
-  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
-  md5: 643c72f55e9de9926eabd069edbf2322
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161935
-  timestamp: 1773935085468
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
-  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
-  md5: c2ebc9fa966f6b08ea187fa807641415
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 226857
-  timestamp: 1773871887979
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
-  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
-  md5: 6f2969069844333afb09ed91b701abe0
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160509
-  timestamp: 1773868198156
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.1-py313haa95532_0.conda
-  sha256: 54ebcbd61bc8d9028e36fa707d19ed6761dab7f3d3376912c2d884a0aab6715b
-  md5: ccd17efbcd4b3ef56b09a7a129088c97
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 100193
-  timestamp: 1780062496652
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
-  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
-  md5: 8d4b877231bde39bd3ef1270fb015389
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82692
-  timestamp: 1776808693739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
-  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
-  md5: 250197e0edb4f89e9d3199c32fcecd5d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11465
-  timestamp: 1763372717011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
-  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
-  md5: 2c7171d6d58b9364b4406ab1c85ee50b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26185
-  timestamp: 1761745147069
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
-  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
-  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318164
-  timestamp: 1773134551978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
-  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
-  md5: 2a3be388a9418ec78c921662e816d826
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 181026
-  timestamp: 1774959795526
-- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
-  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
-  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 448508
-  timestamp: 1775206412930
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
-  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
-  md5: f38f1b967e522121f347c6e53e50386e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488599
-  timestamp: 1772489378490
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
-  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
-  md5: 78e0f7a51d811d64b0d0fa4e886458f2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 523882
-  timestamp: 1751383878776
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
-  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
-  md5: 964620a4cb8353969963fbb7b045b01c
-  depends:
-  - cffi >=1.17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 355904
-  timestamp: 1764961470388
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
-  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
-  md5: 33e784123d565c38e68945f07b461282
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 91870
-  timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
-  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
-  md5: f6f293f1ec437a5a362252af20d31e50
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  size: 203491
-  timestamp: 1769077840032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.5.14-haa95532_0.conda
-  sha256: cd677eba8e5005c16d6c0926b3a6ee54e4a0a466bb1ae8071e6fc49cbd65ad29
-  md5: 120259e1e9fba21a245cfe2a632332c0
-  license: MPL-2.0
-  license_family: Other
-  size: 110063
-  timestamp: 1779369808140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
-  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
-  md5: 9ce972c71a87d4d90534a24d77e99cb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41594
-  timestamp: 1764867445911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.5.20-py313haa95532_0.conda
-  sha256: c00dca94da0cba08243b42c58fe5f896b7661095febcda0d4fe5fb9757e1b9a7
-  md5: 080f8f5683481a20991f10dc4ea654a6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 134382
-  timestamp: 1779370678439
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
-  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
-  md5: d1e9e395ff8688288d67b89e896c2b6c
-  depends:
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 299121
-  timestamp: 1761832847099
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
-  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
-  md5: 9e4732d3d22b2cf01fc408696e8ebd41
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 124770
-  timestamp: 1761745054105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
-  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
-  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
-  depends:
-  - colorama
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328826
-  timestamp: 1764332409785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
-  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
-  md5: b73ebc8eb01ba1e79ad34303e2975694
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55002
-  timestamp: 1729036609433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
-  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
-  md5: 301f7c7830bdf835d4fcf93e0122da7a
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-env >=2.6
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275313
-  timestamp: 1771402340575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
-  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
-  md5: 0bf62b2027e8a656a86e1c4a7e71142c
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 309759
-  timestamp: 1762366569467
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
-  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
-  md5: d9081bd54908ac92135e6fb20d0aade2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38102
-  timestamp: 1762361726254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
-  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
-  md5: 67a55401db50a1d6bde2b153a74bcb07
-  depends:
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.29.30133,<15.0a0
-  license: CC0-1.0
-  license_family: CC
-  size: 133944
-  timestamp: 1734039396266
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.7-py313hbfe00f4_0.conda
-  sha256: 6ef8d801080710183ab192071940fed2d81c468bb25352a7cf69acc554053268
-  md5: 437bbfadf68c247ade554ede99116d43
-  depends:
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1480593
-  timestamp: 1775672660391
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
-  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
-  md5: db173ac83b3843bec70a8b2070881460
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 448738
-  timestamp: 1772065243755
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
-  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
-  md5: 9a502db95e7e272d1b7ed53f03dafab2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63476
-  timestamp: 1729059201537
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
-  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
-  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  - trio >=0.30
-  - idna >=3.10
-  - wmi >=1.5.1
-  - cryptography >=45
-  - h2 >=4.2.0
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 666555
-  timestamp: 1763718371551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
-  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
-  md5: 6c03175c12338ebc8273659a72c462ce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96782
-  timestamp: 1766163871411
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
-  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
-  md5: bbfbf4a353f2adbd724998ab6083802f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 1014370
-  timestamp: 1761746691814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
-  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
-  md5: 0aec5daa5284e9e3967c95a79f775012
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 90963
-  timestamp: 1758610340546
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
-  sha256: fb3ce799f193bcb6e33061ad6f975654b06f3342c3c10a72664f9cfb23ac5c4d
-  md5: b7b2eed90ced3af325d06a98dfa4c4b0
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 91692
-  timestamp: 1779916032565
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
-  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
-  md5: f61420d4421c1f5c8ecb2d0cac6a910c
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37648
-  timestamp: 1774388523034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
-  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
-  md5: be5485351f1313fc4628d30117e0fdd5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49233
-  timestamp: 1761560536661
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.135.4-py313haa95532_0.conda
-  sha256: 6991d1ff653f28d473c3faa78b56dddbe7484e97a8d08533c4b0b6210b73f5d1
-  md5: 08d621ddb70b614c33a8847c48b30cad
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.46.0
-  - typing-extensions >=4.8.0
-  - typing-inspection >=0.4.2
-  constrains:
-  - pydantic-settings >=2.0.0
-  - itsdangerous >=1.1.0
-  - python-multipart >=0.0.18
-  - email-validator >=2.0.0
-  - uvicorn-standard >=0.12.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - pyyaml >=5.3.1
-  - httpx >=0.23.0,<1.0.0
-  - fastapi-cli >=0.0.8
-  - orjson >=3.2.1
-  - jinja2 >=3.1.5
-  - pydantic-extra-types >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 270617
-  timestamp: 1779213555162
 - conda: https://repo.anaconda.com/pkgs/main/win-64/fastmcp-3.1.1-py313haa95532_0.conda
   sha256: e2ac0a58de7fbad8d04788f6cbd9411d8ad4887e20c090270677807dbff6e4a5
   md5: 37a1c03b4d1c38f1844c89147df17bca
@@ -10088,6 +3613,38 @@ packages:
   license_family: Apache
   size: 1086285
   timestamp: 1774377928366
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-12.1.0-h44f220b_0.conda
+  sha256: 75206a86cdcdb0752db803e8ab8b27589d376413f16f8b280f8864b27702636d
+  md5: dd4be9ab91074ac1e2bc78719cf51496
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 196493
+  timestamp: 1772639967801
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-12.1.0-h8e5a627_0.conda
+  sha256: aa7b58e9c755e962d12389a5c8ca40360f23e8acbcc4f40b7d71eacd5def830d
+  md5: 4f7d44864ddd9385f19d54f6bd1c16c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 195404
+  timestamp: 1772639972853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-12.1.0-hc20ec9e_0.conda
+  sha256: 2eef880a6cc5d890b18714f4cdf533d291d35c45670921fd99d62e8413b585a1
+  md5: 4222bb0bb9d851b64a8163104f07d8b8
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 178313
+  timestamp: 1772640095208
 - conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-12.1.0-ha349831_0.conda
   sha256: 5dd4c4ad9a4557c783980ca135e10ec6de1c150b9df3a4099efc8982922de509
   md5: 17ae3f100dfdbf5fd1291f5d42c37913
@@ -10099,6 +3656,41 @@ packages:
   license_family: MIT
   size: 194070
   timestamp: 1772640043830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
+  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
+  md5: 26dfe875df9973e0e98ec5add063e00e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39148
+  timestamp: 1761750688493
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
+  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
+  md5: 8d10823536cc83aca7475e92af48e733
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 38822
+  timestamp: 1761750688451
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
+  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
+  md5: 662529f545d783dc4148ad30f1110b51
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39679
+  timestamp: 1761750693438
 - conda: https://repo.anaconda.com/pkgs/main/win-64/frozendict-2.4.6-py313h02ab6af_0.conda
   sha256: 95ee413c83df0269fea089be2bf2fa7c1761a986d213f1c6926d4bd904176180
   md5: 16d7e8878fbec9e9856e9b7b3a7d41cb
@@ -10112,6 +3704,127 @@ packages:
   license_family: LGPL
   size: 39675
   timestamp: 1761750775394
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
+  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
+  md5: df53b928c3a9dd53c7f4e87cc03e03d2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h6a67909_0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libasprintf-devel 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libgettextpo-devel 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 535333
+  timestamp: 1772045309664
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
+  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
+  md5: 29ce6f4467466ef1155fd8485c41b52c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h304d29d_0
+  - libasprintf 0.25.1 h8121631_0
+  - libasprintf-devel 0.25.1 h8121631_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libgettextpo-devel 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 529353
+  timestamp: 1772045298146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h50c8ec2_0.conda
+  sha256: 40d943c93b3530d872e0d984fe79570debae6cb8f6b8b715a83043fd349f9815
+  md5: 019e4c074d5db31938a582141e0d8af1
+  depends:
+  - __osx >=12.1
+  - gettext-tools 0.25.1 h61de102_0
+  - libasprintf 0.25.1 h7b764f5_0
+  - libasprintf-devel 0.25.1 h7b764f5_0
+  - libcxx >=20
+  - libgettextpo 0.25.1 h7b764f5_0
+  - libgettextpo-devel 0.25.1 h7b764f5_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  - libintl-devel 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 540523
+  timestamp: 1772045399083
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
+  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
+  md5: ac944526cc2d27ffa3c44a42cd86f46d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3777431
+  timestamp: 1772045279414
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
+  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
+  md5: c0f5a28ad7e3facdc8181ef762970499
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3969299
+  timestamp: 1772045273194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h61de102_0.conda
+  sha256: d32649817c09e50b6fac1fe0ff33423e62e72603548486a31e4b4a4bcf21a62e
+  md5: 114bc0088ee0fb1bc617315c0cc35682
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3473993
+  timestamp: 1772045376052
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
+  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
+  md5: 91b9170766e7040dedc182d913a7ff89
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171370
+  timestamp: 1770382383126
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
+  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
+  md5: 5a519fab2daa903499d90bef420c0c8b
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 170581
+  timestamp: 1770382377233
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
+  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
+  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171931
+  timestamp: 1770382381497
 - conda: https://repo.anaconda.com/pkgs/main/win-64/googleapis-common-protos-1.72.0-py313haa95532_0.conda
   sha256: 3ba8735bb797cd4a59c3cfda4fdb4402e8195c3ff73e1c1a4741481cca316570
   md5: f0f53c3478e98fa4a70424c9841b9663
@@ -10125,6 +3838,56 @@ packages:
   license_family: APACHE
   size: 172940
   timestamp: 1770382461709
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
+  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
+  md5: 9b8c1795cc878775116cd01cea2ddad8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 h79c45ec_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 877844
+  timestamp: 1770755209168
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
+  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
+  md5: 4648b65bcb134c3764a9e64f6e6953d8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 hec5afc2_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 831478
+  timestamp: 1770755033862
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
+  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
+  md5: db94ba50dcc724b61f6f51982822577b
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libgrpc 1.78.0 h7694377_0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 761674
+  timestamp: 1770754627213
 - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.78.0-py313ha1f0e13_0.conda
   sha256: 7d6c1bab6553c858ebb29bfdd9c113e99ec8c6076582b718451bfe6f596d5826
   md5: 1667c992706d53ffdc6f05e3577c607d
@@ -10142,6 +3905,36 @@ packages:
   license_family: APACHE
   size: 727985
   timestamp: 1770755894751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
+  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
+  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64750
+  timestamp: 1761931277052
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
+  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
+  md5: 4786f45bc40fd0fb4b60c05d19e32179
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64484
+  timestamp: 1761931284057
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
+  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
+  md5: 38e110c2ae2fb67d3ef1abfc786498f9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64806
+  timestamp: 1761931279662
 - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.16.0-py313haa95532_1.conda
   sha256: 81e22d7167caf13f505697c0a182d428576d865c67b2f5ef0655201527302a9b
   md5: a97fdc66e5c3a6fcb5f8818f4606f22f
@@ -10152,6 +3945,42 @@ packages:
   license_family: MIT
   size: 64663
   timestamp: 1761931421750
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
+  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
+  md5: 77016551f9607c23c6243632bf100507
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127896
+  timestamp: 1748526107673
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
+  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
+  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127463
+  timestamp: 1748526158318
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
+  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
+  md5: 6d33385bdc014731d4369f0d0e09af73
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129364
+  timestamp: 1748526183257
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
   sha256: d500fb5bedabbb40813f548184b7fa6f3fd92893209c0762777d8b7926e94af2
   md5: 2262f0f3863efb10f8f4442438401a8d
@@ -10164,6 +3993,41 @@ packages:
   license_family: BSD
   size: 131010
   timestamp: 1748526313503
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
+  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
+  md5: 4b7c5319a6df6513319768f73969098c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 101585
+  timestamp: 1763634777574
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
+  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
+  md5: e4fc275a391afef3d78ec4149d5ad589
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 98508
+  timestamp: 1763634792733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
+  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
+  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92280
+  timestamp: 1763634775883
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httptools-0.7.1-py313h02ab6af_0.conda
   sha256: e8b67d7608f23cf46b932ebff40fe59ee3d71e0a03ae805662adb2b9391fc2ed
   md5: 1cfe4a9cca6beb28dd5870ef564a73dc
@@ -10177,6 +4041,66 @@ packages:
   license_family: MIT
   size: 84545
   timestamp: 1763634955246
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
+  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
+  md5: d25af3a5cbefe54951cb3dc369b945bb
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=8.0.0,<9.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - zstandard >=0.18.0
+  - socksio >=1.0.0,<2.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217558
+  timestamp: 1760447364823
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
+  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
+  md5: 63a3ec07509610236d9ad578a3b625aa
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - zstandard >=0.18.0
+  - click >=8.0.0,<9.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216526
+  timestamp: 1760447362829
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
+  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
+  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pygments >=2.0.0,<3.0.0a0
+  - zstandard >=0.18.0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217168
+  timestamp: 1760447208891
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
   sha256: 110311c08a60e70198900b6aa5a35e7b1f2175bd3109e0a56610b75d0ea3f20f
   md5: 55a5ebf53109994a5ac8a2f802bd8f43
@@ -10197,6 +4121,39 @@ packages:
   license_family: BSD
   size: 242095
   timestamp: 1760447587973
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.3-py313h06a4308_0.conda
+  sha256: 2839f29be1c271227df948b1afec5fd344e90a69a52f3c2500f5cbcf5c5e6089
+  md5: d935fe60ceefba9d9ef09f9da74f318e
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23252
+  timestamp: 1779705422223
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.3-py313hd43f75c_0.conda
+  sha256: 32f20f7e8b5835ab651597744fc608b9bcbd77638bd6937854ecb13e92ab2a15
+  md5: bb6b82c3e0c456cbcc0aec5dfbcc3afc
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23420
+  timestamp: 1779705412194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.3-py313hca03da5_0.conda
+  sha256: 6c02369fd41c73a1bf806c52d32fa3733786872f81580b25fe034a020b5bc947
+  md5: 318fe0ce85ba910b160151492742c849
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23465
+  timestamp: 1779705367664
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.3-py313haa95532_0.conda
   sha256: 1d8c0b1aa3081aa37a7c7e80cc7a4e53342188c6d2568dd4b12cf45cf9202e6a
   md5: 865f4caec9445359c1ad492b9fe91ec5
@@ -10208,6 +4165,67 @@ packages:
   license_family: MIT
   size: 23567
   timestamp: 1779705561106
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-78.3-h84d19a5_0.conda
+  sha256: b4a4f7bbc3722e658cd1d21c37c4d7b4c7e89a48233bc2b90d430c9ce4a65859
+  md5: b3cca90607d3b176e49048756e89296e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 24357919
+  timestamp: 1777922220477
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-78.3-h184064b_0.conda
+  sha256: a8bbd0804c4ea74a6de8231f27a913a730b3a5e9cf65664d46b9ad5f6cc59fe2
+  md5: 0da5f35ada86b8ac25eb864edd8189ff
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 24630174
+  timestamp: 1777922213958
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
+  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
+  md5: 48dcf4bb007f44e187fe29b1120e0ef9
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 23865757
+  timestamp: 1777922195678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
+  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
+  md5: c8b25d0fe19ba1a7319a0221e7615265
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202882
+  timestamp: 1761911998666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
+  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
+  md5: 93b126011717941f140fd04b6dd6d37b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203848
+  timestamp: 1761912000622
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
+  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
+  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203509
+  timestamp: 1761912023966
 - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
   sha256: 8264d301462d3eb44c813da4c4e092fc2f32b257ef5692a00573ac4c0346d920
   md5: 426a9add5ed691e72c893059ee0485fd
@@ -10218,6 +4236,39 @@ packages:
   license_family: BSD
   size: 203986
   timestamp: 1761912082836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
+  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
+  md5: e3d3dc1bd7e26bef582f874fbb4c543c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71396
+  timestamp: 1772097118324
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
+  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
+  md5: 465aead5c1e7b7a585ebb676781545a1
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71748
+  timestamp: 1772097105461
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
+  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
+  md5: 711d5bcfff34a45210902f5ef91c3ec6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72439
+  timestamp: 1772099900987
 - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.1-py313haa95532_0.conda
   sha256: e31d3af9ae2a8a60d0ab46045ca1c3103bd5c1b878197ad3dbbf42db732bf41f
   md5: f806d7a4777a4c76c01b630b4fdb3732
@@ -10229,6 +4280,68 @@ packages:
   license_family: APACHE
   size: 72171
   timestamp: 1772097268508
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.15.0-hbcba0ee_0.conda
+  sha256: f00270fce560124e2ac09e83130d0128b510d4bfb7143fd85ea70bea6b828d86
+  md5: fa3f5a347af7dc8c8db48c54fe5a2ae2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 66361
+  timestamp: 1779458360191
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.15.0-h588a716_0.conda
+  sha256: bc4f597d0a8c76d0ceffb22028757f45ab551149ed9700d1eb58449f774df3c7
+  md5: 732df9ad011a787c27b4ad59698a68eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 69453
+  timestamp: 1779458327726
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.15.0-h9db958f_0.conda
+  sha256: c71158d76a0575cded1b6d698245b06b48cd9d6d50556c32e64d405a01c69b5c
+  md5: 618eef6415d2646740fe6b59538585c9
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 60223
+  timestamp: 1779458360360
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
+  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
+  md5: c4ea3f7208a811b569bbeae8c42c5b2d
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19952
+  timestamp: 1755516354462
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
+  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
+  md5: 281677614ab4b309ddb5afd24c80cd26
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19436
+  timestamp: 1755516386420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
+  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
+  md5: f4e4bcf521aa18ee57d0607ad48f284c
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 21271
+  timestamp: 1755516531252
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
   sha256: 7eb0c4ee04a96ad65ae0c51d58ad17d5203b76ddcd2d4702503a50127434fd27
   md5: a8fd08b7543a5b778d2e2c29c5aa88e9
@@ -10240,6 +4353,36 @@ packages:
   license_family: MIT
   size: 21078
   timestamp: 1755516602917
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
+  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
+  md5: 54a430923247a921a5c57e330e04549f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17104
+  timestamp: 1769477866762
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
+  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
+  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17035
+  timestamp: 1769477854229
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
+  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
+  md5: 0a89e92618b4328787ef72b0d94d8808
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17072
+  timestamp: 1769477856721
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.context-6.1.0-py313haa95532_0.conda
   sha256: 50f96dd6dc6cfefe9eb81802fdcaec8f1776e723ac8a43d825902e3d1f53e363
   md5: 75a2698e16470e6c8ca5a80decb040f3
@@ -10250,6 +4393,39 @@ packages:
   license_family: MIT
   size: 16899
   timestamp: 1769477938631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
+  md5: 9572b85d5f84049bc36867f49d498520
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23712
+  timestamp: 1768389384997
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
+  md5: 3fc0a300184c6cfbbb48735e637b6f00
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23679
+  timestamp: 1768389385039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
+  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
+  md5: 7174017dd1ce6c709a2b1d87156deb56
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24174
+  timestamp: 1768389389007
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.functools-4.4.0-py313haa95532_0.conda
   sha256: d6495ad19759532a27e73055a1f13de378af550ff07878543e252b76c095660c
   md5: 25711ebee8c977aa282a9aa5ceea0817
@@ -10261,6 +4437,52 @@ packages:
   license_family: MIT
   size: 24310
   timestamp: 1768389476340
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
+  md5: f115ef0af90b59f35ef56743955979a4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 39004
+  timestamp: 1627537099507
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
+  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
+  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 304593
+  timestamp: 1762897374551
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
+  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
+  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 298136
+  timestamp: 1762897357507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
+  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
+  md5: ef1c78fa12751c0d455245582d1cb49b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 268149
+  timestamp: 1762897357212
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jiter-0.12.0-py313h114bc41_0.conda
   sha256: f39d48b2e608459feb932a21598c24ab04c9c32099a6aab94d5a08d7002aa082
   md5: e4a8ded259e4807efe3f846cbc713b75
@@ -10274,6 +4496,39 @@ packages:
   license_family: MIT
   size: 181327
   timestamp: 1762897503347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
+  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
+  md5: 8cb4b1755a4a8fd6a57883863236ef2b
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36479
+  timestamp: 1728399618377
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
+  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
+  md5: 9930fc2e22ba90d25992765ac140be02
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36927
+  timestamp: 1728480664723
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
+  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
+  md5: 9e1af96e93b8278ec9029f1bd38f4517
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37185
+  timestamp: 1728594571279
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpatch-1.33-py313haa95532_1.conda
   sha256: d25504515f356dc8c06dbf73ce598ba7b327431edf6ca1b06fa9a184a786ea04
   md5: 8c5fff5a1d8d36890bc5a297c1445785
@@ -10285,6 +4540,36 @@ packages:
   license_family: BSD
   size: 61903
   timestamp: 1729054823125
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
+  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
+  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18979
+  timestamp: 1774432898196
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
+  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
+  md5: 793eb8901926bede7a6eebdce28cf6a0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19083
+  timestamp: 1774432919346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
+  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
+  md5: 552bd935bf55a9099c7d2910a8d56391
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19004
+  timestamp: 1774432907812
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpointer-3.1.1-py313haa95532_0.conda
   sha256: d0cc264fcb1555ed5e2fea4cbcbef11c2fbdec97b003625b784229aa5255f483
   md5: 75eab033c2afaa3732443501ce5c69a9
@@ -10295,6 +4580,36 @@ packages:
   license_family: BSD
   size: 43602
   timestamp: 1774433242550
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
+  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
+  md5: 259205480d74c969b6bbd3c48662291e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30490
+  timestamp: 1774283018435
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
+  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
+  md5: 4660f274a8ff963e92cb29db01b37c91
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30439
+  timestamp: 1774283011961
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
+  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
+  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30409
+  timestamp: 1774283033815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonref-1.1.0-py313haa95532_0.conda
   sha256: 873027cd600f7bcb3955afff88d739dce468fb97711f984b2aa6daf9228970f4
   md5: 765f2516c806c0efce4302fb729a0c47
@@ -10305,6 +4620,48 @@ packages:
   license_family: MIT
   size: 30266
   timestamp: 1774283061640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
+  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
+  md5: 7125606e211300f51b43b14c7039c163
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198245
+  timestamp: 1767955393666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
+  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
+  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198026
+  timestamp: 1767955403846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
+  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
+  md5: 0be71be35e5503bdecfebf75f1fa55c0
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198501
+  timestamp: 1767955687618
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py313haa95532_0.conda
   sha256: 74712222c6722333c45a9e2b745af71fe2739ab5a6b0ed805b6f716103576821
   md5: 97042d9d769c8b7527882ae7edaba05a
@@ -10319,6 +4676,51 @@ packages:
   license_family: MIT
   size: 223147
   timestamp: 1767955635122
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
+  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
+  md5: dea8a1c280fb8cb391be3b459d8dfac1
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52614
+  timestamp: 1772640999029
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
+  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
+  md5: 022e69a93795b21be36f997e24f2b341
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52583
+  timestamp: 1772640996503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
+  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
+  md5: bd5d17c69a377489445f1cac4b1390e7
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52745
+  timestamp: 1772641022505
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-path-0.4.5-py313haa95532_0.conda
   sha256: d91c2b3156c53733cf5544a44d15fa79e0ecc688383c4c821dc2ee5979e4ef11
   md5: a8451b4e6b9ea3c5b515f06b9ba91e23
@@ -10334,6 +4736,39 @@ packages:
   license_family: Apache
   size: 52421
   timestamp: 1772641050217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
+  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
+  md5: 2dbc150b61f12b744cf873c285f4a418
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17079
+  timestamp: 1762788451045
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
+  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
+  md5: da59899cde4411bae19ae5f15aebe373
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16920
+  timestamp: 1762788449938
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
+  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
+  md5: 6cfee2660e901231d2fe274f02afeaf8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17167
+  timestamp: 1762788437806
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py313haa95532_0.conda
   sha256: 28620856a54ef6885be4360f5b85633685ddb4d88b2a43b57c7bdffc19335e09
   md5: 5c075ecdc29eda1f025dfdc4e0f6efcb
@@ -10345,6 +4780,42 @@ packages:
   license_family: MIT
   size: 17206
   timestamp: 1762788650578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
+  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
+  md5: 292a4c15bbd54feba358997e6d1b35db
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96597
+  timestamp: 1764588298747
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
+  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
+  md5: f303bbea09244d08acd0fad083bbd6eb
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96552
+  timestamp: 1764588304837
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
+  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
+  md5: a691a010a6df73533294e436b2edb780
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97019
+  timestamp: 1764588302845
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
   sha256: ffaafa66cf38b5ac02048ded1a6998ac2b83bc65712b6bc7947c93b78da71bb8
   md5: 3b95819d01e50e21001764a85f9afe81
@@ -10358,6 +4829,64 @@ packages:
   license_family: BSD
   size: 121625
   timestamp: 1764588393434
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
+  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
+  md5: 6d505a62b565ff3d80d5a6662a83d54a
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-mypy >=1.0.1
+  - shtab >=1.1.0
+  - pytest-enabler >=3.4
+  - pytest-checkdocs >=2.4
+  license: MIT
+  license_family: MIT
+  size: 82797
+  timestamp: 1763637203264
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
+  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
+  md5: c96025bac150402baa006c878d604992
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-mypy >=1.0.1
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 82677
+  timestamp: 1763637208740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
+  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
+  md5: d19d185ec9fd87908b74303c8e38893f
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  - pytest-mypy >=1.0.1
+  license: MIT
+  license_family: MIT
+  size: 83253
+  timestamp: 1763637330760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
   sha256: bea45ee837d9962996ba5bc05ed0d9e87e8d711cee9156bc2b649dadace14879
   md5: 793935b26a9203a0e14d442c5edfe91c
@@ -10377,6 +4906,69 @@ packages:
   license_family: MIT
   size: 108233
   timestamp: 1763637248210
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
+  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
+  md5: c563bb71f4df90fc3b92cde204827564
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 742162
+  timestamp: 1773255564362
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
+  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
+  md5: 833bdaaca975deb8a858597241ecd5c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-aarch64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 783012
+  timestamp: 1773255553164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
+  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
+  md5: 569d92e1732a69adff57813342a9c316
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libabseil-static =20260107.0=cxx17*
+  - abseil-cpp =20260107.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1384532
+  timestamp: 1770384636226
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
+  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
+  md5: 50deebc10eb4d612f1bb35aa92538797
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1402413
+  timestamp: 1770384640911
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
+  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
+  md5: 112093c65f205a89992cf9cfc7120f41
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1224935
+  timestamp: 1770384634202
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20260107.0-cxx17_hc587421_0.conda
   sha256: 3f445c4b66ad27ed9c46b1d30f0aae9789fa739dbe8156c9ca9aa31b375fcd88
   md5: 54f8fe8d7b66347164bbf3544bbe9172
@@ -10391,6 +4983,56 @@ packages:
   license_family: Apache
   size: 1913462
   timestamp: 1770384749003
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.7-hb3cce40_0.conda
+  sha256: b53751f828019d420954c263c600f18658990cdb70808db407d710a26d5fb697
+  md5: 6c2434e636c663e6cd532d44143588d0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.5.6,<4.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 887782
+  timestamp: 1777386329226
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.7-h7866cb9_0.conda
+  sha256: 3916a720df2f472c3a953bd8a4f97f9e61e4d21c44f79036f8aa3beca9edd0c5
+  md5: dae6a149f7aab01e0db2b27a7efd6c98
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.5.6,<4.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 946062
+  timestamp: 1777386313184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
+  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
+  md5: 9368c8128813db74810effc28a6d0de2
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 783208
+  timestamp: 1777387020815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.7-h8d653b7_0.conda
   sha256: 729af533e54088cebda836851067d401f93ff3d9dea22957da9ed7e9513779cb
   md5: 75939536c3ad6fc7145090a812b0bf1f
@@ -10410,6 +5052,93 @@ packages:
   license_family: BSD
   size: 844167
   timestamp: 1777386529375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
+  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
+  md5: 9fe17fea3f12a5dcc483b89f48e361da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52393
+  timestamp: 1772045241614
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
+  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
+  md5: 898dd823b7a53a708a69d86847903b0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52342
+  timestamp: 1772045233389
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-h7b764f5_0.conda
+  sha256: a3295db57bc22c78f922c0ee121ac8dbb0c8dae55a190d248e053075700ce902
+  md5: 6003a1343b04c750a86f6efa2f572aed
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: LGPL-2.1-or-later
+  size: 50271
+  timestamp: 1772045324221
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
+  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
+  md5: 114f7a7ae6d01b7f5d568439769857f7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33684
+  timestamp: 1772045249959
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
+  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
+  md5: 7b561a37cd2af9c7c194c2090e419ee3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 h8121631_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33644
+  timestamp: 1772045246611
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-h7b764f5_0.conda
+  sha256: 0aae2a9792cc32bab39ddac313c2af30276f95065ea98b6451d500ac72e5c46b
+  md5: 31af545e511849b35da42d6fb49795e6
+  depends:
+  - __osx >=12.1
+  - libasprintf 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later
+  size: 33878
+  timestamp: 1772045335253
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
+  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
+  md5: cdc0bbfec0c99b30d435b22341a716b0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78282
+  timestamp: 1762363571278
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
+  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
+  md5: 607b0beebe5e0c3643f2fceee006d15e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78099
+  timestamp: 1762363467361
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.conda
+  sha256: 6384ef4189390c3831c74d7c370947c0dcb130bbede2c2f384cf831fd8050254
+  md5: 9f83d2c2497e71ef4b3578fbd78bc673
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 77225
+  timestamp: 1762363445823
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.conda
   sha256: 515b14efb88b6a184c3a228df9d735a60505a77d6d0d85ca2efe3fdf26135f7c
   md5: d9c1dc58106b14e5173de685e8593dde
@@ -10421,6 +5150,38 @@ packages:
   license_family: MIT
   size: 87952
   timestamp: 1762363782214
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
+  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
+  md5: 7cad8348df1c96bf2f0a697806d1b3b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 33634
+  timestamp: 1762363575967
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
+  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
+  md5: 805855f8193938731ccba31427eaa37c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 31209
+  timestamp: 1762363472701
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.conda
+  sha256: 9db56cd97049b73274301c2b9fc8ddb5e103f8c68b3b2a4c04d245c4e5b6fef5
+  md5: 8d41fd7da1d9d44b9ba39ab833f66605
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 27444
+  timestamp: 1762363457191
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.conda
   sha256: 6b9147b66d9807378598c27fc5fff2e3eb3eaa807036d0c18c0d90778f612260
   md5: 6571166b6a690d451fbf6500c4ffba2e
@@ -10433,6 +5194,38 @@ packages:
   license_family: MIT
   size: 40440
   timestamp: 1762363799309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
+  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
+  md5: 854af1d6af8b3565fa8c7edb2141a2de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 279951
+  timestamp: 1762363583050
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
+  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
+  md5: bfc1f2cb23c1f160079289f797e97756
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 286206
+  timestamp: 1762363480172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.conda
+  sha256: 4c70015a24a73ce6559c98b59c35d960661326e6fd218e5aa3d074b9ab34441f
+  md5: ae2005cd80e3d845fe71ab43f4dadd73
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 294292
+  timestamp: 1762363468368
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.conda
   sha256: 5ff2563603fe5f0114da382bc0de34b060751a6aea9690f919fd20fdf448c3be
   md5: f2b21ddeba6f3dc5b3206b6913128cc8
@@ -10445,6 +5238,71 @@ packages:
   license_family: MIT
   size: 259203
   timestamp: 1762363815702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.20.0-hd8fa685_1.conda
+  sha256: 558a029dd317c9610f257fd73a210917c76c6d6ec5de1471ae3d432d6f3fc277
+  md5: 0bce5ed9e5696f46b16b074cf643265e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 502712
+  timestamp: 1777909373160
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.20.0-h7563a4b_1.conda
+  sha256: 1f602c45ac9a23c025ab7d4cabaa9a700d4290030d3b6a3a0d895e45f2b37bdb
+  md5: 30adc3614fcd17e672ee6edb8ad7f4c6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 519428
+  timestamp: 1777909391095
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.20.0-h033922a_1.conda
+  sha256: 326fbb0c80960cbc989eb48910ea7e5a4376f709e3737279c21df80b0780c634
+  md5: f8cb177ffaea62f25e41174bf7ee97ba
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 405787
+  timestamp: 1777909422116
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.20.0-h9440e04_1.conda
   sha256: 9e17afa766dccfafffb5a32fd80c81f89c23b40d22c518cb9ee4b89bcd4cf6ab
   md5: ab923b442ef1342c787c7dc3242118b0
@@ -10464,6 +5322,78 @@ packages:
   license_family: MIT
   size: 451035
   timestamp: 1777909579462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
+  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
+  md5: 344e08f75d799c1e5b57441a2a4c357d
+  depends:
+  - __osx >=12.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 316282
+  timestamp: 1775479658335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
+  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
+  md5: 5065620db4393fb549f30114a33897d1
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 114011
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
+  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
+  md5: 230e8093b929e64244f2c7e181705802
+  depends:
+  - libgcc-ng >=10.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115539
+  timestamp: 1619012635485
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
+  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
+  md5: 00cac99189c361c3b2cbf506ae6cc718
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106490
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.8.1-h7354ed3_0.conda
+  sha256: 57a21ae2dba96d6418a06c0631d36ba16d290840bed8fade3b5feeb527cfc3d2
+  md5: b9cac11f36e352a3c78662310d88ee91
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 126462
+  timestamp: 1779874382476
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.8.1-h5b11e9f_0.conda
+  sha256: a08e2c5d1229d1dde5bd6ef44fa933b61fef6f33a7b1fd1b7a346e46244537f7
+  md5: 2b2a39542506c31ba21df82aafee564d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 120742
+  timestamp: 1779874407783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.8.1-h50f4ffc_0.conda
+  sha256: 9ebbfa7b71762954befc42968df4b7728845ab7add2dcb5a8bf4ab033950eb71
+  md5: c21c46d2abc33b9cdc13d8154df31e39
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 112959
+  timestamp: 1779874356035
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.8.1-hd7fb8db_0.conda
   sha256: 25046714ee1942c1e28b61335ef07d483f16c86baa4fe7150b06fc6f1b2c2791
   md5: d237326a5202bcb08333c8431ff77c68
@@ -10477,6 +5407,38 @@ packages:
   license_family: MIT
   size: 125019
   timestamp: 1779874537343
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.8-hc5d346e_2.conda
+  sha256: e3fbc1100922e09b9e472ae1e92d0b83438e559f4817a55da34288890e56a087
+  md5: f87fb1388f53485d805e355356566519
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 139680
+  timestamp: 1777296450587
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.8-h89d793c_2.conda
+  sha256: 56ee541a21e585e93f12656207573904360862a3833f4cfdaa421926fe9eb165
+  md5: dd2e20b9a0d36cf7ac77f33519a92d43
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 135199
+  timestamp: 1777296435963
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.8-hcfc0b96_2.conda
+  sha256: 2cb0390c3c0ef4078230cfd95030013a59d3f48ace554b7406ee50fd85cfbf4c
+  md5: a491d121dadb72e44774af37f9737e96
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 118699
+  timestamp: 1777296337593
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.8-h2b21627_2.conda
   sha256: df0ee82af2a982e25d6592fd9dab2e1fcc9314708156888a45f1f5af3c6ce324
   md5: 69ce09a0b01c764627f0f1b0272bad48
@@ -10488,6 +5450,173 @@ packages:
   license_family: MIT
   size: 120596
   timestamp: 1777296713086
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_8.conda
+  sha256: 10fbca6e0cc0da1018f82f3c92e3841e734e704dbfee5df88ae652a49d8b402f
+  md5: 44a53b93cf0953bde4b0f4e610cef1c3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex * *_gnu
+  constrains:
+  - libgomp 15.2.0 h4751f2c_8
+  - libgcc-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 822224
+  timestamp: 1779212817826
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_8.conda
+  sha256: 71fc8b5195cb0724371da87c77c45c0428ae6686f5735709315eb54e9948f64b
+  md5: d7b72fca6c8e51b78b9a278a48535717
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex * *_gnu
+  constrains:
+  - libgcc-ng ==15.2.0=*_8
+  - libgomp 15.2.0 hf47c802_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 511167
+  timestamp: 1779212371593
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_8.conda
+  sha256: 3b4b734309a58b3ded42e01aecfbb91b029ad22d768a4c9f0f4f0006a3172203
+  md5: b3f01816cd1e046648fff257be7b0248
+  depends:
+  - libgcc 15.2.0 h69a1729_8
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28452
+  timestamp: 1779212820023
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_8.conda
+  sha256: fc466a301a5e41ca638920f241b0732c00bf503f466dc0504ea8fb8ecf5bc6e3
+  md5: 09df5fac4dec4376d90942c40dede152
+  depends:
+  - libgcc 15.2.0 hc18542e_8
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28472
+  timestamp: 1779212373309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
+  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
+  md5: 775a5698ec2a0aa6e2435b86418b563f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 190134
+  timestamp: 1772045245717
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
+  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
+  md5: 3c39fd72e5a005e81c78cefe0f4b0464
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 214938
+  timestamp: 1772045240107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-h7b764f5_0.conda
+  sha256: 990d09632f566d8fa499d67fe53c307ca451065997ef2f0028534608fffa26cc
+  md5: ff87319dec2259db334819119e4a3c2c
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: GPL-3.0-or-later
+  size: 177749
+  timestamp: 1772045341415
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
+  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
+  md5: 5766eead346251db288d5b13c3dffd6f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36248
+  timestamp: 1772045253856
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
+  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
+  md5: 60521b8fbf132abc3846a700f33374cf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36215
+  timestamp: 1772045253063
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-h7b764f5_0.conda
+  sha256: 21e809a6b0499e783e55e7cfe36a2df5863c3b7dfed70e73234c38dfc334a235
+  md5: 0b6fe86a04c739e37aa3306bc2ed653e
+  depends:
+  - __osx >=12.1
+  - libgettextpo 0.25.1 h7b764f5_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: GPL-3.0-or-later
+  size: 36532
+  timestamp: 1772045351234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
+  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
+  md5: 91b626db75392fc7254aaad8dc9a9850
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7252351
+  timestamp: 1770755115633
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
+  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
+  md5: eb5839753b2b8904f6d7107d6240ef23
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6933116
+  timestamp: 1770754985299
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
+  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
+  md5: 39336ad943dcc5f88ad31e32f1c4c66a
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4848994
+  timestamp: 1770754583246
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.78.0-hecd3d80_0.conda
   sha256: df06429097725d99abf7e174d53454341dc4802b0c4dc9d8cfa3d8dcd6f31fb8
   md5: 714d58c2bb7a1b39978b6fe7011d9876
@@ -10509,6 +5638,32 @@ packages:
   license_family: APACHE
   size: 11897881
   timestamp: 1770755767693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
+  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
+  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 789520
+  timestamp: 1771491869505
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
+  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
+  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 778215
+  timestamp: 1771491870922
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
+  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
+  md5: efcf143adafc878192a4ab5252f4cacb
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-only
+  size: 749113
+  timestamp: 1771491894949
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.18-hc89ec93_0.conda
   sha256: 73e19e873fad84ca239ccfd53a51830a8004a14b388a9d30a8c09ce3b8b386a2
   md5: 53c556b8109eaab09231874106a025f3
@@ -10519,6 +5674,106 @@ packages:
   license: LGPL-2.1-only
   size: 703101
   timestamp: 1771491956799
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
+  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
+  md5: 7ab70b332bb2df9ce90a1567126b5d2a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 82352
+  timestamp: 1760364378431
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
+  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
+  md5: 5bd529c1efa0251f0cebe7f84a504f69
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 119389
+  timestamp: 1760364375350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
+  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
+  md5: 4caba2988c52534c6ba5e88afebba106
+  depends:
+  - __osx >=12.1
+  - gettext >=0.21.0,<1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 114873
+  timestamp: 1760364408172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h7b764f5_0.conda
+  sha256: 3ac68c21c6ef9200dcb2d66f33d9164197876f0107cac807c9f3fc4ab644cde8
+  md5: 71d922b1c84b98246a9990d29cba6e92
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 84499
+  timestamp: 1772045330319
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h7b764f5_0.conda
+  sha256: c7a27dcec6a9b8aa4d24345e201dfd9c9b8c857e08bf3b7173431ff8795dbdcb
+  md5: bc68d80a543744b8b36a957ca8a7f024
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later
+  size: 39263
+  timestamp: 1772045346385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
+  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
+  md5: 3fd122ff074ed6bed89994053feb1fe3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 804625
+  timestamp: 1775137912599
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
+  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
+  md5: 690464725d117c8ec5194f57b56525b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 845865
+  timestamp: 1775137916299
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkrb5-1.22.1-hbbdc3aa_1.conda
+  sha256: 8132c7e25e35deaa37898f358c8517d1ba76ab914dd6e440f439fa8d2ff3a796
+  md5: a7963ec6f60d80d694f71d78d026c7a0
+  depends:
+  - __osx >=12.1
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 666710
+  timestamp: 1775137965346
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libkrb5-1.22.1-h3d06f0e_1.conda
   sha256: b179996d88eb33e2d0adc3418ee08c04dea5b96e49f76502c09af1643f8d9245
   md5: 7cf3e0d3e8de34c05bc06825387cc5d5
@@ -10532,6 +5787,77 @@ packages:
   license_family: MIT
   size: 693609
   timestamp: 1775138282724
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-he97f470_3.conda
+  sha256: 516dd619e0f1ea8b5563c9bbe2ca77bb37b08b06ee2803f6b7a4354766f52c45
+  md5: 717a40340cf56728dedb6ae3d76afe64
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx >=14
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2231146
+  timestamp: 1779881576781
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-h5c8e501_3.conda
+  sha256: f99628f2f7381393808e658ef50a733d1d0197650c7cd788ce89c75a68232b28
+  md5: 46b52c2baac20d3c83becdb333d4fb80
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx >=14
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2083126
+  timestamp: 1779881585683
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-h4b9b42c_3.conda
+  sha256: 4bbf9f6b7921815c2a660f02d944c0f07077eda8147afd6103efda6bb3fd18f6
+  md5: ef5038993841784a4d2d26d2fd432b0b
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libsolv >=0.7.30,<0.8.0a0
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1468057
+  timestamp: 1779881399341
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hf4f7140_3.conda
   sha256: a3c59714e8af649ef281a051679b28d378f325d896220b163063204dbb6841e0
   md5: 69166d59baab8da559185e65f546ab37
@@ -10556,6 +5882,53 @@ packages:
   license_family: BSD
   size: 4616286
   timestamp: 1779881598384
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313heb26620_3.conda
+  sha256: d63244b197b8c19b88ad8f489853c9b8012e7086ec7867c49c9138b62769ceac
+  md5: f927b2cc31e8c82f17ef4bab5d7c9bdf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=12.1.0,<13.0a0
+  - libgcc >=14
+  - libmamba 2.3.2 he97f470_3
+  - libstdcxx >=14
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 697719
+  timestamp: 1779881653608
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h8125cf1_3.conda
+  sha256: b177e5d4df46b07196442175e38c7be1bbff0a0a0d70c6936f36b21338721553
+  md5: 62a7292bd6ed424c0b0d05dcf9786b17
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=12.1.0,<13.0a0
+  - libgcc >=14
+  - libmamba 2.3.2 h5c8e501_3
+  - libstdcxx >=14
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 597015
+  timestamp: 1779881686575
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_3.conda
+  sha256: 7cd815d87112dcb2035d3f3c98991d13252ad6512215a3befb194717fc3ebd76
+  md5: 639e171bd0fb549293a84769c65cb9fa
+  depends:
+  - __osx >=12.1
+  - fmt >=12.1.0,<13.0a0
+  - libcxx >=19
+  - libmamba 2.3.2 h4b9b42c_3
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 587635
+  timestamp: 1779881457155
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h0016b16_3.conda
   sha256: b1aaaf6f95d98aad22841f06d201dfdcf6daac6de68d7066070ee2686e67c8c4
   md5: 8ccdbfc1bd0fe79f629811cce97d6700
@@ -10572,6 +5945,31 @@ packages:
   license_family: BSD
   size: 460953
   timestamp: 1779881725601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
+  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
+  md5: feb10f42b1a7b523acbf85461be41a3e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88085
+  timestamp: 1726088449399
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
+  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
+  md5: 8bd7f4c495a81af4914c899949e52542
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 125873
+  timestamp: 1726088467322
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
+  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
+  md5: 7b01d2d5e276a24dd44e7846406656ed
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 70527
+  timestamp: 1726088461517
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
   sha256: 3851b0985a481e019440ee2720bdfe1a98fe4db8cd67f8cc16333a0fa40f38df
   md5: a294b317c2e3732cafdba824a893b80c
@@ -10582,6 +5980,100 @@ packages:
   license_family: BSD
   size: 96993
   timestamp: 1726088489806
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.69.0-hc59f8b6_0.conda
+  sha256: ef1003b384126778b7d8b88178cf420b2cf15b55e0d9a55ef07166d7a60d48cb
+  md5: 20413e902c09e4d6ecb5ee6a3d27daf5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 663027
+  timestamp: 1777386823667
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.69.0-h2dcec1c_0.conda
+  sha256: 73c5d4b23aef0612d4a473363fec915c892998787b64e58dc29f910e904dd0e4
+  md5: 6f4ab95ca13542c93cd2de03cdc058da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 677342
+  timestamp: 1777386816636
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.69.0-he427349_0.conda
+  sha256: 661509c2dc7db71bef7dac380aab53739fd13e3843af17931d70b284d8c5692f
+  md5: f448ad808be344b2991d1da2d2f2fe84
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libcxx >=20
+  - libev >=4.33,<4.34.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 563791
+  timestamp: 1777387060041
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
+  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
+  md5: 0801fbfd982d1a0de5cc895fed83a19c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3703875
+  timestamp: 1770634775371
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
+  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
+  md5: aa2d494311b59791b542ceedfc12ff2e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3507714
+  timestamp: 1770634686006
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
+  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
+  md5: d45781f34f4b8e74d5b279e2e5d82c25
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2735206
+  timestamp: 1770634426661
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.5-h65d7223_0.conda
   sha256: dc02d4091ddfcae738ed17ba6ddbdeabfacdfa0b26f8a9332ad612925654630b
   md5: 11b8833fdd04816bf58e8b1fec3512ae
@@ -10596,6 +6088,50 @@ packages:
   license_family: BSD
   size: 7207712
   timestamp: 1770635087009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
+  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
+  md5: 0767b8ade520f4927ff9d5866d783f6b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210465
+  timestamp: 1770390434417
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
+  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
+  md5: 2d6e1172997c845d903d346b97494c07
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203733
+  timestamp: 1770390557525
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
+  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
+  md5: 44b6b0d291189d289f38fa7bba97d117
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 164100
+  timestamp: 1770390432249
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-h797e85b_1.conda
   sha256: b3f1b5da9830d15c3505d474343658df271e6ca633499acd268e224257905034
   md5: 531ca8049bd88d4df53d3a58643f31ec
@@ -10611,6 +6147,44 @@ packages:
   license_family: BSD
   size: 272314
   timestamp: 1770390642712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
+  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
+  md5: 0d547d53349f3fcf4a20c9a207c08a3b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 465860
+  timestamp: 1760357067289
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
+  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
+  md5: 40c52830df19329c37dd2f093eb944de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 471404
+  timestamp: 1760357069476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
+  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
+  md5: f39e89f9206a2366089b09a7cd209cf5
+  depends:
+  - __osx >=12.1
+  - libcxx >=17
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383544
+  timestamp: 1760357075048
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libsolv-0.7.30-h23a355e_2.conda
   sha256: b0f6d1ed7cd48d37ae9c1ba34c0fb70baded93a09718c29c6ecf924dd8e0165c
   md5: 0ae4849097816b4452e8fe8a28376a61
@@ -10623,6 +6197,38 @@ packages:
   license_family: BSD
   size: 444021
   timestamp: 1760357137426
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
+  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
+  md5: dd68c24355431c0543339dda1404129d
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 315187
+  timestamp: 1732891131339
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
+  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
+  md5: a88e620d4eafd7f199a0502433e5e0c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332414
+  timestamp: 1732891127645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
+  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
+  md5: b5aa2854a5872c57538743b4a85a731d
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 298763
+  timestamp: 1732891144732
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.conda
   sha256: ff2d46c586844c88b62ef6bb1419f89690a9e4db714ed2cdb3589ffdd0d8ef9e
   md5: d8ae56ee95db60cbd5f8f8ff63ed1f63
@@ -10635,6 +6241,183 @@ packages:
   license_family: BSD
   size: 319541
   timestamp: 1732891385479
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_8.conda
+  sha256: 30b7a96c0f1f527d16ec9ec7f80404f34d4b916332cca0634111ed077d7fc870
+  md5: 157776d72d1eba48854127f461b729cc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 h69a1729_8
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3902423
+  timestamp: 1779212830666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_8.conda
+  sha256: 95b8d1cb433ee7351351e613e3e255967d517eb0eeaedec340818aa6aa90c6e4
+  md5: ad52ae62540e04578c90125eebafa228
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 hc18542e_8
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3830999
+  timestamp: 1779212383079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_8.conda
+  sha256: 35c3aff92b054a79655da09d4435faefcd7b23303d225b327065db9d263766ed
+  md5: 1b632358fe0c3badbd77b81ac05a48c2
+  depends:
+  - libstdcxx 15.2.0 h39759b7_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28504
+  timestamp: 1779212854288
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_8.conda
+  sha256: 56fed649a8357e75320a12f5dc69f8d463ac38f62a808b032d784db913df30b6
+  md5: cece8ba0b16cc5921d56a6b2c808f8ed
+  depends:
+  - libstdcxx 15.2.0 h9538471_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28510
+  timestamp: 1779212405030
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
+  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
+  md5: e79c628574f0ed3b60bd63e6d78501a1
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 671850
+  timestamp: 1777465777755
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
+  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
+  md5: a99663395dab887607b2e5a854389721
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 676495
+  timestamp: 1777465771156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
+  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
+  md5: c457b6d1695d1b5b054632d2d5895517
+  depends:
+  - __osx >=12.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 644497
+  timestamp: 1777466299217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
+  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
+  md5: 4a6a2354414c9080327274aa514e5299
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28110
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
+  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
+  md5: 59cd225a7659291aa716c6cdae7e1363
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30035
+  timestamp: 1668082742967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
+  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
+  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 901634
+  timestamp: 1772644974924
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
+  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
+  md5: 52b484c9618823592d2c26632724dafd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 594684
+  timestamp: 1772644989262
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
+  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
+  md5: 5b151376f98c09831d6bd730ca7794c8
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 418963
+  timestamp: 1772645021860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
+  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
+  md5: fdf0d380fa3809a301e2dbc0d5183883
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 440690
+  timestamp: 1746022211479
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
+  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
+  md5: 28e00a696fd74b7550b7d1b8698e10af
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 443363
+  timestamp: 1746022227484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.14.6-hf2a51f9_1.conda
+  sha256: 459abeddcd64df95b09e2d9d2d92bbe980ad20ef7294a36928977d94742a93ec
+  md5: dffa9db432bf2a7be752498a5d4fa1ac
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 660718
+  timestamp: 1778673166461
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.14.6-hfdc530d_1.conda
+  sha256: 8a5b4ebdb32935b5be251cb82c2754bd83a9eeecbacd6df11091793be65351a3
+  md5: fffd28c6e7836b329aae76a4da1ddecf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 655891
+  timestamp: 1778673050392
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.6-h1ea6aa3_1.conda
+  sha256: 4cd7a61c92db1c7a436d33416d6e139baee110b322bb49046ee06381e5ac8c1d
+  md5: b9abad7050cac8a791658fa62882650a
+  depends:
+  - __osx >=12.1
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.16,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 557652
+  timestamp: 1778673082116
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.14.6-h42c6e62_1.conda
   sha256: 9e07b51fb07fb6f08a36c23e4dd1cbee30903a256e2562a05d9a9e0576406623
   md5: 1487ac6819634ff356aae28dda68008b
@@ -10648,6 +6431,41 @@ packages:
   license_family: MIT
   size: 851922
   timestamp: 1778673294879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-h47b2149_1.conda
+  sha256: 45de7095ec747c8d0e3e47af6f74ff9cbb208473f42b940a284e1998c248b173
+  md5: 7623ef4b77936f7670f6f906c6af4f3a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 60093
+  timestamp: 1776974326015
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h27118de_1.conda
+  sha256: ed2d5f9f5ad9efa6b28163dd79c89f65dacc3cba874921feef961ff06203c809
+  md5: fc57a6ca6d0f766b9d8a96a883afed16
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 59675
+  timestamp: 1776974322337
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-hb4cf58c_1.conda
+  sha256: 39df4501327dc21f6ddfd129db23c9ee6cda4c737c1f1a91e700aa965f8febb6
+  md5: 6cdcab9318862201eb86f27e7efcb7e8
+  depends:
+  - __osx >=12.1
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 44567
+  timestamp: 1776974334576
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h1c6eee0_1.conda
   sha256: 673d46c51c391e52eddf4fecf3418e727fae4750ce4ecdc98b9de8625a0fc85a
   md5: 2196721c1cfe5eeb83a9f7f4642b2eab
@@ -10661,6 +6479,69 @@ packages:
   license_family: OTHER
   size: 63482
   timestamp: 1776974452152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
+  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
+  md5: 1468bc20414b0fa8eb1b18d3a916039f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480121
+  timestamp: 1754999718088
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
+  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
+  md5: ff7911a6103418a2c907d8c0262dd7f2
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414985
+  timestamp: 1754999724928
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lmdb-0.9.31-h79febb2_0.conda
+  sha256: 30f28b8d1eebf4c7bf9600c7fcf4147bdd2b40d0be80326a5994270d6de5f0a0
+  md5: f64afc713eac7e8bf402173915c58ccf
+  depends:
+  - __osx >=11.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205738
+  timestamp: 1754999716617
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
+  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
+  md5: 6f3445d61b923a4e22a50b4ede3c1865
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 377746
+  timestamp: 1775637820996
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
+  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
+  md5: 77eab2a2d275f56e722b1aad11532fd3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 376687
+  timestamp: 1775637816376
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
+  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
+  md5: e535d29ea97147f0f6fb78a5a40c389e
+  depends:
+  - __osx >=12.1
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 374612
+  timestamp: 1775637687250
 - conda: https://repo.anaconda.com/pkgs/main/win-64/luajit-2.1-h1c6eee0_0.conda
   sha256: 2322b012e84cce27d934eca4c8f7e092c3bcd05c7d8ab8ebafc66a83b6d8473d
   md5: 3217ea6e26ad49643fd3b26a727b63be
@@ -10674,6 +6555,44 @@ packages:
   license_family: MIT
   size: 617767
   timestamp: 1775638149997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
+  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
+  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 150496
+  timestamp: 1775657630843
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
+  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
+  md5: 8a1c323359558fc4a4df9191aa6d00fa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 143384
+  timestamp: 1775657550865
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
+  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
+  md5: 8b33a63dd414c362bc478d44fa6cad6b
+  depends:
+  - __osx >=12.1
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 122459
+  timestamp: 1775657525476
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lupa-2.6-py313h1c6eee0_1.conda
   sha256: a5456a9662c69cde19382f8d51817dd9582fc05b74490abb69e1301d19c41e07
   md5: 10caec6073639ad0e7f2c01d186952be
@@ -10688,6 +6607,35 @@ packages:
   license_family: MIT
   size: 136199
   timestamp: 1775658064658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
+  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
+  md5: 2ee58861f2b92b868ce761abb831819d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 159495
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
+  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
+  md5: 70c4ab9462183ac4af60852d2a79fbf6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 185496
+  timestamp: 1714510593467
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
+  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
+  md5: 82202ff2e94bc301fd9c790556506bb7
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160308
+  timestamp: 1714510588159
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
   sha256: 0e848b5004a9dc7a06f459cc67c404d7fb0321bf134ec7512815afafe97960b4
   md5: 723e3ccd4ef7c58ddbfeebe69abff662
@@ -10698,6 +6646,66 @@ packages:
   license_family: BSD
   size: 155711
   timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_2.conda
+  sha256: eb345067b96b14e79c4a1edd4acee63c4b175d1818bb9de1c5ca373a6985cd5a
+  md5: d6250f9e480b12792b75ae296c165286
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - panflute >=2.3,<2.4
+  - mistletoe >=1.0,<2.0
+  - commonmark >=0.9,<0.10
+  - mdit-py-plugins >=0.5.0
+  - sphinx-book-theme >=1,<2
+  - mistune >=3.0,<4.0
+  - markdown >=3.4,<4
+  - linkify-it-py >=1,<3
+  license: MIT
+  license_family: MIT
+  size: 243237
+  timestamp: 1777540569559
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_2.conda
+  sha256: f59fa96e5ecb50a3725d890dda7c8a576b3b1bb51cf468d7718033ad29e99c24
+  md5: 52dfa03cd4fc6fcdf6def4692c07af7e
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - linkify-it-py >=1,<3
+  - sphinx-book-theme >=1,<2
+  - panflute >=2.3,<2.4
+  - mistune >=3.0,<4.0
+  - mdit-py-plugins >=0.5.0
+  - mistletoe >=1.0,<2.0
+  - commonmark >=0.9,<0.10
+  - markdown >=3.4,<4
+  license: MIT
+  license_family: MIT
+  size: 242575
+  timestamp: 1777540565819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_2.conda
+  sha256: 235bd34b21d4599827b3927ca325d34c1a36fe36a9b91014f3aab6e932206949
+  md5: 185560a1e60a38d87b687b47f672ff67
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - commonmark >=0.9,<0.10
+  - mistune >=3.0,<4.0
+  - mdit-py-plugins >=0.5.0
+  - linkify-it-py >=1,<3
+  - markdown >=3.4,<4
+  - mistletoe >=1.0,<2.0
+  - sphinx-book-theme >=1,<2
+  - panflute >=2.3,<2.4
+  license: MIT
+  license_family: MIT
+  size: 243450
+  timestamp: 1777540586959
 - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_2.conda
   sha256: 84ab8f95af7d8c1c6a3d557f7846f927785a288f40fc43f6065f089738097670
   md5: ef8d2f56a292e95c6b0bd6179a1c79ed
@@ -10718,6 +6726,39 @@ packages:
   license_family: MIT
   size: 267752
   timestamp: 1777540636533
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
+  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
+  md5: 28351e7fd716ee4b3baef571be119b98
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151241
+  timestamp: 1728403996163
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
+  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
+  md5: 1225f726844496e3564e4b2d6c539763
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151130
+  timestamp: 1728498536715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
+  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
+  md5: 4c3e970508e6cb3ad65579fb6b576143
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 149478
+  timestamp: 1728598048738
 - conda: https://repo.anaconda.com/pkgs/main/win-64/marshmallow-3.19.0-py313haa95532_0.conda
   sha256: 9c68fb61ad2d99c635e8a3adededd208f4cb13de8593116f0f5fc39bf5ac1057
   md5: aae05fc7685cf4eae8ef741c8203ff8e
@@ -10729,6 +6770,84 @@ packages:
   license_family: MIT
   size: 152235
   timestamp: 1729060636851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
+  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
+  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - python-dotenv >=1.0.0
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 428184
+  timestamp: 1771960075711
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
+  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
+  md5: b7268fc357df1edc377e4a02b5c5c115
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  - python-dotenv >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 430285
+  timestamp: 1771960065247
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
+  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
+  md5: 04ba8f0bfa78cef0456aeff11cfd1308
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - python-dotenv >=1.0.0
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 432541
+  timestamp: 1771960072114
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-1.26.0-py313haa95532_0.conda
   sha256: 6dc3ad40b514baab126201e34b8cbc8ec86a99e6ad5a74d480be7b9bc840a3bb
   md5: 5728b210ab42e67a924dd40f794f6723
@@ -10756,6 +6875,93 @@ packages:
   license_family: MIT
   size: 456382
   timestamp: 1771960175091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
+  sha256: b6ca5bd3f708610801723deb09a29941cb47061832659de55b414f0496bab3b6
+  md5: e909ab91f515181fff72f312cbe1dcb1
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346906
+  timestamp: 1779919393059
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
+  sha256: 830eba7a3d482bf580428ca3df9e79092d6e84525916de57e8a71ba188401ad7
+  md5: 500ea279af0692936f7d51b378eb25ba
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347389
+  timestamp: 1779919403644
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
+  sha256: 7dcb7ab7f6c3c0fd9301a4c760120e6bacd48762aee3269f304bea64e569ce91
+  md5: 9cd2d7945fcb775737365c00913343e4
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-api >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347924
+  timestamp: 1779919417576
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.12-py313haa95532_0.conda
   sha256: f9f81bf7aaf5324c869ee78b1fbcf0d1ea87df9194253207f54a31064bbabedb
   md5: f5d2f32619b86a3eb68ba296bf576548
@@ -10785,6 +6991,36 @@ packages:
   license_family: BSD
   size: 372921
   timestamp: 1779919449722
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
+  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
+  md5: 39da6986b50a3eb3cbf60c9883f4b92e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26871
+  timestamp: 1758552191170
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
+  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
+  md5: 5ab5b1fc729b44eb2872d740d95c495d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26724
+  timestamp: 1758552208116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
+  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
+  md5: cc0fbba5b4ee07d4f979149d050c864a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26834
+  timestamp: 1758552196391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
   sha256: c2748474cedb35b4643872288cedf94deae958ff684d17daf222bbb26bac4e79
   md5: 6c5764715afea281b71aa53cdc81c545
@@ -10795,6 +7031,36 @@ packages:
   license_family: MIT
   size: 26954
   timestamp: 1758552317465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
+  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
+  md5: 3c19869ee69743cd3e6ed44610f7b845
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257750
+  timestamp: 1765382387320
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
+  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
+  md5: 0514a2f7425fe0559d98b6593f8c936d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257086
+  timestamp: 1765382393281
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
+  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
+  md5: e5a706e1b73efa80d1ec1f23256e3b86
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257932
+  timestamp: 1765382400100
 - conda: https://repo.anaconda.com/pkgs/main/win-64/menuinst-2.4.2-py313h885b0b7_1.conda
   sha256: 88a8c0010bd7aab8b0b92e04a411d85881025f3e4eeaa75e4c2dfd3a9ee3b55d
   md5: dfd755d055c9428e5bd5db6edaf24fc1
@@ -10808,6 +7074,36 @@ packages:
   license_family: BSD
   size: 253213
   timestamp: 1765382456721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-11.0.2-py313h06a4308_0.conda
+  sha256: 772cd3c79506ee5060cb6c75db0a4ccdd0cb2ca2364992d0549f0ffabcabb210
+  md5: 1edd221e035f78818555abc20b080edc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 173312
+  timestamp: 1775819413675
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-11.0.2-py313hd43f75c_0.conda
+  sha256: e75b4464d1ba7a1658257980adccee29bbb066c63ca63a7374e32a7874d5565b
+  md5: 1399d3c4c6c2554a5c66960f096ed13d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 174008
+  timestamp: 1775819410873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-11.0.2-py313hca03da5_0.conda
+  sha256: 496025e41f2694702ea58dfd61a922160698b8220766e8e85e74fbd81ec8734a
+  md5: b66a233a8bd8472e809494d0fd8aa4d3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 172229
+  timestamp: 1775819430257
 - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-11.0.2-py313haa95532_0.conda
   sha256: 01086735ceed2314244ec297539f24f49b1d3a9a3091d250648e85e32f5450a6
   md5: a9c2f9cee250f2234d101764cc460021
@@ -10818,6 +7114,41 @@ packages:
   license_family: MIT
   size: 172450
   timestamp: 1775819464842
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
+  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
+  md5: b1fb5c763a2d3e15e633e84bccf52ce4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 123032
+  timestamp: 1750958840666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
+  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
+  md5: 90c7270744a7c8abdf51b5fecf7a9c14
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 120613
+  timestamp: 1750958715349
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
+  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
+  md5: 58664c7ab05f2559e22bc3030c90bd2a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 113263
+  timestamp: 1750958887102
 - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py313h5da7b33_0.conda
   sha256: 945bea6ce19a0f2d6ae8ee2ba4ffe2d19c405de54a80fdcc5a576cd93708a067
   md5: d471b10befe27a405de1c7d126f7aeda
@@ -10830,6 +7161,48 @@ packages:
   license_family: Apache
   size: 114961
   timestamp: 1750958855770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
+  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
+  md5: b9ee8adce00b801f3767671675300a6f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154942
+  timestamp: 1728385601732
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
+  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
+  md5: 4d635e1fed6b6841ae3db1e0377a7712
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153354
+  timestamp: 1728405954288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
+  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
+  md5: 98737e4835cef677dbf6fa0d9d364968
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155808
+  timestamp: 1728586024156
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
   sha256: 7602bb66f5702414d75f7ca4293257fad682282b5a1f83de6e127720437a6b5c
   md5: fa4b4c9dabc5f45e04acbc44e1673b11
@@ -10844,6 +7217,55 @@ packages:
   license_family: BSD
   size: 180795
   timestamp: 1739559123487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
+  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
+  md5: 0abfc090299da4bb031b84c64309757b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1137647
+  timestamp: 1753947487644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
+  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
+  md5: 7a1863281d1b73c33d04a3709fda9bda
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1203577
+  timestamp: 1753947513381
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
+  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
+  md5: d8a28b593d36653bec90bd2d78c7538b
+  depends:
+  - __osx >=11.1
+  license: MIT AND X11
+  license_family: MIT
+  size: 906808
+  timestamp: 1753947535285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
+  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
+  md5: 36890f7abd98066b607211b1773e6343
+  license: MIT
+  license_family: MIT
+  size: 127326
+  timestamp: 1680082329609
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
+  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
+  md5: 9e9d478b40d0e254cd3b448f92f47e8c
+  license: MIT
+  license_family: MIT
+  size: 127337
+  timestamp: 1680082426492
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
+  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
+  md5: 5cc48a403acb53596382724e41f99a6b
+  license: MIT
+  license_family: MIT
+  size: 128547
+  timestamp: 1680082112201
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nlohmann_json-3.11.2-h6c2663c_0.conda
   sha256: c7981dedae2f3d7734a062f4e07e08a060d462f72c17778df206989a3db42446
   md5: 7533a3f9925b9e46ac0c258be87c2877
@@ -10851,6 +7273,78 @@ packages:
   license_family: MIT
   size: 128841
   timestamp: 1680083671336
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.30.0-py313h06a4308_0.conda
+  sha256: 114e4cceb46e0feaa33113a4fe0c8db5b1879e7c23f91464bbe9cb65bc221cda
+  md5: c73e4d5b5823c880b21b545ac12fbacb
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - websockets >=13,<16
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 1116233
+  timestamp: 1777459702066
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.30.0-py313hd43f75c_0.conda
+  sha256: cd055bc3fe872e2481f9e719bcfd586769a9f4153de8e94ca4c72b8cfc8545f7
+  md5: 88160661ed57dd988dddb7985feb0670
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - sounddevice >=0.5.1
+  - websockets >=13,<16
+  - httpx_aiohttp >=0.1.9
+  - pandas >=1.2.3
+  - pandas-stubs >=1.1.0.11
+  license: Apache-2.0
+  license_family: Apache
+  size: 1113065
+  timestamp: 1777459700855
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.30.0-py313hca03da5_0.conda
+  sha256: 111c4c5bc4bfa8441b6148a3a9b788a882e6925b216f4693f2a269327f68dfbf
+  md5: 04b819788d8761511073a2c2ef231ed6
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - pandas-stubs >=1.1.0.11
+  - httpx_aiohttp >=0.1.9
+  - pandas >=1.2.3
+  - websockets >=13,<16
+  - sounddevice >=0.5.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1123473
+  timestamp: 1777459710818
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.30.0-py313haa95532_0.conda
   sha256: cbad1ad7ef96b413e3f64ed5f97242c7b5c6117cc170f271a5d487a8802c3d1e
   md5: 16123b469db44f12596966f56d316971
@@ -10875,6 +7369,39 @@ packages:
   license_family: Apache
   size: 1148948
   timestamp: 1777459774176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
+  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
+  md5: d842c01c08579c4398dc5b15a0bd875d
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79899
+  timestamp: 1763721155768
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
+  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
+  md5: 583ab7940537e3387afa8c18b28eeb1c
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79849
+  timestamp: 1763721155450
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
+  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
+  md5: b2bded54c66346cf90e89ea7e65d80f6
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 80685
+  timestamp: 1763721157221
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openapi-pydantic-0.5.1-py313haa95532_0.conda
   sha256: af0f41dc6f6acd6e46b83ac8c9194e8030ca886534bf9b13ddfa7510b3ae4870
   md5: 4a22cfc41b9cae647b8521b29244e505
@@ -10886,6 +7413,38 @@ packages:
   license_family: MIT
   size: 80996
   timestamp: 1763721195728
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.6-h1b28b03_0.conda
+  sha256: 2ab27b5fe0a8d348262386d36a17c50bb688dc83a8443fe39ef561ea5fc09a7d
+  md5: 5341b8a62a122529fc2083c6ed4174f6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5918095
+  timestamp: 1775749314567
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.6-h39c9139_0.conda
+  sha256: 1a8c2aa57cbef6576d04a2889da51cef641adbfbea56c66577b90772c0964a98
+  md5: 1fea8b1c8a9858054c8ea4ef0a0f0ce4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 6541356
+  timestamp: 1775749241503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.6-ha0b305a_0.conda
+  sha256: fc8e5c30740d42407ab194012329f9f8820832554593821e48fc919d582689a1
+  md5: 58bcf6e120ab49b90438bc8b199dcbc1
+  depends:
+  - __osx >=12.1
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4817235
+  timestamp: 1775749200193
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.6-hbb43b14_0.conda
   sha256: 28f7619d504c79edf0b00035d1001b9a07ba079e60440db55563fe373d82ec73
   md5: dfd3af7d67edfe056d9f6abb83f472c2
@@ -10898,6 +7457,42 @@ packages:
   license_family: Apache
   size: 9344164
   timestamp: 1775751209953
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
+  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
+  md5: 8310c25ce1847aee276a9e2617388f46
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101271
+  timestamp: 1763996098531
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
+  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
+  md5: 85b624fe49b39de9fbe86b79144cb7c4
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 100915
+  timestamp: 1763996095398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
+  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
+  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101534
+  timestamp: 1763996094518
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-api-1.38.0-py313haa95532_0.conda
   sha256: d04d44e41260fcdfc3459bbeae2321294618fd7f947d7bb5e372da2016fc1fb7
   md5: e237a98fa5043fca13e8270162fdcb3b
@@ -10910,6 +7505,39 @@ packages:
   license_family: Apache
   size: 101545
   timestamp: 1763996171123
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
+  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
+  md5: ea9c98e0799195320c546768f562f351
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37782
+  timestamp: 1764236782492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
+  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
+  md5: fab7d6c7cd4ebefb06eada5bee45916c
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37829
+  timestamp: 1764236793947
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
+  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
+  md5: dd551f29b6694f41a405d347e5b7641e
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38099
+  timestamp: 1764236649957
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313haa95532_0.conda
   sha256: b287bd55c69e7f96b52fa7336f296946d636816d60ed286741013bf13b88ae4f
   md5: 1d30146e16512ecb43d947423aabc764
@@ -10921,6 +7549,57 @@ packages:
   license_family: Apache
   size: 37778
   timestamp: 1764236885569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
+  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
+  md5: 4c6786f5a20a0d5705c77a18d97eebec
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43650
+  timestamp: 1764254904983
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
+  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
+  md5: 211d4704424ad214a215cf0378e685cf
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43410
+  timestamp: 1764254906556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
+  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
+  md5: 9b13a4cb589d5fc73e302f66b526c922
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43323
+  timestamp: 1764254973641
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313haa95532_0.conda
   sha256: 0e6c7dab76c8fc49939c1e5f6a0e49ed7ff811e02e6b184ec234f9cc6278e18d
   md5: 7784def4d18a62e9c3b0ababce753f2b
@@ -10938,6 +7617,57 @@ packages:
   license_family: Apache
   size: 43263
   timestamp: 1764254987784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
+  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
+  md5: de2d09e81412c0288e94586569f8276c
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33381
+  timestamp: 1764254429958
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
+  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
+  md5: 928d47e0634131263d53b97b8359431f
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33553
+  timestamp: 1764254406341
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
+  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
+  md5: e65ca1299e5e4ca5f515faa509bd23ae
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33433
+  timestamp: 1764254395627
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313haa95532_0.conda
   sha256: 601ea19950a0e691b12149bd13d06f898d2a25fe060be1038f195be796359f10
   md5: a02ee8b8d3d1f79ab61b0c0f0dcb6dab
@@ -10955,6 +7685,48 @@ packages:
   license_family: Apache
   size: 33568
   timestamp: 1764254472408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
+  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
+  md5: a9aa9b02edaa6e129374ae281b4ace66
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58002
+  timestamp: 1764084155711
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
+  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
+  md5: aae5f23a1a4a2c152ee68f16d380ff15
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57805
+  timestamp: 1764084154068
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
+  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
+  md5: 59267a3e2c335ee1d45d703dfaee30f7
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57708
+  timestamp: 1764084154910
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-instrumentation-0.59b0-py313haa95532_0.conda
   sha256: 68e244391c6f93d7d55e941feb790fd4016a402ffda2b8ba684512dd84fe5e53
   md5: 54d8e5a50cb75f7cb10139d86694f4ce
@@ -10969,6 +7741,39 @@ packages:
   license_family: APACHE
   size: 83182
   timestamp: 1764084236614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
+  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
+  md5: e36ceb40f2e628e2b6d4bb62032539a1
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57320
+  timestamp: 1764164412130
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
+  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
+  md5: a93dfba7f5563c3430eb842ff88b7cb7
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57059
+  timestamp: 1764164411916
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
+  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
+  md5: c2f0aecc8a2ea835b91a7897ab121f5c
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57335
+  timestamp: 1764164412952
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-proto-1.38.0-py313haa95532_0.conda
   sha256: 4d9af6cfdc6484dd269e39445ff8e1ddbc6e60a4b84b61515b4ebcf07fb5d517
   md5: 642de24674e936a3222d72d484a1ef45
@@ -10980,6 +7785,45 @@ packages:
   license_family: Apache
   size: 57588
   timestamp: 1764164490671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
+  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
+  md5: 2a77251102af2651654e23f12c0e58c6
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 274299
+  timestamp: 1764073186249
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
+  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
+  md5: 0ce00548bf7f2bc4d0cca918a84a3989
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275046
+  timestamp: 1764073129503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
+  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
+  md5: c5fda39e599753e09a32115eb8330bac
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275773
+  timestamp: 1764073043306
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-sdk-1.38.0-py313haa95532_0.conda
   sha256: 678a2df75881e5e762497099297bb7d42e1bd2438b3fcd4791337a5ca1eb60dc
   md5: 9692d8b6afeeb44a6c751a3d3c41fdc8
@@ -10993,6 +7837,42 @@ packages:
   license_family: Apache
   size: 275430
   timestamp: 1764073280377
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
+  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
+  md5: e794cf7621bbe67d177b7e279cd6d610
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 179330
+  timestamp: 1764062875253
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
+  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
+  md5: f14b38ac757bcb80c206d16fb2e55592
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177920
+  timestamp: 1764062882890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
+  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
+  md5: 677be6639bad152b927832a09d639b72
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 180260
+  timestamp: 1764062877653
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-semantic-conventions-0.59b0-py313haa95532_0.conda
   sha256: ccaa74ee5c9369fd9a0c7f43297f672fbb079df1d0930bbb3c51c4158b11ef11
   md5: bb98256d4bf0d8f130f7f1d51b7c5425
@@ -11005,6 +7885,41 @@ packages:
   license_family: Apache
   size: 180937
   timestamp: 1764062960760
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
+  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
+  md5: 76bffd8af6e6a162a1e7af69b9b800d7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 337138
+  timestamp: 1771945983540
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
+  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
+  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 334755
+  timestamp: 1771945967596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
+  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
+  md5: 304016a5b391759778800af9f24e1332
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 305477
+  timestamp: 1771946048520
 - conda: https://repo.anaconda.com/pkgs/main/win-64/orjson-3.11.7-py313h51239a8_0.conda
   sha256: 481226561000f1eb1e3a067b33713e209d100031c280a6052679f17985b58aee
   md5: f6d731e5099297ec7be0c2302a0ea354
@@ -11018,6 +7933,36 @@ packages:
   license_family: OTHER
   size: 233868
   timestamp: 1771946278261
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
+  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
+  md5: 0f7d4f61c3851a0d436b96e9cb02c393
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200822
+  timestamp: 1775004135549
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
+  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
+  md5: ba91769862d81cb2c29f4918aae1a245
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 198468
+  timestamp: 1775004133206
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
+  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
+  md5: 16eee0ba12a1721ab94eb4f87517b5e2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200339
+  timestamp: 1775004034672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
   sha256: 377f499629908034474c3ab04a45fcad5ba19158b4e0248a905fe73ffddb8e9f
   md5: 865786bee3991b29c53298346c7f6289
@@ -11028,6 +7973,36 @@ packages:
   license_family: Apache
   size: 201067
   timestamp: 1775004274536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
+  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
+  md5: da78932ffefe7e3f780f75672b3f8b36
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51265
+  timestamp: 1772567686795
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
+  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
+  md5: 730f7454d70a81d991ac05e09c699166
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51488
+  timestamp: 1772567675008
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
+  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
+  md5: edb4dc7d24225792e537e7db178ab7a5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51842
+  timestamp: 1772567682290
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
   sha256: 7f0dd38798a6247880c231a3086130c84e93bc7a17a0344e37f73ad36166f32e
   md5: 7c54e8d8e2c390fbe1ab4bbbd8437def
@@ -11038,6 +8013,41 @@ packages:
   license_family: Apache
   size: 51631
   timestamp: 1772567728989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
+  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
+  md5: 49c2031dcebd085e49c3aff84479e314
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1289658
+  timestamp: 1759825800150
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
+  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
+  md5: d2a1b973881c8c0493bf1fd7b62a2918
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1177858
+  timestamp: 1759825801409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
+  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
+  md5: dc957a9fa85669b0f6ce65ea9343fd8f
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 901944
+  timestamp: 1759825795666
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
   sha256: d54ea3169c090404ca6d9d154adf842d61ca7a0bf1e277a10c02e245f186b934
   md5: ce7492b4ef08cfdeb0fc35ab5447ccf4
@@ -11051,6 +8061,47 @@ packages:
   license_family: BSD
   size: 1317213
   timestamp: 1759825896688
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.1.1-pyhc872135_0.conda
+  sha256: f54190680c16948ec7a2e37ea3a7b149dce90bd6360b0d3f5d855fcd875f77c4
+  md5: a9301655a0e91570c28b9470d0613946
+  depends:
+  - python >=3.9,<3.14.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1197837
+  timestamp: 1780008991949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
+  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
+  md5: a1e79da30a6c62c6398e9bb990ee9ed6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9162
+  timestamp: 1728388115083
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
+  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
+  md5: ed391ccc6d6caaccedd5250fdeb48807
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9176
+  timestamp: 1728408515784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
+  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
+  md5: 5c6344029e52293764fd4f88d6216c07
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9307
+  timestamp: 1728592695690
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
   sha256: 891ecf91eb86227f847743d2519f9f8c3ff70386d56b0d0507c5dc557392b101
   md5: 1dea692228d870c3278e9797ddc0589a
@@ -11061,6 +8112,36 @@ packages:
   license_family: MIT
   size: 10112
   timestamp: 1729049247460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
+  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
+  md5: e1705a98bf3338281b413e1fc8484a12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54729
+  timestamp: 1773652981831
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
+  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
+  md5: cdff168e8e1d6bbfced0f9ce18a6534a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54735
+  timestamp: 1773652976404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
+  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
+  md5: f9e7cc4e6d37a4efe63452519464e148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54951
+  timestamp: 1773653001076
 - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
   sha256: 7c422f786db266a90afe84e10bc2cd2547118032fd46cbc590ef343de0fd411c
   md5: c73cb48e85b2d4c9f6bee9b364adb4d4
@@ -11071,6 +8152,36 @@ packages:
   license_family: MIT
   size: 54633
   timestamp: 1773653037631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
+  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
+  md5: 5c71fdece7639940072a849417bff8da
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47969
+  timestamp: 1776972936162
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
+  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
+  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47904
+  timestamp: 1776972854196
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
+  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
+  md5: 3550efa655956e28eb7282c3210bb015
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47964
+  timestamp: 1776972833748
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
   sha256: d5286244f6ebbceb1cc19c77a342fe6849f646a4a51d2aa8a7fe48af4d75b4c0
   md5: 56ed40dd2a648486a27c2c79f253f2e6
@@ -11081,6 +8192,36 @@ packages:
   license_family: MIT
   size: 48203
   timestamp: 1776973096987
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
+  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
+  md5: 7664f08981772ba49fef33294a096a18
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170398
+  timestamp: 1772733409298
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
+  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
+  md5: 08a8181515e8bdce86ee017bb1153d69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170028
+  timestamp: 1772733403459
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
+  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
+  md5: f686d9126128ed3d50046833a1b555a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170595
+  timestamp: 1772733427973
 - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.24.1-py313haa95532_0.conda
   sha256: a482e9e5c6e30ea4126e3f64fd75590a0d213395adae10e0da11b79fd5a45fb7
   md5: 538e9c192d280b01619787f642e8e5d2
@@ -11091,6 +8232,50 @@ packages:
   license_family: Apache
   size: 171669
   timestamp: 1772733460825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
+  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
+  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570052
+  timestamp: 1770660764829
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
+  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
+  md5: c65088b4df85204138e7899b7bb677c5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579494
+  timestamp: 1770660753322
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
+  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
+  md5: 70879a51504dda5aff5034450b11a84a
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 461761
+  timestamp: 1770660566466
 - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
   sha256: 18213ba9abcbdc83efc0e49693fb96016e883b3a85e58ecca91696898ef6d434
   md5: c981add26704b7d11b6605c103bd02e9
@@ -11106,6 +8291,41 @@ packages:
   license_family: BSD
   size: 490900
   timestamp: 1770660962864
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
+  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
+  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550941
+  timestamp: 1761896477134
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
+  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
+  md5: 55e55bb476470a157cf4b81f44283436
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550478
+  timestamp: 1761896485773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
+  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
+  md5: 6bc6a220a229abae6afa80ccf4c3b06b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561023
+  timestamp: 1761896362276
 - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
   sha256: 62d6a63cc8ea42b78731f1336ad68cee6c33401343632c0f5af532167a6f9184
   md5: e1d87eecc309f85ec24e0950615e985e
@@ -11119,6 +8339,135 @@ packages:
   license_family: BSD
   size: 573993
   timestamp: 1761896633111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
+  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
+  md5: 973a642312d2a28927aaf5b477c67250
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  license_family: MIT
+  size: 5360
+  timestamp: 1505733967605
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
+  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
+  md5: bd26b7e13996984230e8ec67f3ebd4c7
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  license_family: MIT
+  size: 7035
+  timestamp: 1615912729649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_1.conda
+  sha256: a69af6a08868bc24fc1981a22e1e29c20416f150695a31b4ce78dae833140e57
+  md5: 802842f437b616ba517bbe8ab59ed2dd
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - types-aiobotocore-s3 >=2.16.0
+  - valkey-glide >=2.1.0
+  - pydantic >=2.11.9
+  - hvac >=2.3.0
+  - diskcache >=5.0.0
+  - dbus-python >=1.4.0
+  - pytz >=2025.2
+  - python-duckdb >=1.1.1
+  - aiohttp>=3.12
+  - asyncpg >=0.30.0
+  - aiomcache >=0.8.0
+  - pathvalidate >=3.3.1
+  - pymongo >=4.0.0
+  - cachetools >=5.0.0
+  - anyio >=4.4.0
+  - redis-py >=4.3.0
+  - cryptography >=45.0.0
+  - types-hvac >=2.3.0
+  - elasticsearch >=8.0.0
+  - aioboto3 >=13.3.0
+  - rocksdict >=0.3.24
+  - types-aiobotocore-dynamodb >=2.16.0
+  - aiofile >=3.9.0
+  - keyring >=25.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 295896
+  timestamp: 1779978190992
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_1.conda
+  sha256: c3528eaf21b37206af878506da663e604e17be51fb37510459515baa2283c61a
+  md5: 2f3a131bd072f4e2cbee3ad28f540dc2
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - aiofile >=3.9.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - types-aiobotocore-s3 >=2.16.0
+  - cachetools >=5.0.0
+  - aioboto3 >=13.3.0
+  - keyring >=25.6.0
+  - pydantic >=2.11.9
+  - hvac >=2.3.0
+  - types-hvac >=2.3.0
+  - anyio >=4.4.0
+  - pymongo >=4.0.0
+  - valkey-glide >=2.1.0
+  - cryptography >=45.0.0
+  - asyncpg >=0.30.0
+  - pathvalidate >=3.3.1
+  - diskcache >=5.0.0
+  - rocksdict >=0.3.24
+  - dbus-python >=1.4.0
+  - redis-py >=4.3.0
+  - aiomcache >=0.8.0
+  - python-duckdb >=1.1.1
+  - pytz >=2025.2
+  - aiohttp>=3.12
+  - elasticsearch >=8.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 295816
+  timestamp: 1779978081175
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_1.conda
+  sha256: ed21b11c3840d2b1dfcd5595672a36ed71a1b10f12839fba86e52308714f734c
+  md5: 3f09888d38880126245060ae0dd6ec38
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - elasticsearch >=8.0.0
+  - aiomcache >=0.8.0
+  - anyio >=4.4.0
+  - cachetools >=5.0.0
+  - types-aiobotocore-s3 >=2.16.0
+  - asyncpg >=0.30.0
+  - valkey-glide >=2.1.0
+  - redis-py >=4.3.0
+  - aioboto3 >=13.3.0
+  - pathvalidate >=3.3.1
+  - python-duckdb >=1.1.1
+  - pydantic >=2.11.9
+  - diskcache >=5.0.0
+  - dbus-python >=1.4.0
+  - rocksdict >=0.3.24
+  - pytz >=2025.2
+  - aiofile >=3.9.0
+  - hvac >=2.3.0
+  - aiohttp>=3.12
+  - keyring >=25.6.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - pymongo >=4.0.0
+  - cryptography >=45.0.0
+  - types-hvac >=2.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 296892
+  timestamp: 1779978100099
 - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_1.conda
   sha256: 48dac7f101db41a5a62015415e122c59826a0924b8827bb99f61e47ea44ee487
   md5: 0bf986347eb40b585217b8177d1a0baf
@@ -11156,6 +8505,45 @@ packages:
   license_family: Apache
   size: 297537
   timestamp: 1779978135168
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
+  md5: 7f0df6639fdf60ccd3045ee6faedd32f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14215
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
+  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
+  md5: 60ea7416e08d78563e31d16c333bd57f
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 93055
+  timestamp: 1736868559715
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
+  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
+  md5: 574f6176492ab5f26a379307c7377a30
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92719
+  timestamp: 1736868553560
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
+  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
+  md5: 2ee55b934de679d2f73bd0f3840f1dfd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 90639
+  timestamp: 1736868507679
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
   sha256: df4e2759d0dfd24b3e6e00dabfa6583b01c865db0527a0cb4ba21d67ca767b95
   md5: 31fe82cdc830f79c27346b9e66342d2a
@@ -11168,6 +8556,36 @@ packages:
   license_family: MIT
   size: 92654
   timestamp: 1736869076072
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
+  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
+  md5: 3b8ea90c558c424f123c1fc6069c9fa6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155521
+  timestamp: 1774959763398
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
+  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
+  md5: 03fd00dba51a683e8d01f74ec63a1fec
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156035
+  timestamp: 1774959750947
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
+  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
+  md5: 63924165d4c0b49b018d6c6c742d5666
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140335
+  timestamp: 1774959697268
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
   sha256: 48cef9cf6d54f01afab07973fc1b295586120acffb2b9ca592a5bc0deee49dd2
   md5: 9487fca3796d5c8cd0c361909099518d
@@ -11178,6 +8596,54 @@ packages:
   license_family: BSD
   size: 140506
   timestamp: 1774959857744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.13.4-py313h06a4308_0.conda
+  sha256: a95fbf7a462cc0d0510a702f13993f2ae026b0373d788cfd475716aac955a124
+  md5: b669824f2ec61c956ab114143eccf3bd
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1128169
+  timestamp: 1778683891285
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.13.4-py313hd43f75c_0.conda
+  sha256: 92bc3c7526782aa5bf6491a01db155aa4e29d79e5dc170d359341345d8317f3d
+  md5: ef8d3ac799e68017710c0e673f12d38d
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1126826
+  timestamp: 1778683886054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.13.4-py313hca03da5_0.conda
+  sha256: 0fc797970a04dd9485e75ccc37c3bf6b93af0886ebb23d196633fde3a3686395
+  md5: 063dbd636d74525f473fbc88dae48124
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1129564
+  timestamp: 1778683904286
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.13.4-py313haa95532_0.conda
   sha256: 85b66c2032f05eaa7203bd00523b030c30a101028c822c712a2886f9fa912a3a
   md5: 4b854d1dee4ad44d73813be3d8a10fd7
@@ -11195,6 +8661,44 @@ packages:
   license_family: MIT
   size: 1130443
   timestamp: 1778683942191
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.46.4-py313h6e1b9ff_0.conda
+  sha256: 05b763ee21064331e6fbfb20135e801f71fda761556b07c93938cbac6e4b7d6f
+  md5: 1583c5469605cea15689ec0b9ede1bc3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1885652
+  timestamp: 1778677122534
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.46.4-py313hef68074_0.conda
+  sha256: 0d91bcec560dccda2733745b3d5df70c57398172e1c5ffcd05317eb354dd4b86
+  md5: f8de87b7f9d4079e54a3b9d95d01db99
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1735370
+  timestamp: 1778677068356
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.46.4-py313h3983f12_0.conda
+  sha256: ba6b2306d45414884172e8ace37e2ce597a056a51c0667e78564321634709159
+  md5: a6a603da37240ebd3428202bda1eca84
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1679830
+  timestamp: 1778677032197
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.46.4-py313h51239a8_0.conda
   sha256: cf77af379766667be472a95840bd05f250c80d672d6bbaa9fc15908d752c0925
   md5: 15d9c563d8c978085fc5785a51795608
@@ -11209,6 +8713,66 @@ packages:
   license_family: MIT
   size: 1853335
   timestamp: 1778677510770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
+  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
+  md5: 52b991b3676ad69221ac4efe952ea622
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - google-cloud-secret-manager>=2.23.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  - pyyaml >=6.0.1
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  license: MIT
+  license_family: MIT
+  size: 151041
+  timestamp: 1764165180924
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
+  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
+  md5: 8bcdca4304da9f754bfb1f5839f796dc
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - azure-identity >=1.16.0
+  - tomli >=2.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - pyyaml >=6.0.1
+  - google-cloud-secret-manager>=2.23.1
+  license: MIT
+  license_family: MIT
+  size: 150714
+  timestamp: 1764165157426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
+  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
+  md5: 4bc0da3d9e06af7ce644b3901790c1ee
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  - google-cloud-secret-manager>=2.23.1
+  - pyyaml >=6.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  license: MIT
+  license_family: MIT
+  size: 150650
+  timestamp: 1764165172452
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
   sha256: 41e0f59c3321217f4aa6014c3411daec4264f4ea2483ac4711b90accdc8ae080
   md5: 9be00e22c3dd90cc9dd9e183021866db
@@ -11229,6 +8793,36 @@ packages:
   license_family: MIT
   size: 150711
   timestamp: 1764165274424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
+  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
+  md5: ccea3f7c3ca8da985a55fbc042ad8d82
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4943174
+  timestamp: 1775127040649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
+  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
+  md5: 1e4f8926de2d91ff108ecf1f8d30371f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4941418
+  timestamp: 1775127034860
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
+  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
+  md5: 1a096beb854aaa14d863b4da60533f79
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4967892
+  timestamp: 1775127065874
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.20.0-py313haa95532_0.conda
   sha256: 55eb323f6032fe8c04b3336316f03080de2f147a32cc8485a4bf2b3b44cebbb9
   md5: ac3a0314796552bc697699b09c014e71
@@ -11241,6 +8835,42 @@ packages:
   license_family: BSD
   size: 5003268
   timestamp: 1775127093941
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
+  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
+  md5: 3cbe7080967f615cd88efd025391b662
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 102773
+  timestamp: 1773773809562
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
+  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
+  md5: 9f01b187aede17a6e8b192f35472b652
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103005
+  timestamp: 1773773803703
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
+  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
+  md5: 208f064869aaa98b2340cc60eb64c58b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103272
+  timestamp: 1773773829773
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
   sha256: 7aef9d733577597c67e2e122e275063bb1b62289943dde8fc2053e052b4669c4
   md5: ea6817e7fbafb39b117e5d6c30f40a54
@@ -11253,6 +8883,66 @@ packages:
   license_family: MIT
   size: 102610
   timestamp: 1773773869078
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
+  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
+  md5: c7bc813891134328cf9262beac3465db
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 479484
+  timestamp: 1763629905351
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
+  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
+  md5: fd8423aa2c161f1355d9eb5e53958096
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 377280
+  timestamp: 1763651408167
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
+  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
+  md5: 41e5a9f1fb430fad7e10a9db74000502
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26218
+  timestamp: 1773985120703
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
+  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
+  md5: 90a46389b262fac93bd471f2fc0ea5ff
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25832
+  timestamp: 1773985116510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
+  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
+  md5: 505cfc77c635faa08a4a889e1c6c8a10
+  depends:
+  - pyobjc-framework-cocoa
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26139
+  timestamp: 1773985028336
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyperclip-1.11.0-py313haa95532_0.conda
   sha256: fcb763479633b4cc7d05a20cc43670537bf7c4e9c5e473f796860a08104e92c0
   md5: 7aa1773bcce0f593f10a123a140c14db
@@ -11263,6 +8953,36 @@ packages:
   license_family: BSD
   size: 25926
   timestamp: 1773985260113
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
+  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
+  md5: e1ab9ffa1588856f0bdbb204322568c4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35801
+  timestamp: 1761753024312
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
+  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
+  md5: 43da0d039f7b195466a8be650fa38424
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35803
+  timestamp: 1761753028895
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
+  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
+  md5: 16bf831da5d9b80789ca8c06f958ae2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36057
+  timestamp: 1761753032083
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
   sha256: 80a495f4af262ca1119720a007eab7dda13008f48ba1a9e0a0b0003638dc71aa
   md5: fbfa708fb7dba50f62e0363778296f29
@@ -11274,6 +8994,81 @@ packages:
   license_family: BSD
   size: 35859
   timestamp: 1761753068122
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.13-hb7b561f_100_cp313.conda
+  build_number: 100
+  sha256: e43d4697c40efbeaddbe332ead42e50847310fe6169792a3f59ee7f667dc26b3
+  md5: f89a334358da4df35098ca9deba1fbd6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 33153832
+  timestamp: 1776148532010
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.13-h0f2f12d_100_cp313.conda
+  build_number: 100
+  sha256: 00215d7abb904516605d67082c7186b60b6e2484f97b2cb419b401066d105d89
+  md5: 207a787e47fa9bf2a1c0c2c8ac812e08
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.35.1
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 31837743
+  timestamp: 1776148804346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.13-ha8cd034_100_cp313.conda
+  build_number: 100
+  sha256: 845ba4ef73057e2b0abeda829750e605b8dff2b9ddac63315fa7e9846a44c40c
+  md5: 5766ed009ee359deae79be0c731f9d48
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13578757
+  timestamp: 1776147629054
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.13-h39c999c_100_cp313.conda
   build_number: 100
   sha256: dd0d092b55af9afdd2b04cb44be3e3ad3679802bef3cd85b5886d8f176cce41c
@@ -11297,6 +9092,39 @@ packages:
   license_family: PSF
   size: 16758382
   timestamp: 1776147400245
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
+  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
+  md5: a844b3df0b11b33f4742841d25146b6c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313830
+  timestamp: 1728385377316
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
+  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
+  md5: 061428165f4369719796769975341cf7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 315827
+  timestamp: 1728405669914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
+  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
+  md5: 2ac600a5ed014f3b8fe2996b213a68e6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313686
+  timestamp: 1728585595371
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
   sha256: 76a01e3051b5ff8157a5018de495b6f1ca1adaf8854c984a15bb59c7940f1a09
   md5: 43a3d00b9e02e3dea2bdcfec026286ac
@@ -11308,6 +9136,42 @@ packages:
   license_family: BSD
   size: 314702
   timestamp: 1729038434598
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
+  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
+  md5: 6aa550906f91d13d1371c07e9cb5c5c3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51623
+  timestamp: 1768559707638
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
+  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
+  md5: e07c79278a8a508e83e42d176ab595be
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51868
+  timestamp: 1768559706782
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
+  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
+  md5: 69ed706ac95df59f56b448091f4c40fa
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51905
+  timestamp: 1768559713789
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
   sha256: 13d615a42829d3c12dc481c69ab5f1116c3199e288f41254349a06271ce4e9fb
   md5: 072ed01dfef3ee838397aca7daca4909
@@ -11320,6 +9184,36 @@ packages:
   license_family: BSD
   size: 76112
   timestamp: 1768559797418
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
+  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
+  md5: 213fed7b509c30119154cf77a958aa7d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253447
+  timestamp: 1763718602538
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
+  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
+  md5: b8dc8f719d9a94474d335a89ff1ab0a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253530
+  timestamp: 1763718606784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
+  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
+  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253652
+  timestamp: 1763718722391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
   sha256: 82a7013143a81abbf1c7657bf8b808bf0dc0a8e3a4b985eda5ad1c57526341e4
   md5: f8d83d25272d9810a1b8f8fc36d6d6b2
@@ -11330,6 +9224,36 @@ packages:
   license_family: BSD
   size: 254671
   timestamp: 1763718769611
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.29-py313h06a4308_0.conda
+  sha256: 38518c171929d43aebd14d5b3a4ae07ca8fc1e3c5b559d93d2c7d1fdfd474ac5
+  md5: f6da44f1a0c19701204d3814cd8f5a00
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 70371
+  timestamp: 1779889654398
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.29-py313hd43f75c_0.conda
+  sha256: c54c6f208047bc8c94bae5cdb295cafdce0072b0fef525735ecedbc50fa462a8
+  md5: 06a1d96bd36a9a13fd00b5855cea64c0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 70879
+  timestamp: 1779889663325
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.29-py313hca03da5_0.conda
+  sha256: 290dee7525f088cf979065df63cad60fbf82c0e02c1f1773be0163513529add2
+  md5: eefc93dc9958b1a4450bbe1c66a95b5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 71167
+  timestamp: 1779889676641
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.29-py313haa95532_0.conda
   sha256: f654a8578c15c7d4341952c6b1a3fb623f8b0579e22fda10670c397b1ecb831d
   md5: d484ad349ee04e4ff3180e0d486899c4
@@ -11340,6 +9264,36 @@ packages:
   license_family: Apache
   size: 70230
   timestamp: 1779889703227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
+  md5: 5af1bf885def2fa779b0bb002e53651b
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157
+  timestamp: 1764349599777
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
+  md5: fb2966848729243e63cc897cb90f1eda
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101
+  timestamp: 1764349598421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
+  md5: 12e362aabff119a51f51ac3c0f3d0a84
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6010
+  timestamp: 1764349560639
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
   build_number: 3
   sha256: d0a5b4e854c76a4ff354a9ce22725cff8986afff92e3fccca14a02171fccd56e
@@ -11350,6 +9304,36 @@ packages:
   license_family: BSD
   size: 6092
   timestamp: 1764349785264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
+  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
+  md5: f700a9cc4e35fd699b4df403f8f14148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 224571
+  timestamp: 1773043070463
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
+  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
+  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 223054
+  timestamp: 1773043038462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
+  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
+  md5: 7faf2150ef3d3493e3554582fec52fcb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 226666
+  timestamp: 1773042949673
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
   sha256: c56ad8b43d5b1c0839d9bb87ddbb1b969c3591d67df173fa416e38d094c8d81e
   md5: e2698e9bf539b4e68b9b7fde985f7cdc
@@ -11383,6 +9367,44 @@ packages:
   license_family: BSD
   size: 55951
   timestamp: 1768296662106
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
+  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
+  md5: 2384f037ab798b6ce6097c717a8758dc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 253759
+  timestamp: 1763465523432
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
+  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
+  md5: a9b067a53f219bf9ed2a4583154facf9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 245388
+  timestamp: 1763465541517
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
+  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
+  md5: 5ea183aac23f4bbe41412f200a70d09d
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237854
+  timestamp: 1763465528485
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py313hb9a58be_0.conda
   sha256: cdf7b48afb00e8f1c75b8009bf288015f3f894925807350c412d2b40505ff71b
   md5: 99d3b0d7895f14c833020bae2637fbd0
@@ -11397,6 +9419,33 @@ packages:
   license_family: MIT
   size: 232090
   timestamp: 1763465571269
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
+  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
+  md5: 631d76b2ec86efd85d6266113f7b20d5
+  depends:
+  - libre2-11 2025.11.05 h3356fce_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26001
+  timestamp: 1770390441796
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
+  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
+  md5: bb43fdeb5e1bc6595d63be00f22eaf00
+  depends:
+  - libre2-11 2025.11.05 h1b0d54c_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25969
+  timestamp: 1770390562916
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
+  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
+  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
+  depends:
+  - libre2-11 2025.11.05 hce96306_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26013
+  timestamp: 1770390441654
 - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hca2749c_1.conda
   sha256: 37ed6c029f2d0ca481bd36dd1a46be9c56d6aefd3af67238aad08a4058078cb1
   md5: 7b2b70a3962203de30cb3f7d4a21e759
@@ -11406,6 +9455,36 @@ packages:
   license_family: BSD
   size: 218680
   timestamp: 1770390656414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
+  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
+  md5: 33b7455bfa1462c42bbc9a0535070313
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19959
+  timestamp: 1760613452708
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
+  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
+  md5: d2228764ccb4ad95813f44effcaaa38a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19961
+  timestamp: 1760613342830
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
+  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
+  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 20018
+  timestamp: 1760613321490
 - conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
   sha256: ce9cb1907f5ad2f1da9a073bf941532fcae38754ee519092d675ed2632c15eb0
   md5: 2686c6ca4329a9d6a587103c986e7026
@@ -11416,6 +9495,73 @@ packages:
   license_family: MIT
   size: 20322
   timestamp: 1760613512213
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
+  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
+  md5: 8578e006d4ef5cb98a6cda232b3490f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 481826
+  timestamp: 1754485653893
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
+  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
+  md5: f04b3cb7ab28e886ceb012e4e9626e82
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 509455
+  timestamp: 1754485781954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
+  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
+  md5: fed853901ec41684b9e08b0c7ee4d7f0
+  depends:
+  - __osx >=11.1
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 475276
+  timestamp: 1754485689285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
+  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
+  md5: ce6e467c7e671a9214bc5d118b8e24a7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82123
+  timestamp: 1762536905383
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
+  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
+  md5: f1cd02f5cac4c78dd00805f81f7b66d8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82590
+  timestamp: 1762536906694
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
+  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
+  md5: 3fa52decbfabf965e84fd38bfb2e268f
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82518
+  timestamp: 1762536906534
 - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
   sha256: 175d71ed03e9e70ec164fe1f944955859f1e94b78bd068131737366f52863348
   md5: 45abed89b4fa72b0b16dc01408537551
@@ -11428,6 +9574,38 @@ packages:
   license_family: MIT
   size: 82654
   timestamp: 1762536944331
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.7-h7bdf020_0.conda
+  sha256: afcc50a102a20a62df24c7fc24633890890af7cf64d9c08ca2286bccf8eec5c7
+  md5: 6457711c539cd20f56d9fa5e6ae5a5f5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 33172
+  timestamp: 1779874661488
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.7-h301ae1c_0.conda
+  sha256: ac4f8229d2aa423275f34dc53516f464d80fe3627412ee7ef2c1f8f00e823b8a
+  md5: 3543296e743c9cb365f2d1dee9cb6e71
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 35011
+  timestamp: 1779874676017
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.7-h279499b_0.conda
+  sha256: 15f2f9b90cacb20e84d4ca7870b15ae0226113910f070f12036228a185ee9617
+  md5: c7e057a695cfc78b1d4c785ddec6a37f
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 30651
+  timestamp: 1779874778017
 - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.7-h557c29b_0.conda
   sha256: 0e25fa8814c0154a9e589e68b319b22a39aa2a9d256b3ff8eebc4e0a5be828d7
   md5: a1848bc3395d29fff4f81de7be74d472
@@ -11439,6 +9617,41 @@ packages:
   license_family: MIT
   size: 43916
   timestamp: 1779874863790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.7-h7bdf020_0.conda
+  sha256: 9120848526b0a8e31e77203b49a55fbee85cf76ce660271681725520abb0b93f
+  md5: cd9ab66296f9984949c0435f41e72b55
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - reproc 14.2.7 h7bdf020_0
+  license: MIT
+  license_family: MIT
+  size: 24820
+  timestamp: 1779874672388
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.7-h301ae1c_0.conda
+  sha256: 6aabc3074e7c0195de04f8bfafbbd9ba40c34e7598f91837cb835b1da9abe1bf
+  md5: 0798f80fc7bef933ba09c8f4ddba5555
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - reproc 14.2.7 h301ae1c_0
+  license: MIT
+  license_family: MIT
+  size: 24782
+  timestamp: 1779874688284
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.7-h279499b_0.conda
+  sha256: 061c07d08829138f34c19aa3053402e0bf6f925906a7d7578a1635c7e3932dda
+  md5: a80f5d41ad365f36f785e6e322299762
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - reproc 14.2.7 h279499b_0
+  license: MIT
+  license_family: MIT
+  size: 23644
+  timestamp: 1779874801900
 - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.7-h557c29b_0.conda
   sha256: 47156389bf7f9d04f3c116e6c98c5b9c4311e197fb8be42074ecb16743607187
   md5: f6ea26bc9084409d0a2a9be480bad52f
@@ -11451,6 +9664,57 @@ packages:
   license_family: MIT
   size: 37142
   timestamp: 1779874893417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
+  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
+  md5: 120fcdc3014753b33a63db5930b7a085
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170579
+  timestamp: 1775066095969
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
+  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
+  md5: a7bcec6c82277f3990f35708bd05d660
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 171420
+  timestamp: 1775066082442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
+  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
+  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170039
+  timestamp: 1775066216803
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.33.1-py313haa95532_0.conda
   sha256: 2e3287357fab55e326b1d2ed0a4a648647e2ad1ea1851c1da2a98059427558b0
   md5: db2c3d5b826ca6275015bfaaf007188e
@@ -11468,6 +9732,39 @@ packages:
   license_family: Apache
   size: 170995
   timestamp: 1775066185516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
+  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
+  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88122
+  timestamp: 1728411680534
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
+  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
+  md5: 3f4000830e7a25be1df38114d361b976
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88285
+  timestamp: 1728500408740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
+  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
+  md5: 85f9714b8bf50cf6f9c75deb5441bba8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88498
+  timestamp: 1731721373383
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
   sha256: 522043089fc1642c8c8798864bdeaad6b7ddcdbfee8a3083fc31bdcc02577166
   md5: b11a903414ef47b3faed42691b1d2c9d
@@ -11479,6 +9776,48 @@ packages:
   license_family: Apache
   size: 89136
   timestamp: 1731731373752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-15.0.0-py313h06a4308_0.conda
+  sha256: e6056b611316c3f7a8b4b6f0cd6ed38275f825c3598303e783a07614539158f7
+  md5: 78f44153bae9a28238cf140f78cef7be
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 626259
+  timestamp: 1778860811865
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-15.0.0-py313hd43f75c_0.conda
+  sha256: 39e74971e59b4d9d2c9a6ad5638108eb9511ca7d137990e308dea7ca77567af5
+  md5: bff53525066be213bbde1a5bb3a1f0c7
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 628546
+  timestamp: 1778860800445
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
+  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
+  md5: ffc0d1741d0d0dbff07518323feb64d8
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603836
+  timestamp: 1760375502207
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-15.0.0-py313haa95532_0.conda
   sha256: 31cf33152a74005a7b5cd8a8baa8d8dc415197a34e91a144f3d1f67c61b67d7c
   md5: 844538246a04a0dd3006f70e801aabed
@@ -11493,6 +9832,42 @@ packages:
   license_family: MIT
   size: 629366
   timestamp: 1778860861487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
+  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
+  md5: 42d308b4487e6a58261a971eb689044b
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33936
+  timestamp: 1771961295227
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
+  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
+  md5: 167fe8ee5af593667148b74a02090717
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33721
+  timestamp: 1771961162662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
+  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
+  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33777
+  timestamp: 1771961170073
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-rst-1.3.2-py313haa95532_0.conda
   sha256: ad249f5c8aae6b75219fad602950c0287295a1b6baf118de85ee83afe1caa9e4
   md5: 0331fdc656de0c90b60866c109b7c686
@@ -11505,6 +9880,41 @@ packages:
   license_family: MIT
   size: 33623
   timestamp: 1771961216902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
+  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
+  md5: 9630d019be2bb127699a375157124a0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 346701
+  timestamp: 1762366536075
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
+  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
+  md5: 7f93cb69d835d6256cc68d0c22843159
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 335795
+  timestamp: 1762366544737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
+  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
+  md5: 150c83ebdcae2067ae5c34a05c1da4ed
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 311962
+  timestamp: 1762366565780
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
   sha256: e9d4ae95e182d385fad599b171f7dbdf125a385566cd551e5ae579aa6699a9f0
   md5: 3253a635462ed5652fb9f5241e201d69
@@ -11518,6 +9928,50 @@ packages:
   license_family: MIT
   size: 219848
   timestamp: 1762366911453
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
+  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
+  md5: dc961556c7bbe4e2aa959e36ab816dcd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271868
+  timestamp: 1762535994695
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
+  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
+  md5: 28b23d252e0d230044637b0f8f88cca6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271533
+  timestamp: 1762535980215
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
+  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
+  md5: b292e4688f8ac6f1c97f1f3e895f5cff
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271430
+  timestamp: 1762535976251
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
   sha256: 4e8a117ed84fdf47dd2ef8ce7c6395af0a1310845917b4087aa98ec045796454
   md5: 97843e1c3c45660d8aa2c6dd6a7d1fc2
@@ -11534,6 +9988,41 @@ packages:
   license_family: MIT
   size: 271852
   timestamp: 1762536109923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
+  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
+  md5: dad8d758af9c2b4369776c601407d9bd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 136835
+  timestamp: 1762530306911
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
+  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
+  md5: 26960af9de364b5745c254d1a6890c45
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 127958
+  timestamp: 1762530151153
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
+  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
+  md5: ca9e7978a1057363f0c36d975b764dcb
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 114492
+  timestamp: 1762530107760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.14-py313hb9a58be_0.conda
   sha256: 3ca28bf6841518b5004d899bd726b3f0230fd1ebfee34a9c336e6dc0cb41523c
   md5: cac6a4b727d18eb086ea401e817043af
@@ -11547,6 +10036,62 @@ packages:
   license_family: MIT
   size: 108685
   timestamp: 1762530153943
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
+  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
+  md5: 6ce9737188317c940d461c09c18d0ab3
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31382
+  timestamp: 1775127026347
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
+  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
+  md5: 529575cd8e6b7becb44a50d0d35009f0
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31316
+  timestamp: 1775127025036
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
+  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
+  md5: 985226bbcb23ebc859128ca676ad6321
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45387
+  timestamp: 1761903210853
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
+  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
+  md5: c9d0d757b916ddfd019821dbbc02a0d9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45447
+  timestamp: 1761903130898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
+  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
+  md5: 8b4a9bf142beac7513382b0a84ce51f5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45786
+  timestamp: 1761903046636
 - conda: https://repo.anaconda.com/pkgs/main/win-64/semver-3.0.4-py313haa95532_0.conda
   sha256: 5158570e5a5891716906743ce9eebe1a0572143dffe808ecba634e5a2c0b3859
   md5: 2dbcf40ddf66f02858c49c67ce0fd953
@@ -11557,6 +10102,36 @@ packages:
   license_family: BSD
   size: 70112
   timestamp: 1761903400398
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
+  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
+  md5: 08038e054ee9e8419ea6aa3fd04455ea
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1665385
+  timestamp: 1775048728528
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
+  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
+  md5: 10081f3addefc88e8127e68448bf9f6d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1666759
+  timestamp: 1775048722771
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
+  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
+  md5: c396551324d88dfb8c688affa5226c2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1669346
+  timestamp: 1775048820327
 - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-82.0.1-py313haa95532_0.conda
   sha256: 8c047064c40aa8a1c02c2488a7466178b71e87f5fce2ca9b95c96acc60d434b0
   md5: c5e8aa64b4745bdbadc0d37754385ccd
@@ -11567,6 +10142,36 @@ packages:
   license_family: MIT
   size: 1666057
   timestamp: 1775048790435
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
+  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
+  md5: 843241073919fc2c912f6ed85d14681d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23136
+  timestamp: 1761912223128
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
+  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
+  md5: d32e4a1ec001c6cef1aae68c11480c55
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23120
+  timestamp: 1761912222490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
+  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
+  md5: 58fe2f1c6896f6e26cea231b74e3888c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 22962
+  timestamp: 1761912224859
 - conda: https://repo.anaconda.com/pkgs/main/win-64/shellingham-1.5.4-py313haa95532_0.conda
   sha256: 1f6a915225fb3e8712d8734cae5276eb4527f93f5051f79269c1e1e4d03cd9e5
   md5: 48a11caef15ab91bf7360541a0842d05
@@ -11577,6 +10182,35 @@ packages:
   license_family: OTHER
   size: 23375
   timestamp: 1761912263432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
+  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
+  md5: 7b2a4b5be590071e1b4dce77b413d26a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 264262
+  timestamp: 1734048099531
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
+  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
+  md5: 0cefa22396b339a17597faad550d9582
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 226027
+  timestamp: 1734048100065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
+  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
+  md5: 443db5b88521ce0e2aaeb77bcf8fb488
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 220407
+  timestamp: 1734048107599
 - conda: https://repo.anaconda.com/pkgs/main/win-64/simdjson-3.10.1-h214f63a_0.conda
   sha256: fc942285ef1ed85c6ae955752e7ebadda95161eefc560c8e034d0d56f33110e1
   md5: e89a4c728f54ef6e0d7845fd1992af58
@@ -11587,6 +10221,36 @@ packages:
   license_family: Apache
   size: 281697
   timestamp: 1734048180938
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
+  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
+  md5: 648ce63d75b826e85fb8801c8b4b4e44
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37483
+  timestamp: 1744271525796
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
+  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
+  md5: 626970a8b8398716c9b9f9025eafd307
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37500
+  timestamp: 1744271573927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
+  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
+  md5: 4af6f9244bd475289f3410b1c8880ed9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 39474
+  timestamp: 1744271575294
 - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py313haa95532_0.conda
   sha256: fe16c893061086d4882b77d91b95efa937a831ce78bd3eb17cb18c99539b8232
   md5: e7fc4d83bea7ee99038d43c773df475f
@@ -11597,6 +10261,36 @@ packages:
   license_family: MIT
   size: 38706
   timestamp: 1744271651700
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
+  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
+  md5: face17589cf2b386d76cc870234dfe6e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17447
+  timestamp: 1764329206740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
+  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
+  md5: 219c67c8ff19787a64b06c2517d063e9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17506
+  timestamp: 1764329173905
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
+  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
+  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17410
+  timestamp: 1764329171349
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
   sha256: 256d04f9d78737274877cd1fb9d7b15ef9efa940737cba71701ab20f9555322a
   md5: ec4cfcc2fe1e1b4325af67997d46ba36
@@ -11607,6 +10301,47 @@ packages:
   license_family: Other
   size: 17469
   timestamp: 1764329260587
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
+  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
+  md5: c7b847a43363d2d77724b9ea04881088
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1265119
+  timestamp: 1773313781324
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
+  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
+  md5: 55600c8be72a7624ebd63e54ed72cbe0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1281272
+  timestamp: 1773313781654
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
+  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
+  md5: cf083b0b25fff8ddab995ac001076f38
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1182590
+  timestamp: 1773314600429
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
   sha256: d9d5f8b3ba4afcf43baca9386ae69f3b7b0f1d30f35ced10bc52d61fe0d1cd28
   md5: b273f421592da633715a1c28058d0ea9
@@ -11618,6 +10353,42 @@ packages:
   license_family: Other
   size: 938682
   timestamp: 1773313787688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
+  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
+  md5: 1fb18f68f15d21748310b2a09ea2f923
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21821
+  timestamp: 1745413175232
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
+  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
+  md5: 1596a495a1f3def74862ce0efcc8281e
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21754
+  timestamp: 1745413132458
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
+  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
+  md5: 685d7b964cfdfd152fb5ddc0951b16d2
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23284
+  timestamp: 1745413263670
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
   sha256: 9f666e8156f111864ed9db7cfc4ade7408c9ca70f7f2b83f21bb17028715b6e0
   md5: cdb1d606ebfdb4a999b3936644911c34
@@ -11630,6 +10401,39 @@ packages:
   license_family: BSD
   size: 22693
   timestamp: 1745413221013
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.52.1-py313h06a4308_0.conda
+  sha256: 205f2efa8f24e445fdd2efc879eb43fd19885a77d5f72f86ba29ab1e09c5b154
+  md5: d9137689e3d1e45fee0613c791807ca6
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179416
+  timestamp: 1773935038245
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.52.1-py313hd43f75c_0.conda
+  sha256: 13d68b3a88d81c4379d44d65d3d269c34a6752dd6869553a934f7a93a696409c
+  md5: 57f468854fad649b203e90595c14129b
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178961
+  timestamp: 1773935043775
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.52.1-py313hca03da5_0.conda
+  sha256: 8c8698c7ef19c251efad29aa3373b9b0254e6fb33a62dc92ef31682e00c6de57
+  md5: 3f457d26bf49537f9afbf846ef1e84f7
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179700
+  timestamp: 1773935049678
 - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.52.1-py313haa95532_0.conda
   sha256: 747c1e409f3b1b25dbb11d51b477adffe911caef8a680799c6791a1770ca4812
   md5: d9500a3026c68819025ee4573be8b839
@@ -11641,6 +10445,39 @@ packages:
   license_family: BSD
   size: 180098
   timestamp: 1773935096668
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
+  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3610181
+  timestamp: 1755243907117
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
+  md5: 6a7f42565108e00d27f68f4ae5751c53
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3717438
+  timestamp: 1755243976411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
+  md5: d1329e6c7292f448cdeed21290dd1035
+  depends:
+  - __osx >=11.1
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3448719
+  timestamp: 1755244020166
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
   sha256: 2f7e9d06b513bcabce6d9ae195e45ccf94fd249edfefc591a5430a9f6f92a7fa
   md5: ddff7b6a72958ef802f40a735e505474
@@ -11653,6 +10490,45 @@ packages:
   license_family: BSD
   size: 3700492
   timestamp: 1755244051664
+- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
+  md5: cda05f5f6d8509529d1a2743288d197a
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 20302
+  timestamp: 1616166645426
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
+  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
+  md5: 782987d420694bdc4a207a16db446a56
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82730
+  timestamp: 1768296500871
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
+  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
+  md5: d5ba67844244cfccfa37b1b23ec83b23
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82633
+  timestamp: 1768296495852
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
+  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
+  md5: 65d4e75c4c995d35de71b4e16174828c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82474
+  timestamp: 1768297453889
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
   sha256: cfd820f3b7c2cb7e7ff53c7110fc11d45220724457831c4b7b44e10f24b4e081
   md5: bf2d1a34135ca0731780c7b012fa5c89
@@ -11663,6 +10539,36 @@ packages:
   license_family: MIT
   size: 82570
   timestamp: 1768296694724
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
+  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
+  md5: d625085e004f964c54b88a3c6c5e8d7e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189342
+  timestamp: 1762896696002
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
+  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
+  md5: 8949c7ff2861d1b903cee84c0607eacf
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 188584
+  timestamp: 1762896685732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
+  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
+  md5: 9199e3c9a0451d04eff558d461dd1b2c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189601
+  timestamp: 1762896659686
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
   sha256: 5ab0840c91097eb033eb73a06cae0dee6317379b1c15cff4fe9672168488d28b
   md5: c5c83cb181bee0abb42aa29669eecee6
@@ -11673,6 +10579,42 @@ packages:
   license_family: MIT
   size: 189958
   timestamp: 1762896691761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
+  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
+  md5: 17b9f23e939b55ab9cab471b694a79d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 161112
+  timestamp: 1771398721582
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
+  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
+  md5: 54a2c4b9c33935687b977159f85bb4cb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160713
+  timestamp: 1771398718073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
+  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
+  md5: af4d88d628ea31190ed1432bba93b9c2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160792
+  timestamp: 1771398721170
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
   sha256: d3fe275f6dbc5bd68277660f7cbc07ced89a4fb5198a35ce2c32bc5d02eaa042
   md5: a797878a96f1b422ec8eee84371459f2
@@ -11686,6 +10628,36 @@ packages:
   license_family: MOZILLA
   size: 185961
   timestamp: 1771398813387
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.15.0-py313h06a4308_0.conda
+  sha256: 274c0ad0b14fca0b3a3d2d5fff8804d2d99ca660ac338b30224f2824005b1c40
+  md5: 93dd7d3739aa3e9a0b3ce910b5c91d5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216754
+  timestamp: 1778743205283
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.15.0-py313hd43f75c_0.conda
+  sha256: 36d3dcc1fcf349d492bc1fc183f99102f1ad504ea5910e318cbc18e62114d64b
+  md5: 127cf9452aabe77ff4daea094120dcb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218385
+  timestamp: 1778743205817
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.15.0-py313hca03da5_0.conda
+  sha256: 3e4e87649ffd0483f6bf8cffe8098106679cd83ca56f3aadd9b18bb183515dbb
+  md5: 17ac336b222db9cf45b6d74890371e12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217925
+  timestamp: 1778743224108
 - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.15.0-py313haa95532_0.conda
   sha256: 417774d590210211eb55d4be0103b73d53a390e26363a990b94c212ea11221e3
   md5: 2baa556e463ae440468ad8353ef83b83
@@ -11696,6 +10668,36 @@ packages:
   license_family: BSD
   size: 217412
   timestamp: 1778743452939
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.4-py313h06a4308_0.conda
+  sha256: b69555753dd28bdecf8c6a94f879d8315127f04f4c7a9acd6785f41d5e193edf
+  md5: f8e8226a4e9b6c4c7676c78022f8d003
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 50225
+  timestamp: 1778600084355
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.4-py313hd43f75c_0.conda
+  sha256: 07d7707d700d3ddda46216c4cce3eb8c39b3ab4244ef2600e950a9fdf3352893
+  md5: 9c2d1e8c9740dca79f9281eff9f431fb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 50345
+  timestamp: 1778600086391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.4-py313hca03da5_0.conda
+  sha256: 23f924b06f0fcf96757fcce25b5de1c35674da2e9fc8f8157fb7174442b73772
+  md5: c9caedd05a758f1f9df3c49b6225fa37
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 50313
+  timestamp: 1778600098786
 - conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.4-py313haa95532_0.conda
   sha256: 6d440c1e88ae74beb26c2f44183cec007ad6b3b4fec076a2f7b23ffa4e698429
   md5: 48181e0c8f132e1a57fb0d1948a63ffd
@@ -11706,6 +10708,48 @@ packages:
   license_family: MIT
   size: 50164
   timestamp: 1778600148421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.25.1-py313h06a4308_0.conda
+  sha256: 477ede6c19edc3ec9ac08684e3fc2c3d863cfc1d71042f50ba60f094df177450
+  md5: b524467d0bb8751ea35a55fa87ba71bc
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 210715
+  timestamp: 1778701935356
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.25.1-py313hd43f75c_0.conda
+  sha256: 62ce86e20a16502f21f9d6b19ec878354695c7d2e016f5491d9dca1ea1f9262c
+  md5: c9e278b2ba623fa3634302a105cff672
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 210065
+  timestamp: 1778701931511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.25.1-py313hca03da5_0.conda
+  sha256: 7c2efb472fd099419f690ff8e5ef42a44c44ad0d06cae1271ad42a75f4fdee65
+  md5: bd9e935bfa0c48ef639e5ccf2cc96dc4
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 210811
+  timestamp: 1778701946808
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.25.1-py313haa95532_0.conda
   sha256: 4285aa3c362408858342d132a21302e1511a285f2be494ec88a86771e11c6ab3
   md5: c1b556b36cdd4beda8ff938d08b5987f
@@ -11720,6 +10764,39 @@ packages:
   license_family: MIT
   size: 234563
   timestamp: 1778701999688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
+  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
+  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11238
+  timestamp: 1756280930223
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
+  md5: 055d37ff4e41c9b9e33d2bb8919c263b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hd43f75c_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11203
+  timestamp: 1756280951293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
+  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
+  md5: 22b46f0e6d389d4199ffaa317e9c9a05
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12434
+  timestamp: 1756281597870
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
   sha256: 3503a6100d19cd88fcc28c21d6e3517f78e77f4541408266f0d6ffc2010a6ed0
   md5: b9d604ca2915d5b5c2e71c56eddcf39e
@@ -11731,6 +10808,39 @@ packages:
   license_family: PSF
   size: 12368
   timestamp: 1756281409751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
+  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
+  md5: b5ea08882d6d5cca3e38a27a3575e85c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32310
+  timestamp: 1760614182019
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
+  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
+  md5: ff4e707bcf34fee0e2065cf2487e2103
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32401
+  timestamp: 1760614185275
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
+  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
+  md5: 1398c39b86119164f19498b6fbcfdb69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32465
+  timestamp: 1760614190333
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
   sha256: 2d10e45ad212588bd03eded99708a7d2dc50f4353577c890e82a28e6e3593f2a
   md5: e20a2281ead8112e87233f7ced446b0d
@@ -11742,6 +10852,36 @@ packages:
   license_family: MIT
   size: 32527
   timestamp: 1760614225492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
+  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 104756
+  timestamp: 1756280924315
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
+  md5: 017a18fc16caf581ce26bac0ad6f9efb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 101647
+  timestamp: 1756280944673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
+  md5: 3c37609330dd4baeb0f4842f02cb783e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 106009
+  timestamp: 1756281579411
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
   sha256: 7ffee67192fba083f61c95f197fc119cb77ef83528d5d18ed2f63a881e46c0b9
   md5: 0e3cbe58bfd973d09298bcbf2de72675
@@ -11752,6 +10892,13 @@ packages:
   license_family: PSF
   size: 103139
   timestamp: 1756281400010
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
+  sha256: 88f1c183adaf24df340d03ef5df510447973b0e80641ab1538e2d66db689c34b
+  md5: 805dd0dbe5ecde428f3c6c1afb6d94e2
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 120718
+  timestamp: 1779900350004
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
   sha256: 9dfca4fb23f20e62a48b9c52e2fdf4d0d34bb31eb6a930c2195fcd10651b3cc3
   md5: 15e1b10231d7d236520501fcfb440f31
@@ -11760,6 +10907,36 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 634816
   timestamp: 1752158202557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
+  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
+  md5: ad4d17d499c69cca7e35518f53419f5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24140
+  timestamp: 1774276104417
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
+  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
+  md5: e857fd0d00de0e82669ff9e06d27f6dd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24215
+  timestamp: 1774276085005
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
+  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
+  md5: 7c281290dab4999400a1e12be880c3a2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24287
+  timestamp: 1774276373831
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
   sha256: 19b9ca9d334f4dad46930fad8dbd029817e78e1b5b1e4571fa703cdd196ece8b
   md5: 1b5b33b6f59be43d466b89eca9058e3f
@@ -11770,6 +10947,51 @@ packages:
   license_family: MIT
   size: 24294
   timestamp: 1774276137392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.7.0-py313h06a4308_0.conda
+  sha256: 02cfb9c30d1cf750a42523f273398edd5d8fcb31df0d0da07cf47c94891381c8
+  md5: b5fd092add49ea41b474bc98a75af1da
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 358018
+  timestamp: 1778536210174
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.7.0-py313hd43f75c_0.conda
+  sha256: 2f429e9acc04a010d2b78629fda1d3c4f31da97de071c876f8a09739a6694e3d
+  md5: 12fbb02050f301302859c818d3f1e396
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 357165
+  timestamp: 1778536199781
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.7.0-py313hca03da5_0.conda
+  sha256: 1663c484954fe3a1c2e6f656ad29dd4a6e31c99635617cc4bc67a583f35c2cac
+  md5: 523fd5bb78899f64e2e04c1b15bd4041
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 358132
+  timestamp: 1778536217975
 - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.7.0-py313haa95532_0.conda
   sha256: f4aa4d5590a45ea91b4b89f2f306c19be0d2ab21c76b4d0995e5938b5328aa37
   md5: aaabd598ba288a5d67bc60bdf5705c99
@@ -11785,6 +11007,42 @@ packages:
   license_family: MIT
   size: 358522
   timestamp: 1778536256029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
+  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
+  md5: 302fdbeea413b0dc179b3ea16886718e
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141937
+  timestamp: 1768226450635
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
+  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
+  md5: ebabc185d4b18349d7bf0d9f5c3d2901
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140643
+  timestamp: 1768226452652
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
+  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
+  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142181
+  timestamp: 1768226456487
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-0.40.0-py313haa95532_0.conda
   sha256: 79a3d79f156b4e3c2c0403dd306673d0ce0eab9fe826ce222fcd278e25736412
   md5: 892ba822f39d820e448a427969b75326
@@ -11797,6 +11055,57 @@ packages:
   license_family: BSD
   size: 167281
   timestamp: 1768226570499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
+  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
+  md5: 2e099756135a2ef67be288cb2d8c3119
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313h06a4308_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39548
+  timestamp: 1768226455792
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
+  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
+  md5: cb02ecced70ccf3114a942f060eb4f66
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hd43f75c_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39602
+  timestamp: 1768226458187
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
+  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
+  md5: eea1461696459cc24a16b5a689281400
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hca03da5_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39438
+  timestamp: 1768226463310
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-standard-0.40.0-py313haa95532_0.conda
   sha256: bf489bb11dd95158312c6b4691d73f1b1a639203cfa9f16e1b0cc5c50b9bb8f8
   md5: 6d196786ef6b84ab5630c064a6163ac1
@@ -11814,6 +11123,50 @@ packages:
   license_family: BSD
   size: 39668
   timestamp: 1768226581896
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
+  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
+  md5: c28e5468c6d8844e76d22ac7baea58e4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 665707
+  timestamp: 1762175545430
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
+  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
+  md5: 27e470f3b095fe3116358db877c2a2ea
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 612267
+  timestamp: 1762175558240
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
+  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
+  md5: 62098dfc2ae82083a56bfd7bc319cf0e
+  depends:
+  - __osx >=12.1
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 545986
+  timestamp: 1762175544791
 - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_12.conda
   sha256: 81f68bd3f7e74032547fc3c2b1d7d914b2688cc11f2470625c5c65d49d1474bd
   md5: 6737bfee92a331a876eadd8a2af7bc09
@@ -11843,6 +11196,44 @@ packages:
   license_family: BSD
   size: 16841
   timestamp: 1779209282759
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.2.0-py313h6e1b9ff_0.conda
+  sha256: 9c64211b9730f97994f85e74d8c0ce9e75d40e76e77143437e073aaf32118529
+  md5: 7e4c16f4508a618af7b3757139e75c00
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 423560
+  timestamp: 1780040674043
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.2.0-py313hef68074_0.conda
+  sha256: 0d31c70736b4c3a16f846659e66afa8b8e1444719170f0bc234912935cca8d0c
+  md5: 6a287602e1f2e6b342b2d8106bdbf2e5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 413654
+  timestamp: 1780040646077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.2.0-py313h3983f12_0.conda
+  sha256: ba19385d58257bd8c07b4de8d3b82cef3399e290497df616267735dd96b27121
+  md5: 983bdbc82459b93df85c889fa64e55d4
+  depends:
+  - __osx >=12.1
+  - anyio >=3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 368365
+  timestamp: 1780040586935
 - conda: https://repo.anaconda.com/pkgs/main/win-64/watchfiles-1.2.0-py313h51239a8_0.conda
   sha256: d173ddfc861c3d31abc3996aed7a2bb05f83d5d98bcb3046858426932baeeac9
   md5: 3167139ca5b5fc5428fe46e936c26886
@@ -11857,6 +11248,38 @@ packages:
   license_family: MIT
   size: 309154
   timestamp: 1780040953762
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
+  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
+  md5: 946018cc418258ab8d35ed63099a3181
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361630
+  timestamp: 1751974452259
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
+  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
+  md5: d6b2c092cb970c634a4b1376a8c212b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368295
+  timestamp: 1751974662854
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
+  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
+  md5: ec80386b367f09af4b44b3824e29acce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363811
+  timestamp: 1751974819165
 - conda: https://repo.anaconda.com/pkgs/main/win-64/websockets-15.0.1-py313h827c3e9_0.conda
   sha256: 1422f7434ce43647a3336ce4703d6a57905b6ffaf9906a5809fa09cc4fb06bbe
   md5: 05f2ea39368835a4209afca69a5b479c
@@ -11869,6 +11292,39 @@ packages:
   license_family: BSD
   size: 402372
   timestamp: 1751974975676
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
+  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
+  md5: 6730c94b00e7d802f421acd3a435af84
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70377
+  timestamp: 1769450261731
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
+  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
+  md5: caf0597b40222d6f17f745bd54636cea
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70703
+  timestamp: 1769450262181
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
+  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
+  md5: 0d4dafde912fdee412dadf279d688eb5
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70617
+  timestamp: 1769450358672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.46.3-py313haa95532_0.conda
   sha256: 8206b8d3b204549064bb11d50b812cf283f898444ade26f2bcde765424980575
   md5: 5d0ad25154aadbe531052f5aebb2e9f5
@@ -11889,6 +11345,38 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10272
   timestamp: 1761746316414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
+  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
+  md5: 446fbd19ad7929dd70635f0303c5047b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67121
+  timestamp: 1736540936116
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
+  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
+  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67625
+  timestamp: 1736540966215
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
+  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
+  md5: d75550f3641901250eaa43ed71dc40d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65365
+  timestamp: 1736541780222
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.17.0-py313h827c3e9_0.conda
   sha256: bb5df055aa57eb6b5f9d90cfe6d13c40c6437f4da0bf3611188e8380cceeab3d
   md5: 280ad1ae053ab8dee8a864e78ddf501d
@@ -11901,6 +11389,315 @@ packages:
   license_family: BSD
   size: 70322
   timestamp: 1736543533940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
+  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
+  md5: 8d5b22b094b6802334d7c8316c4091ce
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23000
+  timestamp: 1771372478643
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
+  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
+  md5: 750a7b171e663c39f6ecc0771452514a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23909
+  timestamp: 1771372468468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
+  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
+  md5: 7a684ffa744044240b3061ad28531930
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 58122
+  timestamp: 1746171563556
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
+  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
+  md5: 4f190efcbddae546e15d54f3f0314b96
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 59357
+  timestamp: 1746171572210
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
+  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
+  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26341
+  timestamp: 1746172168013
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
+  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
+  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26965
+  timestamp: 1746172174098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
+  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
+  md5: 6298b27afae6f49f03765b2a03df2fcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 916212
+  timestamp: 1746110020649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
+  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
+  md5: e87565f2b050d575ee056f472d062383
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 950329
+  timestamp: 1746110056137
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
+  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
+  md5: a8005a9f6eb903e113cd5363e8a11459
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 13582
+  timestamp: 1745958707989
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
+  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
+  md5: 96f0df92ef31ad0aaf27b6b373e4f510
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 14118
+  timestamp: 1745958715370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
+  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
+  md5: c284a09ddfba81d9c4e740110f09ea06
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19260
+  timestamp: 1745992279492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
+  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
+  md5: 5bfda69ee113cfc8e38e0214c078ef4e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19895
+  timestamp: 1745992295156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
+  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
+  md5: d810521a7b4a177fb3d1152cf84a778d
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 49889
+  timestamp: 1746169291297
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
+  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
+  md5: 607d46e3586e0c7b93a4495e0fe52db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 50277
+  timestamp: 1746169296094
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
+  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
+  md5: d95e8903fc0067086f153d04b8cbe578
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 95151
+  timestamp: 1746431898579
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
+  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
+  md5: f5e59a8d2737934ac40c9bf645a75c52
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 100170
+  timestamp: 1746431911997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
+  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
+  md5: 79d7d6794c6adbc537fc98f94e204270
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 409903
+  timestamp: 1746172685149
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
+  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
+  md5: c4b133535086cbaaf2403b18dc377e4a
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 417862
+  timestamp: 1746172689660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
+  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
+  md5: 412a0d97a7a51d23326e57226189da92
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-xextproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-renderproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 594175
+  timestamp: 1746046234466
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
+  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
+  md5: 46b530510556e0b1830c40b5ac625f0e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-renderproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-xextproto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 595620
+  timestamp: 1746046239552
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
+  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
+  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 635646
+  timestamp: 1772548381644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
+  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
+  md5: 0d2e76f65075404a9c26010882e7a786
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 643308
+  timestamp: 1772548369777
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
+  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
+  md5: bc7f39bd763f6957ec91046f0e67a9f3
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 269216
+  timestamp: 1772548381049
 - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
   sha256: e09005f52c41234213bd52ebd07092d945855b6d631dd709dcf35dbc71a15c63
   md5: 70e604035b6c97b915114912f047fb2a
@@ -11912,6 +11709,28 @@ packages:
   license_family: GPL2
   size: 271653
   timestamp: 1772548477626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
+  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
+  md5: 39fdbf4db769e494ffb06d95680c83d8
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 76992
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
+  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
+  md5: 588d487b103786708d10c1800d048fd4
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  size: 77652
+  timestamp: 1619009841594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
+  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
+  md5: 23a9bda10db68f27fac5c379466c98b7
+  license: MIT
+  size: 73088
+  timestamp: 1629137313522
 - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
   sha256: e197edaa90488491bd6e0eaa51329d2d93242c6acd7d0aa7b0351d4b24412368
   md5: 959a63017c520ef9d345bd82ab344e3e
@@ -11921,6 +11740,38 @@ packages:
   license: MIT
   size: 63112
   timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.9.0-he852c71_0.conda
+  sha256: 9881d22ff3a472b6d424ef885baa619b31dd27f2f0a7c3f6dbbace71aa1a5603
+  md5: 7e0c8c5e43d4065f5bb3cb40de4126aa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 234370
+  timestamp: 1779458140041
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.9.0-hcd08bf0_0.conda
+  sha256: 65852665efa9433cf9add0ea2b46bf409663af4528f17d120410371c6d4731c4
+  md5: 80b96527a03b6186e574059d6af883e2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 222186
+  timestamp: 1779458144514
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.9.0-h9fe17f6_0.conda
+  sha256: d519dc160c79bc40da9ca424a1daed5441d08c58d940516dc387ca25151a3a3a
+  md5: 80f60a3e6c45cddd8e956c50649639a5
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 131238
+  timestamp: 1779458127666
 - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.9.0-h9081779_0.conda
   sha256: b860f44879f826759f3686fea65eefbb86f40ce58ca577eaa2765246f3c49e28
   md5: e4fd736681f37662a9637b0b9d53fe1b
@@ -11932,6 +11783,36 @@ packages:
   license_family: MIT
   size: 154790
   timestamp: 1779458199902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
+  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
+  md5: 0c22474f16e65bd9b52fd3b8d60a0372
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32106
+  timestamp: 1763977880529
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
+  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
+  md5: 89dedf7658549815d9e8d5456231932b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32299
+  timestamp: 1763977879242
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
+  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
+  md5: 1b87c5130b5fd6d1738e28799f8b8236
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32097
+  timestamp: 1763977879589
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py313haa95532_0.conda
   sha256: e1fabe5d67279888410b53ad3fe26f02d6c82cb3f4124e07b08e7988815cde31
   md5: 58f9bf466a66b75fee3e9522803e26f8
@@ -11942,6 +11823,38 @@ packages:
   license_family: MIT
   size: 32592
   timestamp: 1763978011708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-h47b2149_1.conda
+  sha256: a31e7df4e55a0040e533095c09275a9d58747fb19e5cf9825820af20d4d55c02
+  md5: b987e8069100421df3350e8662d6a96a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib 1.3.1 h47b2149_1
+  license: Zlib
+  license_family: OTHER
+  size: 91138
+  timestamp: 1776974327859
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h27118de_1.conda
+  sha256: dcec75ae492e5c0149f4b2d3e8d70d3bf4a892fe0e38f9e8231004e762533a8f
+  md5: 08ed08b247f3fc6c4a5bd14875419365
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib 1.3.1 h27118de_1
+  license: Zlib
+  license_family: OTHER
+  size: 88075
+  timestamp: 1776974324319
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-hb4cf58c_1.conda
+  sha256: 46ea11a239f326ff410d148a882b9c1daf5a26f4811cf8929e06b5ffb7907e27
+  md5: af4b715d560a4a8c11223309f733d433
+  depends:
+  - __osx >=12.1
+  - libzlib 1.3.1 hb4cf58c_1
+  license: Zlib
+  license_family: OTHER
+  size: 76072
+  timestamp: 1776974337144
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h1c6eee0_1.conda
   sha256: 10596d5e73832102d7c09031ba2cd6e6ce47dd0c71ff94e660bd5759e681ecc2
   md5: 2cabd7930e833462962979b8bfce6ff3
@@ -11954,6 +11867,50 @@ packages:
   license_family: OTHER
   size: 106377
   timestamp: 1776974467764
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
+  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
+  md5: 78685aca3b481cf213b92abfbe0b2b21
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 422402
+  timestamp: 1758189113863
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
+  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
+  md5: 8d4a8433cf437f7ecc5aafa9874c2012
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 396870
+  timestamp: 1758189118512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
+  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
+  md5: b282b2aecb718102ee0bb3848514689a
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349977
+  timestamp: 1758189118260
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
   sha256: ecc86fd8a56adb8e6cfc2f6ede240b93350cdbf7382662c6ffb12f526e4dff03
   md5: 2fcbc03acf75dedbb17fec7ef2ba5803
@@ -11970,6 +11927,46 @@ packages:
   license_family: BSD
   size: 337202
   timestamp: 1758189153500
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
+  md5: 93b0e546434bfb874aeefd6bb6cf40bb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 622604
+  timestamp: 1758039176606
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
+  md5: abc05ce4daceeb1fa321b365cb847975
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 594707
+  timestamp: 1758039173244
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
+  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
+  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 471230
+  timestamp: 1758039171969
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
   sha256: c822ed29c20166934ef9c9e29b863bc382b2c3c602ac1f3a62e9af2c0495a74c
   md5: fd829528313216f62505dd7a281230ea

--- a/tool-specs/anaconda-cli/pixi.lock
+++ b/tool-specs/anaconda-cli/pixi.lock
@@ -1,29 +1,30 @@
-version: 6
+version: 7
+platforms:
+- name: linux-64
+- name: linux-aarch64
+- name: osx-arm64
+- name: win-64
 environments:
   default:
     channels:
     - url: https://repo.anaconda.com/pkgs/main/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-conda-0.1.11-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-core-0.1.11-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-utilities-0.1.11-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.0.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
@@ -38,20 +39,18 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.6-py313h04fe016_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/docutils-0.21.2-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/email-validator-2.3.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.7-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/environs-11.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.5-h7354ed3_0.conda
@@ -75,7 +74,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
@@ -129,7 +127,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.11-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
@@ -152,7 +150,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
@@ -161,7 +158,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
@@ -203,7 +199,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.47.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
@@ -215,7 +210,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
@@ -242,24 +236,31 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       linux-aarch64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.0.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
@@ -274,20 +275,18 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.6-py313haa502f6_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.5-h5b11e9f_0.conda
@@ -311,7 +310,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
@@ -365,7 +363,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.11-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
@@ -388,7 +386,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
@@ -397,7 +394,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
@@ -439,7 +435,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.47.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
@@ -451,7 +446,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
@@ -478,22 +472,37 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.0.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
@@ -508,19 +517,17 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.6-py313hae07363_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.128.0-py313hca03da5_0.conda
@@ -585,7 +592,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.11-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
@@ -608,7 +615,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
@@ -616,7 +622,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
@@ -659,7 +664,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.47.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
@@ -671,7 +675,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
@@ -689,21 +692,27 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
       win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.0.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
@@ -719,19 +728,17 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.6-py313hbfe00f4_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.128.0-py313haa95532_0.conda
@@ -785,7 +792,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/marshmallow-3.19.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-1.26.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.11-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.12-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/menuinst-2.4.2-py313h885b0b7_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
@@ -807,7 +814,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
@@ -815,7 +821,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
@@ -857,7 +862,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.47.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
@@ -869,7 +873,6 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
@@ -896,12 +899,6 @@ packages:
   md5: c3473ff8bdb3d124ed5ff11ec380d6f9
   size: 3473
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
-  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
-  md5: b272288d02db5520249ca7870c2287b4
-  license: None
-  size: 2491
-  timestamp: 1617219512888
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
   sha256: 576011048d23f2e03372263493c5529f802286ff53e8426df99a5b11cc2572f3
   md5: 71d281e9c2192cb3fa425655a8defb85
@@ -913,18 +910,6 @@ packages:
   license: BSD-3-Clause
   size: 21315
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
-  build_number: 51
-  sha256: 70892a5efb5803b565ba889b5479b6e866a0fabce3a7d2f648e494a9e7bff49b
-  md5: 66329dd81c60123e0d7c4c39b7ee7afe
-  depends:
-  - _libgcc_mutex 0.1 main
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
-  license: BSD-3-Clause
-  size: 1427721
-  timestamp: 1621385842900
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
   sha256: a7d0c79a1946344c8878079b89d7c054d71e4ff4b5cea04ec392b24ec785cd93
   md5: c2c8e35353fa943fa74108dd431a7b9f
@@ -935,36 +920,6 @@ packages:
   license_family: Apache
   size: 35419
   timestamp: 1773069249301
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
-  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
-  md5: 6327e33161b8e0ae8b501af0b07ee435
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35447
-  timestamp: 1773069243126
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
-  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
-  md5: 1784bef0a518f47b0cb442e02b75ce84
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35320
-  timestamp: 1773069152139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
-  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
-  md5: c62bd3bff5cb11570247115c1ab81225
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35318
-  timestamp: 1773069363087
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
   sha256: 22acee4a47176055648cbe19f0ca8d9ee29ac8dec54d7279e0b4572bb00bffd2
   md5: 68ae0d156d8f42f20253ab6936a58180
@@ -989,89 +944,6 @@ packages:
   license_family: BSD
   size: 117028
   timestamp: 1773844617250
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
-  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
-  md5: a8de75045d038d62c3553bdb1a2bf2b3
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - langchain-openai >=0.2.8
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116895
-  timestamp: 1773844596952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
-  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
-  md5: 88dc2eae5116b824692db6bb9b443eed
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  - langchain-openai >=0.2.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116841
-  timestamp: 1773844602363
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
-  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
-  md5: c486692f9df9720276afb556abff5361
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - mcp >=1.26
-  - pydantic-ai >=1.50
-  - langchain-openai >=0.2.8
-  - llm >=0.22
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116690
-  timestamp: 1773844804490
-- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
-  md5: c78d47374611a8e86f7a9817f3768160
-  depends:
-  - python >=3.8
-  constrains:
-  - conda >=23.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19864
-  timestamp: 1774907942644
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
   sha256: c52fe534ed3a4e6cf09289d60bf6c458c7150f82c0bd00c791a02985dc1f2c98
   md5: 7c9db0780c2764d1b9a8965b58d07d99
@@ -1097,81 +969,6 @@ packages:
   license_family: BSD
   size: 127651
   timestamp: 1777996211774
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
-  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
-  md5: cc86d0a53de1c9d4559f84313d92f08d
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda-token >=0.7.0
-  - conda >=23.9.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127355
-  timestamp: 1777996210212
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
-  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
-  md5: be96323ace383458edf5ef71f8e72654
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127712
-  timestamp: 1777996231900
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
-  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
-  md5: 5f4b80f4355b922b23fdd3456c6d4001
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 152577
-  timestamp: 1777996277515
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
   sha256: 6ea3ced350e4d3f744774ba3bc5aa6a5eff3751d0ddd39ac6496868efbd78226
   md5: a256fa8ae4cf05d1cfb990cfee0b7976
@@ -1195,75 +992,6 @@ packages:
   license_family: BSD
   size: 62178
   timestamp: 1775469271573
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
-  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
-  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62286
-  timestamp: 1775469252673
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
-  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
-  md5: 52656bda190a7f2bec974f508a9f35f2
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-auth >=0.12.0
-  - anaconda-client >=1.13.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62048
-  timestamp: 1775469312642
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
-  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
-  md5: 5717d515db735fe7167bd3b5ea7bdc50
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  - anaconda-cloud-cli >=0.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86912
-  timestamp: 1775469436561
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
   sha256: 4a979bb0b48ad2712884695a3056453fbc5208acfc6a250aa3ed049831263f5e
   md5: 7233ba45150b5530456f5da5b9054d48
@@ -1292,90 +1020,6 @@ packages:
   license_family: BSD
   size: 845691
   timestamp: 1772491237524
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
-  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
-  md5: 0b644ecae935ac975164247e9f4d981d
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 845333
-  timestamp: 1772491214305
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
-  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
-  md5: c2a25adb6831401a65a5cdb63f88ba27
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 846994
-  timestamp: 1772491115479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
-  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
-  md5: e10dea7c74568841ed1cd5d8ec12ca92
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 870768
-  timestamp: 1772491405834
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-conda-0.1.11-py313h06a4308_0.conda
   sha256: acca75e8798b376e92646a8b5d7b262b215ec947e01dae4742c212b23d44abcc
   md5: af3167e083aefe1a08c832819e9256e7
@@ -1396,66 +1040,6 @@ packages:
   license_family: Other
   size: 160999
   timestamp: 1773935004052
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
-  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
-  md5: bfb5d8d4df085842d8c0b2e056b9257f
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161380
-  timestamp: 1773934997584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
-  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
-  md5: ed7020be4e2288dff58f60f7bf106fa9
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 162438
-  timestamp: 1773935019675
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
-  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
-  md5: 643c72f55e9de9926eabd069edbf2322
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161935
-  timestamp: 1773935085468
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-core-0.1.11-py313h06a4308_0.conda
   sha256: 683e0c239c7efa04fb6bc7523dd61a2005278d6eee3c9c084708075c27c10b77
   md5: 73c3d30b01b18ada722168b8a163afb3
@@ -1472,54 +1056,6 @@ packages:
   license_family: Other
   size: 169433
   timestamp: 1773871645177
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
-  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
-  md5: 7112210d85ff777ac172307690b79f45
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 168446
-  timestamp: 1773871519885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
-  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
-  md5: a9010a6c725f4a11001406492d49f35e
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 169752
-  timestamp: 1773871547623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
-  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
-  md5: c2ebc9fa966f6b08ea187fa807641415
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 226857
-  timestamp: 1773871887979
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-utilities-0.1.11-py313h06a4308_0.conda
   sha256: 9d64a3304c848ba7e5639ad99e3d513b3390ce38c1ae7d9371a4f09d9fc0564c
   md5: 9e0c6279430723e71d9b46aa80c1a66f
@@ -1536,122 +1072,25 @@ packages:
   license_family: Proprietary
   size: 161158
   timestamp: 1773868125336
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
-  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
-  md5: 213c7a858140be70244c210c31e4da04
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160774
-  timestamp: 1773868123073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
-  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
-  md5: eeca273b542009d5cd4e022bd2cb827d
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 162392
-  timestamp: 1773868150264
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
-  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
-  md5: 6f2969069844333afb09ed91b701abe0
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160509
-  timestamp: 1773868198156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.0.3-py313h06a4308_0.conda
-  sha256: 28ff5cca8d32335d46482b6517007d960fbd5c56ba7e83f5a04a4e7d40d3b5a1
-  md5: b6874f0acb0674ac87749949f870a732
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.0-py313h06a4308_0.conda
+  sha256: 05c88390cbccc5899245d3f64f1bc0d4c70bdabc181a566f8f6c0b1dfc42834f
+  md5: 18445f9c01ae774d10af183aaf947e65
   depends:
   - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<0.15.0
+  - anaconda-auth >=0.13.0,<1.0.0
   - anaconda-cli-base >=0.8.1,<1.0.0
   - anaconda-opentelemetry >=0.8.1,<1.2.0
   - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=0.1.0,<2.0.0
-  - mcp-compose >=0.1.11,<2.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 66682
-  timestamp: 1777650142339
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.0.3-py313hd43f75c_0.conda
-  sha256: 07b0bbeb48592f87c9792b6f5c90d3981cbd48d258699bc698648886e6ac8b4c
-  md5: 3342da6f475c7cb48ef8b586544039d4
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=0.1.0,<2.0.0
-  - mcp-compose >=0.1.11,<2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 66570
-  timestamp: 1777650164123
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.0.3-py313hca03da5_0.conda
-  sha256: 73a267c52599b0ba186694537aeb2c8429a94e4e6f806190fa7b64842b547964
-  md5: 6270762214b6a2b4f7cc3780518309b7
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=0.1.0,<2.0.0
-  - mcp-compose >=0.1.11,<2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 66743
-  timestamp: 1777650213469
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.0.3-py313haa95532_0.conda
-  sha256: c7fb9350827f7fc210e6d6373fa2d52cf0b066e9ceefc75481ee16ace4213729
-  md5: 74b1da5e7b431bbcdedb96f0e2b802d3
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=0.1.0,<2.0.0
-  - mcp-compose >=0.1.11,<2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 91167
-  timestamp: 1777650115510
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75022
+  timestamp: 1779920833758
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
   sha256: 0cd6732f7a3f8c4f2911c6bc963a5d5fcd6aeb061a408842d5b6207a6a20aa77
   md5: d8c5512c00cfaa0c16b6b2c51d866378
@@ -1672,66 +1111,6 @@ packages:
   license_family: APACHE
   size: 82788
   timestamp: 1776808534361
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
-  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
-  md5: aab07c0ab08553546780a3a40f8f2cec
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82829
-  timestamp: 1776808540195
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
-  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
-  md5: 9916fa1108527ee314251aec8a0c7353
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 83086
-  timestamp: 1776808490341
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
-  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
-  md5: 8d4b877231bde39bd3ef1270fb015389
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82692
-  timestamp: 1776808693739
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
   sha256: 436b89319aa90a7338c308e0779c595276ae01430febf7968e8f40c5ae17a456
   md5: 6ceee906e5cc1dae03776e7c64e56877
@@ -1742,36 +1121,6 @@ packages:
   license_family: MIT
   size: 11432
   timestamp: 1763372671839
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
-  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
-  md5: 37fbf9726b0439b29bba0e1cf52ae35c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11421
-  timestamp: 1763372675300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
-  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
-  md5: f39857a71feb6e39da9739228f340a78
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11405
-  timestamp: 1763372676418
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
-  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
-  md5: 250197e0edb4f89e9d3199c32fcecd5d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11465
-  timestamp: 1763372717011
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
   sha256: 382f07779f01e3a6621b963ebd8f01b1759fd71c64cb8d47b4b1da17451e07a4
   md5: 3d0213cea41b88c15fdf1ed04eba799c
@@ -1782,36 +1131,6 @@ packages:
   license_family: MIT
   size: 26097
   timestamp: 1761744946758
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
-  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
-  md5: 108a8bcd136312e83793f5cda2f350fb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26012
-  timestamp: 1761744922996
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
-  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
-  md5: c0c2fb9483677bb657eda6d491e5f29c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 25909
-  timestamp: 1761744968164
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
-  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
-  md5: 2c7171d6d58b9364b4406ab1c85ee50b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26185
-  timestamp: 1761745147069
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
   sha256: f14560ae804db5d9289a4ddec171cbbacf78dd49b4a640f21fd0829ee55b333f
   md5: fcc4b2673d3d0b0a203bf1496a694ec3
@@ -1825,53 +1144,6 @@ packages:
   license_family: MIT
   size: 317979
   timestamp: 1773134446379
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
-  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
-  md5: 910687ebf7746e8562300e8f1996edc6
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318118
-  timestamp: 1773134422321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
-  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
-  md5: 7e400853597f6d7237e927baa6706aa7
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 317912
-  timestamp: 1773134435123
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
-  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
-  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318164
-  timestamp: 1773134551978
-- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
-  md5: c0ad195970a65c174b997011ac13f2f8
-  depends:
-  - python >=3.7
-  license: MIT OR Apache-2.0
-  size: 49261
-  timestamp: 1758125010311
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
   sha256: 0c54f6998dfa0ce079af488624d12f1541ae5e4c77eadbb728f01c89d24a419e
   md5: 7abefd1bcc7f971ebe2e905b54d3d9af
@@ -1882,36 +1154,6 @@ packages:
   license_family: MIT
   size: 180870
   timestamp: 1774959670748
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
-  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
-  md5: 711f61b5492b94625605422dd8e326ed
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180516
-  timestamp: 1774959654156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
-  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
-  md5: bafc36567bd5432aea186b203ccbe80d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180639
-  timestamp: 1774959652662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
-  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
-  md5: 2a3be388a9418ec78c921662e816d826
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 181026
-  timestamp: 1774959795526
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
   sha256: eca5799ea6fe42c404d575fe3e6a1296ab4a77477338e4844e3ce55cfb92d51e
   md5: 8b691d36a48bb3b11af5acca7ef5f3b7
@@ -1926,48 +1168,6 @@ packages:
   license_family: BSD
   size: 446172
   timestamp: 1775206363270
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
-  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
-  md5: 3bee8eb5a01e45d657bc7edc508dcde4
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 445207
-  timestamp: 1775206365399
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
-  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
-  md5: a76eeaf70ce3bead86b2c5da38121a69
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 446875
-  timestamp: 1775206378569
-- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
-  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
-  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 448508
-  timestamp: 1775206412930
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
   sha256: 12e6857595968ad28911cf185f7696365ff92eaa4a9ad9cead223a7332a3a6bb
   md5: 468a6120b4db27b9d6de4aa86e6c6a45
@@ -1978,36 +1178,6 @@ packages:
   license_family: MIT
   size: 1486546
   timestamp: 1772489320625
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
-  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
-  md5: 63457f5636c2230e585b265ea721c2f8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1484918
-  timestamp: 1772489319478
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
-  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
-  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488689
-  timestamp: 1772489325506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
-  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
-  md5: f38f1b967e522121f347c6e53e50386e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488599
-  timestamp: 1772489378490
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/boltons-25.0.0-py313h06a4308_0.conda
   sha256: 248e6cb425de676a39915d1c241e0434d9ec8b19d27771f7132907519f7fbc77
   md5: afd30cc40ab0edf4e246b901c8eca725
@@ -2018,36 +1188,6 @@ packages:
   license_family: BSD
   size: 522428
   timestamp: 1751383912748
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
-  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
-  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 522348
-  timestamp: 1751383856268
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
-  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
-  md5: a5b55c281bf03fadccc2b9fb5e6c567d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 524228
-  timestamp: 1751383887927
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
-  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
-  md5: 78e0f7a51d811d64b0d0fa4e886458f2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 523882
-  timestamp: 1751383878776
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
   sha256: 1d13694da029eb587dcdce691e4a6a1590ac5de65f0cde234fff849fd7985168
   md5: d309f82c145a73fedf7bc6930f689dba
@@ -2062,47 +1202,6 @@ packages:
   license_family: MIT
   size: 381299
   timestamp: 1764961365931
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
-  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
-  md5: 9dd92861bec232ccdf7869b0b05b453b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17.0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 385446
-  timestamp: 1764961345156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
-  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
-  md5: 4f002093422042d948885e06821f150b
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17.0
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 375456
-  timestamp: 1764961201718
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
-  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
-  md5: 964620a4cb8353969963fbb7b045b01c
-  depends:
-  - cffi >=1.17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 355904
-  timestamp: 1764961470388
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
   sha256: 235f266d5f9c3c61748bb1af0eff21bc7ed2a2a356b97ff28d9c1135039b08b0
   md5: f21a3ff51c1b271977f53ce956a69297
@@ -2112,32 +1211,6 @@ packages:
   license_family: BSD
   size: 268384
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
-  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
-  md5: f580b2013db742598b2d59875bccf774
-  depends:
-  - libgcc-ng >=11.2.0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 215406
-  timestamp: 1714510578082
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
-  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
-  md5: 27a1ffbd30ff6427c112a733410e2f57
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 132212
-  timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
-  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
-  md5: 33e784123d565c38e68945f07b461282
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 91870
-  timestamp: 1714511182837
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.34.6-hd44998d_0.conda
   sha256: a5bdd98c8c2ef2bbe52b0fb018ddda3e62f91b2f96089e66e903052e1e91498e
   md5: e16f3bb02771b2e37ea421a3f8ee1ebb
@@ -2149,38 +1222,6 @@ packages:
   license_family: MIT
   size: 206586
   timestamp: 1769077678178
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
-  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
-  md5: 6e3e5f38a8efcb439d36f091baa23034
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 217449
-  timestamp: 1769077676509
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
-  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
-  md5: ceb5c473b56eb1b79fd079f6b0d029df
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 177571
-  timestamp: 1769077680758
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
-  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
-  md5: f6f293f1ec437a5a362252af20d31e50
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  size: 203491
-  timestamp: 1769077840032
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.3.19-h06a4308_0.conda
   sha256: 8a9aef8816cff77cfde5d9d90e45b67653bf5099b0f7c221cf0746da3461d95b
   md5: 291793559c71f945283cdb33962e7761
@@ -2188,27 +1229,6 @@ packages:
   license_family: Other
   size: 128969
   timestamp: 1774365804711
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.3.19-hd43f75c_0.conda
-  sha256: 3e384eff3151ac56bddedb0e283b8fd48e5f0f01467b46cbf6246323f2e213c2
-  md5: 51d892f6d58c233a961bb88a72a80d16
-  license: MPL-2.0
-  license_family: Other
-  size: 128939
-  timestamp: 1774365802467
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.3.19-hca03da5_0.conda
-  sha256: 8a14f3cf9c266735eaa01a6879185e5a0518d0377f76d760633c7698e3cab036
-  md5: a7e9cfcf108c1488853b1d205e5ae380
-  license: MPL-2.0
-  license_family: Other
-  size: 129019
-  timestamp: 1774365821682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.3.19-haa95532_0.conda
-  sha256: 922ec2dc939cf5a6790a391d5164952ab4c3802ab882fad71da361888a20ad81
-  md5: 646f2cc64c282566396335d4e352a3b4
-  license: MPL-2.0
-  license_family: Other
-  size: 128933
-  timestamp: 1774365840323
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-6.2.2-py313h06a4308_0.conda
   sha256: 1f940a1c17e8fec366dfeee42f16adb2226caee1fc7a14cffa9ba69f024b3d72
   md5: fff0be0678af050cf070caf6112afb73
@@ -2219,36 +1239,6 @@ packages:
   license_family: MIT
   size: 41231
   timestamp: 1764867398576
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
-  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
-  md5: 1d25e042eebc783ff4804fc9c42852d2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41563
-  timestamp: 1764867403876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
-  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
-  md5: bb47e0b8fa0f637b245c34b5b357a5d4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41149
-  timestamp: 1764867366355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
-  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
-  md5: 9ce972c71a87d4d90534a24d77e99cb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41594
-  timestamp: 1764867445911
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py313h06a4308_0.conda
   sha256: dca4a436b34e5ab1f62a2dbbd0989e03e7ef375288c10f0b3bc95f1614095dba
   md5: 76d1efd083cb0251ec8295c355adb1e2
@@ -2259,36 +1249,6 @@ packages:
   license_family: Other
   size: 152128
   timestamp: 1767659200360
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
-  sha256: a3de2871ed01954e278c620333e134398b609eb2b40a065b5f285c33e8980ac3
-  md5: da57c7bf0bbdf1849008dbe93d75643a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151899
-  timestamp: 1767659159197
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
-  sha256: 839ea683a30bfd322076dceafaa8752882feebb654afe9ddd8595e71db99faa1
-  md5: 65d56422e29c425a3a91c8e1c17888d0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151748
-  timestamp: 1767659160370
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
-  sha256: cc1f29494f63fed7d925e545e1f8c47f51e8e06f856b4d15a40925c07e81fed5
-  md5: 5808bf0191f70eb95f0cc7d7faf7eaea
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151549
-  timestamp: 1767659399196
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
   sha256: a16eafa37a73eb521aef93e9760f44be8f0180f9ff3e5bccbf2de8f6e762e9a0
   md5: 48989473c291f70b074ba57b48d4eda5
@@ -2303,47 +1263,6 @@ packages:
   license_family: MIT
   size: 295376
   timestamp: 1761832800589
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
-  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
-  md5: d010d105070e615750bbb51b8f2b17f5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 317809
-  timestamp: 1761832800132
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
-  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
-  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
-  depends:
-  - __osx >=12.1
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 288576
-  timestamp: 1761832806745
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
-  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
-  md5: d1e9e395ff8688288d67b89e896c2b6c
-  depends:
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 299121
-  timestamp: 1761832847099
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
   sha256: d84312b64791eac1dad798c86110a0ac53e7d980d6d4c5d32f60ebbb82e4eb4b
   md5: 36134f1eb9574beab525f137faa53cd7
@@ -2354,36 +1273,6 @@ packages:
   license_family: MIT
   size: 100520
   timestamp: 1761744847216
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
-  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
-  md5: c89d95c43d07b658088bb12631ce9132
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100336
-  timestamp: 1761744908393
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
-  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
-  md5: 6301ec890b186cbe5d8243254450651e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100213
-  timestamp: 1761744861372
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
-  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
-  md5: 9e4732d3d22b2cf01fc408696e8ebd41
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 124770
-  timestamp: 1761745054105
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
   sha256: c743088f34421989511925c4fd47bd2d1627e0d47a9ce17ac522971456559dbf
   md5: cd0c96b38e17a2b268d15d0b22da55b3
@@ -2394,47 +1283,6 @@ packages:
   license_family: BSD
   size: 327716
   timestamp: 1764332274729
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
-  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
-  md5: 7813f91a66f3a442e803469cf76e3e1c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328923
-  timestamp: 1764332280328
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
-  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
-  md5: 7ac45ddb190136a57ad9b02e7e365ec0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328813
-  timestamp: 1764332257562
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
-  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
-  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
-  depends:
-  - colorama
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328826
-  timestamp: 1764332409785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
-  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
-  md5: b73ebc8eb01ba1e79ad34303e2975694
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55002
-  timestamp: 1729036609433
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
   sha256: 7fa70086625233a494e92418fb58591f43e2c6309cb4c082e3fd778a0280c506
   md5: c47ffd5c56a75b1b62855a3c8e430889
@@ -2470,126 +1318,6 @@ packages:
   license_family: BSD
   size: 1273463
   timestamp: 1771402226765
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
-  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
-  md5: efb9dc33b510e1c882b597d994f6ab3d
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-env >=2.6
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1270780
-  timestamp: 1771402352584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
-  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
-  md5: 1fbe06ba53189032094abfe761e965ce
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-env >=2.6
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275763
-  timestamp: 1771402227023
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
-  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
-  md5: 301f7c7830bdf835d4fcf93e0122da7a
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-env >=2.6
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275313
-  timestamp: 1771402340575
-- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-  sha256: ae098ebc94df3b64f449052c4f2c765187a3e30e4981362d7a52fb802930f357
-  md5: 3e467ddfbd4e40a574474ae928f7a423
-  depends:
-  - boltons >=23.0.0
-  - conda >=26.1
-  - libmambapy >=2
-  - msgpack-python >=1.1.1
-  - python >=3.10
-  - requests >=2.28.0,<3.0.0
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 58057
-  timestamp: 1777900169394
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
   sha256: d1e652dbd4390b12bcf938ece3e85636c12ab54d91a25de7dd1ac8ca84b1b8b1
   md5: 8df01d8631f16021fe6e7f0093de07db
@@ -2602,42 +1330,6 @@ packages:
   license_family: BSD
   size: 284840
   timestamp: 1762366426064
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
-  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
-  md5: 6577f526b527308e4bf66a7bdef0e7fe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285635
-  timestamp: 1762366425854
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
-  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
-  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285376
-  timestamp: 1762366427916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
-  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
-  md5: 0bf62b2027e8a656a86e1c4a7e71142c
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 309759
-  timestamp: 1762366569467
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
   sha256: 8d1ff42b4560986c9d46ef2114cd77ae791ec4400a5ba4eb9a4b22ad540466c1
   md5: 56c2a9c6a706a12193c0b98ef951b4b6
@@ -2650,42 +1342,6 @@ packages:
   license_family: BSD
   size: 38518
   timestamp: 1762361653472
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
-  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
-  md5: 313fca7b4d867f8b06df3140548f9440
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38256
-  timestamp: 1762361650200
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
-  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
-  md5: 01a0bc32a49fd331d514dfd64446fb1e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38499
-  timestamp: 1762361650835
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
-  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
-  md5: d9081bd54908ac92135e6fb20d0aade2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38102
-  timestamp: 1762361726254
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
   sha256: 8718137ba3afc2eb8eb986e17442968aec45b32bbd746b64bc239c3019ec7216
   md5: 3a195bcf47b691adb4a635a8b7f396f7
@@ -2696,35 +1352,6 @@ packages:
   license_family: CC
   size: 132687
   timestamp: 1734039334436
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
-  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
-  md5: 06c2848c6311674e19391d4b81b3188a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: CC0-1.0
-  license_family: CC
-  size: 132686
-  timestamp: 1734039347698
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
-  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
-  md5: 9a83af67c17d1c760cd7aff545ef7e0f
-  depends:
-  - libcxx >=14.0.6
-  license: CC0-1.0
-  license_family: CC
-  size: 134133
-  timestamp: 1734039345192
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
-  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
-  md5: 67a55401db50a1d6bde2b153a74bcb07
-  depends:
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.29.30133,<15.0a0
-  license: CC0-1.0
-  license_family: CC
-  size: 133944
-  timestamp: 1734039396266
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.6-py313h04fe016_1.conda
   sha256: 16dd4718288c67aecf5206931b47879ee4faedb057d914a278716569f9a6b537
   md5: cd18893d2e2a58f20ae7ab9133e172d9
@@ -2741,54 +1368,6 @@ packages:
   license_family: OTHER
   size: 1705099
   timestamp: 1775166014972
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.6-py313haa502f6_1.conda
-  sha256: ea8a8929b26ce11b136093b49ed47842617d235262abce14275a08b8733fa8dc
-  md5: 15cce1cf3010a45c2282a7c0a04a39ed
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=2.0.0
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1685129
-  timestamp: 1775165946454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.6-py313hae07363_1.conda
-  sha256: 98fb481ec4aaa2986a1e3db853e4b72423a6ca0fe6ab9be9bc0d9ed79a412d11
-  md5: 3ac69dec44f28472bec0a94ce8dc44cd
-  depends:
-  - __osx >=12.1
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1583766
-  timestamp: 1775167156757
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.6-py313hbfe00f4_1.conda
-  sha256: 6ffe06d9e0fdc259fa0ff6637c9a5d1e5cf63956cd14ac2b773e02ce55432327
-  md5: 60bf04e1104890a8841e4517a028cf6c
-  depends:
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1481930
-  timestamp: 1775166420995
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
   sha256: ae53fd9454d789e5d815340cf2fc2dc08890e7d49a5709c3b990c923a58e8c05
   md5: 470893a428fe943c25311711c34b8912
@@ -2803,48 +1382,6 @@ packages:
   license_family: Apache
   size: 392859
   timestamp: 1772065044827
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
-  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
-  md5: 8f3083bd30c06eace150fbf4ff5acd33
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392308
-  timestamp: 1772065019547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
-  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
-  md5: 85c2e5e0e00bcd63d85871b80f060b1b
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392115
-  timestamp: 1772064911124
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
-  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
-  md5: db173ac83b3843bec70a8b2070881460
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 448738
-  timestamp: 1772065243755
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
   sha256: ff936d58ce18451f18cba16a8ade9365199a6321d4eb1c60c1eb1d8e3932c65b
   md5: 4c4aef417b613e7111d90cf2348b231a
@@ -2858,27 +1395,6 @@ packages:
   license_family: GPL
   size: 1259937
   timestamp: 1756144852972
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
-  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
-  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
-  depends:
-  - expat >=2.7.1,<3.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1275876
-  timestamp: 1756144876643
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
-  md5: d912068b0729930972adcaac338882c0
-  depends:
-  - python
-  license: PSF 2.0
-  license_family: PSF
-  size: 23826
-  timestamp: 1615228158573
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
   sha256: 57e25d204f2e891ab2f68a776b9e21cc681adfe089ea35a18aa05e5aa950a4c7
   md5: 1fd7ab065e9958e7bbd4d3fbf175742b
@@ -2889,36 +1405,6 @@ packages:
   license_family: Apache
   size: 37917
   timestamp: 1728396132498
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
-  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
-  md5: 77f95d4b0a5bf1b775dda3372544dbeb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37699
-  timestamp: 1728480059192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
-  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
-  md5: 5e948f3d746f13d209bd09a9d2fb7758
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38129
-  timestamp: 1728591870413
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
-  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
-  md5: 9a502db95e7e272d1b7ed53f03dafab2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63476
-  timestamp: 1729059201537
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
   sha256: 76ed0f399394a99c99f89ea8525b89f50412a75d0230d99b07137f6f9bdc117f
   md5: d9d17b8c0998984fbde4103a0113fb34
@@ -2937,61 +1423,6 @@ packages:
   license_family: OTHER
   size: 665462
   timestamp: 1763718275784
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
-  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
-  md5: 23079a69d0ac19cf9f264cfc36dfaf67
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  license: ISC
-  license_family: OTHER
-  size: 666622
-  timestamp: 1763718283404
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
-  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
-  md5: 83b6045550ea3f3984ad063b58c44f83
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpx >=0.28.0
-  - httpcore >=1.0.0
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 667571
-  timestamp: 1763718279384
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
-  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
-  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  - trio >=0.30
-  - idna >=3.10
-  - wmi >=1.5.1
-  - cryptography >=45
-  - h2 >=4.2.0
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 666555
-  timestamp: 1763718371551
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
   sha256: 4b99a2d38d4324cff99f21bcf1b938e25f178e5f22615b0dc8b6a7c6f17a0774
   md5: be1740cddc233f9ab333989a30091afb
@@ -3002,36 +1433,6 @@ packages:
   license_family: MIT
   size: 96105
   timestamp: 1766163640372
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
-  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
-  md5: 3a916231ebb779a7c2d5230fca7a2792
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96633
-  timestamp: 1766163709520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
-  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
-  md5: 84ceb2792085acb3459abeedb47f888d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96396
-  timestamp: 1766163600127
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
-  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
-  md5: 6c03175c12338ebc8273659a72c462ce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96782
-  timestamp: 1766163871411
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docutils-0.21.2-py313h06a4308_1.conda
   sha256: f07ce74ab05c47d99351bf2a8f40721f8211c3cc33a4db95f5f9d946b0ba3584
   md5: e9073a661561fdcd74f47e5e1116d686
@@ -3042,36 +1443,6 @@ packages:
   license_family: Other
   size: 938474
   timestamp: 1761746639546
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
-  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
-  md5: c73024412ae68d6afa90b3bfca1a3b28
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 939239
-  timestamp: 1761746641765
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
-  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
-  md5: 54a125d07b398d692c81bcad8c0fc6df
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 940136
-  timestamp: 1761746670106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
-  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
-  md5: bbfbf4a353f2adbd724998ab6083802f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 1014370
-  timestamp: 1761746691814
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/email-validator-2.3.0-py313h06a4308_0.conda
   sha256: e9010e12bc5ec063fada7c7f93908ebaee19f8c00fbcb42a6293e9854a92f54b
   md5: 147defdb8eb1d949155ba6dfcd33dfb7
@@ -3084,54 +1455,18 @@ packages:
   license_family: OTHER
   size: 66155
   timestamp: 1758610271322
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
-  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
-  md5: 4f6a93a269938d34f89e6c56b07905a1
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.7-py313h06a4308_0.conda
+  sha256: 34a464a65059b8878aca3cbc996597285cee847cd5ded1a121951126b2d30706
+  md5: 919252a39e7e6b88c0d2f10af26c81e0
   depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 65683
-  timestamp: 1758610280179
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
-  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
-  md5: c1112f1321fda31b8b182c011bd25f39
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 66105
-  timestamp: 1758610134265
-- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
-  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
-  md5: 0aec5daa5284e9e3967c95a79f775012
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 90963
-  timestamp: 1758610340546
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.0-py313h06a4308_0.conda
-  sha256: cd63fe8dda80b34bb8444ef64996b869d2517915165fe2621de82d1933da5776
-  md5: 42234dd1f5580df9a1ec9615a9577ef3
-  depends:
-  - anaconda-auth >=0.13.0,<0.15.0
+  - anaconda-auth >=0.13.0
   - anaconda-connector-conda >=0.1.11,<0.2.0a0
   - anaconda-connector-core >=0.1.11,<0.2.0a0
   - anaconda-connector-utilities >=0.1.11,<0.2.0a0
   - click >=8.1,<9.0
   - conda >=25.11.0,<26.2.0
   - environs >=9.0,<12.0
-  - fastmcp >=2.12,<4
+  - fastmcp >=2.12
   - httpx >=0.24,<1.0
   - lupa >=2.6,<3.0
   - opentelemetry-instrumentation >=0.51b0,<5.59b0
@@ -3142,80 +1477,8 @@ packages:
   - typer >=0.7,<1.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 63379
-  timestamp: 1774459891348
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.0-py313hd43f75c_0.conda
-  sha256: 496998463e92309aed614ae6af8e42a0befba902adc1640d5d64319808725fbc
-  md5: e1c3ac2d4dc34f2c086d5c12a3eb3f59
-  depends:
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12,<4
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 63427
-  timestamp: 1774459893311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.0-py313hca03da5_0.conda
-  sha256: 32d07bdad286133d2ef292c7f4c0d3b6f0c4b7eed90a6fa8dc3d9aa3102d084b
-  md5: 844ce777f31dae10a9c41298fb599f9f
-  depends:
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12,<4
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 64089
-  timestamp: 1774459917705
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.0-py313haa95532_0.conda
-  sha256: 48d4962367f2667a52d2e43c361dc23766124dc383f67574207cbe9a763e82db
-  md5: a119aa708559dabc4760b3dcf6aaf733
-  depends:
-  - anaconda-auth >=0.13.0,<0.15.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12,<4
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 88010
-  timestamp: 1774460071251
+  size: 66976
+  timestamp: 1779916005740
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/environs-11.2.1-py313h06a4308_0.conda
   sha256: 3f42e89e9e231d76b622db947fe92ea894610c0b47dc05c672248a3de542e70d
   md5: 44df1fdd5286369932065aa827ed55cd
@@ -3228,42 +1491,6 @@ packages:
   license_family: MIT
   size: 37166
   timestamp: 1774388511813
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
-  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
-  md5: b34fd0d10946da439f9b357e3d42e1f5
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37088
-  timestamp: 1774388461266
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
-  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
-  md5: a1db257019eb3930e461aa5626be2c0e
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37392
-  timestamp: 1774388481869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
-  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
-  md5: f61420d4421c1f5c8ecb2d0cac6a910c
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37648
-  timestamp: 1774388523034
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py313h06a4308_0.conda
   sha256: ce30b8b076188b90cca5b053884631f7c9ecd669b023bdbe77b0b4aae4df3192
   md5: ca4915b2c8f67574d512d40f117617a1
@@ -3274,36 +1501,6 @@ packages:
   license_family: MIT
   size: 48909
   timestamp: 1761560358064
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
-  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
-  md5: 23b284ce11d60c82ef766dbfc024277c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49018
-  timestamp: 1761560361917
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
-  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
-  md5: cd68188eea25cf618d3ed80a746e34cd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 48744
-  timestamp: 1761560378218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
-  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
-  md5: be5485351f1313fc4628d30117e0fdd5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49233
-  timestamp: 1761560536661
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.5-h7354ed3_0.conda
   sha256: ca2c5e649f35a9bdf6af0db5c596ebe060f5f6136417285348ab8e1eaa2f1dfa
   md5: 26ee2ccb746d7d06dfc5f83f906bd650
@@ -3316,18 +1513,6 @@ packages:
   license_family: MIT
   size: 24686
   timestamp: 1774555959871
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.5-h5b11e9f_0.conda
-  sha256: 7a040dac98974da19f3ad8c62349c3e2e99295671c35716da917e3ae42f42c88
-  md5: 90d02a912cfb7f3bea1f0107c5276c2a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libexpat 2.7.5 h5b11e9f_0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 25656
-  timestamp: 1774555880096
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.128.0-py313h06a4308_0.conda
   sha256: 2e67b70f7c75b738fe9cee99e8f2426fc78e9e28a1fa39688553ff4d49b9a039
   md5: 58fb538a4ee5225beaed597d3525a75e
@@ -3355,87 +1540,6 @@ packages:
   license_family: MIT
   size: 195578
   timestamp: 1768401129399
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.128.0-py313hd43f75c_0.conda
-  sha256: 10831bcd9e780eff2e3a1045d11d77eefaf38028eb9e1926291ceac5b9bb8d43
-  md5: e426f9ebee861421e9b7c984bb64a10f
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - httpx >=0.23.0,<1.0.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - email-validator >=2.0.0
-  - jinja2 >=3.1.5
-  - pyyaml >=5.3.1
-  - fastapi-cli >=0.0.8
-  - python-multipart >=0.0.18
-  - orjson >=3.2.1
-  - pydantic-extra-types >=2.0.0
-  - pydantic-settings >=2.0.0
-  - itsdangerous >=1.1.0
-  - uvicorn-standard >=0.12.0
-  license: MIT
-  license_family: MIT
-  size: 195510
-  timestamp: 1768401128402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.128.0-py313hca03da5_0.conda
-  sha256: 6fb3db76bfeb30e28707b52a5056e512bd42f96c731b4ef437a2bea5d35da208
-  md5: 944377cd6e1d22c9079dc7d605de20ec
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - uvicorn-standard >=0.12.0
-  - fastapi-cli >=0.0.8
-  - pydantic-settings >=2.0.0
-  - pyyaml >=5.3.1
-  - orjson >=3.2.1
-  - email-validator >=2.0.0
-  - pydantic-extra-types >=2.0.0
-  - httpx >=0.23.0,<1.0.0
-  - itsdangerous >=1.1.0
-  - python-multipart >=0.0.18
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - jinja2 >=3.1.5
-  license: MIT
-  license_family: MIT
-  size: 196018
-  timestamp: 1768401131556
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.128.0-py313haa95532_0.conda
-  sha256: 0f0185034ee22e4d7e4cd27a7422be8dec68f67ea42c2c9a3dfe0d29d8c21da9
-  md5: 27ac4e0463fbab1360fe56504c95396e
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - pyyaml >=5.3.1
-  - uvicorn-standard >=0.12.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - fastapi-cli >=0.0.8
-  - python-multipart >=0.0.18
-  - email-validator >=2.0.0
-  - orjson >=3.2.1
-  - pydantic-extra-types >=2.0.0
-  - itsdangerous >=1.1.0
-  - httpx >=0.23.0,<1.0.0
-  - jinja2 >=3.1.5
-  - pydantic-settings >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 253473
-  timestamp: 1768401259271
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastmcp-3.1.1-py313h06a4308_0.conda
   sha256: a7a9431f336fd35f1002ece0009ebd72bce46618c4cc1a488205ee8ab8ec6516
   md5: 715ed31b021b666ddf86d091f58d455e
@@ -3480,6 +1584,2926 @@ packages:
   license_family: Apache
   size: 1060147
   timestamp: 1774377863253
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-11.2.0-hca5f364_0.conda
+  sha256: 851afd6890164c6894572c275a7d3fb87dac4ce8b3760925febb2c3779306275
+  md5: 0615a40b477dd3a4488d67cd422a1365
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 206513
+  timestamp: 1754990938922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
+  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
+  md5: 26dfe875df9973e0e98ec5add063e00e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39148
+  timestamp: 1761750688493
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
+  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
+  md5: df53b928c3a9dd53c7f4e87cc03e03d2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h6a67909_0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libasprintf-devel 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libgettextpo-devel 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 535333
+  timestamp: 1772045309664
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
+  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
+  md5: ac944526cc2d27ffa3c44a42cd86f46d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3777431
+  timestamp: 1772045279414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
+  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
+  md5: 91b9170766e7040dedc182d913a7ff89
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171370
+  timestamp: 1770382383126
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
+  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
+  md5: 9b8c1795cc878775116cd01cea2ddad8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 h79c45ec_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 877844
+  timestamp: 1770755209168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
+  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
+  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64750
+  timestamp: 1761931277052
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
+  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
+  md5: 77016551f9607c23c6243632bf100507
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127896
+  timestamp: 1748526107673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
+  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
+  md5: 4b7c5319a6df6513319768f73969098c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 101585
+  timestamp: 1763634777574
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
+  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
+  md5: d25af3a5cbefe54951cb3dc369b945bb
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=8.0.0,<9.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - zstandard >=0.18.0
+  - socksio >=1.0.0,<2.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217558
+  timestamp: 1760447364823
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.0-py313h06a4308_0.conda
+  sha256: 323856b6498b26b978b3c553b8ed4965002b940574032057f8818c1b63954bf0
+  md5: 55a43a7e939a3fcc4987774478a735ee
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 16656
+  timestamp: 1735845644279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.conda
+  sha256: f60e8a4b965ba50214f5a7a24308c060860fa5062d9d69d581287a520006abba
+  md5: 6d09df641fc23f7d277a04dc7ea32dd4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 27195861
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
+  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
+  md5: c8b25d0fe19ba1a7319a0221e7615265
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202882
+  timestamp: 1761911998666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
+  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
+  md5: e3d3dc1bd7e26bef582f874fbb4c543c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71396
+  timestamp: 1772097118324
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.14-h5eee18b_1.conda
+  sha256: e76928987010e8d60fe7e2edbbf733643ed16f17eb9cbcd96bc4dcb2d823dec2
+  md5: 852537d568f5ed410a100d65424039dc
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 38170
+  timestamp: 1705704612984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
+  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
+  md5: c4ea3f7208a811b569bbeae8c42c5b2d
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19952
+  timestamp: 1755516354462
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
+  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
+  md5: 54a430923247a921a5c57e330e04549f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17104
+  timestamp: 1769477866762
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
+  md5: 9572b85d5f84049bc36867f49d498520
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23712
+  timestamp: 1768389384997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
+  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
+  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 304593
+  timestamp: 1762897374551
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
+  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
+  md5: 8cb4b1755a4a8fd6a57883863236ef2b
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36479
+  timestamp: 1728399618377
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
+  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
+  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18979
+  timestamp: 1774432898196
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
+  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
+  md5: 259205480d74c969b6bbd3c48662291e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30490
+  timestamp: 1774283018435
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
+  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
+  md5: 7125606e211300f51b43b14c7039c163
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198245
+  timestamp: 1767955393666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
+  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
+  md5: dea8a1c280fb8cb391be3b459d8dfac1
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52614
+  timestamp: 1772640999029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
+  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
+  md5: 2dbc150b61f12b744cf873c285f4a418
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17079
+  timestamp: 1762788451045
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
+  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
+  md5: 292a4c15bbd54feba358997e6d1b35db
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96597
+  timestamp: 1764588298747
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
+  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
+  md5: 6d505a62b565ff3d80d5a6662a83d54a
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-mypy >=1.0.1
+  - shtab >=1.1.0
+  - pytest-enabler >=3.4
+  - pytest-checkdocs >=2.4
+  license: MIT
+  license_family: MIT
+  size: 82797
+  timestamp: 1763637203264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
+  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
+  md5: c563bb71f4df90fc3b92cde204827564
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 742162
+  timestamp: 1773255564362
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
+  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
+  md5: 569d92e1732a69adff57813342a9c316
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libabseil-static =20260107.0=cxx17*
+  - abseil-cpp =20260107.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1384532
+  timestamp: 1770384636226
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.2-h3ec8f01_0.conda
+  sha256: 47b727b2add2529ee9f983fefda5307a728941e95f48b467119865ef17ec417c
+  md5: 7e646e7deafe4482bb0b9525ab748132
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.18,<4.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 875632
+  timestamp: 1761151790516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
+  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
+  md5: 9fe17fea3f12a5dcc483b89f48e361da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52393
+  timestamp: 1772045241614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
+  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
+  md5: 114f7a7ae6d01b7f5d568439769857f7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33684
+  timestamp: 1772045249959
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
+  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
+  md5: cdc0bbfec0c99b30d435b22341a716b0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78282
+  timestamp: 1762363571278
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
+  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
+  md5: 7cad8348df1c96bf2f0a697806d1b3b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 33634
+  timestamp: 1762363575967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
+  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
+  md5: 854af1d6af8b3565fa8c7edb2141a2de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 279951
+  timestamp: 1762363583050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.19.0-ha05a353_0.conda
+  sha256: d485833f2828450de36e7abf46645b05c56a72175c2d42e1963c92dce9fce2f6
+  md5: bf3bea70fcf78aa1ad48e76976bc67c0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.67.1,<1.68.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 499620
+  timestamp: 1774299460402
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
+  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
+  md5: 5065620db4393fb549f30114a33897d1
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 114011
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.5-h7354ed3_0.conda
+  sha256: cda922c9f09bfa17933d55849b9232416872b068018ab89580e379d5487a2c14
+  md5: 67c73f16b2eb58c1c73d5a3dc1645d14
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  size: 125091
+  timestamp: 1774555957601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
+  sha256: b0e7fe2e5d498bc5a2c57cf942701bba8f22ec55de55e092ffbffc40b816df88
+  md5: 70646cc713f0c43926cfdcfe9b695fe0
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 144691
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
+  sha256: baf9d8d16e2a8ae7a4d1b80f2c1a932deaca1a87c677a370f6ab4688482db47b
+  md5: 01fb1b8725fc7f66312b9d409758917a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_7
+  - libgomp 15.2.0 h4751f2c_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 825084
+  timestamp: 1762772576461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
+  sha256: 3a3678f17a8916777d03b83f19f673107b4a9bf55366234dcfa42edbd5173123
+  md5: 2783efb2502b9caa7f08e25fd54df899
+  depends:
+  - libgcc 15.2.0 h69a1729_7
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28356
+  timestamp: 1762772577850
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
+  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
+  md5: 775a5698ec2a0aa6e2435b86418b563f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 190134
+  timestamp: 1772045245717
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
+  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
+  md5: 5766eead346251db288d5b13c3dffd6f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36248
+  timestamp: 1772045253856
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
+  sha256: 835e44371812c91563a00dec8bc98c460f8b9f33f50543244bc8774c446a2172
+  md5: 82025ed6da944bd419d42d9b1ff116aa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 446183
+  timestamp: 1762772542830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
+  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
+  md5: 91b626db75392fc7254aaad8dc9a9850
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7252351
+  timestamp: 1770755115633
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
+  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
+  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 789520
+  timestamp: 1771491869505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
+  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
+  md5: 7ab70b332bb2df9ce90a1567126b5d2a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 82352
+  timestamp: 1760364378431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
+  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
+  md5: 3fd122ff074ed6bed89994053feb1fe3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 804625
+  timestamp: 1775137912599
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-h860b5fb_1.conda
+  sha256: 87776624e4882955942a61799db0cafd19e5ab26874ddcb99cca2d66a4ea287d
+  md5: c9351e4b3b09fbe3c3bba5526acbf19c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=11.2.0,<12.0a0
+  - libarchive >=3.8.2,<3.9.0a0
+  - libcurl >=8.16.0,<9.0a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx
+  - libstdcxx-ng >=11.2.0
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.0.18,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2061828
+  timestamp: 1763111696644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313h3f77f5b_1.conda
+  sha256: feedf8857d483851cf41a5ff9d625ea9c100194d54a974259072e215a3f86307
+  md5: a974c724de77f79cd7e926116fd861df
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=11.2.0,<12.0a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - libmamba 2.3.2 h860b5fb_1
+  - libstdcxx
+  - libstdcxx-ng >=11.2.0
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 663170
+  timestamp: 1763111784452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
+  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
+  md5: feb10f42b1a7b523acbf85461be41a3e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88085
+  timestamp: 1726088449399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.67.1-h697f920_0.conda
+  sha256: 73b3c00697e9a1a5693e9ff70f7995dc27ac11a72524cb9fd71b60b6da480a1d
+  md5: c509cea724fbc22300e5ce9ced97d569
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - c-ares >=1.7.5
+  - jansson >=2.14,<3.0a0
+  - jansson >=2.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libstdcxx-ng
+  - libxml2 >=2.13.9,<2.14.0a0
+  - libxml2 >=2.6.26
+  - openssl >=1.1.1
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zlib >=1.2.3
+  license: MIT
+  license_family: MIT
+  size: 651583
+  timestamp: 1762785235166
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
+  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
+  md5: 0801fbfd982d1a0de5cc895fed83a19c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3703875
+  timestamp: 1770634775371
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
+  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
+  md5: 0767b8ade520f4927ff9d5866d783f6b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210465
+  timestamp: 1770390434417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
+  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
+  md5: 0d547d53349f3fcf4a20c9a207c08a3b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 465860
+  timestamp: 1760357067289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
+  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
+  md5: dd68c24355431c0543339dda1404129d
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 315187
+  timestamp: 1732891131339
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
+  sha256: 747474162ae421d680ab3374d8b11158701206d4a9c4a8f9de557dd6fc13345a
+  md5: 7dc7ec61ceea5de17f3e2c4c5f442fc6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 h69a1729_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3903663
+  timestamp: 1762772586621
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
+  sha256: 7a39becf3c7dd6016d4b6d24587071cda2afefcdf2886ad16572095261c87b90
+  md5: cf200522c0b13d64bf81035358d05f5b
+  depends:
+  - libstdcxx 15.2.0 h39759b7_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28429
+  timestamp: 1762772606373
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
+  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
+  md5: e79c628574f0ed3b60bd63e6d78501a1
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 671850
+  timestamp: 1777465777755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
+  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
+  md5: 4a6a2354414c9080327274aa514e5299
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28110
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
+  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
+  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 901634
+  timestamp: 1772644974924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
+  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
+  md5: fdf0d380fa3809a301e2dbc0d5183883
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 440690
+  timestamp: 1746022211479
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.9-h2c43086_0.conda
+  sha256: 9bb90ed726ba5868488184f03aa1c18fe654e00aa36b570a16a66c3d350a868b
+  md5: 72d5d2d627dd9b7780781e7aa6a12689
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 684847
+  timestamp: 1761768971660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
+  sha256: 2e0a3ea3aba7ffaa9c2ce9b267b34b12859f93bde8e62cedcbbab6144776568f
+  md5: 338ee51e19ee211b7fc994d4ba88c631
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 60697
+  timestamp: 1756475934898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
+  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
+  md5: 1468bc20414b0fa8eb1b18d3a916039f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480121
+  timestamp: 1754999718088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
+  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
+  md5: 6f3445d61b923a4e22a50b4ede3c1865
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 377746
+  timestamp: 1775637820996
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
+  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
+  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 150496
+  timestamp: 1775657630843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
+  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
+  md5: 2ee58861f2b92b868ce761abb831819d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 159495
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
+  sha256: bfed5539652f10a2c344501a4d9928856b50d323fdd390c578fd08e856b7d648
+  md5: f515d22e3c87bcf86d4cd5c877bc34cd
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - sphinx-book-theme >=1,<2
+  - commonmark >=0.9,<0.10
+  - panflute >=2.3,<2.4
+  - markdown >=3.4,<3.9
+  - mistletoe >=1.0,<2.0
+  - mistune >=3.0,<4.0
+  - linkify-it-py >=1,<3
+  license: MIT
+  license_family: MIT
+  size: 242668
+  timestamp: 1767001668294
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
+  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
+  md5: 28351e7fd716ee4b3baef571be119b98
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151241
+  timestamp: 1728403996163
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
+  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
+  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - python-dotenv >=1.0.0
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 428184
+  timestamp: 1771960075711
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
+  sha256: b6ca5bd3f708610801723deb09a29941cb47061832659de55b414f0496bab3b6
+  md5: e909ab91f515181fff72f312cbe1dcb1
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346906
+  timestamp: 1779919393059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
+  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
+  md5: 39da6986b50a3eb3cbf60c9883f4b92e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26871
+  timestamp: 1758552191170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
+  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
+  md5: 3c19869ee69743cd3e6ed44610f7b845
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257750
+  timestamp: 1765382387320
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
+  sha256: a6da3706af1a527f98e4db5e9e492836d9315825ee99336230865493ae4ee0a6
+  md5: bd0dee4808dd6acb561fce514a345c3d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 167359
+  timestamp: 1761121509531
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
+  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
+  md5: b1fb5c763a2d3e15e633e84bccf52ce4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 123032
+  timestamp: 1750958840666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
+  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
+  md5: b9ee8adce00b801f3767671675300a6f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154942
+  timestamp: 1728385601732
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
+  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
+  md5: 0abfc090299da4bb031b84c64309757b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1137647
+  timestamp: 1753947487644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
+  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
+  md5: 36890f7abd98066b607211b1773e6343
+  license: MIT
+  license_family: MIT
+  size: 127326
+  timestamp: 1680082329609
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
+  sha256: 0b5bf6306956956c8346844723db74144b3d278bdb62cec34a0a74d3595f5b5d
+  md5: 718b1fc51e7c834eab78ed742d720a45
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - websockets >=13,<16
+  license: Apache-2.0
+  license_family: Apache
+  size: 1048147
+  timestamp: 1767167972500
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
+  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
+  md5: d842c01c08579c4398dc5b15a0bd875d
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79899
+  timestamp: 1763721155768
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
+  sha256: 0dcbe182b4b5270e2c5b35ec90418ae7e2de7a925f8617fdc939dee732a21b8b
+  md5: 96c41caadc229cc56c4fbcb26bb5b8cd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5818141
+  timestamp: 1772119658375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
+  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
+  md5: 8310c25ce1847aee276a9e2617388f46
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101271
+  timestamp: 1763996098531
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
+  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
+  md5: ea9c98e0799195320c546768f562f351
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37782
+  timestamp: 1764236782492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
+  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
+  md5: 4c6786f5a20a0d5705c77a18d97eebec
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43650
+  timestamp: 1764254904983
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
+  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
+  md5: de2d09e81412c0288e94586569f8276c
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33381
+  timestamp: 1764254429958
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
+  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
+  md5: a9aa9b02edaa6e129374ae281b4ace66
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58002
+  timestamp: 1764084155711
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
+  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
+  md5: e36ceb40f2e628e2b6d4bb62032539a1
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57320
+  timestamp: 1764164412130
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
+  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
+  md5: 2a77251102af2651654e23f12c0e58c6
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 274299
+  timestamp: 1764073186249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
+  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
+  md5: e794cf7621bbe67d177b7e279cd6d610
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 179330
+  timestamp: 1764062875253
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
+  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
+  md5: 76bffd8af6e6a162a1e7af69b9b800d7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 337138
+  timestamp: 1771945983540
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
+  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
+  md5: 0f7d4f61c3851a0d436b96e9cb02c393
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200822
+  timestamp: 1775004135549
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
+  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
+  md5: da78932ffefe7e3f780f75672b3f8b36
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51265
+  timestamp: 1772567686795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
+  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
+  md5: 49c2031dcebd085e49c3aff84479e314
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1289658
+  timestamp: 1759825800150
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
+  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
+  md5: a1e79da30a6c62c6398e9bb990ee9ed6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9162
+  timestamp: 1728388115083
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
+  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
+  md5: e1705a98bf3338281b413e1fc8484a12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54729
+  timestamp: 1773652981831
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
+  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
+  md5: 5c71fdece7639940072a849417bff8da
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47969
+  timestamp: 1776972936162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
+  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
+  md5: 7664f08981772ba49fef33294a096a18
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170398
+  timestamp: 1772733409298
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
+  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
+  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570052
+  timestamp: 1770660764829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
+  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
+  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550941
+  timestamp: 1761896477134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
+  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
+  md5: 973a642312d2a28927aaf5b477c67250
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  license_family: MIT
+  size: 5360
+  timestamp: 1505733967605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_0.conda
+  sha256: 1342d17b10c8d4c2a1299e64c2e9e9b3bb21f5d20a340f8fd95bc19bd484b652
+  md5: 615b5f8a0a168480d9c09adda1c4d690
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - pytz >=2025.2
+  - pydantic >=2.11.9
+  - keyring >=25.6.0
+  - asyncpg >=0.30.0
+  - hvac >=2.3.0
+  - rocksdict >=0.3.24
+  - elasticsearch >=8.0.0
+  - diskcache >=5.0.0
+  - cryptography >=45.0.0
+  - aiohttp>=3.12
+  - types-aiobotocore-s3 >=2.16.0
+  - pymongo >=4.0.0
+  - python-duckdb >=1.1.1
+  - dbus-python >=1.4.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - types-hvac >=2.3.0
+  - pathvalidate >=3.3.1
+  - aioboto3 >=13.3.0
+  - aiomcache >=0.8.0
+  - redis-py >=4.3.0
+  - cachetools >=5.0.0
+  - valkey-glide >=2.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 258923
+  timestamp: 1774282532566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
+  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
+  md5: 60ea7416e08d78563e31d16c333bd57f
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 93055
+  timestamp: 1736868559715
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
+  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
+  md5: 3b8ea90c558c424f123c1fc6069c9fa6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155521
+  timestamp: 1774959763398
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
+  sha256: 6c081cbd4131236658531e64370f14aabd59335a63a6b78360505bf8ba06e885
+  md5: 95234214667460a6e4eb9cd44c5facba
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1107018
+  timestamp: 1773134413559
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
+  sha256: 4964ef04532cce861183176123287df387db41329ad24a7256518b1ec1bb99b9
+  md5: d943970fbb63d8d9e6f5d805f2a6fbdf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1932101
+  timestamp: 1764009859395
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
+  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
+  md5: 52b991b3676ad69221ac4efe952ea622
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - google-cloud-secret-manager>=2.23.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  - pyyaml >=6.0.1
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  license: MIT
+  license_family: MIT
+  size: 151041
+  timestamp: 1764165180924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
+  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
+  md5: ccea3f7c3ca8da985a55fbc042ad8d82
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4943174
+  timestamp: 1775127040649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
+  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
+  md5: 3cbe7080967f615cd88efd025391b662
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 102773
+  timestamp: 1773773809562
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
+  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
+  md5: 41e5a9f1fb430fad7e10a9db74000502
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26218
+  timestamp: 1773985120703
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
+  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
+  md5: e1ab9ffa1588856f0bdbb204322568c4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35801
+  timestamp: 1761753024312
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
+  build_number: 100
+  sha256: 558a087f71909db8c04f634af023c94d128305f1b313560bf6ed9bb404f731bf
+  md5: f0c9d56e080ab6f2838d1626225cdd37
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 33182243
+  timestamp: 1771950585257
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
+  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
+  md5: a844b3df0b11b33f4742841d25146b6c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313830
+  timestamp: 1728385377316
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
+  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
+  md5: 6aa550906f91d13d1371c07e9cb5c5c3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51623
+  timestamp: 1768559707638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
+  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
+  md5: 213fed7b509c30119154cf77a958aa7d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253447
+  timestamp: 1763718602538
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.22-py313h06a4308_0.conda
+  sha256: 1698108e7f224df70f6514dc9bb833975b5c3f47345a4e1282db18e3598b5700
+  md5: aa89c2ed9a05853082cd19c20ba08656
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63807
+  timestamp: 1770213120083
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
+  md5: 5af1bf885def2fa779b0bb002e53651b
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157
+  timestamp: 1764349599777
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
+  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
+  md5: f700a9cc4e35fd699b4df403f8f14148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 224571
+  timestamp: 1773043070463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
+  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
+  md5: 2384f037ab798b6ce6097c717a8758dc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 253759
+  timestamp: 1763465523432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
+  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
+  md5: 631d76b2ec86efd85d6266113f7b20d5
+  depends:
+  - libre2-11 2025.11.05 h3356fce_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26001
+  timestamp: 1770390441796
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
+  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
+  md5: 33b7455bfa1462c42bbc9a0535070313
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19959
+  timestamp: 1760613452708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
+  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
+  md5: 8578e006d4ef5cb98a6cda232b3490f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 481826
+  timestamp: 1754485653893
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
+  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
+  md5: ce6e467c7e671a9214bc5d118b8e24a7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82123
+  timestamp: 1762536905383
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.4-h6a678d5_2.conda
+  sha256: 3c9233dc26c1e4264966c5b95ab7cb80748153ae1c3de688a503d9f84c888210
+  md5: 3c6dbc6c60b3897222d79359343e90fa
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29681
+  timestamp: 1714680903817
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.4-h6a678d5_2.conda
+  sha256: 7211f85590295c8dc29622fe02514f081a3a25dcc2dafcc741365ddb5aedee95
+  md5: b03aa4903158279f003e7032ab9f5601
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - reproc 14.2.4 h6a678d5_2
+  license: MIT
+  license_family: MIT
+  size: 21248
+  timestamp: 1714680919761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
+  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
+  md5: 120fcdc3014753b33a63db5930b7a085
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170579
+  timestamp: 1775066095969
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
+  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
+  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88122
+  timestamp: 1728411680534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
+  sha256: 4006abedbb05553a7f667566d23afbac4beea2097a96d0508c629b044affde0c
+  md5: f4775d8f7f987cff7f067c7a47c66723
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 604815
+  timestamp: 1760375652641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
+  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
+  md5: 42d308b4487e6a58261a971eb689044b
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33936
+  timestamp: 1771961295227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
+  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
+  md5: 9630d019be2bb127699a375157124a0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 346701
+  timestamp: 1762366536075
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
+  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
+  md5: dc961556c7bbe4e2aa959e36ab816dcd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271868
+  timestamp: 1762535994695
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
+  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
+  md5: dad8d758af9c2b4369776c601407d9bd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 136835
+  timestamp: 1762530306911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
+  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
+  md5: 6ce9737188317c940d461c09c18d0ab3
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31382
+  timestamp: 1775127026347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
+  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
+  md5: 985226bbcb23ebc859128ca676ad6321
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45387
+  timestamp: 1761903210853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
+  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
+  md5: 08038e054ee9e8419ea6aa3fd04455ea
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1665385
+  timestamp: 1775048728528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
+  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
+  md5: 843241073919fc2c912f6ed85d14681d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23136
+  timestamp: 1761912223128
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
+  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
+  md5: 7b2a4b5be590071e1b4dce77b413d26a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 264262
+  timestamp: 1734048099531
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
+  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
+  md5: 648ce63d75b826e85fb8801c8b4b4e44
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37483
+  timestamp: 1744271525796
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
+  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
+  md5: face17589cf2b386d76cc870234dfe6e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17447
+  timestamp: 1764329206740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
+  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
+  md5: c7b847a43363d2d77724b9ea04881088
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1265119
+  timestamp: 1773313781324
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
+  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
+  md5: 1fb18f68f15d21748310b2a09ea2f923
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21821
+  timestamp: 1745413175232
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.47.3-py313h06a4308_0.conda
+  sha256: f8d1b5a04bc9094bdc37f10bf227477dd3d1d7c02b5f41be1c91515b58649abb
+  md5: d75839b48c8d42e3e863de59994c4f96
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 176882
+  timestamp: 1756910754331
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
+  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3610181
+  timestamp: 1755243907117
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
+  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
+  md5: 782987d420694bdc4a207a16db446a56
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82730
+  timestamp: 1768296500871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
+  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
+  md5: d625085e004f964c54b88a3c6c5e8d7e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189342
+  timestamp: 1762896696002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
+  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
+  md5: 17b9f23e939b55ab9cab471b694a79d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 161112
+  timestamp: 1771398721582
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
+  sha256: 0e7167d3723f10bfade1a0b6c3c59829c2bf9705d8f3ffd57bdebdc3b6ddf1ba
+  md5: e3ab7e8538a252ccb235f1cf218bda52
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216170
+  timestamp: 1728385119935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.1-py313h06a4308_1.conda
+  sha256: 5236b0311bb9dc1b8643fed1666c2ff465225d055e14f7730ca43e63258c6257
+  md5: f365c6753a35068503a4fba9a29953ff
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49373
+  timestamp: 1762520921980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
+  sha256: abf3e9b5820c78d1ca3d41b91f9b7b67d13d3e6c3f2892cc10f6f2361b3f0c3f
+  md5: d9b03aa4048c711087209d7c35e3fb32
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313h06a4308_1
+  constrains:
+  - typer-cli 0.20.0.*
+  - typer-slim 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157493
+  timestamp: 1771513026151
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
+  sha256: 31e03fddda42d42d36db861c134ea402e4a7abe20a69a7a2b5bb07d42530737b
+  md5: 1d5785a482a13f84097ba02722141e5d
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - shellingham >=1.3.0
+  - rich >=10.11.0
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 112535
+  timestamp: 1771513011655
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
+  sha256: b8a7d942b5032ecb3fd4faa83c7f51aa290d38773eb74195d7df136998aef8b6
+  md5: 9dd2ed87dd542c2ccde13c6e2e29a311
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313h06a4308_1
+  constrains:
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7309
+  timestamp: 1771513016825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
+  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
+  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11238
+  timestamp: 1756280930223
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
+  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
+  md5: b5ea08882d6d5cca3e38a27a3575e85c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32310
+  timestamp: 1760614182019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
+  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 104756
+  timestamp: 1756280924315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
+  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
+  md5: ad4d17d499c69cca7e35518f53419f5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24140
+  timestamp: 1774276104417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
+  sha256: 450d16974ba2405a26ad7da3a2a2dc4f395246427d3f3471520f7a0810e57e74
+  md5: 23108bceb7bbce3e449c9c55ecbaa296
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 357351
+  timestamp: 1767810287147
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
+  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
+  md5: 302fdbeea413b0dc179b3ea16886718e
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141937
+  timestamp: 1768226450635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
+  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
+  md5: 2e099756135a2ef67be288cb2d8c3119
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313h06a4308_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39548
+  timestamp: 1768226455792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
+  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
+  md5: c28e5468c6d8844e76d22ac7baea58e4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 665707
+  timestamp: 1762175545430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.1.1-py313h828f358_1.conda
+  sha256: 8ba2673045897d4b473dd974281b5d17db2e3cd42feec3a57dace7ca5a2faae2
+  md5: 9a7b7a4267a510d59d226cd2c271e9cd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 431640
+  timestamp: 1767984676303
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
+  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
+  md5: 946018cc418258ab8d35ed63099a3181
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361630
+  timestamp: 1751974452259
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
+  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
+  md5: 6730c94b00e7d802f421acd3a435af84
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70377
+  timestamp: 1769450261731
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
+  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
+  md5: 446fbd19ad7929dd70635f0303c5047b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67121
+  timestamp: 1736540936116
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
+  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
+  md5: 8d5b22b094b6802334d7c8316c4091ce
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23000
+  timestamp: 1771372478643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
+  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
+  md5: 7a684ffa744044240b3061ad28531930
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 58122
+  timestamp: 1746171563556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
+  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
+  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26341
+  timestamp: 1746172168013
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
+  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
+  md5: 6298b27afae6f49f03765b2a03df2fcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 916212
+  timestamp: 1746110020649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
+  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
+  md5: a8005a9f6eb903e113cd5363e8a11459
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 13582
+  timestamp: 1745958707989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
+  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
+  md5: c284a09ddfba81d9c4e740110f09ea06
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19260
+  timestamp: 1745992279492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
+  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
+  md5: d810521a7b4a177fb3d1152cf84a778d
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 49889
+  timestamp: 1746169291297
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
+  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
+  md5: d95e8903fc0067086f153d04b8cbe578
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 95151
+  timestamp: 1746431898579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
+  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
+  md5: 79d7d6794c6adbc537fc98f94e204270
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 409903
+  timestamp: 1746172685149
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
+  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
+  md5: 412a0d97a7a51d23326e57226189da92
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-xextproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-renderproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 594175
+  timestamp: 1746046234466
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
+  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
+  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 635646
+  timestamp: 1772548381644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
+  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
+  md5: 39fdbf4db769e494ffb06d95680c83d8
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 76992
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.8.0-h6a678d5_1.conda
+  sha256: 47beed31dd48cbe0041f221e5b4521f2bd3d907b5dcc74cabfae9346c2ba5784
+  md5: 015d2d74ad3c8e53eec3358637433718
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 621367
+  timestamp: 1714510789193
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
+  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
+  md5: 0c22474f16e65bd9b52fd3b8d60a0372
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32106
+  timestamp: 1763977880529
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
+  sha256: cf30f83189a30b12a9239f132ea0ce676fa822a52045adb0f9ff9b3b4d79ead6
+  md5: 9f3a877e5e0fa0fb39253a59ff824861
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libzlib 1.3.1 hb25bd0a_0
+  license: Zlib
+  license_family: OTHER
+  size: 98150
+  timestamp: 1756475939641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
+  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
+  md5: 78685aca3b481cf213b92abfbe0b2b21
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 422402
+  timestamp: 1758189113863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
+  md5: 93b0e546434bfb874aeefd6bb6cf40bb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 622604
+  timestamp: 1758039176606
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
+  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
+  md5: b272288d02db5520249ca7870c2287b4
+  license: None
+  size: 2491
+  timestamp: 1617219512888
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
+  build_number: 51
+  sha256: 70892a5efb5803b565ba889b5479b6e866a0fabce3a7d2f648e494a9e7bff49b
+  md5: 66329dd81c60123e0d7c4c39b7ee7afe
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 1427721
+  timestamp: 1621385842900
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
+  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
+  md5: 6327e33161b8e0ae8b501af0b07ee435
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35447
+  timestamp: 1773069243126
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
+  md5: a8de75045d038d62c3553bdb1a2bf2b3
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - langchain-openai >=0.2.8
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116895
+  timestamp: 1773844596952
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
+  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
+  md5: cc86d0a53de1c9d4559f84313d92f08d
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda-token >=0.7.0
+  - conda >=23.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127355
+  timestamp: 1777996210212
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
+  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
+  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62286
+  timestamp: 1775469252673
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
+  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
+  md5: 0b644ecae935ac975164247e9f4d981d
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 845333
+  timestamp: 1772491214305
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
+  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
+  md5: bfb5d8d4df085842d8c0b2e056b9257f
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161380
+  timestamp: 1773934997584
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
+  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
+  md5: 7112210d85ff777ac172307690b79f45
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 168446
+  timestamp: 1773871519885
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
+  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
+  md5: 213c7a858140be70244c210c31e4da04
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160774
+  timestamp: 1773868123073
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
+  sha256: bb6cea8523fef86fdea911c9aa1a952f9a69b0f21e769263a7240e81be64693c
+  md5: 7cb0f3e63900985c9bbd872a4d0f2123
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75605
+  timestamp: 1779920836271
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
+  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
+  md5: aab07c0ab08553546780a3a40f8f2cec
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82829
+  timestamp: 1776808540195
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
+  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
+  md5: 37fbf9726b0439b29bba0e1cf52ae35c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11421
+  timestamp: 1763372675300
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
+  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
+  md5: 108a8bcd136312e83793f5cda2f350fb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26012
+  timestamp: 1761744922996
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
+  md5: 910687ebf7746e8562300e8f1996edc6
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318118
+  timestamp: 1773134422321
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
+  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
+  md5: 711f61b5492b94625605422dd8e326ed
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180516
+  timestamp: 1774959654156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
+  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
+  md5: 3bee8eb5a01e45d657bc7edc508dcde4
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 445207
+  timestamp: 1775206365399
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
+  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
+  md5: 63457f5636c2230e585b265ea721c2f8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1484918
+  timestamp: 1772489319478
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
+  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
+  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 522348
+  timestamp: 1751383856268
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
+  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
+  md5: 9dd92861bec232ccdf7869b0b05b453b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 385446
+  timestamp: 1764961345156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
+  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
+  md5: f580b2013db742598b2d59875bccf774
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 215406
+  timestamp: 1714510578082
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
+  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
+  md5: 6e3e5f38a8efcb439d36f091baa23034
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 217449
+  timestamp: 1769077676509
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.3.19-hd43f75c_0.conda
+  sha256: 3e384eff3151ac56bddedb0e283b8fd48e5f0f01467b46cbf6246323f2e213c2
+  md5: 51d892f6d58c233a961bb88a72a80d16
+  license: MPL-2.0
+  license_family: Other
+  size: 128939
+  timestamp: 1774365802467
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
+  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
+  md5: 1d25e042eebc783ff4804fc9c42852d2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41563
+  timestamp: 1764867403876
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
+  sha256: a3de2871ed01954e278c620333e134398b609eb2b40a065b5f285c33e8980ac3
+  md5: da57c7bf0bbdf1849008dbe93d75643a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151899
+  timestamp: 1767659159197
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
+  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
+  md5: d010d105070e615750bbb51b8f2b17f5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 317809
+  timestamp: 1761832800132
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
+  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
+  md5: c89d95c43d07b658088bb12631ce9132
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100336
+  timestamp: 1761744908393
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
+  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
+  md5: 7813f91a66f3a442e803469cf76e3e1c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328923
+  timestamp: 1764332280328
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
+  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
+  md5: efb9dc33b510e1c882b597d994f6ab3d
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-env >=2.6
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1270780
+  timestamp: 1771402352584
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
+  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
+  md5: 6577f526b527308e4bf66a7bdef0e7fe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285635
+  timestamp: 1762366425854
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
+  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
+  md5: 313fca7b4d867f8b06df3140548f9440
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38256
+  timestamp: 1762361650200
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
+  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
+  md5: 06c2848c6311674e19391d4b81b3188a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: CC0-1.0
+  license_family: CC
+  size: 132686
+  timestamp: 1734039347698
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.6-py313haa502f6_1.conda
+  sha256: ea8a8929b26ce11b136093b49ed47842617d235262abce14275a08b8733fa8dc
+  md5: 15cce1cf3010a45c2282a7c0a04a39ed
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=2.0.0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1685129
+  timestamp: 1775165946454
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
+  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
+  md5: 8f3083bd30c06eace150fbf4ff5acd33
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392308
+  timestamp: 1772065019547
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
+  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
+  depends:
+  - expat >=2.7.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1275876
+  timestamp: 1756144876643
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
+  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
+  md5: 77f95d4b0a5bf1b775dda3372544dbeb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37699
+  timestamp: 1728480059192
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
+  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
+  md5: 23079a69d0ac19cf9f264cfc36dfaf67
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  license: ISC
+  license_family: OTHER
+  size: 666622
+  timestamp: 1763718283404
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
+  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
+  md5: 3a916231ebb779a7c2d5230fca7a2792
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96633
+  timestamp: 1766163709520
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
+  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
+  md5: c73024412ae68d6afa90b3bfca1a3b28
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 939239
+  timestamp: 1761746641765
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
+  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
+  md5: 4f6a93a269938d34f89e6c56b07905a1
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 65683
+  timestamp: 1758610280179
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
+  sha256: 4d498a91280bc6dc6d9d0108f1f7fbf3cc732014b522621ee0ce2ee1dea24b8e
+  md5: d2c9e173a97f6bbc2bc18c77796c5a6f
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66788
+  timestamp: 1779915955594
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
+  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
+  md5: b34fd0d10946da439f9b357e3d42e1f5
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37088
+  timestamp: 1774388461266
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
+  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
+  md5: 23b284ce11d60c82ef766dbfc024277c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49018
+  timestamp: 1761560361917
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.5-h5b11e9f_0.conda
+  sha256: 7a040dac98974da19f3ad8c62349c3e2e99295671c35716da917e3ae42f42c88
+  md5: 90d02a912cfb7f3bea1f0107c5276c2a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libexpat 2.7.5 h5b11e9f_0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 25656
+  timestamp: 1774555880096
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.128.0-py313hd43f75c_0.conda
+  sha256: 10831bcd9e780eff2e3a1045d11d77eefaf38028eb9e1926291ceac5b9bb8d43
+  md5: e426f9ebee861421e9b7c984bb64a10f
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.40.0,<0.51.0
+  - typing-extensions >=4.8.0
+  constrains:
+  - httpx >=0.23.0,<1.0.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - email-validator >=2.0.0
+  - jinja2 >=3.1.5
+  - pyyaml >=5.3.1
+  - fastapi-cli >=0.0.8
+  - python-multipart >=0.0.18
+  - orjson >=3.2.1
+  - pydantic-extra-types >=2.0.0
+  - pydantic-settings >=2.0.0
+  - itsdangerous >=1.1.0
+  - uvicorn-standard >=0.12.0
+  license: MIT
+  license_family: MIT
+  size: 195510
+  timestamp: 1768401128402
 - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastmcp-3.1.1-py313hd43f75c_0.conda
   sha256: 25541e8c2d463538a366efe3768a9bc2c410d9d7b62c78023bedd113d05244ae
   md5: 890b979716890bda333d2b8da4e9df67
@@ -3524,6 +4548,2956 @@ packages:
   license_family: Apache
   size: 1057392
   timestamp: 1774377861488
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-11.2.0-hc5e0126_0.conda
+  sha256: 71d2a7ed8e4eceefbc6711d95295ba2a616de464a1e357282865bb631cd2ee58
+  md5: c7d95da4afe9887b02a792a5707a4bba
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 206105
+  timestamp: 1754990985187
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
+  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
+  md5: 8d10823536cc83aca7475e92af48e733
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 38822
+  timestamp: 1761750688451
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
+  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
+  md5: 29ce6f4467466ef1155fd8485c41b52c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h304d29d_0
+  - libasprintf 0.25.1 h8121631_0
+  - libasprintf-devel 0.25.1 h8121631_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libgettextpo-devel 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 529353
+  timestamp: 1772045298146
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
+  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
+  md5: c0f5a28ad7e3facdc8181ef762970499
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3969299
+  timestamp: 1772045273194
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
+  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
+  md5: 5a519fab2daa903499d90bef420c0c8b
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 170581
+  timestamp: 1770382377233
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
+  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
+  md5: 4648b65bcb134c3764a9e64f6e6953d8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 hec5afc2_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 831478
+  timestamp: 1770755033862
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
+  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
+  md5: 4786f45bc40fd0fb4b60c05d19e32179
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64484
+  timestamp: 1761931284057
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
+  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
+  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127463
+  timestamp: 1748526158318
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
+  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
+  md5: e4fc275a391afef3d78ec4149d5ad589
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 98508
+  timestamp: 1763634792733
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
+  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
+  md5: 63a3ec07509610236d9ad578a3b625aa
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - zstandard >=0.18.0
+  - click >=8.0.0,<9.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216526
+  timestamp: 1760447362829
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.0-py313hd43f75c_0.conda
+  sha256: c6954bcac5ea4799c6e7ae83e1a19b58df39819793109a2bf69ebfe4c33a4727
+  md5: db176a960a159bcfd981f1c16d4f3d88
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 16571
+  timestamp: 1735845498447
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-73.1-h419075a_0.conda
+  sha256: 666aa21f839d88ebafb9804da64076a61b081c0d390c2f57150400080cce9e41
+  md5: cb0845107bfb0b019a07516080fd9431
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 27496589
+  timestamp: 1692293356718
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
+  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
+  md5: 93b126011717941f140fd04b6dd6d37b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203848
+  timestamp: 1761912000622
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
+  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
+  md5: 465aead5c1e7b7a585ebb676781545a1
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71748
+  timestamp: 1772097105461
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.14-h998d150_1.conda
+  sha256: 4e8c5fbfee25074df634337a5d30841fc88bb5feedb89a02c138f85d5e7b54f5
+  md5: e0a9db0de5a436a8fa92f72bd09617c9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 42724
+  timestamp: 1705704607717
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
+  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
+  md5: 281677614ab4b309ddb5afd24c80cd26
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19436
+  timestamp: 1755516386420
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
+  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
+  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17035
+  timestamp: 1769477854229
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
+  md5: 3fc0a300184c6cfbbb48735e637b6f00
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23679
+  timestamp: 1768389385039
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
+  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
+  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 298136
+  timestamp: 1762897357507
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
+  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
+  md5: 9930fc2e22ba90d25992765ac140be02
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36927
+  timestamp: 1728480664723
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
+  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
+  md5: 793eb8901926bede7a6eebdce28cf6a0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19083
+  timestamp: 1774432919346
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
+  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
+  md5: 4660f274a8ff963e92cb29db01b37c91
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30439
+  timestamp: 1774283011961
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
+  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
+  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198026
+  timestamp: 1767955403846
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
+  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
+  md5: 022e69a93795b21be36f997e24f2b341
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52583
+  timestamp: 1772640996503
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
+  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
+  md5: da59899cde4411bae19ae5f15aebe373
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16920
+  timestamp: 1762788449938
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
+  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
+  md5: f303bbea09244d08acd0fad083bbd6eb
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96552
+  timestamp: 1764588304837
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
+  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
+  md5: c96025bac150402baa006c878d604992
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-mypy >=1.0.1
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 82677
+  timestamp: 1763637208740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
+  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
+  md5: 833bdaaca975deb8a858597241ecd5c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-aarch64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 783012
+  timestamp: 1773255553164
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
+  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
+  md5: 50deebc10eb4d612f1bb35aa92538797
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1402413
+  timestamp: 1770384640911
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.2-h9e3fb69_0.conda
+  sha256: 2e066b7f308658f772bd453b4e151ba43e7e1e9aef40fb80a88fd1a9d3f1e8d5
+  md5: f1e2109005623363f0bca6854a0e9a10
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.18,<4.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1002269
+  timestamp: 1761151803239
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
+  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
+  md5: 898dd823b7a53a708a69d86847903b0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52342
+  timestamp: 1772045233389
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
+  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
+  md5: 7b561a37cd2af9c7c194c2090e419ee3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 h8121631_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33644
+  timestamp: 1772045246611
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
+  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
+  md5: 607b0beebe5e0c3643f2fceee006d15e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78099
+  timestamp: 1762363467361
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
+  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
+  md5: 805855f8193938731ccba31427eaa37c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 31209
+  timestamp: 1762363472701
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
+  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
+  md5: bfc1f2cb23c1f160079289f797e97756
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 286206
+  timestamp: 1762363480172
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.19.0-hd99d008_0.conda
+  sha256: 8cd359cab520aec169feb0cfe08503d4efc878c324071b9a666c9a8d2afaca6c
+  md5: 923a7d9c10712dfc997e685ea445dc94
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.67.1,<1.68.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 516746
+  timestamp: 1774299451585
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
+  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
+  md5: 230e8093b929e64244f2c7e181705802
+  depends:
+  - libgcc-ng >=10.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115539
+  timestamp: 1619012635485
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.5-h5b11e9f_0.conda
+  sha256: e50822f322079932eb4ff6c806f7ea7043260bb1e4afd4ff74f258f06fa0a954
+  md5: 13c85e5a1e3397428462cb9c364abd16
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  size: 118612
+  timestamp: 1774555877019
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
+  sha256: 18fd986f0ef7f6a59c363e5305d06fe3f20509c39e3393fef60d722316828992
+  md5: 34c197394030fa553d97fc902585ee9b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 143394
+  timestamp: 1714483284040
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
+  sha256: 06ae831ca00e09a65ba8b5536e8b728be3eb909e0cf041ebcc542b92fa4bc969
+  md5: a31a8c63a5fe7234863f8e9dd2b20901
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_7
+  - libgomp 15.2.0 hf47c802_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 511039
+  timestamp: 1762772353789
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
+  sha256: e672543a5f8d8ae30c7feab3ba57a2960c46756ca24fb027e3f6284a88d44acb
+  md5: e7d01ec71523a231b0d3b83f33a2dd21
+  depends:
+  - libgcc 15.2.0 hc18542e_7
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28446
+  timestamp: 1762772355060
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
+  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
+  md5: 3c39fd72e5a005e81c78cefe0f4b0464
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 214938
+  timestamp: 1772045240107
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
+  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
+  md5: 60521b8fbf132abc3846a700f33374cf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36215
+  timestamp: 1772045253063
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
+  sha256: 69eeb9a1342df1ba18d0fa994ebf3a43a653cf48a006b8778682cf032cf1e565
+  md5: 3403656472f38870e65c29aa6065e00e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 449546
+  timestamp: 1762772309007
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
+  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
+  md5: eb5839753b2b8904f6d7107d6240ef23
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6933116
+  timestamp: 1770754985299
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
+  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
+  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 778215
+  timestamp: 1771491870922
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
+  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
+  md5: 5bd529c1efa0251f0cebe7f84a504f69
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 119389
+  timestamp: 1760364375350
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
+  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
+  md5: 690464725d117c8ec5194f57b56525b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 845865
+  timestamp: 1775137916299
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-hc4b5eec_1.conda
+  sha256: 3a06ed5da101445a72bbed867abcbb43b9cf05bf54ce9b6c40382554ca06991b
+  md5: b05e5a9cc5fc7b166d37b3859c4034bc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=11.2.0,<12.0a0
+  - libarchive >=3.8.2,<3.9.0a0
+  - libcurl >=8.16.0,<9.0a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx
+  - libstdcxx-ng >=11.2.0
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.0.18,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1989864
+  timestamp: 1763111663378
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h9fbafe8_1.conda
+  sha256: 266d4763906b5811fc8af23ec7b69b8b2b40b3588ec5999a199df4020d49db27
+  md5: d2269de613080d5a54a306aeed65cdfe
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=11.2.0,<12.0a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - libmamba 2.3.2 hc4b5eec_1
+  - libstdcxx
+  - libstdcxx-ng >=11.2.0
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 574461
+  timestamp: 1763111749830
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
+  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
+  md5: 8bd7f4c495a81af4914c899949e52542
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 125873
+  timestamp: 1726088467322
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.67.1-h9561ae0_0.conda
+  sha256: 130c8e0aa79b541c473b701a6cb598e5200e0ce02735485ce1aab85e66a3c141
+  md5: 0a0b516b0f968b856717d559944efbac
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - c-ares >=1.7.5
+  - jansson >=2.14,<3.0a0
+  - jansson >=2.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libstdcxx-ng
+  - libxml2 >=2.13.9,<2.14.0a0
+  - libxml2 >=2.6.26
+  - openssl >=1.1.1
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zlib >=1.2.3
+  license: MIT
+  license_family: MIT
+  size: 667251
+  timestamp: 1762785214718
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
+  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
+  md5: aa2d494311b59791b542ceedfc12ff2e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3507714
+  timestamp: 1770634686006
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
+  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
+  md5: 2d6e1172997c845d903d346b97494c07
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203733
+  timestamp: 1770390557525
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
+  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
+  md5: 40c52830df19329c37dd2f093eb944de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 471404
+  timestamp: 1760357069476
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
+  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
+  md5: a88e620d4eafd7f199a0502433e5e0c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332414
+  timestamp: 1732891127645
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
+  sha256: 13c51fceabb26176b862042f079e74bc6bfc527a658dfd76d184bfb4c0cf5e90
+  md5: 90938778a2b6d4ba5c618b6e95b07a4b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 hc18542e_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3832701
+  timestamp: 1762772364181
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
+  sha256: 928ee09e47b0ec7a7125e36a604e157ae24724117dd20706e1875e3bfb273f8f
+  md5: 34e6c37bb398595bc67ef229f5e60c80
+  depends:
+  - libstdcxx 15.2.0 h9538471_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28507
+  timestamp: 1762772385720
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
+  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
+  md5: a99663395dab887607b2e5a854389721
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 676495
+  timestamp: 1777465771156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
+  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
+  md5: 59cd225a7659291aa716c6cdae7e1363
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30035
+  timestamp: 1668082742967
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
+  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
+  md5: 52b484c9618823592d2c26632724dafd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 594684
+  timestamp: 1772644989262
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
+  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
+  md5: 28e00a696fd74b7550b7d1b8698e10af
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 443363
+  timestamp: 1746022227484
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.13.9-h729a2f8_0.conda
+  sha256: 4934f41e2776b11efab87b9e1cd28c2aa150ec6c4ba0df1ee61dbab23462d288
+  md5: ad018fbdca2c6fd5edb874ea572bb089
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 720922
+  timestamp: 1761768979409
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
+  sha256: 8dd49d0fe4a8a309e1aa22f96ff61d203eb719710436737042f6d0336635e18f
+  md5: 7d92046a5eb7a64af7ffbd0bc5ae7366
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 66950
+  timestamp: 1756475943009
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
+  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
+  md5: ff7911a6103418a2c907d8c0262dd7f2
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414985
+  timestamp: 1754999724928
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
+  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
+  md5: 77eab2a2d275f56e722b1aad11532fd3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 376687
+  timestamp: 1775637816376
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
+  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
+  md5: 8a1c323359558fc4a4df9191aa6d00fa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 143384
+  timestamp: 1775657550865
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
+  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
+  md5: 70c4ab9462183ac4af60852d2a79fbf6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 185496
+  timestamp: 1714510593467
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
+  sha256: a05d920a2e8fb12ed3778262c5f089533dee6b6288e2424738ec1e7aeab95287
+  md5: 39f85b75ecca46ab04ffaed82496e0fd
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - mistune >=3.0,<4.0
+  - linkify-it-py >=1,<3
+  - panflute >=2.3,<2.4
+  - commonmark >=0.9,<0.10
+  - sphinx-book-theme >=1,<2
+  - mistletoe >=1.0,<2.0
+  - markdown >=3.4,<3.9
+  license: MIT
+  license_family: MIT
+  size: 242704
+  timestamp: 1767001694138
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
+  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
+  md5: 1225f726844496e3564e4b2d6c539763
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151130
+  timestamp: 1728498536715
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
+  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
+  md5: b7268fc357df1edc377e4a02b5c5c115
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  - python-dotenv >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 430285
+  timestamp: 1771960065247
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
+  sha256: 830eba7a3d482bf580428ca3df9e79092d6e84525916de57e8a71ba188401ad7
+  md5: 500ea279af0692936f7d51b378eb25ba
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347389
+  timestamp: 1779919403644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
+  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
+  md5: 5ab5b1fc729b44eb2872d740d95c495d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26724
+  timestamp: 1758552208116
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
+  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
+  md5: 0514a2f7425fe0559d98b6593f8c936d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257086
+  timestamp: 1765382393281
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
+  sha256: 1f321a79e93054e15a30b78ef59a169d2c48bb81411304bdd5a08f9a6103b48f
+  md5: d8aa86705b3aa00966554fd8d3d6e3d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 168226
+  timestamp: 1761121492722
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
+  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
+  md5: 90c7270744a7c8abdf51b5fecf7a9c14
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 120613
+  timestamp: 1750958715349
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
+  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
+  md5: 4d635e1fed6b6841ae3db1e0377a7712
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153354
+  timestamp: 1728405954288
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
+  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
+  md5: 7a1863281d1b73c33d04a3709fda9bda
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1203577
+  timestamp: 1753947513381
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
+  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
+  md5: 9e9d478b40d0e254cd3b448f92f47e8c
+  license: MIT
+  license_family: MIT
+  size: 127337
+  timestamp: 1680082426492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
+  sha256: cbf21b326814a1d043b8ca3c5f5d5fec6cfc082e31d4a2e3a4b66a1837352a33
+  md5: 1f863d45456e44fda9e9d01e6ecf3679
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - websockets >=13,<16
+  - httpx_aiohttp >=0.1.9
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  - sounddevice >=0.5.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1039763
+  timestamp: 1767167972967
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
+  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
+  md5: 583ab7940537e3387afa8c18b28eeb1c
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79849
+  timestamp: 1763721155450
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
+  sha256: 8fadf5dae2d6cf940ab38fa58d964325032fcb1f5105783e928ec3068841168a
+  md5: d3628d798e959fc4dcb6f5521f98c9da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5672689
+  timestamp: 1772119615171
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
+  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
+  md5: 85b624fe49b39de9fbe86b79144cb7c4
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 100915
+  timestamp: 1763996095398
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
+  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
+  md5: fab7d6c7cd4ebefb06eada5bee45916c
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37829
+  timestamp: 1764236793947
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
+  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
+  md5: 211d4704424ad214a215cf0378e685cf
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43410
+  timestamp: 1764254906556
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
+  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
+  md5: 928d47e0634131263d53b97b8359431f
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33553
+  timestamp: 1764254406341
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
+  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
+  md5: aae5f23a1a4a2c152ee68f16d380ff15
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57805
+  timestamp: 1764084154068
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
+  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
+  md5: a93dfba7f5563c3430eb842ff88b7cb7
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57059
+  timestamp: 1764164411916
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
+  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
+  md5: 0ce00548bf7f2bc4d0cca918a84a3989
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275046
+  timestamp: 1764073129503
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
+  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
+  md5: f14b38ac757bcb80c206d16fb2e55592
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177920
+  timestamp: 1764062882890
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
+  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
+  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 334755
+  timestamp: 1771945967596
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
+  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
+  md5: ba91769862d81cb2c29f4918aae1a245
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 198468
+  timestamp: 1775004133206
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
+  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
+  md5: 730f7454d70a81d991ac05e09c699166
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51488
+  timestamp: 1772567675008
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
+  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
+  md5: d2a1b973881c8c0493bf1fd7b62a2918
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1177858
+  timestamp: 1759825801409
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
+  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
+  md5: ed391ccc6d6caaccedd5250fdeb48807
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9176
+  timestamp: 1728408515784
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
+  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
+  md5: cdff168e8e1d6bbfced0f9ce18a6534a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54735
+  timestamp: 1773652976404
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
+  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
+  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47904
+  timestamp: 1776972854196
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
+  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
+  md5: 08a8181515e8bdce86ee017bb1153d69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170028
+  timestamp: 1772733403459
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
+  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
+  md5: c65088b4df85204138e7899b7bb677c5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579494
+  timestamp: 1770660753322
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
+  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
+  md5: 55e55bb476470a157cf4b81f44283436
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550478
+  timestamp: 1761896485773
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
+  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
+  md5: bd26b7e13996984230e8ec67f3ebd4c7
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  license_family: MIT
+  size: 7035
+  timestamp: 1615912729649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_0.conda
+  sha256: f1bc44d14e47248ac41cd19f4248eefd19e0c8c653def8ebe34da121aac143f9
+  md5: 41d9139e9cf072086e73d2b8674a161c
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - valkey-glide >=2.1.0
+  - hvac >=2.3.0
+  - cryptography >=45.0.0
+  - aioboto3 >=13.3.0
+  - types-hvac >=2.3.0
+  - types-aiobotocore-s3 >=2.16.0
+  - pymongo >=4.0.0
+  - python-duckdb >=1.1.1
+  - cachetools >=5.0.0
+  - diskcache >=5.0.0
+  - keyring >=25.6.0
+  - rocksdict >=0.3.24
+  - pydantic >=2.11.9
+  - pathvalidate >=3.3.1
+  - dbus-python >=1.4.0
+  - elasticsearch >=8.0.0
+  - pytz >=2025.2
+  - aiohttp>=3.12
+  - redis-py >=4.3.0
+  - aiomcache >=0.8.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - asyncpg >=0.30.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 258279
+  timestamp: 1774282530353
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
+  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
+  md5: 574f6176492ab5f26a379307c7377a30
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92719
+  timestamp: 1736868553560
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
+  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
+  md5: 03fd00dba51a683e8d01f74ec63a1fec
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156035
+  timestamp: 1774959750947
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
+  sha256: 075b85319122a84033ed5e8671a404878daad18d896f69b8a7e5b946f1463667
+  md5: 02a133da4f575464a6424b568d582954
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1107670
+  timestamp: 1773134406974
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
+  sha256: f756ae4ab74fea66ac0f7b687e5ff72a736521e5d30c2959f5e06bb26b43bb92
+  md5: cb6fcb4bb58138dc49beda6d90d2f4cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1771859
+  timestamp: 1764009871699
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
+  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
+  md5: 8bcdca4304da9f754bfb1f5839f796dc
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - azure-identity >=1.16.0
+  - tomli >=2.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - pyyaml >=6.0.1
+  - google-cloud-secret-manager>=2.23.1
+  license: MIT
+  license_family: MIT
+  size: 150714
+  timestamp: 1764165157426
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
+  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
+  md5: 1e4f8926de2d91ff108ecf1f8d30371f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4941418
+  timestamp: 1775127034860
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
+  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
+  md5: 9f01b187aede17a6e8b192f35472b652
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103005
+  timestamp: 1773773803703
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
+  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
+  md5: 90a46389b262fac93bd471f2fc0ea5ff
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25832
+  timestamp: 1773985116510
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
+  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
+  md5: 43da0d039f7b195466a8be650fa38424
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35803
+  timestamp: 1761753028895
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
+  build_number: 100
+  sha256: 3440eaa5799c8adb5cf8973c0181f114b116ba9b3ef44a9ff31fbb50575a2243
+  md5: 1d5ed28a2ac1369d7d94b834e8d3a505
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.35.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 31723170
+  timestamp: 1771950827906
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
+  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
+  md5: 061428165f4369719796769975341cf7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 315827
+  timestamp: 1728405669914
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
+  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
+  md5: e07c79278a8a508e83e42d176ab595be
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51868
+  timestamp: 1768559706782
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
+  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
+  md5: b8dc8f719d9a94474d335a89ff1ab0a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253530
+  timestamp: 1763718606784
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.22-py313hd43f75c_0.conda
+  sha256: f868a7e78c5c2a474306668060bceed1f06b6a95e0525c0c34560dff68316759
+  md5: b936e94e4dc4c1841fa1cfd250cb3ab1
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63443
+  timestamp: 1770213004301
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
+  md5: fb2966848729243e63cc897cb90f1eda
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101
+  timestamp: 1764349598421
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
+  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
+  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 223054
+  timestamp: 1773043038462
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
+  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
+  md5: a9b067a53f219bf9ed2a4583154facf9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 245388
+  timestamp: 1763465541517
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
+  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
+  md5: bb43fdeb5e1bc6595d63be00f22eaf00
+  depends:
+  - libre2-11 2025.11.05 h1b0d54c_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25969
+  timestamp: 1770390562916
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
+  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
+  md5: d2228764ccb4ad95813f44effcaaa38a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19961
+  timestamp: 1760613342830
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
+  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
+  md5: f04b3cb7ab28e886ceb012e4e9626e82
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 509455
+  timestamp: 1754485781954
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
+  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
+  md5: f1cd02f5cac4c78dd00805f81f7b66d8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82590
+  timestamp: 1762536906694
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.4-h419075a_2.conda
+  sha256: 6b1fdbf185a6df47d04b841618860735efcc5cb6729835a7d381af0576743d44
+  md5: 50bf464f48566d71a2778149c54d9fb1
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 30679
+  timestamp: 1714680903704
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.4-h419075a_2.conda
+  sha256: 7637fbc980328f813717563f123a8d8f8f2da24920e35e1984f2fd860c9cec5c
+  md5: d4a07ee63f2fded787246f3eb2d2157c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - reproc 14.2.4 h419075a_2
+  license: MIT
+  license_family: MIT
+  size: 21136
+  timestamp: 1714680918050
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
+  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
+  md5: a7bcec6c82277f3990f35708bd05d660
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 171420
+  timestamp: 1775066082442
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
+  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
+  md5: 3f4000830e7a25be1df38114d361b976
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88285
+  timestamp: 1728500408740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
+  sha256: 3f941bc0664875e48deba64e64686f44b75b29d323063ec504a9e40c6b8c621c
+  md5: 097a66ceed127b2918383880bed077d2
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603684
+  timestamp: 1760375647067
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
+  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
+  md5: 167fe8ee5af593667148b74a02090717
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33721
+  timestamp: 1771961162662
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
+  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
+  md5: 7f93cb69d835d6256cc68d0c22843159
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 335795
+  timestamp: 1762366544737
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
+  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
+  md5: 28b23d252e0d230044637b0f8f88cca6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271533
+  timestamp: 1762535980215
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
+  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
+  md5: 26960af9de364b5745c254d1a6890c45
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 127958
+  timestamp: 1762530151153
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
+  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
+  md5: 529575cd8e6b7becb44a50d0d35009f0
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31316
+  timestamp: 1775127025036
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
+  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
+  md5: c9d0d757b916ddfd019821dbbc02a0d9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45447
+  timestamp: 1761903130898
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
+  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
+  md5: 10081f3addefc88e8127e68448bf9f6d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1666759
+  timestamp: 1775048722771
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
+  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
+  md5: d32e4a1ec001c6cef1aae68c11480c55
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23120
+  timestamp: 1761912222490
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
+  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
+  md5: 0cefa22396b339a17597faad550d9582
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 226027
+  timestamp: 1734048100065
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
+  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
+  md5: 626970a8b8398716c9b9f9025eafd307
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37500
+  timestamp: 1744271573927
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
+  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
+  md5: 219c67c8ff19787a64b06c2517d063e9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17506
+  timestamp: 1764329173905
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
+  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
+  md5: 55600c8be72a7624ebd63e54ed72cbe0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1281272
+  timestamp: 1773313781654
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
+  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
+  md5: 1596a495a1f3def74862ce0efcc8281e
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21754
+  timestamp: 1745413132458
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.47.3-py313hd43f75c_0.conda
+  sha256: 1143a28c21d0c234bf292910fd32f471cac3617850dc930f9760c8743fdab6bb
+  md5: 4e7e8a7d8b32b54e6fe2a5bc1ae2df44
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 176653
+  timestamp: 1756910709929
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
+  md5: 6a7f42565108e00d27f68f4ae5751c53
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3717438
+  timestamp: 1755243976411
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
+  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
+  md5: d5ba67844244cfccfa37b1b23ec83b23
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82633
+  timestamp: 1768296495852
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
+  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
+  md5: 8949c7ff2861d1b903cee84c0607eacf
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 188584
+  timestamp: 1762896685732
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
+  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
+  md5: 54a2c4b9c33935687b977159f85bb4cb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160713
+  timestamp: 1771398718073
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
+  sha256: ab62d2a4692749c680612ab3330fea299ff9245a550a9d0a07bebc969b5435ba
+  md5: 7df7fc6bcb911d97032699617ee74718
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212695
+  timestamp: 1728405381017
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.1-py313hd43f75c_1.conda
+  sha256: ff9d5e072d130624fe642a1005d9bdf27a4c0775b0eea072b38b9e6a605de83d
+  md5: 8900fdf0ddd06efe24eb8f7c6794ccb4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49415
+  timestamp: 1762520920919
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
+  sha256: 72528b21b18f32ce743af2e3e2bc1518935cde1cdf36dd46fd0189e98ef3901c
+  md5: a404eaf65b18781d5e5d0f3a02db930b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313hd43f75c_1
+  constrains:
+  - typer-slim 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157663
+  timestamp: 1771513020641
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
+  sha256: 7c1d7f40115ceba0cc000135f2e88a4dc41ca26615984bf01803f42de7e13647
+  md5: 06f7840d8233d7d3815c803d8950d653
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - shellingham >=1.3.0
+  - rich >=10.11.0
+  - typer-cli 0.20.0.*
+  - typer 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 112583
+  timestamp: 1771513006666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
+  sha256: 4695a00df558018887f458bd70b04c672d30d114b900444bfe845a577d8d1302
+  md5: 74f2f9f2479e83b49c21a310182f04d8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313hd43f75c_1
+  constrains:
+  - typer-cli 0.20.0.*
+  - typer 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7307
+  timestamp: 1771513011450
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
+  md5: 055d37ff4e41c9b9e33d2bb8919c263b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hd43f75c_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11203
+  timestamp: 1756280951293
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
+  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
+  md5: ff4e707bcf34fee0e2065cf2487e2103
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32401
+  timestamp: 1760614185275
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
+  md5: 017a18fc16caf581ce26bac0ad6f9efb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 101647
+  timestamp: 1756280944673
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
+  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
+  md5: e857fd0d00de0e82669ff9e06d27f6dd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24215
+  timestamp: 1774276085005
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
+  sha256: 82275c3c5f7e5eab48d74089cc207d4aa692f4a2efd30d4e992d1fd2d7775cca
+  md5: d7dea689ca62516ce02639d4663d1c53
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 357777
+  timestamp: 1767810287557
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
+  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
+  md5: ebabc185d4b18349d7bf0d9f5c3d2901
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140643
+  timestamp: 1768226452652
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
+  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
+  md5: cb02ecced70ccf3114a942f060eb4f66
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hd43f75c_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39602
+  timestamp: 1768226458187
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
+  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
+  md5: 27e470f3b095fe3116358db877c2a2ea
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 612267
+  timestamp: 1762175558240
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.1.1-py313h5331b00_1.conda
+  sha256: 1c63f47cdd8a02e84a0eac4310a93e386ca83c30c066d698a02e0ffa472e5593
+  md5: b60abe6911b141fc8469ee8852c5b1cc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 421473
+  timestamp: 1767984729070
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
+  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
+  md5: d6b2c092cb970c634a4b1376a8c212b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368295
+  timestamp: 1751974662854
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
+  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
+  md5: caf0597b40222d6f17f745bd54636cea
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70703
+  timestamp: 1769450262181
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
+  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
+  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67625
+  timestamp: 1736540966215
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
+  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
+  md5: 750a7b171e663c39f6ecc0771452514a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23909
+  timestamp: 1771372468468
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
+  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
+  md5: 4f190efcbddae546e15d54f3f0314b96
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 59357
+  timestamp: 1746171572210
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
+  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
+  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26965
+  timestamp: 1746172174098
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
+  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
+  md5: e87565f2b050d575ee056f472d062383
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 950329
+  timestamp: 1746110056137
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
+  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
+  md5: 96f0df92ef31ad0aaf27b6b373e4f510
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 14118
+  timestamp: 1745958715370
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
+  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
+  md5: 5bfda69ee113cfc8e38e0214c078ef4e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19895
+  timestamp: 1745992295156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
+  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
+  md5: 607d46e3586e0c7b93a4495e0fe52db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 50277
+  timestamp: 1746169296094
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
+  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
+  md5: f5e59a8d2737934ac40c9bf645a75c52
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 100170
+  timestamp: 1746431911997
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
+  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
+  md5: c4b133535086cbaaf2403b18dc377e4a
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 417862
+  timestamp: 1746172689660
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
+  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
+  md5: 46b530510556e0b1830c40b5ac625f0e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-renderproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-xextproto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 595620
+  timestamp: 1746046239552
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
+  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
+  md5: 0d2e76f65075404a9c26010882e7a786
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 643308
+  timestamp: 1772548369777
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
+  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
+  md5: 588d487b103786708d10c1800d048fd4
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  size: 77652
+  timestamp: 1619009841594
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.8.0-h419075a_1.conda
+  sha256: 85eff1a70501daf5e228b6f2f326506043886db106c03d170b0f931cb55b695b
+  md5: 51a2369fb0d068241603303f704835db
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 607901
+  timestamp: 1714510851512
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
+  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
+  md5: 89dedf7658549815d9e8d5456231932b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32299
+  timestamp: 1763977879242
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
+  sha256: db213b9f69ccaf2457daabc1a92a4ce0c7aab6bba8145a2e349812cd6f0b41b4
+  md5: 58ccfae41b6e3ad4fd6961071d450f6a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libzlib 1.3.1 h998d150_0
+  license: Zlib
+  license_family: OTHER
+  size: 105760
+  timestamp: 1756475948207
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
+  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
+  md5: 8d4a8433cf437f7ecc5aafa9874c2012
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 396870
+  timestamp: 1758189118512
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
+  md5: abc05ce4daceeb1fa321b365cb847975
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 594707
+  timestamp: 1758039173244
+- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
+  md5: c78d47374611a8e86f7a9817f3768160
+  depends:
+  - python >=3.8
+  constrains:
+  - conda >=23.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19864
+  timestamp: 1774907942644
+- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
+  md5: c0ad195970a65c174b997011ac13f2f8
+  depends:
+  - python >=3.7
+  license: MIT OR Apache-2.0
+  size: 49261
+  timestamp: 1758125010311
+- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
+  sha256: ae098ebc94df3b64f449052c4f2c765187a3e30e4981362d7a52fb802930f357
+  md5: 3e467ddfbd4e40a574474ae928f7a423
+  depends:
+  - boltons >=23.0.0
+  - conda >=26.1
+  - libmambapy >=2
+  - msgpack-python >=1.1.1
+  - python >=3.10
+  - requests >=2.28.0,<3.0.0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1777900169394
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
+  md5: d912068b0729930972adcaac338882c0
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 23826
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
+  md5: f115ef0af90b59f35ef56743955979a4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 39004
+  timestamp: 1627537099507
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+  sha256: a3ffa3423f3a1c2a5184fd3e83c4555c9b6d627b0ed2e101b2ab615d585c1f40
+  md5: 694138f71ea48d078f301a9a701bbc62
+  depends:
+  - python >=3.9,<3.14.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1178932
+  timestamp: 1774988902802
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
+  md5: 7f0df6639fdf60ccd3045ee6faedd32f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14215
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
+  md5: cda05f5f6d8509529d1a2743288d197a
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 20302
+  timestamp: 1616166645426
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
+  sha256: bab9c667cb352cdbbc895b4aa8c867221e2e98d5310d884e494540c0b5c1efce
+  md5: b46d6837d6e1ceabdf40378de048c581
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 120000
+  timestamp: 1772652196967
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
+  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
+  md5: 1784bef0a518f47b0cb442e02b75ce84
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35320
+  timestamp: 1773069152139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
+  md5: 88dc2eae5116b824692db6bb9b443eed
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  - langchain-openai >=0.2.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116841
+  timestamp: 1773844602363
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
+  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
+  md5: be96323ace383458edf5ef71f8e72654
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127712
+  timestamp: 1777996231900
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
+  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
+  md5: 52656bda190a7f2bec974f508a9f35f2
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-auth >=0.12.0
+  - anaconda-client >=1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62048
+  timestamp: 1775469312642
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
+  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
+  md5: c2a25adb6831401a65a5cdb63f88ba27
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 846994
+  timestamp: 1772491115479
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
+  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
+  md5: ed7020be4e2288dff58f60f7bf106fa9
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 162438
+  timestamp: 1773935019675
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
+  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
+  md5: a9010a6c725f4a11001406492d49f35e
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 169752
+  timestamp: 1773871547623
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
+  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
+  md5: eeca273b542009d5cd4e022bd2cb827d
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 162392
+  timestamp: 1773868150264
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
+  sha256: c4ddc9e821fc73d2febaa69445773a2d1e566197beb9ae76b217a09fec75a3d5
+  md5: 4fccbb8b017a20c662308ad20a1e72fe
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75562
+  timestamp: 1779920861440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
+  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
+  md5: 9916fa1108527ee314251aec8a0c7353
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 83086
+  timestamp: 1776808490341
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
+  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
+  md5: f39857a71feb6e39da9739228f340a78
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11405
+  timestamp: 1763372676418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
+  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
+  md5: c0c2fb9483677bb657eda6d491e5f29c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 25909
+  timestamp: 1761744968164
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
+  md5: 7e400853597f6d7237e927baa6706aa7
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1773134435123
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
+  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
+  md5: bafc36567bd5432aea186b203ccbe80d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180639
+  timestamp: 1774959652662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
+  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
+  md5: a76eeaf70ce3bead86b2c5da38121a69
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446875
+  timestamp: 1775206378569
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
+  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
+  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488689
+  timestamp: 1772489325506
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
+  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
+  md5: a5b55c281bf03fadccc2b9fb5e6c567d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 524228
+  timestamp: 1751383887927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
+  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
+  md5: 4f002093422042d948885e06821f150b
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17.0
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375456
+  timestamp: 1764961201718
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
+  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
+  md5: 27a1ffbd30ff6427c112a733410e2f57
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 132212
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
+  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
+  md5: ceb5c473b56eb1b79fd079f6b0d029df
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 177571
+  timestamp: 1769077680758
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.3.19-hca03da5_0.conda
+  sha256: 8a14f3cf9c266735eaa01a6879185e5a0518d0377f76d760633c7698e3cab036
+  md5: a7e9cfcf108c1488853b1d205e5ae380
+  license: MPL-2.0
+  license_family: Other
+  size: 129019
+  timestamp: 1774365821682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
+  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
+  md5: bb47e0b8fa0f637b245c34b5b357a5d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41149
+  timestamp: 1764867366355
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
+  sha256: 839ea683a30bfd322076dceafaa8752882feebb654afe9ddd8595e71db99faa1
+  md5: 65d56422e29c425a3a91c8e1c17888d0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151748
+  timestamp: 1767659160370
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
+  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
+  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
+  depends:
+  - __osx >=12.1
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 288576
+  timestamp: 1761832806745
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
+  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
+  md5: 6301ec890b186cbe5d8243254450651e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100213
+  timestamp: 1761744861372
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
+  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
+  md5: 7ac45ddb190136a57ad9b02e7e365ec0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328813
+  timestamp: 1764332257562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
+  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
+  md5: 1fbe06ba53189032094abfe761e965ce
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-env >=2.6
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275763
+  timestamp: 1771402227023
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
+  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
+  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285376
+  timestamp: 1762366427916
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
+  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
+  md5: 01a0bc32a49fd331d514dfd64446fb1e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38499
+  timestamp: 1762361650835
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
+  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
+  md5: 9a83af67c17d1c760cd7aff545ef7e0f
+  depends:
+  - libcxx >=14.0.6
+  license: CC0-1.0
+  license_family: CC
+  size: 134133
+  timestamp: 1734039345192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.6-py313hae07363_1.conda
+  sha256: 98fb481ec4aaa2986a1e3db853e4b72423a6ca0fe6ab9be9bc0d9ed79a412d11
+  md5: 3ac69dec44f28472bec0a94ce8dc44cd
+  depends:
+  - __osx >=12.1
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1583766
+  timestamp: 1775167156757
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
+  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
+  md5: 85c2e5e0e00bcd63d85871b80f060b1b
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392115
+  timestamp: 1772064911124
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
+  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
+  md5: 5e948f3d746f13d209bd09a9d2fb7758
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38129
+  timestamp: 1728591870413
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
+  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
+  md5: 83b6045550ea3f3984ad063b58c44f83
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpx >=0.28.0
+  - httpcore >=1.0.0
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 667571
+  timestamp: 1763718279384
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
+  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
+  md5: 84ceb2792085acb3459abeedb47f888d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96396
+  timestamp: 1766163600127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
+  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
+  md5: 54a125d07b398d692c81bcad8c0fc6df
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 940136
+  timestamp: 1761746670106
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
+  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
+  md5: c1112f1321fda31b8b182c011bd25f39
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 66105
+  timestamp: 1758610134265
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
+  sha256: 9ef08d154b7f88a5e232804d55aff2ff14c57693d4de856fdb6840ea97937034
+  md5: 2644ebe94b48d6c7e0b179c30807dfbd
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67101
+  timestamp: 1779916082564
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
+  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
+  md5: a1db257019eb3930e461aa5626be2c0e
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37392
+  timestamp: 1774388481869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
+  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
+  md5: cd68188eea25cf618d3ed80a746e34cd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 48744
+  timestamp: 1761560378218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.128.0-py313hca03da5_0.conda
+  sha256: 6fb3db76bfeb30e28707b52a5056e512bd42f96c731b4ef437a2bea5d35da208
+  md5: 944377cd6e1d22c9079dc7d605de20ec
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.40.0,<0.51.0
+  - typing-extensions >=4.8.0
+  constrains:
+  - uvicorn-standard >=0.12.0
+  - fastapi-cli >=0.0.8
+  - pydantic-settings >=2.0.0
+  - pyyaml >=5.3.1
+  - orjson >=3.2.1
+  - email-validator >=2.0.0
+  - pydantic-extra-types >=2.0.0
+  - httpx >=0.23.0,<1.0.0
+  - itsdangerous >=1.1.0
+  - python-multipart >=0.0.18
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - jinja2 >=3.1.5
+  license: MIT
+  license_family: MIT
+  size: 196018
+  timestamp: 1768401131556
 - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastmcp-3.1.1-py313hca03da5_0.conda
   sha256: fcdac29589ed776f311b521b563f41b81553bf176cd7c3489c7dd62e84f98721
   md5: 306acc6065d62af1f39051a6a4457fab
@@ -3568,6 +7542,2557 @@ packages:
   license_family: Apache
   size: 1062410
   timestamp: 1774377883971
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-11.2.0-h643473a_0.conda
+  sha256: 4a5fc475d626338504ac2f9947936c511151712b3d98f41e14091cbdbbcbecdc
+  md5: 4658ef48e7980c9c02455e16fb874492
+  depends:
+  - __osx >=11.1
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 192134
+  timestamp: 1754990881142
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
+  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
+  md5: 662529f545d783dc4148ad30f1110b51
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39679
+  timestamp: 1761750693438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h0087489_1.conda
+  sha256: 474dfdcd92ff2f76346f259e988a41d413e731558fdb515dc5b623bf89cbf897
+  md5: e348dbb8c6f1a03b14e13b5ec06128a8
+  depends:
+  - __osx >=12.1
+  - gettext-tools 0.25.1 h86cef2d_1
+  - libasprintf 0.25.1 hcc4682f_1
+  - libasprintf-devel 0.25.1 hcc4682f_1
+  - libcxx >=20
+  - libgettextpo 0.25.1 hd3943a6_1
+  - libgettextpo-devel 0.25.1 hd3943a6_1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h55097f8_1
+  - libintl-devel 0.25.1 h55097f8_1
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 541343
+  timestamp: 1777366825427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h86cef2d_1.conda
+  sha256: c49c5eb435c4a15367dcc722dab90ba8fe15a0ac7ab7ed01f8255e3448b18cad
+  md5: 002abaa93cfa4d989a91122d55719ed6
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h55097f8_1
+  - libxml2 2.14.4.*
+  - libxml2 >=2.14.4,<2.15.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3469625
+  timestamp: 1777366802264
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
+  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
+  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171931
+  timestamp: 1770382381497
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
+  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
+  md5: db94ba50dcc724b61f6f51982822577b
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libgrpc 1.78.0 h7694377_0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 761674
+  timestamp: 1770754627213
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
+  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
+  md5: 38e110c2ae2fb67d3ef1abfc786498f9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64806
+  timestamp: 1761931279662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
+  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
+  md5: 6d33385bdc014731d4369f0d0e09af73
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129364
+  timestamp: 1748526183257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
+  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
+  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92280
+  timestamp: 1763634775883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
+  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
+  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pygments >=2.0.0,<3.0.0a0
+  - zstandard >=0.18.0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217168
+  timestamp: 1760447208891
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.0-py313hca03da5_0.conda
+  sha256: 3b36d113033fbd06873ec3a42a43593655ed8b9d676cc5b4b9dac2472a4c158a
+  md5: cb105fd0a4a87512800bc9d5a6ad99b7
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 16865
+  timestamp: 1735845800331
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
+  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
+  md5: 48dcf4bb007f44e187fe29b1120e0ef9
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 23865757
+  timestamp: 1777922195678
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
+  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
+  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203509
+  timestamp: 1761912023966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
+  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
+  md5: 711d5bcfff34a45210902f5ef91c3ec6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72439
+  timestamp: 1772099900987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
+  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
+  md5: f4e4bcf521aa18ee57d0607ad48f284c
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 21271
+  timestamp: 1755516531252
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
+  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
+  md5: 0a89e92618b4328787ef72b0d94d8808
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17072
+  timestamp: 1769477856721
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
+  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
+  md5: 7174017dd1ce6c709a2b1d87156deb56
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24174
+  timestamp: 1768389389007
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
+  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
+  md5: ef1c78fa12751c0d455245582d1cb49b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 268149
+  timestamp: 1762897357212
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
+  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
+  md5: 9e1af96e93b8278ec9029f1bd38f4517
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37185
+  timestamp: 1728594571279
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
+  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
+  md5: 552bd935bf55a9099c7d2910a8d56391
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19004
+  timestamp: 1774432907812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
+  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
+  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30409
+  timestamp: 1774283033815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
+  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
+  md5: 0be71be35e5503bdecfebf75f1fa55c0
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198501
+  timestamp: 1767955687618
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
+  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
+  md5: bd5d17c69a377489445f1cac4b1390e7
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52745
+  timestamp: 1772641022505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
+  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
+  md5: 6cfee2660e901231d2fe274f02afeaf8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17167
+  timestamp: 1762788437806
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
+  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
+  md5: a691a010a6df73533294e436b2edb780
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97019
+  timestamp: 1764588302845
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
+  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
+  md5: d19d185ec9fd87908b74303c8e38893f
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  - pytest-mypy >=1.0.1
+  license: MIT
+  license_family: MIT
+  size: 83253
+  timestamp: 1763637330760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
+  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
+  md5: 112093c65f205a89992cf9cfc7120f41
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1224935
+  timestamp: 1770384634202
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
+  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
+  md5: 9368c8128813db74810effc28a6d0de2
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 783208
+  timestamp: 1777387020815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-hcc4682f_1.conda
+  sha256: 92490f2d7a793173adc3fc6ea31fedcceedf36e03bd60ae0ed0054a8db58ec4c
+  md5: d2a53560d3ed522db0e42c3359b5b485
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: LGPL-2.1-or-later
+  size: 50062
+  timestamp: 1777366750809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-hcc4682f_1.conda
+  sha256: 68c83c6e80279aa8fe0bb2b0166ff7e445ed5e20284103ebc7efdc95d2b3f889
+  md5: 30b14cd969c3443791d9a02cc3670915
+  depends:
+  - __osx >=12.1
+  - libasprintf 0.25.1 hcc4682f_1
+  license: LGPL-2.1-or-later
+  size: 33791
+  timestamp: 1777366761731
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.16.0-h01d3526_0.conda
+  sha256: b5fcc7e7382bca42ce86b3038ae03b9ebaa6ea69b581079a16d973c5f33c44fa
+  md5: 80e6e03e9a967b1c89975845e0596756
+  depends:
+  - __osx >=12.1
+  - libidn2 >=2,<3.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 390969
+  timestamp: 1761555409156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
+  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
+  md5: 344e08f75d799c1e5b57441a2a4c357d
+  depends:
+  - __osx >=12.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 316282
+  timestamp: 1775479658335
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
+  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
+  md5: 00cac99189c361c3b2cbf506ae6cc718
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106490
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.5-h50f4ffc_0.conda
+  sha256: aa8a1edb1076afd0c3f1881dc4cd57ab58c8d7a3289ac39ca103504d2c956c73
+  md5: 39948de0b74df7103d32d9eeab59cb3b
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  size: 110894
+  timestamp: 1774555845024
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
+  sha256: 800216cb554d0beaf970fe7c3efeee7974bb76576c1c5e0ae070c57fca2bba93
+  md5: 2bec9ee4b1214a3c3e2d1f2e18725daf
+  license: MIT
+  license_family: MIT
+  size: 122887
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-hd3943a6_1.conda
+  sha256: a79bc3262177055c8d4a367ac61975756942db5c4e97d319d167dd6c1fc3362c
+  md5: 008a4033018ea9ef9bac5a49af7b52ff
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h55097f8_1
+  license: GPL-3.0-or-later
+  size: 176696
+  timestamp: 1777366767819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-hd3943a6_1.conda
+  sha256: 87541ceaad5c717a8814b4d2dbae5051778af0e36b5afc5b1e3f1d152a786200
+  md5: b268ecbfe62a0030b050a4a04cac014b
+  depends:
+  - __osx >=12.1
+  - libgettextpo 0.25.1 hd3943a6_1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h55097f8_1
+  license: GPL-3.0-or-later
+  size: 36399
+  timestamp: 1777366777968
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
+  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
+  md5: 39336ad943dcc5f88ad31e32f1c4c66a
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4848994
+  timestamp: 1770754583246
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
+  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
+  md5: efcf143adafc878192a4ab5252f4cacb
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-only
+  size: 749113
+  timestamp: 1771491894949
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
+  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
+  md5: 4caba2988c52534c6ba5e88afebba106
+  depends:
+  - __osx >=12.1
+  - gettext >=0.21.0,<1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 114873
+  timestamp: 1760364408172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h55097f8_1.conda
+  sha256: c968c240abbf7cb8e716b6e46c000e41080431d43e9c9288dc27a9cb974edd63
+  md5: d2a79ee17b6db1b6c7dc3319c79fde05
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 84226
+  timestamp: 1777366756740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h55097f8_1.conda
+  sha256: 055656e5c2ec8cbdb9d89a2a48ff11a4e7d0480483920c123077eb4bc25d252e
+  md5: 792d607bddde98d9bebc7ec853f8b271
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h55097f8_1
+  license: LGPL-2.1-or-later
+  size: 38922
+  timestamp: 1777366772836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-hcdddc3d_1.conda
+  sha256: 4a9771ab23729aea3d9a9736c2f6ff1eb548d7dd5737934e8b571b7e31593552
+  md5: 7cd60c4d398e629da02f85ca1c9c6620
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=11.2.0,<12.0a0
+  - libarchive >=3.8.2,<3.9.0a0
+  - libcurl >=8.16.0,<9.0a0
+  - libcxx >=19
+  - libsolv >=0.7.30,<0.8.0a0
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.0.18,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1466323
+  timestamp: 1763111449765
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_1.conda
+  sha256: c297878fcf3baf04de81875eac275dce4cd1a19017ee68fc9364aae53068f7ea
+  md5: 8af2f87a53f6ee1d4396e609402e6dac
+  depends:
+  - __osx >=12.1
+  - fmt >=11.2.0,<12.0a0
+  - libcxx >=19
+  - libmamba 2.3.2 hcdddc3d_1
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 587576
+  timestamp: 1763111506082
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
+  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
+  md5: 7b01d2d5e276a24dd44e7846406656ed
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 70527
+  timestamp: 1726088461517
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.conda
+  sha256: 6f26e84b4452251879cf8d12af77833202736d6081eebd5fa8757cfa7eac67aa
+  md5: 32eac5d9a166c3cbce9b6dfef765b138
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 648894
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
+  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
+  md5: d45781f34f4b8e74d5b279e2e5d82c25
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2735206
+  timestamp: 1770634426661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
+  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
+  md5: 44b6b0d291189d289f38fa7bba97d117
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 164100
+  timestamp: 1770390432249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
+  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
+  md5: f39e89f9206a2366089b09a7cd209cf5
+  depends:
+  - __osx >=12.1
+  - libcxx >=17
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383544
+  timestamp: 1760357075048
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
+  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
+  md5: b5aa2854a5872c57538743b4a85a731d
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 298763
+  timestamp: 1732891144732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
+  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
+  md5: c457b6d1695d1b5b054632d2d5895517
+  depends:
+  - __osx >=12.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 644497
+  timestamp: 1777466299217
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
+  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
+  md5: 5b151376f98c09831d6bd730ca7794c8
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 418963
+  timestamp: 1772645021860
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.4-h2acab8a_1.conda
+  sha256: 1ec937aa6abde15942f00e9d7ec2b6e2082144e0502ff83e962e4a6a4033886a
+  md5: 87ae8fd271f57247baa0a1a7eea23ab8
+  depends:
+  - __osx >=12.1
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.16,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 557636
+  timestamp: 1778064229309
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
+  sha256: a51872f0fc7ccc4e448babffc9361a3544efe4fce31af0c63a4bb17e9f047615
+  md5: 5a533023e8ce9cae4f939e5eb9eceef7
+  depends:
+  - __osx >=11.1
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 47901
+  timestamp: 1756475936697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
+  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
+  md5: e535d29ea97147f0f6fb78a5a40c389e
+  depends:
+  - __osx >=12.1
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 374612
+  timestamp: 1775637687250
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
+  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
+  md5: 8b33a63dd414c362bc478d44fa6cad6b
+  depends:
+  - __osx >=12.1
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 122459
+  timestamp: 1775657525476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
+  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
+  md5: 82202ff2e94bc301fd9c790556506bb7
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160308
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
+  sha256: c8277cdfdc835839eb6c2acc162ca1f8d4357e13c32d842b282dc9654fff5e6f
+  md5: 2114d29335579a39de598a3208576547
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - mdit-py-plugins >=0.5.0
+  - mistune >=3.0,<4.0
+  - mistletoe >=1.0,<2.0
+  - sphinx-book-theme >=1,<2
+  - markdown >=3.4,<3.9
+  - commonmark >=0.9,<0.10
+  - panflute >=2.3,<2.4
+  - linkify-it-py >=1,<3
+  license: MIT
+  license_family: MIT
+  size: 243627
+  timestamp: 1767001669424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
+  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
+  md5: 4c3e970508e6cb3ad65579fb6b576143
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 149478
+  timestamp: 1728598048738
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
+  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
+  md5: 04ba8f0bfa78cef0456aeff11cfd1308
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - python-dotenv >=1.0.0
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 432541
+  timestamp: 1771960072114
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
+  sha256: 7dcb7ab7f6c3c0fd9301a4c760120e6bacd48762aee3269f304bea64e569ce91
+  md5: 9cd2d7945fcb775737365c00913343e4
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-api >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347924
+  timestamp: 1779919417576
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
+  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
+  md5: cc0fbba5b4ee07d4f979149d050c864a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26834
+  timestamp: 1758552196391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
+  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
+  md5: e5a706e1b73efa80d1ec1f23256e3b86
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257932
+  timestamp: 1765382400100
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
+  sha256: b9ab925d227d92daf0e76666bdfcd602197fce4a13ff2ae3792b86712ecce3ad
+  md5: ba0fd81d15324ef0abfb4110b83d82cc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 166259
+  timestamp: 1761121562080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
+  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
+  md5: 58664c7ab05f2559e22bc3030c90bd2a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 113263
+  timestamp: 1750958887102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
+  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
+  md5: 98737e4835cef677dbf6fa0d9d364968
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155808
+  timestamp: 1728586024156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
+  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
+  md5: d8a28b593d36653bec90bd2d78c7538b
+  depends:
+  - __osx >=11.1
+  license: MIT AND X11
+  license_family: MIT
+  size: 906808
+  timestamp: 1753947535285
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
+  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
+  md5: 5cc48a403acb53596382724e41f99a6b
+  license: MIT
+  license_family: MIT
+  size: 128547
+  timestamp: 1680082112201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
+  sha256: e669bbd6b577ee3e09db578293c262c37bc631beab5a6887c1944f9e56745b81
+  md5: 73458dbb241114ed06a5b561f7b048e5
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - websockets >=13,<16
+  - pandas-stubs >=1.1.0.11
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - pandas >=1.2.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 1050444
+  timestamp: 1767167836275
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
+  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
+  md5: b2bded54c66346cf90e89ea7e65d80f6
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 80685
+  timestamp: 1763721157221
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
+  sha256: 92cd3b69b02e8ca149bd387cfb168ba07d1d4f91f0921af5a280271c7aae1cad
+  md5: 1ff1b3ba66cd97c9be2819d012d58df4
+  depends:
+  - __osx >=12.1
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4948202
+  timestamp: 1772119560161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
+  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
+  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101534
+  timestamp: 1763996094518
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
+  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
+  md5: dd551f29b6694f41a405d347e5b7641e
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38099
+  timestamp: 1764236649957
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
+  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
+  md5: 9b13a4cb589d5fc73e302f66b526c922
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43323
+  timestamp: 1764254973641
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
+  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
+  md5: e65ca1299e5e4ca5f515faa509bd23ae
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33433
+  timestamp: 1764254395627
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
+  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
+  md5: 59267a3e2c335ee1d45d703dfaee30f7
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57708
+  timestamp: 1764084154910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
+  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
+  md5: c2f0aecc8a2ea835b91a7897ab121f5c
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57335
+  timestamp: 1764164412952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
+  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
+  md5: c5fda39e599753e09a32115eb8330bac
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275773
+  timestamp: 1764073043306
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
+  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
+  md5: 677be6639bad152b927832a09d639b72
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 180260
+  timestamp: 1764062877653
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
+  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
+  md5: 304016a5b391759778800af9f24e1332
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 305477
+  timestamp: 1771946048520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
+  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
+  md5: 16eee0ba12a1721ab94eb4f87517b5e2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200339
+  timestamp: 1775004034672
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
+  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
+  md5: edb4dc7d24225792e537e7db178ab7a5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51842
+  timestamp: 1772567682290
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
+  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
+  md5: dc957a9fa85669b0f6ce65ea9343fd8f
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 901944
+  timestamp: 1759825795666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
+  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
+  md5: 5c6344029e52293764fd4f88d6216c07
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9307
+  timestamp: 1728592695690
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
+  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
+  md5: f9e7cc4e6d37a4efe63452519464e148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54951
+  timestamp: 1773653001076
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
+  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
+  md5: 3550efa655956e28eb7282c3210bb015
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47964
+  timestamp: 1776972833748
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
+  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
+  md5: f686d9126128ed3d50046833a1b555a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170595
+  timestamp: 1772733427973
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
+  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
+  md5: 70879a51504dda5aff5034450b11a84a
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 461761
+  timestamp: 1770660566466
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
+  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
+  md5: 6bc6a220a229abae6afa80ccf4c3b06b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561023
+  timestamp: 1761896362276
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_0.conda
+  sha256: eeb86bfc9db2ecb4bfe8852460295b5dcd37d244ab302d67a920e18a98478646
+  md5: 08a6f7bf52ab151c245dd7dd816df303
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - types-aiobotocore-s3 >=2.16.0
+  - dbus-python >=1.4.0
+  - pytz >=2025.2
+  - aiomcache >=0.8.0
+  - python-duckdb >=1.1.1
+  - elasticsearch >=8.0.0
+  - redis-py >=4.3.0
+  - hvac >=2.3.0
+  - asyncpg >=0.30.0
+  - pydantic >=2.11.9
+  - cryptography >=45.0.0
+  - diskcache >=5.0.0
+  - types-hvac >=2.3.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - aiohttp>=3.12
+  - rocksdict >=0.3.24
+  - pymongo >=4.0.0
+  - valkey-glide >=2.1.0
+  - cachetools >=5.0.0
+  - pathvalidate >=3.3.1
+  - aioboto3 >=13.3.0
+  - keyring >=25.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 260440
+  timestamp: 1774282548095
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
+  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
+  md5: 2ee55b934de679d2f73bd0f3840f1dfd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 90639
+  timestamp: 1736868507679
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
+  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
+  md5: 63924165d4c0b49b018d6c6c742d5666
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140335
+  timestamp: 1774959697268
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
+  sha256: 263e4a340ba4b6425eca95b681181941bd060686daab3864062870e7d39fe7b5
+  md5: dffaab726a9b2000756aaebc6da806d7
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.41.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1108443
+  timestamp: 1773134360203
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
+  sha256: e18c0428812b74200603b8944868ad2ba753a30e1d5be86a44e84b560ad95bfb
+  md5: fb4b0939fbc6cce6be885131224f9c35
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1726048
+  timestamp: 1764009904442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
+  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
+  md5: 4bc0da3d9e06af7ce644b3901790c1ee
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  - google-cloud-secret-manager>=2.23.1
+  - pyyaml >=6.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  license: MIT
+  license_family: MIT
+  size: 150650
+  timestamp: 1764165172452
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
+  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
+  md5: 1a096beb854aaa14d863b4da60533f79
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4967892
+  timestamp: 1775127065874
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
+  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
+  md5: 208f064869aaa98b2340cc60eb64c58b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103272
+  timestamp: 1773773829773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
+  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
+  md5: c7bc813891134328cf9262beac3465db
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 479484
+  timestamp: 1763629905351
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
+  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
+  md5: fd8423aa2c161f1355d9eb5e53958096
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 377280
+  timestamp: 1763651408167
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
+  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
+  md5: 505cfc77c635faa08a4a889e1c6c8a10
+  depends:
+  - pyobjc-framework-cocoa
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26139
+  timestamp: 1773985028336
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
+  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
+  md5: 16bf831da5d9b80789ca8c06f958ae2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36057
+  timestamp: 1761753032083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
+  build_number: 100
+  sha256: cdb79b470fdce5061bfcc0188800e92361f24668d79b212d057240b0ff5ffc7a
+  md5: 19a38ad6775e08a4774572c2bbf2f187
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.19,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13569673
+  timestamp: 1771949586042
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
+  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
+  md5: 2ac600a5ed014f3b8fe2996b213a68e6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313686
+  timestamp: 1728585595371
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
+  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
+  md5: 69ed706ac95df59f56b448091f4c40fa
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51905
+  timestamp: 1768559713789
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
+  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
+  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253652
+  timestamp: 1763718722391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.22-py313hca03da5_0.conda
+  sha256: 1193284d818979968ff3ea025db81dead8b7ce6a25bc8ee8fb7ea88a863f228a
+  md5: 664d7612270a36fe3894eb84777ae034
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63072
+  timestamp: 1770212979157
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
+  md5: 12e362aabff119a51f51ac3c0f3d0a84
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6010
+  timestamp: 1764349560639
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
+  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
+  md5: 7faf2150ef3d3493e3554582fec52fcb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 226666
+  timestamp: 1773042949673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
+  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
+  md5: 5ea183aac23f4bbe41412f200a70d09d
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237854
+  timestamp: 1763465528485
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
+  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
+  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
+  depends:
+  - libre2-11 2025.11.05 hce96306_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26013
+  timestamp: 1770390441654
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
+  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
+  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 20018
+  timestamp: 1760613321490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
+  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
+  md5: fed853901ec41684b9e08b0c7ee4d7f0
+  depends:
+  - __osx >=11.1
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 475276
+  timestamp: 1754485689285
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
+  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
+  md5: 3fa52decbfabf965e84fd38bfb2e268f
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82518
+  timestamp: 1762536906534
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.4-h313beb8_2.conda
+  sha256: c762e27a07ece0e9977ae96f454ed40c4bef396d9f0c0fe3e7fb8059945b6d4d
+  md5: 91a2f6f75e6c6614f43ddc8ac2b3e0aa
+  license: MIT
+  license_family: MIT
+  size: 28562
+  timestamp: 1714680923465
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.4-h313beb8_2.conda
+  sha256: 86078c391e11c380a58e83825cd9f3e0498e0866e0aa2b77ba8fe6cce49e5274
+  md5: dde005914879790985acd3af3bf84e65
+  depends:
+  - libcxx >=14.0.6
+  - reproc 14.2.4 h313beb8_2
+  license: MIT
+  license_family: MIT
+  size: 21399
+  timestamp: 1714680948045
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
+  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
+  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170039
+  timestamp: 1775066216803
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
+  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
+  md5: 85f9714b8bf50cf6f9c75deb5441bba8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88498
+  timestamp: 1731721373383
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
+  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
+  md5: ffc0d1741d0d0dbff07518323feb64d8
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603836
+  timestamp: 1760375502207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
+  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
+  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33777
+  timestamp: 1771961170073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
+  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
+  md5: 150c83ebdcae2067ae5c34a05c1da4ed
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 311962
+  timestamp: 1762366565780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
+  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
+  md5: b292e4688f8ac6f1c97f1f3e895f5cff
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271430
+  timestamp: 1762535976251
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
+  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
+  md5: ca9e7978a1057363f0c36d975b764dcb
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 114492
+  timestamp: 1762530107760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
+  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
+  md5: 8b4a9bf142beac7513382b0a84ce51f5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45786
+  timestamp: 1761903046636
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
+  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
+  md5: c396551324d88dfb8c688affa5226c2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1669346
+  timestamp: 1775048820327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
+  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
+  md5: 58fe2f1c6896f6e26cea231b74e3888c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 22962
+  timestamp: 1761912224859
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
+  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
+  md5: 443db5b88521ce0e2aaeb77bcf8fb488
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 220407
+  timestamp: 1734048107599
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
+  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
+  md5: 4af6f9244bd475289f3410b1c8880ed9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 39474
+  timestamp: 1744271575294
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
+  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
+  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17410
+  timestamp: 1764329171349
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
+  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
+  md5: cf083b0b25fff8ddab995ac001076f38
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1182590
+  timestamp: 1773314600429
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
+  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
+  md5: 685d7b964cfdfd152fb5ddc0951b16d2
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23284
+  timestamp: 1745413263670
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.47.3-py313hca03da5_0.conda
+  sha256: 4e340c9a1a336a863e70ddeedfac8407e5753b6ca77496f17d992c137361514a
+  md5: e17a539f880afd365a5ff1a388ec6605
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 177175
+  timestamp: 1756910711562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
+  md5: d1329e6c7292f448cdeed21290dd1035
+  depends:
+  - __osx >=11.1
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3448719
+  timestamp: 1755244020166
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
+  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
+  md5: 65d4e75c4c995d35de71b4e16174828c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82474
+  timestamp: 1768297453889
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
+  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
+  md5: 9199e3c9a0451d04eff558d461dd1b2c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189601
+  timestamp: 1762896659686
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
+  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
+  md5: af4d88d628ea31190ed1432bba93b9c2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160792
+  timestamp: 1771398721170
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
+  sha256: c06d6a4a9b21b72720bbbe2bcb0d850290df50925360cdc744115e1894f5176b
+  md5: 176fa6f06b48bfbbe763addd30ff154f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213397
+  timestamp: 1728585495815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.1-py313hca03da5_1.conda
+  sha256: 678639cde456bae6e4a11ce9118be17eebb4113963eb7aca2be86bd425d64e59
+  md5: c65542bf580047dbffdedaf763057c77
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49457
+  timestamp: 1762520944435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
+  sha256: fe035489f4bed2ab2fa0f51ae50faaf7c9b7390252b86123cbae4d3e45e178df
+  md5: 2a00d5da027f2f72dfd4b05c178afb29
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer-slim-standard 0.20.0 py313hca03da5_1
+  constrains:
+  - typer-slim 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 157900
+  timestamp: 1771513056344
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
+  sha256: 3e3e58ea2dabbc9ebe99e5a83d360c33642de0485fa07bcfa4f4bb1fa870f58b
+  md5: eaad783ddbeddae5d991cf850033e284
+  depends:
+  - click >=8.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=3.7.4.3
+  constrains:
+  - rich >=10.11.0
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 112806
+  timestamp: 1771513038567
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
+  sha256: f10f6c39573b002cd7ed525c97e3a1033525b17e2ca9f635c7965ad1578e5d98
+  md5: 9d8e87a1f5725cf60bba4ec5094b80ae
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - shellingham
+  - typer-slim 0.20.0 py313hca03da5_1
+  constrains:
+  - typer 0.20.0.*
+  - typer-cli 0.20.0.*
+  license: MIT
+  license_family: MIT
+  size: 7235
+  timestamp: 1771513045167
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
+  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
+  md5: 22b46f0e6d389d4199ffaa317e9c9a05
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12434
+  timestamp: 1756281597870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
+  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
+  md5: 1398c39b86119164f19498b6fbcfdb69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32465
+  timestamp: 1760614190333
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
+  md5: 3c37609330dd4baeb0f4842f02cb783e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 106009
+  timestamp: 1756281579411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
+  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
+  md5: 7c281290dab4999400a1e12be880c3a2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24287
+  timestamp: 1774276373831
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
+  sha256: 375349eeb47983e6e2b2d2608f7141d948e5396e2906b087781d4f49df8dad0c
+  md5: 464328fc7f4e77667c63d5284e866e85
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 357592
+  timestamp: 1767810426391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
+  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
+  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142181
+  timestamp: 1768226456487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
+  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
+  md5: eea1461696459cc24a16b5a689281400
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hca03da5_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39438
+  timestamp: 1768226463310
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
+  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
+  md5: 62098dfc2ae82083a56bfd7bc319cf0e
+  depends:
+  - __osx >=12.1
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 545986
+  timestamp: 1762175544791
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.1.1-py313h931abed_1.conda
+  sha256: 53edfc478b14716b82ac71ee21940a4d0512e6af5a5426cccdc1f67ac32d03fb
+  md5: 3ef9c9cd73f6f7bd7cb9ec85cf3440aa
+  depends:
+  - __osx >=12.1
+  - anyio >=3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375190
+  timestamp: 1767984700820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
+  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
+  md5: ec80386b367f09af4b44b3824e29acce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363811
+  timestamp: 1751974819165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
+  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
+  md5: 0d4dafde912fdee412dadf279d688eb5
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70617
+  timestamp: 1769450358672
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
+  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
+  md5: d75550f3641901250eaa43ed71dc40d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65365
+  timestamp: 1736541780222
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
+  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
+  md5: bc7f39bd763f6957ec91046f0e67a9f3
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 269216
+  timestamp: 1772548381049
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
+  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
+  md5: 23a9bda10db68f27fac5c379466c98b7
+  license: MIT
+  size: 73088
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.8.0-h313beb8_1.conda
+  sha256: 116aa14d2455e97e892141e57bb215b747c09caa4d34de289bfcc6bd962cb507
+  md5: 788e42390f4b031fb47b547797baff69
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 484110
+  timestamp: 1714510972284
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
+  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
+  md5: 1b87c5130b5fd6d1738e28799f8b8236
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32097
+  timestamp: 1763977879589
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
+  sha256: 0af76c0fbf1697cfd54ada59547e8d086ab113b6dfcc9360aab573a6eb711771
+  md5: eb0fb89b08890d755421c26fae5a8909
+  depends:
+  - __osx >=11.1
+  - libzlib 1.3.1 h5f15de7_0
+  license: Zlib
+  license_family: OTHER
+  size: 78512
+  timestamp: 1756475938331
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
+  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
+  md5: b282b2aecb718102ee0bb3848514689a
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349977
+  timestamp: 1758189118260
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
+  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
+  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 471230
+  timestamp: 1758039171969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
+  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
+  md5: c62bd3bff5cb11570247115c1ab81225
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35318
+  timestamp: 1773069363087
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
+  md5: c486692f9df9720276afb556abff5361
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - mcp >=1.26
+  - pydantic-ai >=1.50
+  - langchain-openai >=0.2.8
+  - llm >=0.22
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116690
+  timestamp: 1773844804490
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
+  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
+  md5: 5f4b80f4355b922b23fdd3456c6d4001
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152577
+  timestamp: 1777996277515
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
+  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
+  md5: 5717d515db735fe7167bd3b5ea7bdc50
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86912
+  timestamp: 1775469436561
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
+  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
+  md5: e10dea7c74568841ed1cd5d8ec12ca92
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 870768
+  timestamp: 1772491405834
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
+  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
+  md5: 643c72f55e9de9926eabd069edbf2322
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161935
+  timestamp: 1773935085468
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
+  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
+  md5: c2ebc9fa966f6b08ea187fa807641415
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 226857
+  timestamp: 1773871887979
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
+  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
+  md5: 6f2969069844333afb09ed91b701abe0
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160509
+  timestamp: 1773868198156
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
+  sha256: 4aee689864b9fb410377657a00567a91a8684a5c65d9d6f652334b01712a479c
+  md5: fdbf822269394ba6e2e0eabd16a007d6
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100191
+  timestamp: 1779920913902
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
+  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
+  md5: 8d4b877231bde39bd3ef1270fb015389
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82692
+  timestamp: 1776808693739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
+  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
+  md5: 250197e0edb4f89e9d3199c32fcecd5d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11465
+  timestamp: 1763372717011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
+  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
+  md5: 2c7171d6d58b9364b4406ab1c85ee50b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26185
+  timestamp: 1761745147069
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
+  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318164
+  timestamp: 1773134551978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
+  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
+  md5: 2a3be388a9418ec78c921662e816d826
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 181026
+  timestamp: 1774959795526
+- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
+  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
+  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 448508
+  timestamp: 1775206412930
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
+  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
+  md5: f38f1b967e522121f347c6e53e50386e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488599
+  timestamp: 1772489378490
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
+  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
+  md5: 78e0f7a51d811d64b0d0fa4e886458f2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523882
+  timestamp: 1751383878776
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
+  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
+  md5: 964620a4cb8353969963fbb7b045b01c
+  depends:
+  - cffi >=1.17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 355904
+  timestamp: 1764961470388
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
+  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
+  md5: 33e784123d565c38e68945f07b461282
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 91870
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
+  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
+  md5: f6f293f1ec437a5a362252af20d31e50
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 203491
+  timestamp: 1769077840032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.3.19-haa95532_0.conda
+  sha256: 922ec2dc939cf5a6790a391d5164952ab4c3802ab882fad71da361888a20ad81
+  md5: 646f2cc64c282566396335d4e352a3b4
+  license: MPL-2.0
+  license_family: Other
+  size: 128933
+  timestamp: 1774365840323
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
+  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
+  md5: 9ce972c71a87d4d90534a24d77e99cb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41594
+  timestamp: 1764867445911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
+  sha256: cc1f29494f63fed7d925e545e1f8c47f51e8e06f856b4d15a40925c07e81fed5
+  md5: 5808bf0191f70eb95f0cc7d7faf7eaea
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 151549
+  timestamp: 1767659399196
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
+  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
+  md5: d1e9e395ff8688288d67b89e896c2b6c
+  depends:
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 299121
+  timestamp: 1761832847099
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
+  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
+  md5: 9e4732d3d22b2cf01fc408696e8ebd41
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 124770
+  timestamp: 1761745054105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
+  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
+  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
+  depends:
+  - colorama
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328826
+  timestamp: 1764332409785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
+  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
+  md5: b73ebc8eb01ba1e79ad34303e2975694
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55002
+  timestamp: 1729036609433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
+  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
+  md5: 301f7c7830bdf835d4fcf93e0122da7a
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-env >=2.6
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275313
+  timestamp: 1771402340575
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
+  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
+  md5: 0bf62b2027e8a656a86e1c4a7e71142c
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 309759
+  timestamp: 1762366569467
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
+  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
+  md5: d9081bd54908ac92135e6fb20d0aade2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38102
+  timestamp: 1762361726254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
+  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
+  md5: 67a55401db50a1d6bde2b153a74bcb07
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: CC0-1.0
+  license_family: CC
+  size: 133944
+  timestamp: 1734039396266
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.6-py313hbfe00f4_1.conda
+  sha256: 6ffe06d9e0fdc259fa0ff6637c9a5d1e5cf63956cd14ac2b773e02ce55432327
+  md5: 60bf04e1104890a8841e4517a028cf6c
+  depends:
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1481930
+  timestamp: 1775166420995
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
+  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
+  md5: db173ac83b3843bec70a8b2070881460
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 448738
+  timestamp: 1772065243755
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
+  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
+  md5: 9a502db95e7e272d1b7ed53f03dafab2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63476
+  timestamp: 1729059201537
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
+  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
+  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  - trio >=0.30
+  - idna >=3.10
+  - wmi >=1.5.1
+  - cryptography >=45
+  - h2 >=4.2.0
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 666555
+  timestamp: 1763718371551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
+  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
+  md5: 6c03175c12338ebc8273659a72c462ce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96782
+  timestamp: 1766163871411
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
+  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
+  md5: bbfbf4a353f2adbd724998ab6083802f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 1014370
+  timestamp: 1761746691814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
+  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
+  md5: 0aec5daa5284e9e3967c95a79f775012
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 90963
+  timestamp: 1758610340546
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
+  sha256: fb3ce799f193bcb6e33061ad6f975654b06f3342c3c10a72664f9cfb23ac5c4d
+  md5: b7b2eed90ced3af325d06a98dfa4c4b0
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91692
+  timestamp: 1779916032565
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
+  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
+  md5: f61420d4421c1f5c8ecb2d0cac6a910c
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37648
+  timestamp: 1774388523034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
+  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
+  md5: be5485351f1313fc4628d30117e0fdd5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49233
+  timestamp: 1761560536661
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.128.0-py313haa95532_0.conda
+  sha256: 0f0185034ee22e4d7e4cd27a7422be8dec68f67ea42c2c9a3dfe0d29d8c21da9
+  md5: 27ac4e0463fbab1360fe56504c95396e
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.40.0,<0.51.0
+  - typing-extensions >=4.8.0
+  constrains:
+  - pyyaml >=5.3.1
+  - uvicorn-standard >=0.12.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - fastapi-cli >=0.0.8
+  - python-multipart >=0.0.18
+  - email-validator >=2.0.0
+  - orjson >=3.2.1
+  - pydantic-extra-types >=2.0.0
+  - itsdangerous >=1.1.0
+  - httpx >=0.23.0,<1.0.0
+  - jinja2 >=3.1.5
+  - pydantic-settings >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 253473
+  timestamp: 1768401259271
 - conda: https://repo.anaconda.com/pkgs/main/win-64/fastmcp-3.1.1-py313haa95532_0.conda
   sha256: e2ac0a58de7fbad8d04788f6cbd9411d8ad4887e20c090270677807dbff6e4a5
   md5: 37a1c03b4d1c38f1844c89147df17bca
@@ -3612,37 +10137,6 @@ packages:
   license_family: Apache
   size: 1086285
   timestamp: 1774377928366
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-11.2.0-hca5f364_0.conda
-  sha256: 851afd6890164c6894572c275a7d3fb87dac4ce8b3760925febb2c3779306275
-  md5: 0615a40b477dd3a4488d67cd422a1365
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 206513
-  timestamp: 1754990938922
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-11.2.0-hc5e0126_0.conda
-  sha256: 71d2a7ed8e4eceefbc6711d95295ba2a616de464a1e357282865bb631cd2ee58
-  md5: c7d95da4afe9887b02a792a5707a4bba
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 206105
-  timestamp: 1754990985187
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-11.2.0-h643473a_0.conda
-  sha256: 4a5fc475d626338504ac2f9947936c511151712b3d98f41e14091cbdbbcbecdc
-  md5: 4658ef48e7980c9c02455e16fb874492
-  depends:
-  - __osx >=11.1
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 192134
-  timestamp: 1754990881142
 - conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-11.2.0-h58b7f6e_0.conda
   sha256: 34df803b78d9c5b23674c0663b505980025afbc6098d8fb53cb9b6c1b4b33082
   md5: de02359dfe1a0b71736085f1e65508f1
@@ -3654,41 +10148,6 @@ packages:
   license_family: MIT
   size: 209011
   timestamp: 1754991152830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
-  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
-  md5: 26dfe875df9973e0e98ec5add063e00e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39148
-  timestamp: 1761750688493
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
-  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
-  md5: 8d10823536cc83aca7475e92af48e733
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 38822
-  timestamp: 1761750688451
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
-  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
-  md5: 662529f545d783dc4148ad30f1110b51
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39679
-  timestamp: 1761750693438
 - conda: https://repo.anaconda.com/pkgs/main/win-64/frozendict-2.4.6-py313h02ab6af_0.conda
   sha256: 95ee413c83df0269fea089be2bf2fa7c1761a986d213f1c6926d4bd904176180
   md5: 16d7e8878fbec9e9856e9b7b3a7d41cb
@@ -3702,129 +10161,6 @@ packages:
   license_family: LGPL
   size: 39675
   timestamp: 1761750775394
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
-  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
-  md5: df53b928c3a9dd53c7f4e87cc03e03d2
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h6a67909_0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libasprintf-devel 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libgettextpo-devel 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 535333
-  timestamp: 1772045309664
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
-  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
-  md5: 29ce6f4467466ef1155fd8485c41b52c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h304d29d_0
-  - libasprintf 0.25.1 h8121631_0
-  - libasprintf-devel 0.25.1 h8121631_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libgettextpo-devel 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 529353
-  timestamp: 1772045298146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h0087489_1.conda
-  sha256: 474dfdcd92ff2f76346f259e988a41d413e731558fdb515dc5b623bf89cbf897
-  md5: e348dbb8c6f1a03b14e13b5ec06128a8
-  depends:
-  - __osx >=12.1
-  - gettext-tools 0.25.1 h86cef2d_1
-  - libasprintf 0.25.1 hcc4682f_1
-  - libasprintf-devel 0.25.1 hcc4682f_1
-  - libcxx >=20
-  - libgettextpo 0.25.1 hd3943a6_1
-  - libgettextpo-devel 0.25.1 hd3943a6_1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  - libintl-devel 0.25.1 h55097f8_1
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 541343
-  timestamp: 1777366825427
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
-  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
-  md5: ac944526cc2d27ffa3c44a42cd86f46d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3777431
-  timestamp: 1772045279414
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
-  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
-  md5: c0f5a28ad7e3facdc8181ef762970499
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3969299
-  timestamp: 1772045273194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h86cef2d_1.conda
-  sha256: c49c5eb435c4a15367dcc722dab90ba8fe15a0ac7ab7ed01f8255e3448b18cad
-  md5: 002abaa93cfa4d989a91122d55719ed6
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  - libxml2 2.14.4.*
-  - libxml2 >=2.14.4,<2.15.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3469625
-  timestamp: 1777366802264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
-  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
-  md5: 91b9170766e7040dedc182d913a7ff89
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171370
-  timestamp: 1770382383126
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
-  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
-  md5: 5a519fab2daa903499d90bef420c0c8b
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 170581
-  timestamp: 1770382377233
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
-  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
-  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171931
-  timestamp: 1770382381497
 - conda: https://repo.anaconda.com/pkgs/main/win-64/googleapis-common-protos-1.72.0-py313haa95532_0.conda
   sha256: 3ba8735bb797cd4a59c3cfda4fdb4402e8195c3ff73e1c1a4741481cca316570
   md5: f0f53c3478e98fa4a70424c9841b9663
@@ -3838,56 +10174,6 @@ packages:
   license_family: APACHE
   size: 172940
   timestamp: 1770382461709
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
-  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
-  md5: 9b8c1795cc878775116cd01cea2ddad8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 h79c45ec_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 877844
-  timestamp: 1770755209168
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
-  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
-  md5: 4648b65bcb134c3764a9e64f6e6953d8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 hec5afc2_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 831478
-  timestamp: 1770755033862
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
-  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
-  md5: db94ba50dcc724b61f6f51982822577b
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libgrpc 1.78.0 h7694377_0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 761674
-  timestamp: 1770754627213
 - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.78.0-py313ha1f0e13_0.conda
   sha256: 7d6c1bab6553c858ebb29bfdd9c113e99ec8c6076582b718451bfe6f596d5826
   md5: 1667c992706d53ffdc6f05e3577c607d
@@ -3905,36 +10191,6 @@ packages:
   license_family: APACHE
   size: 727985
   timestamp: 1770755894751
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
-  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
-  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64750
-  timestamp: 1761931277052
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
-  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
-  md5: 4786f45bc40fd0fb4b60c05d19e32179
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64484
-  timestamp: 1761931284057
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
-  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
-  md5: 38e110c2ae2fb67d3ef1abfc786498f9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64806
-  timestamp: 1761931279662
 - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.16.0-py313haa95532_1.conda
   sha256: 81e22d7167caf13f505697c0a182d428576d865c67b2f5ef0655201527302a9b
   md5: a97fdc66e5c3a6fcb5f8818f4606f22f
@@ -3945,42 +10201,6 @@ packages:
   license_family: MIT
   size: 64663
   timestamp: 1761931421750
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
-  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
-  md5: 77016551f9607c23c6243632bf100507
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127896
-  timestamp: 1748526107673
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
-  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
-  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127463
-  timestamp: 1748526158318
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
-  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
-  md5: 6d33385bdc014731d4369f0d0e09af73
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 129364
-  timestamp: 1748526183257
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
   sha256: d500fb5bedabbb40813f548184b7fa6f3fd92893209c0762777d8b7926e94af2
   md5: 2262f0f3863efb10f8f4442438401a8d
@@ -3993,41 +10213,6 @@ packages:
   license_family: BSD
   size: 131010
   timestamp: 1748526313503
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
-  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
-  md5: 4b7c5319a6df6513319768f73969098c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 101585
-  timestamp: 1763634777574
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
-  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
-  md5: e4fc275a391afef3d78ec4149d5ad589
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 98508
-  timestamp: 1763634792733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
-  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
-  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92280
-  timestamp: 1763634775883
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httptools-0.7.1-py313h02ab6af_0.conda
   sha256: e8b67d7608f23cf46b932ebff40fe59ee3d71e0a03ae805662adb2b9391fc2ed
   md5: 1cfe4a9cca6beb28dd5870ef564a73dc
@@ -4041,66 +10226,6 @@ packages:
   license_family: MIT
   size: 84545
   timestamp: 1763634955246
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
-  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
-  md5: d25af3a5cbefe54951cb3dc369b945bb
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=8.0.0,<9.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - zstandard >=0.18.0
-  - socksio >=1.0.0,<2.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217558
-  timestamp: 1760447364823
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
-  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
-  md5: 63a3ec07509610236d9ad578a3b625aa
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - zstandard >=0.18.0
-  - click >=8.0.0,<9.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216526
-  timestamp: 1760447362829
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
-  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
-  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pygments >=2.0.0,<3.0.0a0
-  - zstandard >=0.18.0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  - click >=8.0.0,<9.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217168
-  timestamp: 1760447208891
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
   sha256: 110311c08a60e70198900b6aa5a35e7b1f2175bd3109e0a56610b75d0ea3f20f
   md5: 55a5ebf53109994a5ac8a2f802bd8f43
@@ -4121,39 +10246,6 @@ packages:
   license_family: BSD
   size: 242095
   timestamp: 1760447587973
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.0-py313h06a4308_0.conda
-  sha256: 323856b6498b26b978b3c553b8ed4965002b940574032057f8818c1b63954bf0
-  md5: 55a43a7e939a3fcc4987774478a735ee
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16656
-  timestamp: 1735845644279
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.0-py313hd43f75c_0.conda
-  sha256: c6954bcac5ea4799c6e7ae83e1a19b58df39819793109a2bf69ebfe4c33a4727
-  md5: db176a960a159bcfd981f1c16d4f3d88
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16571
-  timestamp: 1735845498447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.0-py313hca03da5_0.conda
-  sha256: 3b36d113033fbd06873ec3a42a43593655ed8b9d676cc5b4b9dac2472a4c158a
-  md5: cb105fd0a4a87512800bc9d5a6ad99b7
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16865
-  timestamp: 1735845800331
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.0-py313haa95532_0.conda
   sha256: be0e01deed35e9d81f96eb543e8dc8973f1cd2c8810426fa4e544279a29e480a
   md5: e37085d0059052288a703a850ebcbf71
@@ -4165,65 +10257,6 @@ packages:
   license_family: MIT
   size: 17881
   timestamp: 1735853319955
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.conda
-  sha256: f60e8a4b965ba50214f5a7a24308c060860fa5062d9d69d581287a520006abba
-  md5: 6d09df641fc23f7d277a04dc7ea32dd4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 27195861
-  timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-73.1-h419075a_0.conda
-  sha256: 666aa21f839d88ebafb9804da64076a61b081c0d390c2f57150400080cce9e41
-  md5: cb0845107bfb0b019a07516080fd9431
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 27496589
-  timestamp: 1692293356718
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
-  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
-  md5: 48dcf4bb007f44e187fe29b1120e0ef9
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 23865757
-  timestamp: 1777922195678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
-  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
-  md5: c8b25d0fe19ba1a7319a0221e7615265
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 202882
-  timestamp: 1761911998666
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
-  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
-  md5: 93b126011717941f140fd04b6dd6d37b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203848
-  timestamp: 1761912000622
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
-  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
-  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203509
-  timestamp: 1761912023966
 - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
   sha256: 8264d301462d3eb44c813da4c4e092fc2f32b257ef5692a00573ac4c0346d920
   md5: 426a9add5ed691e72c893059ee0485fd
@@ -4234,39 +10267,6 @@ packages:
   license_family: BSD
   size: 203986
   timestamp: 1761912082836
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
-  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
-  md5: e3d3dc1bd7e26bef582f874fbb4c543c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71396
-  timestamp: 1772097118324
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
-  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
-  md5: 465aead5c1e7b7a585ebb676781545a1
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71748
-  timestamp: 1772097105461
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
-  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
-  md5: 711d5bcfff34a45210902f5ef91c3ec6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 72439
-  timestamp: 1772099900987
 - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.1-py313haa95532_0.conda
   sha256: e31d3af9ae2a8a60d0ab46045ca1c3103bd5c1b878197ad3dbbf42db732bf41f
   md5: f806d7a4777a4c76c01b630b4fdb3732
@@ -4278,57 +10278,6 @@ packages:
   license_family: APACHE
   size: 72171
   timestamp: 1772097268508
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.14-h5eee18b_1.conda
-  sha256: e76928987010e8d60fe7e2edbbf733643ed16f17eb9cbcd96bc4dcb2d823dec2
-  md5: 852537d568f5ed410a100d65424039dc
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 38170
-  timestamp: 1705704612984
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.14-h998d150_1.conda
-  sha256: 4e8c5fbfee25074df634337a5d30841fc88bb5feedb89a02c138f85d5e7b54f5
-  md5: e0a9db0de5a436a8fa92f72bd09617c9
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 42724
-  timestamp: 1705704607717
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
-  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
-  md5: c4ea3f7208a811b569bbeae8c42c5b2d
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19952
-  timestamp: 1755516354462
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
-  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
-  md5: 281677614ab4b309ddb5afd24c80cd26
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19436
-  timestamp: 1755516386420
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
-  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
-  md5: f4e4bcf521aa18ee57d0607ad48f284c
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 21271
-  timestamp: 1755516531252
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
   sha256: 7eb0c4ee04a96ad65ae0c51d58ad17d5203b76ddcd2d4702503a50127434fd27
   md5: a8fd08b7543a5b778d2e2c29c5aa88e9
@@ -4340,36 +10289,6 @@ packages:
   license_family: MIT
   size: 21078
   timestamp: 1755516602917
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
-  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
-  md5: 54a430923247a921a5c57e330e04549f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17104
-  timestamp: 1769477866762
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
-  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
-  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17035
-  timestamp: 1769477854229
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
-  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
-  md5: 0a89e92618b4328787ef72b0d94d8808
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17072
-  timestamp: 1769477856721
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.context-6.1.0-py313haa95532_0.conda
   sha256: 50f96dd6dc6cfefe9eb81802fdcaec8f1776e723ac8a43d825902e3d1f53e363
   md5: 75a2698e16470e6c8ca5a80decb040f3
@@ -4380,39 +10299,6 @@ packages:
   license_family: MIT
   size: 16899
   timestamp: 1769477938631
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
-  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
-  md5: 9572b85d5f84049bc36867f49d498520
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23712
-  timestamp: 1768389384997
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
-  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
-  md5: 3fc0a300184c6cfbbb48735e637b6f00
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23679
-  timestamp: 1768389385039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
-  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
-  md5: 7174017dd1ce6c709a2b1d87156deb56
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24174
-  timestamp: 1768389389007
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.functools-4.4.0-py313haa95532_0.conda
   sha256: d6495ad19759532a27e73055a1f13de378af550ff07878543e252b76c095660c
   md5: 25711ebee8c977aa282a9aa5ceea0817
@@ -4424,52 +10310,6 @@ packages:
   license_family: MIT
   size: 24310
   timestamp: 1768389476340
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
-  md5: f115ef0af90b59f35ef56743955979a4
-  depends:
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 39004
-  timestamp: 1627537099507
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
-  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
-  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 304593
-  timestamp: 1762897374551
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
-  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
-  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 298136
-  timestamp: 1762897357507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
-  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
-  md5: ef1c78fa12751c0d455245582d1cb49b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 268149
-  timestamp: 1762897357212
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jiter-0.12.0-py313h114bc41_0.conda
   sha256: f39d48b2e608459feb932a21598c24ab04c9c32099a6aab94d5a08d7002aa082
   md5: e4a8ded259e4807efe3f846cbc713b75
@@ -4483,39 +10323,6 @@ packages:
   license_family: MIT
   size: 181327
   timestamp: 1762897503347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
-  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
-  md5: 8cb4b1755a4a8fd6a57883863236ef2b
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36479
-  timestamp: 1728399618377
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
-  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
-  md5: 9930fc2e22ba90d25992765ac140be02
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36927
-  timestamp: 1728480664723
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
-  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
-  md5: 9e1af96e93b8278ec9029f1bd38f4517
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 37185
-  timestamp: 1728594571279
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpatch-1.33-py313haa95532_1.conda
   sha256: d25504515f356dc8c06dbf73ce598ba7b327431edf6ca1b06fa9a184a786ea04
   md5: 8c5fff5a1d8d36890bc5a297c1445785
@@ -4527,36 +10334,6 @@ packages:
   license_family: BSD
   size: 61903
   timestamp: 1729054823125
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
-  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
-  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18979
-  timestamp: 1774432898196
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
-  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
-  md5: 793eb8901926bede7a6eebdce28cf6a0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19083
-  timestamp: 1774432919346
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
-  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
-  md5: 552bd935bf55a9099c7d2910a8d56391
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19004
-  timestamp: 1774432907812
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpointer-3.1.1-py313haa95532_0.conda
   sha256: d0cc264fcb1555ed5e2fea4cbcbef11c2fbdec97b003625b784229aa5255f483
   md5: 75eab033c2afaa3732443501ce5c69a9
@@ -4567,36 +10344,6 @@ packages:
   license_family: BSD
   size: 43602
   timestamp: 1774433242550
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
-  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
-  md5: 259205480d74c969b6bbd3c48662291e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30490
-  timestamp: 1774283018435
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
-  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
-  md5: 4660f274a8ff963e92cb29db01b37c91
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30439
-  timestamp: 1774283011961
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
-  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
-  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30409
-  timestamp: 1774283033815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonref-1.1.0-py313haa95532_0.conda
   sha256: 873027cd600f7bcb3955afff88d739dce468fb97711f984b2aa6daf9228970f4
   md5: 765f2516c806c0efce4302fb729a0c47
@@ -4607,48 +10354,6 @@ packages:
   license_family: MIT
   size: 30266
   timestamp: 1774283061640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
-  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
-  md5: 7125606e211300f51b43b14c7039c163
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198245
-  timestamp: 1767955393666
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
-  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
-  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198026
-  timestamp: 1767955403846
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
-  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
-  md5: 0be71be35e5503bdecfebf75f1fa55c0
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198501
-  timestamp: 1767955687618
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py313haa95532_0.conda
   sha256: 74712222c6722333c45a9e2b745af71fe2739ab5a6b0ed805b6f716103576821
   md5: 97042d9d769c8b7527882ae7edaba05a
@@ -4663,51 +10368,6 @@ packages:
   license_family: MIT
   size: 223147
   timestamp: 1767955635122
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
-  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
-  md5: dea8a1c280fb8cb391be3b459d8dfac1
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52614
-  timestamp: 1772640999029
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
-  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
-  md5: 022e69a93795b21be36f997e24f2b341
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52583
-  timestamp: 1772640996503
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
-  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
-  md5: bd5d17c69a377489445f1cac4b1390e7
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52745
-  timestamp: 1772641022505
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-path-0.4.5-py313haa95532_0.conda
   sha256: d91c2b3156c53733cf5544a44d15fa79e0ecc688383c4c821dc2ee5979e4ef11
   md5: a8451b4e6b9ea3c5b515f06b9ba91e23
@@ -4723,39 +10383,6 @@ packages:
   license_family: Apache
   size: 52421
   timestamp: 1772641050217
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
-  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
-  md5: 2dbc150b61f12b744cf873c285f4a418
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17079
-  timestamp: 1762788451045
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
-  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
-  md5: da59899cde4411bae19ae5f15aebe373
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 16920
-  timestamp: 1762788449938
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
-  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
-  md5: 6cfee2660e901231d2fe274f02afeaf8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17167
-  timestamp: 1762788437806
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py313haa95532_0.conda
   sha256: 28620856a54ef6885be4360f5b85633685ddb4d88b2a43b57c7bdffc19335e09
   md5: 5c075ecdc29eda1f025dfdc4e0f6efcb
@@ -4767,42 +10394,6 @@ packages:
   license_family: MIT
   size: 17206
   timestamp: 1762788650578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
-  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
-  md5: 292a4c15bbd54feba358997e6d1b35db
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96597
-  timestamp: 1764588298747
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
-  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
-  md5: f303bbea09244d08acd0fad083bbd6eb
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96552
-  timestamp: 1764588304837
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
-  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
-  md5: a691a010a6df73533294e436b2edb780
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 97019
-  timestamp: 1764588302845
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
   sha256: ffaafa66cf38b5ac02048ded1a6998ac2b83bc65712b6bc7947c93b78da71bb8
   md5: 3b95819d01e50e21001764a85f9afe81
@@ -4816,64 +10407,6 @@ packages:
   license_family: BSD
   size: 121625
   timestamp: 1764588393434
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
-  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
-  md5: 6d505a62b565ff3d80d5a6662a83d54a
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-mypy >=1.0.1
-  - shtab >=1.1.0
-  - pytest-enabler >=3.4
-  - pytest-checkdocs >=2.4
-  license: MIT
-  license_family: MIT
-  size: 82797
-  timestamp: 1763637203264
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
-  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
-  md5: c96025bac150402baa006c878d604992
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-mypy >=1.0.1
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  license: MIT
-  license_family: MIT
-  size: 82677
-  timestamp: 1763637208740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
-  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
-  md5: d19d185ec9fd87908b74303c8e38893f
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  - pytest-mypy >=1.0.1
-  license: MIT
-  license_family: MIT
-  size: 83253
-  timestamp: 1763637330760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
   sha256: bea45ee837d9962996ba5bc05ed0d9e87e8d711cee9156bc2b649dadace14879
   md5: 793935b26a9203a0e14d442c5edfe91c
@@ -4893,69 +10426,6 @@ packages:
   license_family: MIT
   size: 108233
   timestamp: 1763637248210
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
-  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
-  md5: c563bb71f4df90fc3b92cde204827564
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 742162
-  timestamp: 1773255564362
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
-  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
-  md5: 833bdaaca975deb8a858597241ecd5c9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-aarch64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 783012
-  timestamp: 1773255553164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
-  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
-  md5: 569d92e1732a69adff57813342a9c316
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - libabseil-static =20260107.0=cxx17*
-  - abseil-cpp =20260107.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384532
-  timestamp: 1770384636226
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
-  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
-  md5: 50deebc10eb4d612f1bb35aa92538797
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1402413
-  timestamp: 1770384640911
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
-  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
-  md5: 112093c65f205a89992cf9cfc7120f41
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1224935
-  timestamp: 1770384634202
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20260107.0-cxx17_hc587421_0.conda
   sha256: 3f445c4b66ad27ed9c46b1d30f0aae9789fa739dbe8156c9ca9aa31b375fcd88
   md5: 54f8fe8d7b66347164bbf3544bbe9172
@@ -4970,56 +10440,6 @@ packages:
   license_family: Apache
   size: 1913462
   timestamp: 1770384749003
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.2-h3ec8f01_0.conda
-  sha256: 47b727b2add2529ee9f983fefda5307a728941e95f48b467119865ef17ec417c
-  md5: 7e646e7deafe4482bb0b9525ab748132
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libxml2 >=2.13.8,<2.14.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.18,<4.0a0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 875632
-  timestamp: 1761151790516
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.2-h9e3fb69_0.conda
-  sha256: 2e066b7f308658f772bd453b4e151ba43e7e1e9aef40fb80a88fd1a9d3f1e8d5
-  md5: f1e2109005623363f0bca6854a0e9a10
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libxml2 >=2.13.8,<2.14.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.18,<4.0a0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1002269
-  timestamp: 1761151803239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
-  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
-  md5: 9368c8128813db74810effc28a6d0de2
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.8.2,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 783208
-  timestamp: 1777387020815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.2-h6c023e8_0.conda
   sha256: 35427e640b7852c894f568384a36e07e27ef70d3b4f2ac3e6b658d7dcdf0f5a1
   md5: 775fe9d0f2f8c22ac9e3a56d2b0f327a
@@ -5039,84 +10459,6 @@ packages:
   license_family: BSD
   size: 1860635
   timestamp: 1761152150940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
-  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
-  md5: 9fe17fea3f12a5dcc483b89f48e361da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52393
-  timestamp: 1772045241614
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
-  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
-  md5: 898dd823b7a53a708a69d86847903b0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52342
-  timestamp: 1772045233389
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-hcc4682f_1.conda
-  sha256: 92490f2d7a793173adc3fc6ea31fedcceedf36e03bd60ae0ed0054a8db58ec4c
-  md5: d2a53560d3ed522db0e42c3359b5b485
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: LGPL-2.1-or-later
-  size: 50062
-  timestamp: 1777366750809
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
-  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
-  md5: 114f7a7ae6d01b7f5d568439769857f7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33684
-  timestamp: 1772045249959
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
-  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
-  md5: 7b561a37cd2af9c7c194c2090e419ee3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 h8121631_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33644
-  timestamp: 1772045246611
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-hcc4682f_1.conda
-  sha256: 68c83c6e80279aa8fe0bb2b0166ff7e445ed5e20284103ebc7efdc95d2b3f889
-  md5: 30b14cd969c3443791d9a02cc3670915
-  depends:
-  - __osx >=12.1
-  - libasprintf 0.25.1 hcc4682f_1
-  license: LGPL-2.1-or-later
-  size: 33791
-  timestamp: 1777366761731
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
-  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
-  md5: cdc0bbfec0c99b30d435b22341a716b0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78282
-  timestamp: 1762363571278
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
-  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
-  md5: 607b0beebe5e0c3643f2fceee006d15e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78099
-  timestamp: 1762363467361
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.conda
   sha256: 515b14efb88b6a184c3a228df9d735a60505a77d6d0d85ca2efe3fdf26135f7c
   md5: d9c1dc58106b14e5173de685e8593dde
@@ -5128,28 +10470,6 @@ packages:
   license_family: MIT
   size: 87952
   timestamp: 1762363782214
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
-  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
-  md5: 7cad8348df1c96bf2f0a697806d1b3b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 33634
-  timestamp: 1762363575967
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
-  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
-  md5: 805855f8193938731ccba31427eaa37c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 31209
-  timestamp: 1762363472701
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.conda
   sha256: 6b9147b66d9807378598c27fc5fff2e3eb3eaa807036d0c18c0d90778f612260
   md5: 6571166b6a690d451fbf6500c4ffba2e
@@ -5162,28 +10482,6 @@ packages:
   license_family: MIT
   size: 40440
   timestamp: 1762363799309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
-  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
-  md5: 854af1d6af8b3565fa8c7edb2141a2de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 279951
-  timestamp: 1762363583050
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
-  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
-  md5: bfc1f2cb23c1f160079289f797e97756
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 286206
-  timestamp: 1762363480172
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.conda
   sha256: 5ff2563603fe5f0114da382bc0de34b060751a6aea9690f919fd20fdf448c3be
   md5: f2b21ddeba6f3dc5b3206b6913128cc8
@@ -5196,67 +10494,6 @@ packages:
   license_family: MIT
   size: 259203
   timestamp: 1762363815702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.19.0-ha05a353_0.conda
-  sha256: d485833f2828450de36e7abf46645b05c56a72175c2d42e1963c92dce9fce2f6
-  md5: bf3bea70fcf78aa1ad48e76976bc67c0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.67.1,<1.68.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 499620
-  timestamp: 1774299460402
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.19.0-hd99d008_0.conda
-  sha256: 8cd359cab520aec169feb0cfe08503d4efc878c324071b9a666c9a8d2afaca6c
-  md5: 923a7d9c10712dfc997e685ea445dc94
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.67.1,<1.68.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 516746
-  timestamp: 1774299451585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.16.0-h01d3526_0.conda
-  sha256: b5fcc7e7382bca42ce86b3038ae03b9ebaa6ea69b581079a16d973c5f33c44fa
-  md5: 80e6e03e9a967b1c89975845e0596756
-  depends:
-  - __osx >=12.1
-  - libidn2 >=2,<3.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.57.0,<2.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 390969
-  timestamp: 1761555409156
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.20.0-h9440e04_1.conda
   sha256: 9e17afa766dccfafffb5a32fd80c81f89c23b40d22c518cb9ee4b89bcd4cf6ab
   md5: ab923b442ef1342c787c7dc3242118b0
@@ -5276,78 +10513,6 @@ packages:
   license_family: MIT
   size: 451035
   timestamp: 1777909579462
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
-  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
-  md5: 344e08f75d799c1e5b57441a2a4c357d
-  depends:
-  - __osx >=12.1
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 316282
-  timestamp: 1775479658335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
-  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
-  md5: 5065620db4393fb549f30114a33897d1
-  depends:
-  - libgcc-ng >=7.5.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 114011
-  timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
-  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
-  md5: 230e8093b929e64244f2c7e181705802
-  depends:
-  - libgcc-ng >=10.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 115539
-  timestamp: 1619012635485
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
-  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
-  md5: 00cac99189c361c3b2cbf506ae6cc718
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106490
-  timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.5-h7354ed3_0.conda
-  sha256: cda922c9f09bfa17933d55849b9232416872b068018ab89580e379d5487a2c14
-  md5: 67c73f16b2eb58c1c73d5a3dc1645d14
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 125091
-  timestamp: 1774555957601
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.5-h5b11e9f_0.conda
-  sha256: e50822f322079932eb4ff6c806f7ea7043260bb1e4afd4ff74f258f06fa0a954
-  md5: 13c85e5a1e3397428462cb9c364abd16
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 118612
-  timestamp: 1774555877019
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.5-h50f4ffc_0.conda
-  sha256: aa8a1edb1076afd0c3f1881dc4cd57ab58c8d7a3289ac39ca103504d2c956c73
-  md5: 39948de0b74df7103d32d9eeab59cb3b
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 110894
-  timestamp: 1774555845024
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.5-hd7fb8db_0.conda
   sha256: e30d43671816e39e4b1d49120cd25ee0a38080f207bc7e230c8abf4eeae347f5
   md5: ea2ebdfc4a16a5cbc06d09a374f62f34
@@ -5361,33 +10526,6 @@ packages:
   license_family: MIT
   size: 123312
   timestamp: 1774555907563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
-  sha256: b0e7fe2e5d498bc5a2c57cf942701bba8f22ec55de55e092ffbffc40b816df88
-  md5: 70646cc713f0c43926cfdcfe9b695fe0
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 144691
-  timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
-  sha256: 18fd986f0ef7f6a59c363e5305d06fe3f20509c39e3393fef60d722316828992
-  md5: 34c197394030fa553d97fc902585ee9b
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 143394
-  timestamp: 1714483284040
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
-  sha256: 800216cb554d0beaf970fe7c3efeee7974bb76576c1c5e0ae070c57fca2bba93
-  md5: 2bec9ee4b1214a3c3e2d1f2e18725daf
-  license: MIT
-  license_family: MIT
-  size: 122887
-  timestamp: 1714483461787
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.conda
   sha256: 43a437fde4c064b2f1be2342a7bc6edccbc13da6a4fb8a44d87e4e6e34c54b63
   md5: 9807b377e11739ae3e920e10e607e460
@@ -5398,189 +10536,6 @@ packages:
   license_family: MIT
   size: 124747
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
-  sha256: baf9d8d16e2a8ae7a4d1b80f2c1a932deaca1a87c677a370f6ab4688482db47b
-  md5: 01fb1b8725fc7f66312b9d409758917a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_7
-  - libgomp 15.2.0 h4751f2c_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 825084
-  timestamp: 1762772576461
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
-  sha256: 06ae831ca00e09a65ba8b5536e8b728be3eb909e0cf041ebcc542b92fa4bc969
-  md5: a31a8c63a5fe7234863f8e9dd2b20901
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_7
-  - libgomp 15.2.0 hf47c802_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 511039
-  timestamp: 1762772353789
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
-  sha256: 3a3678f17a8916777d03b83f19f673107b4a9bf55366234dcfa42edbd5173123
-  md5: 2783efb2502b9caa7f08e25fd54df899
-  depends:
-  - libgcc 15.2.0 h69a1729_7
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28356
-  timestamp: 1762772577850
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
-  sha256: e672543a5f8d8ae30c7feab3ba57a2960c46756ca24fb027e3f6284a88d44acb
-  md5: e7d01ec71523a231b0d3b83f33a2dd21
-  depends:
-  - libgcc 15.2.0 hc18542e_7
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28446
-  timestamp: 1762772355060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
-  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
-  md5: 775a5698ec2a0aa6e2435b86418b563f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 190134
-  timestamp: 1772045245717
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
-  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
-  md5: 3c39fd72e5a005e81c78cefe0f4b0464
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 214938
-  timestamp: 1772045240107
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-hd3943a6_1.conda
-  sha256: a79bc3262177055c8d4a367ac61975756942db5c4e97d319d167dd6c1fc3362c
-  md5: 008a4033018ea9ef9bac5a49af7b52ff
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: GPL-3.0-or-later
-  size: 176696
-  timestamp: 1777366767819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
-  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
-  md5: 5766eead346251db288d5b13c3dffd6f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36248
-  timestamp: 1772045253856
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
-  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
-  md5: 60521b8fbf132abc3846a700f33374cf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36215
-  timestamp: 1772045253063
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-hd3943a6_1.conda
-  sha256: 87541ceaad5c717a8814b4d2dbae5051778af0e36b5afc5b1e3f1d152a786200
-  md5: b268ecbfe62a0030b050a4a04cac014b
-  depends:
-  - __osx >=12.1
-  - libgettextpo 0.25.1 hd3943a6_1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: GPL-3.0-or-later
-  size: 36399
-  timestamp: 1777366777968
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
-  sha256: 835e44371812c91563a00dec8bc98c460f8b9f33f50543244bc8774c446a2172
-  md5: 82025ed6da944bd419d42d9b1ff116aa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 446183
-  timestamp: 1762772542830
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
-  sha256: 69eeb9a1342df1ba18d0fa994ebf3a43a653cf48a006b8778682cf032cf1e565
-  md5: 3403656472f38870e65c29aa6065e00e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 449546
-  timestamp: 1762772309007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
-  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
-  md5: 91b626db75392fc7254aaad8dc9a9850
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7252351
-  timestamp: 1770755115633
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
-  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
-  md5: eb5839753b2b8904f6d7107d6240ef23
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6933116
-  timestamp: 1770754985299
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
-  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
-  md5: 39336ad943dcc5f88ad31e32f1c4c66a
-  depends:
-  - __osx >=12.1
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4848994
-  timestamp: 1770754583246
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.78.0-hecd3d80_0.conda
   sha256: df06429097725d99abf7e174d53454341dc4802b0c4dc9d8cfa3d8dcd6f31fb8
   md5: 714d58c2bb7a1b39978b6fe7011d9876
@@ -5602,32 +10557,6 @@ packages:
   license_family: APACHE
   size: 11897881
   timestamp: 1770755767693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
-  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
-  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 789520
-  timestamp: 1771491869505
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
-  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
-  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 778215
-  timestamp: 1771491870922
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
-  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
-  md5: efcf143adafc878192a4ab5252f4cacb
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-only
-  size: 749113
-  timestamp: 1771491894949
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.18-hc89ec93_0.conda
   sha256: 73e19e873fad84ca239ccfd53a51830a8004a14b388a9d30a8c09ce3b8b386a2
   md5: 53c556b8109eaab09231874106a025f3
@@ -5638,93 +10567,6 @@ packages:
   license: LGPL-2.1-only
   size: 703101
   timestamp: 1771491956799
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
-  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
-  md5: 7ab70b332bb2df9ce90a1567126b5d2a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 82352
-  timestamp: 1760364378431
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
-  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
-  md5: 5bd529c1efa0251f0cebe7f84a504f69
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 119389
-  timestamp: 1760364375350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
-  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
-  md5: 4caba2988c52534c6ba5e88afebba106
-  depends:
-  - __osx >=12.1
-  - gettext >=0.21.0,<1.0a0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 114873
-  timestamp: 1760364408172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h55097f8_1.conda
-  sha256: c968c240abbf7cb8e716b6e46c000e41080431d43e9c9288dc27a9cb974edd63
-  md5: d2a79ee17b6db1b6c7dc3319c79fde05
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 84226
-  timestamp: 1777366756740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h55097f8_1.conda
-  sha256: 055656e5c2ec8cbdb9d89a2a48ff11a4e7d0480483920c123077eb4bc25d252e
-  md5: 792d607bddde98d9bebc7ec853f8b271
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: LGPL-2.1-or-later
-  size: 38922
-  timestamp: 1777366772836
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
-  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
-  md5: 3fd122ff074ed6bed89994053feb1fe3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 804625
-  timestamp: 1775137912599
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
-  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
-  md5: 690464725d117c8ec5194f57b56525b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 845865
-  timestamp: 1775137916299
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libkrb5-1.22.1-h3d06f0e_1.conda
   sha256: b179996d88eb33e2d0adc3418ee08c04dea5b96e49f76502c09af1643f8d9245
   md5: 7cf3e0d3e8de34c05bc06825387cc5d5
@@ -5738,81 +10580,6 @@ packages:
   license_family: MIT
   size: 693609
   timestamp: 1775138282724
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-h860b5fb_1.conda
-  sha256: 87776624e4882955942a61799db0cafd19e5ab26874ddcb99cca2d66a4ea287d
-  md5: c9351e4b3b09fbe3c3bba5526acbf19c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2061828
-  timestamp: 1763111696644
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-hc4b5eec_1.conda
-  sha256: 3a06ed5da101445a72bbed867abcbb43b9cf05bf54ce9b6c40382554ca06991b
-  md5: b05e5a9cc5fc7b166d37b3859c4034bc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1989864
-  timestamp: 1763111663378
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-hcdddc3d_1.conda
-  sha256: 4a9771ab23729aea3d9a9736c2f6ff1eb548d7dd5737934e8b571b7e31593552
-  md5: 7cd60c4d398e629da02f85ca1c9c6620
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libcxx >=19
-  - libsolv >=0.7.30,<0.8.0a0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1466323
-  timestamp: 1763111449765
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hc213065_1.conda
   sha256: 64af08eb355d00b312560535c40415125deb59495ffaa567effc611309d69ede
   md5: 7fae14d333102ededdc1f1e7f2977d4d
@@ -5837,57 +10604,6 @@ packages:
   license_family: BSD
   size: 4596223
   timestamp: 1763112028349
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313h3f77f5b_1.conda
-  sha256: feedf8857d483851cf41a5ff9d625ea9c100194d54a974259072e215a3f86307
-  md5: a974c724de77f79cd7e926116fd861df
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=11.2.0,<12.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libmamba 2.3.2 h860b5fb_1
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 663170
-  timestamp: 1763111784452
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h9fbafe8_1.conda
-  sha256: 266d4763906b5811fc8af23ec7b69b8b2b40b3588ec5999a199df4020d49db27
-  md5: d2269de613080d5a54a306aeed65cdfe
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=11.2.0,<12.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libmamba 2.3.2 hc4b5eec_1
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 574461
-  timestamp: 1763111749830
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_1.conda
-  sha256: c297878fcf3baf04de81875eac275dce4cd1a19017ee68fc9364aae53068f7ea
-  md5: 8af2f87a53f6ee1d4396e609402e6dac
-  depends:
-  - __osx >=12.1
-  - fmt >=11.2.0,<12.0a0
-  - libcxx >=19
-  - libmamba 2.3.2 hcdddc3d_1
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 587576
-  timestamp: 1763111506082
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h364efb6_1.conda
   sha256: d7f859d0cf60805f7759162ec5fb3faa9fd97f6279e7b596e632e459471c6cec
   md5: 3d64e598adad837e3aa2fbb2ec352298
@@ -5904,31 +10620,6 @@ packages:
   license_family: BSD
   size: 454648
   timestamp: 1763112121992
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
-  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
-  md5: feb10f42b1a7b523acbf85461be41a3e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 88085
-  timestamp: 1726088449399
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
-  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
-  md5: 8bd7f4c495a81af4914c899949e52542
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 125873
-  timestamp: 1726088467322
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
-  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
-  md5: 7b01d2d5e276a24dd44e7846406656ed
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 70527
-  timestamp: 1726088461517
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
   sha256: 3851b0985a481e019440ee2720bdfe1a98fe4db8cd67f8cc16333a0fa40f38df
   md5: a294b317c2e3732cafdba824a893b80c
@@ -5939,110 +10630,6 @@ packages:
   license_family: BSD
   size: 96993
   timestamp: 1726088489806
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.67.1-h697f920_0.conda
-  sha256: 73b3c00697e9a1a5693e9ff70f7995dc27ac11a72524cb9fd71b60b6da480a1d
-  md5: c509cea724fbc22300e5ce9ced97d569
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.5,<2.0a0
-  - c-ares >=1.7.5
-  - jansson >=2.14,<3.0a0
-  - jansson >=2.5
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libstdcxx-ng
-  - libxml2 >=2.13.9,<2.14.0a0
-  - libxml2 >=2.6.26
-  - openssl >=1.1.1
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zlib >=1.2.3
-  license: MIT
-  license_family: MIT
-  size: 651583
-  timestamp: 1762785235166
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.67.1-h9561ae0_0.conda
-  sha256: 130c8e0aa79b541c473b701a6cb598e5200e0ce02735485ce1aab85e66a3c141
-  md5: 0a0b516b0f968b856717d559944efbac
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.5,<2.0a0
-  - c-ares >=1.7.5
-  - jansson >=2.14,<3.0a0
-  - jansson >=2.5
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libstdcxx-ng
-  - libxml2 >=2.13.9,<2.14.0a0
-  - libxml2 >=2.6.26
-  - openssl >=1.1.1
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zlib >=1.2.3
-  license: MIT
-  license_family: MIT
-  size: 667251
-  timestamp: 1762785214718
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.conda
-  sha256: 6f26e84b4452251879cf8d12af77833202736d6081eebd5fa8757cfa7eac67aa
-  md5: 32eac5d9a166c3cbce9b6dfef765b138
-  depends:
-  - c-ares >=1.19.1,<2.0a0
-  - c-ares >=1.7.5
-  - libcxx >=14.0.6
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - openssl >=3.0.11,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 648894
-  timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
-  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
-  md5: 0801fbfd982d1a0de5cc895fed83a19c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3703875
-  timestamp: 1770634775371
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
-  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
-  md5: aa2d494311b59791b542ceedfc12ff2e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3507714
-  timestamp: 1770634686006
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
-  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
-  md5: d45781f34f4b8e74d5b279e2e5d82c25
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2735206
-  timestamp: 1770634426661
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.5-h65d7223_0.conda
   sha256: dc02d4091ddfcae738ed17ba6ddbdeabfacdfa0b26f8a9332ad612925654630b
   md5: 11b8833fdd04816bf58e8b1fec3512ae
@@ -6057,50 +10644,6 @@ packages:
   license_family: BSD
   size: 7207712
   timestamp: 1770635087009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
-  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
-  md5: 0767b8ade520f4927ff9d5866d783f6b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210465
-  timestamp: 1770390434417
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
-  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
-  md5: 2d6e1172997c845d903d346b97494c07
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203733
-  timestamp: 1770390557525
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
-  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
-  md5: 44b6b0d291189d289f38fa7bba97d117
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 164100
-  timestamp: 1770390432249
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-h797e85b_1.conda
   sha256: b3f1b5da9830d15c3505d474343658df271e6ca633499acd268e224257905034
   md5: 531ca8049bd88d4df53d3a58643f31ec
@@ -6116,44 +10659,6 @@ packages:
   license_family: BSD
   size: 272314
   timestamp: 1770390642712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
-  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
-  md5: 0d547d53349f3fcf4a20c9a207c08a3b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 465860
-  timestamp: 1760357067289
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
-  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
-  md5: 40c52830df19329c37dd2f093eb944de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 471404
-  timestamp: 1760357069476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
-  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
-  md5: f39e89f9206a2366089b09a7cd209cf5
-  depends:
-  - __osx >=12.1
-  - libcxx >=17
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 383544
-  timestamp: 1760357075048
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libsolv-0.7.30-h23a355e_2.conda
   sha256: b0f6d1ed7cd48d37ae9c1ba34c0fb70baded93a09718c29c6ecf924dd8e0165c
   md5: 0ae4849097816b4452e8fe8a28376a61
@@ -6166,38 +10671,6 @@ packages:
   license_family: BSD
   size: 444021
   timestamp: 1760357137426
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
-  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
-  md5: dd68c24355431c0543339dda1404129d
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 315187
-  timestamp: 1732891131339
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
-  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
-  md5: a88e620d4eafd7f199a0502433e5e0c0
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 332414
-  timestamp: 1732891127645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
-  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
-  md5: b5aa2854a5872c57538743b4a85a731d
-  depends:
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 298763
-  timestamp: 1732891144732
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.conda
   sha256: ff2d46c586844c88b62ef6bb1419f89690a9e4db714ed2cdb3589ffdd0d8ef9e
   md5: d8ae56ee95db60cbd5f8f8ff63ed1f63
@@ -6210,183 +10683,6 @@ packages:
   license_family: BSD
   size: 319541
   timestamp: 1732891385479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
-  sha256: 747474162ae421d680ab3374d8b11158701206d4a9c4a8f9de557dd6fc13345a
-  md5: 7dc7ec61ceea5de17f3e2c4c5f442fc6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 h69a1729_7
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3903663
-  timestamp: 1762772586621
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
-  sha256: 13c51fceabb26176b862042f079e74bc6bfc527a658dfd76d184bfb4c0cf5e90
-  md5: 90938778a2b6d4ba5c618b6e95b07a4b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 hc18542e_7
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3832701
-  timestamp: 1762772364181
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
-  sha256: 7a39becf3c7dd6016d4b6d24587071cda2afefcdf2886ad16572095261c87b90
-  md5: cf200522c0b13d64bf81035358d05f5b
-  depends:
-  - libstdcxx 15.2.0 h39759b7_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28429
-  timestamp: 1762772606373
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
-  sha256: 928ee09e47b0ec7a7125e36a604e157ae24724117dd20706e1875e3bfb273f8f
-  md5: 34e6c37bb398595bc67ef229f5e60c80
-  depends:
-  - libstdcxx 15.2.0 h9538471_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28507
-  timestamp: 1762772385720
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
-  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
-  md5: e79c628574f0ed3b60bd63e6d78501a1
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 671850
-  timestamp: 1777465777755
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
-  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
-  md5: a99663395dab887607b2e5a854389721
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 676495
-  timestamp: 1777465771156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
-  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
-  md5: c457b6d1695d1b5b054632d2d5895517
-  depends:
-  - __osx >=12.1
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 644497
-  timestamp: 1777466299217
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
-  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
-  md5: 4a6a2354414c9080327274aa514e5299
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28110
-  timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
-  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
-  md5: 59cd225a7659291aa716c6cdae7e1363
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 30035
-  timestamp: 1668082742967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
-  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
-  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 901634
-  timestamp: 1772644974924
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
-  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
-  md5: 52b484c9618823592d2c26632724dafd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 594684
-  timestamp: 1772644989262
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
-  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
-  md5: 5b151376f98c09831d6bd730ca7794c8
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 418963
-  timestamp: 1772645021860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
-  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
-  md5: fdf0d380fa3809a301e2dbc0d5183883
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 440690
-  timestamp: 1746022211479
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
-  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
-  md5: 28e00a696fd74b7550b7d1b8698e10af
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 443363
-  timestamp: 1746022227484
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.9-h2c43086_0.conda
-  sha256: 9bb90ed726ba5868488184f03aa1c18fe654e00aa36b570a16a66c3d350a868b
-  md5: 72d5d2d627dd9b7780781e7aa6a12689
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 684847
-  timestamp: 1761768971660
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.13.9-h729a2f8_0.conda
-  sha256: 4934f41e2776b11efab87b9e1cd28c2aa150ec6c4ba0df1ee61dbab23462d288
-  md5: ad018fbdca2c6fd5edb874ea572bb089
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 720922
-  timestamp: 1761768979409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.4-h2acab8a_1.conda
-  sha256: 1ec937aa6abde15942f00e9d7ec2b6e2082144e0502ff83e962e4a6a4033886a
-  md5: 87ae8fd271f57247baa0a1a7eea23ab8
-  depends:
-  - __osx >=12.1
-  - icu >=78.3,<79.0a0
-  - libiconv >=1.16,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.8.2,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 557636
-  timestamp: 1778064229309
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.conda
   sha256: 7f90427c984b96deda664a993dcda120490c955c2298cdffc9860f20f7caf1e0
   md5: 32feaa8872e9a7c839069a0c2a37df20
@@ -6400,40 +10696,6 @@ packages:
   license_family: MIT
   size: 1531227
   timestamp: 1761769014771
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
-  sha256: 2e0a3ea3aba7ffaa9c2ce9b267b34b12859f93bde8e62cedcbbab6144776568f
-  md5: 338ee51e19ee211b7fc994d4ba88c631
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 60697
-  timestamp: 1756475934898
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
-  sha256: 8dd49d0fe4a8a309e1aa22f96ff61d203eb719710436737042f6d0336635e18f
-  md5: 7d92046a5eb7a64af7ffbd0bc5ae7366
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 66950
-  timestamp: 1756475943009
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
-  sha256: a51872f0fc7ccc4e448babffc9361a3544efe4fce31af0c63a4bb17e9f047615
-  md5: 5a533023e8ce9cae4f939e5eb9eceef7
-  depends:
-  - __osx >=11.1
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 47901
-  timestamp: 1756475936697
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.conda
   sha256: 0478d0e08e9737e6680343cd26380d8faf4f038bb59170818868cd2fb69e5481
   md5: 1e313539489432d5edd44efbec8a4d53
@@ -6447,60 +10709,6 @@ packages:
   license_family: OTHER
   size: 65950
   timestamp: 1756476045869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
-  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
-  md5: 1468bc20414b0fa8eb1b18d3a916039f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 480121
-  timestamp: 1754999718088
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
-  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
-  md5: ff7911a6103418a2c907d8c0262dd7f2
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 414985
-  timestamp: 1754999724928
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
-  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
-  md5: 6f3445d61b923a4e22a50b4ede3c1865
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 377746
-  timestamp: 1775637820996
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
-  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
-  md5: 77eab2a2d275f56e722b1aad11532fd3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 376687
-  timestamp: 1775637816376
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
-  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
-  md5: e535d29ea97147f0f6fb78a5a40c389e
-  depends:
-  - __osx >=12.1
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 374612
-  timestamp: 1775637687250
 - conda: https://repo.anaconda.com/pkgs/main/win-64/luajit-2.1-h1c6eee0_0.conda
   sha256: 2322b012e84cce27d934eca4c8f7e092c3bcd05c7d8ab8ebafc66a83b6d8473d
   md5: 3217ea6e26ad49643fd3b26a727b63be
@@ -6514,44 +10722,6 @@ packages:
   license_family: MIT
   size: 617767
   timestamp: 1775638149997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
-  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
-  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 150496
-  timestamp: 1775657630843
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
-  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
-  md5: 8a1c323359558fc4a4df9191aa6d00fa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 143384
-  timestamp: 1775657550865
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
-  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
-  md5: 8b33a63dd414c362bc478d44fa6cad6b
-  depends:
-  - __osx >=12.1
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 122459
-  timestamp: 1775657525476
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lupa-2.6-py313h1c6eee0_1.conda
   sha256: a5456a9662c69cde19382f8d51817dd9582fc05b74490abb69e1301d19c41e07
   md5: 10caec6073639ad0e7f2c01d186952be
@@ -6566,35 +10736,6 @@ packages:
   license_family: MIT
   size: 136199
   timestamp: 1775658064658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
-  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
-  md5: 2ee58861f2b92b868ce761abb831819d
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 159495
-  timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
-  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
-  md5: 70c4ab9462183ac4af60852d2a79fbf6
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 185496
-  timestamp: 1714510593467
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
-  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
-  md5: 82202ff2e94bc301fd9c790556506bb7
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 160308
-  timestamp: 1714510588159
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
   sha256: 0e848b5004a9dc7a06f459cc67c404d7fb0321bf134ec7512815afafe97960b4
   md5: 723e3ccd4ef7c58ddbfeebe69abff662
@@ -6605,66 +10746,6 @@ packages:
   license_family: BSD
   size: 155711
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
-  sha256: bfed5539652f10a2c344501a4d9928856b50d323fdd390c578fd08e856b7d648
-  md5: f515d22e3c87bcf86d4cd5c877bc34cd
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - sphinx-book-theme >=1,<2
-  - commonmark >=0.9,<0.10
-  - panflute >=2.3,<2.4
-  - markdown >=3.4,<3.9
-  - mistletoe >=1.0,<2.0
-  - mistune >=3.0,<4.0
-  - linkify-it-py >=1,<3
-  license: MIT
-  license_family: MIT
-  size: 242668
-  timestamp: 1767001668294
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
-  sha256: a05d920a2e8fb12ed3778262c5f089533dee6b6288e2424738ec1e7aeab95287
-  md5: 39f85b75ecca46ab04ffaed82496e0fd
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - mistune >=3.0,<4.0
-  - linkify-it-py >=1,<3
-  - panflute >=2.3,<2.4
-  - commonmark >=0.9,<0.10
-  - sphinx-book-theme >=1,<2
-  - mistletoe >=1.0,<2.0
-  - markdown >=3.4,<3.9
-  license: MIT
-  license_family: MIT
-  size: 242704
-  timestamp: 1767001694138
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
-  sha256: c8277cdfdc835839eb6c2acc162ca1f8d4357e13c32d842b282dc9654fff5e6f
-  md5: 2114d29335579a39de598a3208576547
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - mistune >=3.0,<4.0
-  - mistletoe >=1.0,<2.0
-  - sphinx-book-theme >=1,<2
-  - markdown >=3.4,<3.9
-  - commonmark >=0.9,<0.10
-  - panflute >=2.3,<2.4
-  - linkify-it-py >=1,<3
-  license: MIT
-  license_family: MIT
-  size: 243627
-  timestamp: 1767001669424
 - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
   sha256: c293c76f4c1e1b3d61517cd165db9a04c871dbdd9911e7fc32df927fef22d083
   md5: a099b975d158c47c2c38ae406f4d0659
@@ -6685,39 +10766,6 @@ packages:
   license_family: MIT
   size: 268521
   timestamp: 1767001912508
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
-  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
-  md5: 28351e7fd716ee4b3baef571be119b98
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151241
-  timestamp: 1728403996163
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
-  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
-  md5: 1225f726844496e3564e4b2d6c539763
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151130
-  timestamp: 1728498536715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
-  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
-  md5: 4c3e970508e6cb3ad65579fb6b576143
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 149478
-  timestamp: 1728598048738
 - conda: https://repo.anaconda.com/pkgs/main/win-64/marshmallow-3.19.0-py313haa95532_0.conda
   sha256: 9c68fb61ad2d99c635e8a3adededd208f4cb13de8593116f0f5fc39bf5ac1057
   md5: aae05fc7685cf4eae8ef741c8203ff8e
@@ -6729,84 +10777,6 @@ packages:
   license_family: MIT
   size: 152235
   timestamp: 1729060636851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
-  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
-  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - python-dotenv >=1.0.0
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 428184
-  timestamp: 1771960075711
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
-  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
-  md5: b7268fc357df1edc377e4a02b5c5c115
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  - python-dotenv >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 430285
-  timestamp: 1771960065247
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
-  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
-  md5: 04ba8f0bfa78cef0456aeff11cfd1308
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - python-dotenv >=1.0.0
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 432541
-  timestamp: 1771960072114
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-1.26.0-py313haa95532_0.conda
   sha256: 6dc3ad40b514baab126201e34b8cbc8ec86a99e6ad5a74d480be7b9bc840a3bb
   md5: 5728b210ab42e67a924dd40f794f6723
@@ -6834,9 +10804,9 @@ packages:
   license_family: MIT
   size: 456382
   timestamp: 1771960175091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.11-py313h06a4308_0.conda
-  sha256: f86edaf7942d8d686eee066320ea45a2525a8f843a0ee76ab499d955e6aad540
-  md5: c7471bd14ba72c6aa9e897eb0e70faa5
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.12-py313haa95532_0.conda
+  sha256: f9f81bf7aaf5324c869ee78b1fbcf0d1ea87df9194253207f54a31064bbabedb
+  md5: f5d2f32619b86a3eb68ba296bf576548
   depends:
   - cryptography >=41.0.0
   - fastapi-core >=0.104.0
@@ -6856,130 +10826,13 @@ packages:
   - typing-extensions >=4
   - uvicorn-standard >=0.24.0
   constrains:
+  - opentelemetry-sdk >=1.20.0
   - opentelemetry-api >=1.20.0
   - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 348399
-  timestamp: 1774038237333
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.11-py313hd43f75c_0.conda
-  sha256: dbed8320c4abc69199c879c6f31f4546b059e4f2f9e3ddd26dc7c69044b5a54c
-  md5: 982cce64ad707a90fb76c13e73cf8f07
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-api >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 346636
-  timestamp: 1774038230639
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.11-py313hca03da5_0.conda
-  sha256: 08387743fcf6238e8e4d2f6e8508eb306978b3f867ef0119aedde4578ecb806c
-  md5: fd57c9884b446422f348bab3b61f73bd
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-api >=1.20.0
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 347146
-  timestamp: 1774038255104
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.11-py313haa95532_0.conda
-  sha256: 81cc06ee930333a358ab95072731b0afd415939f505740fb2c46293ae8692e1b
-  md5: a5abfb53fb301dfe7ddf8d33a5d265a6
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-api >=1.20.0
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 372392
-  timestamp: 1774038291435
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
-  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
-  md5: 39da6986b50a3eb3cbf60c9883f4b92e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26871
-  timestamp: 1758552191170
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
-  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
-  md5: 5ab5b1fc729b44eb2872d740d95c495d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26724
-  timestamp: 1758552208116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
-  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
-  md5: cc0fbba5b4ee07d4f979149d050c864a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26834
-  timestamp: 1758552196391
+  size: 372921
+  timestamp: 1779919449722
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
   sha256: c2748474cedb35b4643872288cedf94deae958ff684d17daf222bbb26bac4e79
   md5: 6c5764715afea281b71aa53cdc81c545
@@ -6990,36 +10843,6 @@ packages:
   license_family: MIT
   size: 26954
   timestamp: 1758552317465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
-  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
-  md5: 3c19869ee69743cd3e6ed44610f7b845
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257750
-  timestamp: 1765382387320
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
-  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
-  md5: 0514a2f7425fe0559d98b6593f8c936d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257086
-  timestamp: 1765382393281
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
-  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
-  md5: e5a706e1b73efa80d1ec1f23256e3b86
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257932
-  timestamp: 1765382400100
 - conda: https://repo.anaconda.com/pkgs/main/win-64/menuinst-2.4.2-py313h885b0b7_1.conda
   sha256: 88a8c0010bd7aab8b0b92e04a411d85881025f3e4eeaa75e4c2dfd3a9ee3b55d
   md5: dfd755d055c9428e5bd5db6edaf24fc1
@@ -7033,36 +10856,6 @@ packages:
   license_family: BSD
   size: 253213
   timestamp: 1765382456721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
-  sha256: a6da3706af1a527f98e4db5e9e492836d9315825ee99336230865493ae4ee0a6
-  md5: bd0dee4808dd6acb561fce514a345c3d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 167359
-  timestamp: 1761121509531
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
-  sha256: 1f321a79e93054e15a30b78ef59a169d2c48bb81411304bdd5a08f9a6103b48f
-  md5: d8aa86705b3aa00966554fd8d3d6e3d4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 168226
-  timestamp: 1761121492722
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
-  sha256: b9ab925d227d92daf0e76666bdfcd602197fce4a13ff2ae3792b86712ecce3ad
-  md5: ba0fd81d15324ef0abfb4110b83d82cc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 166259
-  timestamp: 1761121562080
 - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
   sha256: b0a1eee1ac57f7fc418b41ce1be5e591057ec4445e888ba5489f8fcaf184349b
   md5: 84c4bc844419c60fb8bce4d066acd07a
@@ -7073,41 +10866,6 @@ packages:
   license_family: MIT
   size: 169455
   timestamp: 1761121600827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
-  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
-  md5: b1fb5c763a2d3e15e633e84bccf52ce4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 123032
-  timestamp: 1750958840666
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
-  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
-  md5: 90c7270744a7c8abdf51b5fecf7a9c14
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 120613
-  timestamp: 1750958715349
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
-  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
-  md5: 58664c7ab05f2559e22bc3030c90bd2a
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 113263
-  timestamp: 1750958887102
 - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py313h5da7b33_0.conda
   sha256: 945bea6ce19a0f2d6ae8ee2ba4ffe2d19c405de54a80fdcc5a576cd93708a067
   md5: d471b10befe27a405de1c7d126f7aeda
@@ -7120,48 +10878,6 @@ packages:
   license_family: Apache
   size: 114961
   timestamp: 1750958855770
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
-  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
-  md5: b9ee8adce00b801f3767671675300a6f
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 154942
-  timestamp: 1728385601732
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
-  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
-  md5: 4d635e1fed6b6841ae3db1e0377a7712
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 153354
-  timestamp: 1728405954288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
-  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
-  md5: 98737e4835cef677dbf6fa0d9d364968
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155808
-  timestamp: 1728586024156
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
   sha256: 7602bb66f5702414d75f7ca4293257fad682282b5a1f83de6e127720437a6b5c
   md5: fa4b4c9dabc5f45e04acbc44e1673b11
@@ -7176,55 +10892,6 @@ packages:
   license_family: BSD
   size: 180795
   timestamp: 1739559123487
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
-  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
-  md5: 0abfc090299da4bb031b84c64309757b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1137647
-  timestamp: 1753947487644
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
-  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
-  md5: 7a1863281d1b73c33d04a3709fda9bda
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1203577
-  timestamp: 1753947513381
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
-  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
-  md5: d8a28b593d36653bec90bd2d78c7538b
-  depends:
-  - __osx >=11.1
-  license: MIT AND X11
-  license_family: MIT
-  size: 906808
-  timestamp: 1753947535285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
-  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
-  md5: 36890f7abd98066b607211b1773e6343
-  license: MIT
-  license_family: MIT
-  size: 127326
-  timestamp: 1680082329609
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
-  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
-  md5: 9e9d478b40d0e254cd3b448f92f47e8c
-  license: MIT
-  license_family: MIT
-  size: 127337
-  timestamp: 1680082426492
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
-  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
-  md5: 5cc48a403acb53596382724e41f99a6b
-  license: MIT
-  license_family: MIT
-  size: 128547
-  timestamp: 1680082112201
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nlohmann_json-3.11.2-h6c2663c_0.conda
   sha256: c7981dedae2f3d7734a062f4e07e08a060d462f72c17778df206989a3db42446
   md5: 7533a3f9925b9e46ac0c258be87c2877
@@ -7232,78 +10899,6 @@ packages:
   license_family: MIT
   size: 128841
   timestamp: 1680083671336
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
-  sha256: 0b5bf6306956956c8346844723db74144b3d278bdb62cec34a0a74d3595f5b5d
-  md5: 718b1fc51e7c834eab78ed742d720a45
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - pandas-stubs >=1.1.0.11
-  - pandas >=1.2.3
-  - httpx_aiohttp >=0.1.9
-  - sounddevice >=0.5.1
-  - websockets >=13,<16
-  license: Apache-2.0
-  license_family: Apache
-  size: 1048147
-  timestamp: 1767167972500
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
-  sha256: cbf21b326814a1d043b8ca3c5f5d5fec6cfc082e31d4a2e3a4b66a1837352a33
-  md5: 1f863d45456e44fda9e9d01e6ecf3679
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - websockets >=13,<16
-  - httpx_aiohttp >=0.1.9
-  - pandas-stubs >=1.1.0.11
-  - pandas >=1.2.3
-  - sounddevice >=0.5.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1039763
-  timestamp: 1767167972967
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
-  sha256: e669bbd6b577ee3e09db578293c262c37bc631beab5a6887c1944f9e56745b81
-  md5: 73458dbb241114ed06a5b561f7b048e5
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - websockets >=13,<16
-  - pandas-stubs >=1.1.0.11
-  - httpx_aiohttp >=0.1.9
-  - sounddevice >=0.5.1
-  - pandas >=1.2.3
-  license: Apache-2.0
-  license_family: Apache
-  size: 1050444
-  timestamp: 1767167836275
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.14.0-py313haa95532_0.conda
   sha256: 8733722172b598c317765fa957b1f380fc89fc25745e837ff1059c75c8e33fc5
   md5: 7871b47644f1a81af9f8a4bf98650d14
@@ -7328,39 +10923,6 @@ packages:
   license_family: Apache
   size: 1081595
   timestamp: 1767168143409
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
-  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
-  md5: d842c01c08579c4398dc5b15a0bd875d
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79899
-  timestamp: 1763721155768
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
-  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
-  md5: 583ab7940537e3387afa8c18b28eeb1c
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79849
-  timestamp: 1763721155450
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
-  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
-  md5: b2bded54c66346cf90e89ea7e65d80f6
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 80685
-  timestamp: 1763721157221
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openapi-pydantic-0.5.1-py313haa95532_0.conda
   sha256: af0f41dc6f6acd6e46b83ac8c9194e8030ca886534bf9b13ddfa7510b3ae4870
   md5: 4a22cfc41b9cae647b8521b29244e505
@@ -7372,38 +10934,6 @@ packages:
   license_family: MIT
   size: 80996
   timestamp: 1763721195728
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
-  sha256: 0dcbe182b4b5270e2c5b35ec90418ae7e2de7a925f8617fdc939dee732a21b8b
-  md5: 96c41caadc229cc56c4fbcb26bb5b8cd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 5818141
-  timestamp: 1772119658375
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
-  sha256: 8fadf5dae2d6cf940ab38fa58d964325032fcb1f5105783e928ec3068841168a
-  md5: d3628d798e959fc4dcb6f5521f98c9da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 5672689
-  timestamp: 1772119615171
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
-  sha256: 92cd3b69b02e8ca149bd387cfb168ba07d1d4f91f0921af5a280271c7aae1cad
-  md5: 1ff1b3ba66cd97c9be2819d012d58df4
-  depends:
-  - __osx >=12.1
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 4948202
-  timestamp: 1772119560161
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.5-hbb43b14_0.conda
   sha256: 74838df34c6e4e0d5279a33b7d82ca287b42c45c468e9993668b94fefea1853c
   md5: 06f0b0505049ec5179fa18c61974bcfb
@@ -7416,42 +10946,6 @@ packages:
   license_family: Apache
   size: 9306859
   timestamp: 1772121458614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
-  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
-  md5: 8310c25ce1847aee276a9e2617388f46
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101271
-  timestamp: 1763996098531
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
-  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
-  md5: 85b624fe49b39de9fbe86b79144cb7c4
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 100915
-  timestamp: 1763996095398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
-  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
-  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101534
-  timestamp: 1763996094518
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-api-1.38.0-py313haa95532_0.conda
   sha256: d04d44e41260fcdfc3459bbeae2321294618fd7f947d7bb5e372da2016fc1fb7
   md5: e237a98fa5043fca13e8270162fdcb3b
@@ -7464,39 +10958,6 @@ packages:
   license_family: Apache
   size: 101545
   timestamp: 1763996171123
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
-  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
-  md5: ea9c98e0799195320c546768f562f351
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37782
-  timestamp: 1764236782492
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
-  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
-  md5: fab7d6c7cd4ebefb06eada5bee45916c
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37829
-  timestamp: 1764236793947
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
-  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
-  md5: dd551f29b6694f41a405d347e5b7641e
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38099
-  timestamp: 1764236649957
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313haa95532_0.conda
   sha256: b287bd55c69e7f96b52fa7336f296946d636816d60ed286741013bf13b88ae4f
   md5: 1d30146e16512ecb43d947423aabc764
@@ -7508,57 +10969,6 @@ packages:
   license_family: Apache
   size: 37778
   timestamp: 1764236885569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
-  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
-  md5: 4c6786f5a20a0d5705c77a18d97eebec
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43650
-  timestamp: 1764254904983
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
-  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
-  md5: 211d4704424ad214a215cf0378e685cf
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43410
-  timestamp: 1764254906556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
-  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
-  md5: 9b13a4cb589d5fc73e302f66b526c922
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43323
-  timestamp: 1764254973641
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313haa95532_0.conda
   sha256: 0e6c7dab76c8fc49939c1e5f6a0e49ed7ff811e02e6b184ec234f9cc6278e18d
   md5: 7784def4d18a62e9c3b0ababce753f2b
@@ -7576,57 +10986,6 @@ packages:
   license_family: Apache
   size: 43263
   timestamp: 1764254987784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
-  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
-  md5: de2d09e81412c0288e94586569f8276c
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33381
-  timestamp: 1764254429958
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
-  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
-  md5: 928d47e0634131263d53b97b8359431f
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33553
-  timestamp: 1764254406341
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
-  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
-  md5: e65ca1299e5e4ca5f515faa509bd23ae
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33433
-  timestamp: 1764254395627
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313haa95532_0.conda
   sha256: 601ea19950a0e691b12149bd13d06f898d2a25fe060be1038f195be796359f10
   md5: a02ee8b8d3d1f79ab61b0c0f0dcb6dab
@@ -7644,48 +11003,6 @@ packages:
   license_family: Apache
   size: 33568
   timestamp: 1764254472408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
-  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
-  md5: a9aa9b02edaa6e129374ae281b4ace66
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 58002
-  timestamp: 1764084155711
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
-  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
-  md5: aae5f23a1a4a2c152ee68f16d380ff15
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57805
-  timestamp: 1764084154068
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
-  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
-  md5: 59267a3e2c335ee1d45d703dfaee30f7
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57708
-  timestamp: 1764084154910
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-instrumentation-0.59b0-py313haa95532_0.conda
   sha256: 68e244391c6f93d7d55e941feb790fd4016a402ffda2b8ba684512dd84fe5e53
   md5: 54d8e5a50cb75f7cb10139d86694f4ce
@@ -7700,39 +11017,6 @@ packages:
   license_family: APACHE
   size: 83182
   timestamp: 1764084236614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
-  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
-  md5: e36ceb40f2e628e2b6d4bb62032539a1
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57320
-  timestamp: 1764164412130
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
-  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
-  md5: a93dfba7f5563c3430eb842ff88b7cb7
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57059
-  timestamp: 1764164411916
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
-  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
-  md5: c2f0aecc8a2ea835b91a7897ab121f5c
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57335
-  timestamp: 1764164412952
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-proto-1.38.0-py313haa95532_0.conda
   sha256: 4d9af6cfdc6484dd269e39445ff8e1ddbc6e60a4b84b61515b4ebcf07fb5d517
   md5: 642de24674e936a3222d72d484a1ef45
@@ -7744,45 +11028,6 @@ packages:
   license_family: Apache
   size: 57588
   timestamp: 1764164490671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
-  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
-  md5: 2a77251102af2651654e23f12c0e58c6
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 274299
-  timestamp: 1764073186249
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
-  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
-  md5: 0ce00548bf7f2bc4d0cca918a84a3989
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275046
-  timestamp: 1764073129503
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
-  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
-  md5: c5fda39e599753e09a32115eb8330bac
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275773
-  timestamp: 1764073043306
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-sdk-1.38.0-py313haa95532_0.conda
   sha256: 678a2df75881e5e762497099297bb7d42e1bd2438b3fcd4791337a5ca1eb60dc
   md5: 9692d8b6afeeb44a6c751a3d3c41fdc8
@@ -7796,42 +11041,6 @@ packages:
   license_family: Apache
   size: 275430
   timestamp: 1764073280377
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
-  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
-  md5: e794cf7621bbe67d177b7e279cd6d610
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 179330
-  timestamp: 1764062875253
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
-  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
-  md5: f14b38ac757bcb80c206d16fb2e55592
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 177920
-  timestamp: 1764062882890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
-  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
-  md5: 677be6639bad152b927832a09d639b72
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 180260
-  timestamp: 1764062877653
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-semantic-conventions-0.59b0-py313haa95532_0.conda
   sha256: ccaa74ee5c9369fd9a0c7f43297f672fbb079df1d0930bbb3c51c4158b11ef11
   md5: bb98256d4bf0d8f130f7f1d51b7c5425
@@ -7844,41 +11053,6 @@ packages:
   license_family: Apache
   size: 180937
   timestamp: 1764062960760
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
-  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
-  md5: 76bffd8af6e6a162a1e7af69b9b800d7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 337138
-  timestamp: 1771945983540
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
-  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
-  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 334755
-  timestamp: 1771945967596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
-  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
-  md5: 304016a5b391759778800af9f24e1332
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 305477
-  timestamp: 1771946048520
 - conda: https://repo.anaconda.com/pkgs/main/win-64/orjson-3.11.7-py313h51239a8_0.conda
   sha256: 481226561000f1eb1e3a067b33713e209d100031c280a6052679f17985b58aee
   md5: f6d731e5099297ec7be0c2302a0ea354
@@ -7892,36 +11066,6 @@ packages:
   license_family: OTHER
   size: 233868
   timestamp: 1771946278261
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
-  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
-  md5: 0f7d4f61c3851a0d436b96e9cb02c393
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200822
-  timestamp: 1775004135549
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
-  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
-  md5: ba91769862d81cb2c29f4918aae1a245
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 198468
-  timestamp: 1775004133206
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
-  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
-  md5: 16eee0ba12a1721ab94eb4f87517b5e2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200339
-  timestamp: 1775004034672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
   sha256: 377f499629908034474c3ab04a45fcad5ba19158b4e0248a905fe73ffddb8e9f
   md5: 865786bee3991b29c53298346c7f6289
@@ -7932,36 +11076,6 @@ packages:
   license_family: Apache
   size: 201067
   timestamp: 1775004274536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
-  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
-  md5: da78932ffefe7e3f780f75672b3f8b36
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51265
-  timestamp: 1772567686795
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
-  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
-  md5: 730f7454d70a81d991ac05e09c699166
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51488
-  timestamp: 1772567675008
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
-  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
-  md5: edb4dc7d24225792e537e7db178ab7a5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51842
-  timestamp: 1772567682290
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
   sha256: 7f0dd38798a6247880c231a3086130c84e93bc7a17a0344e37f73ad36166f32e
   md5: 7c54e8d8e2c390fbe1ab4bbbd8437def
@@ -7972,41 +11086,6 @@ packages:
   license_family: Apache
   size: 51631
   timestamp: 1772567728989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
-  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
-  md5: 49c2031dcebd085e49c3aff84479e314
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1289658
-  timestamp: 1759825800150
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
-  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
-  md5: d2a1b973881c8c0493bf1fd7b62a2918
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1177858
-  timestamp: 1759825801409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
-  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
-  md5: dc957a9fa85669b0f6ce65ea9343fd8f
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 901944
-  timestamp: 1759825795666
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
   sha256: d54ea3169c090404ca6d9d154adf842d61ca7a0bf1e277a10c02e245f186b934
   md5: ce7492b4ef08cfdeb0fc35ab5447ccf4
@@ -8020,47 +11099,6 @@ packages:
   license_family: BSD
   size: 1317213
   timestamp: 1759825896688
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-  sha256: a3ffa3423f3a1c2a5184fd3e83c4555c9b6d627b0ed2e101b2ab615d585c1f40
-  md5: 694138f71ea48d078f301a9a701bbc62
-  depends:
-  - python >=3.9,<3.14.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 1178932
-  timestamp: 1774988902802
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
-  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
-  md5: a1e79da30a6c62c6398e9bb990ee9ed6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9162
-  timestamp: 1728388115083
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
-  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
-  md5: ed391ccc6d6caaccedd5250fdeb48807
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9176
-  timestamp: 1728408515784
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
-  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
-  md5: 5c6344029e52293764fd4f88d6216c07
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9307
-  timestamp: 1728592695690
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
   sha256: 891ecf91eb86227f847743d2519f9f8c3ff70386d56b0d0507c5dc557392b101
   md5: 1dea692228d870c3278e9797ddc0589a
@@ -8071,36 +11109,6 @@ packages:
   license_family: MIT
   size: 10112
   timestamp: 1729049247460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
-  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
-  md5: e1705a98bf3338281b413e1fc8484a12
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54729
-  timestamp: 1773652981831
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
-  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
-  md5: cdff168e8e1d6bbfced0f9ce18a6534a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54735
-  timestamp: 1773652976404
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
-  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
-  md5: f9e7cc4e6d37a4efe63452519464e148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54951
-  timestamp: 1773653001076
 - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
   sha256: 7c422f786db266a90afe84e10bc2cd2547118032fd46cbc590ef343de0fd411c
   md5: c73cb48e85b2d4c9f6bee9b364adb4d4
@@ -8111,36 +11119,6 @@ packages:
   license_family: MIT
   size: 54633
   timestamp: 1773653037631
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
-  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
-  md5: 5c71fdece7639940072a849417bff8da
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47969
-  timestamp: 1776972936162
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
-  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
-  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47904
-  timestamp: 1776972854196
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
-  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
-  md5: 3550efa655956e28eb7282c3210bb015
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47964
-  timestamp: 1776972833748
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
   sha256: d5286244f6ebbceb1cc19c77a342fe6849f646a4a51d2aa8a7fe48af4d75b4c0
   md5: 56ed40dd2a648486a27c2c79f253f2e6
@@ -8151,36 +11129,6 @@ packages:
   license_family: MIT
   size: 48203
   timestamp: 1776973096987
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
-  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
-  md5: 7664f08981772ba49fef33294a096a18
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170398
-  timestamp: 1772733409298
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
-  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
-  md5: 08a8181515e8bdce86ee017bb1153d69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170028
-  timestamp: 1772733403459
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
-  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
-  md5: f686d9126128ed3d50046833a1b555a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170595
-  timestamp: 1772733427973
 - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.24.1-py313haa95532_0.conda
   sha256: a482e9e5c6e30ea4126e3f64fd75590a0d213395adae10e0da11b79fd5a45fb7
   md5: 538e9c192d280b01619787f642e8e5d2
@@ -8191,50 +11139,6 @@ packages:
   license_family: Apache
   size: 171669
   timestamp: 1772733460825
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
-  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
-  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 570052
-  timestamp: 1770660764829
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
-  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
-  md5: c65088b4df85204138e7899b7bb677c5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 579494
-  timestamp: 1770660753322
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
-  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
-  md5: 70879a51504dda5aff5034450b11a84a
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 461761
-  timestamp: 1770660566466
 - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
   sha256: 18213ba9abcbdc83efc0e49693fb96016e883b3a85e58ecca91696898ef6d434
   md5: c981add26704b7d11b6605c103bd02e9
@@ -8250,41 +11154,6 @@ packages:
   license_family: BSD
   size: 490900
   timestamp: 1770660962864
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
-  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
-  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550941
-  timestamp: 1761896477134
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
-  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
-  md5: 55e55bb476470a157cf4b81f44283436
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550478
-  timestamp: 1761896485773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
-  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
-  md5: 6bc6a220a229abae6afa80ccf4c3b06b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 561023
-  timestamp: 1761896362276
 - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
   sha256: 62d6a63cc8ea42b78731f1336ad68cee6c33401343632c0f5af532167a6f9184
   md5: e1d87eecc309f85ec24e0950615e985e
@@ -8298,129 +11167,6 @@ packages:
   license_family: BSD
   size: 573993
   timestamp: 1761896633111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
-  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
-  md5: 973a642312d2a28927aaf5b477c67250
-  depends:
-  - libgcc-ng >=7.2.0
-  license: MIT
-  license_family: MIT
-  size: 5360
-  timestamp: 1505733967605
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
-  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
-  md5: bd26b7e13996984230e8ec67f3ebd4c7
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  license_family: MIT
-  size: 7035
-  timestamp: 1615912729649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_0.conda
-  sha256: 1342d17b10c8d4c2a1299e64c2e9e9b3bb21f5d20a340f8fd95bc19bd484b652
-  md5: 615b5f8a0a168480d9c09adda1c4d690
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - pytz >=2025.2
-  - pydantic >=2.11.9
-  - keyring >=25.6.0
-  - asyncpg >=0.30.0
-  - hvac >=2.3.0
-  - rocksdict >=0.3.24
-  - elasticsearch >=8.0.0
-  - diskcache >=5.0.0
-  - cryptography >=45.0.0
-  - aiohttp>=3.12
-  - types-aiobotocore-s3 >=2.16.0
-  - pymongo >=4.0.0
-  - python-duckdb >=1.1.1
-  - dbus-python >=1.4.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - types-hvac >=2.3.0
-  - pathvalidate >=3.3.1
-  - aioboto3 >=13.3.0
-  - aiomcache >=0.8.0
-  - redis-py >=4.3.0
-  - cachetools >=5.0.0
-  - valkey-glide >=2.1.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 258923
-  timestamp: 1774282532566
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_0.conda
-  sha256: f1bc44d14e47248ac41cd19f4248eefd19e0c8c653def8ebe34da121aac143f9
-  md5: 41d9139e9cf072086e73d2b8674a161c
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - valkey-glide >=2.1.0
-  - hvac >=2.3.0
-  - cryptography >=45.0.0
-  - aioboto3 >=13.3.0
-  - types-hvac >=2.3.0
-  - types-aiobotocore-s3 >=2.16.0
-  - pymongo >=4.0.0
-  - python-duckdb >=1.1.1
-  - cachetools >=5.0.0
-  - diskcache >=5.0.0
-  - keyring >=25.6.0
-  - rocksdict >=0.3.24
-  - pydantic >=2.11.9
-  - pathvalidate >=3.3.1
-  - dbus-python >=1.4.0
-  - elasticsearch >=8.0.0
-  - pytz >=2025.2
-  - aiohttp>=3.12
-  - redis-py >=4.3.0
-  - aiomcache >=0.8.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - asyncpg >=0.30.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 258279
-  timestamp: 1774282530353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_0.conda
-  sha256: eeb86bfc9db2ecb4bfe8852460295b5dcd37d244ab302d67a920e18a98478646
-  md5: 08a6f7bf52ab151c245dd7dd816df303
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - types-aiobotocore-s3 >=2.16.0
-  - dbus-python >=1.4.0
-  - pytz >=2025.2
-  - aiomcache >=0.8.0
-  - python-duckdb >=1.1.1
-  - elasticsearch >=8.0.0
-  - redis-py >=4.3.0
-  - hvac >=2.3.0
-  - asyncpg >=0.30.0
-  - pydantic >=2.11.9
-  - cryptography >=45.0.0
-  - diskcache >=5.0.0
-  - types-hvac >=2.3.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - aiohttp>=3.12
-  - rocksdict >=0.3.24
-  - pymongo >=4.0.0
-  - valkey-glide >=2.1.0
-  - cachetools >=5.0.0
-  - pathvalidate >=3.3.1
-  - aioboto3 >=13.3.0
-  - keyring >=25.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 260440
-  timestamp: 1774282548095
 - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_0.conda
   sha256: cc2d35e134b8f401be9544dc98b78b126633c73fbae7f4494e358a8ddf67a300
   md5: d7ac9b1a569d1c2cd9ee3a4bff6e2e18
@@ -8456,45 +11202,6 @@ packages:
   license_family: Apache
   size: 259866
   timestamp: 1774282584624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
-  md5: 7f0df6639fdf60ccd3045ee6faedd32f
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14215
-  timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
-  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
-  md5: 60ea7416e08d78563e31d16c333bd57f
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 93055
-  timestamp: 1736868559715
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
-  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
-  md5: 574f6176492ab5f26a379307c7377a30
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92719
-  timestamp: 1736868553560
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
-  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
-  md5: 2ee55b934de679d2f73bd0f3840f1dfd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 90639
-  timestamp: 1736868507679
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
   sha256: df4e2759d0dfd24b3e6e00dabfa6583b01c865db0527a0cb4ba21d67ca767b95
   md5: 31fe82cdc830f79c27346b9e66342d2a
@@ -8507,36 +11214,6 @@ packages:
   license_family: MIT
   size: 92654
   timestamp: 1736869076072
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
-  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
-  md5: 3b8ea90c558c424f123c1fc6069c9fa6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155521
-  timestamp: 1774959763398
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
-  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
-  md5: 03fd00dba51a683e8d01f74ec63a1fec
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 156035
-  timestamp: 1774959750947
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
-  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
-  md5: 63924165d4c0b49b018d6c6c742d5666
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140335
-  timestamp: 1774959697268
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
   sha256: 48cef9cf6d54f01afab07973fc1b295586120acffb2b9ca592a5bc0deee49dd2
   md5: 9487fca3796d5c8cd0c361909099518d
@@ -8547,54 +11224,6 @@ packages:
   license_family: BSD
   size: 140506
   timestamp: 1774959857744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
-  sha256: 6c081cbd4131236658531e64370f14aabd59335a63a6b78360505bf8ba06e885
-  md5: 95234214667460a6e4eb9cd44c5facba
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1107018
-  timestamp: 1773134413559
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
-  sha256: 075b85319122a84033ed5e8671a404878daad18d896f69b8a7e5b946f1463667
-  md5: 02a133da4f575464a6424b568d582954
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1107670
-  timestamp: 1773134406974
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
-  sha256: 263e4a340ba4b6425eca95b681181941bd060686daab3864062870e7d39fe7b5
-  md5: dffaab726a9b2000756aaebc6da806d7
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1108443
-  timestamp: 1773134360203
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
   sha256: 923cb9aa819ea8f6b258b391c4ef4abd860ae016b793a2b1aab28ad6b7271e0b
   md5: 57e5cd75c0aefb820229739e54e986c8
@@ -8612,46 +11241,6 @@ packages:
   license_family: MIT
   size: 1110528
   timestamp: 1773134450949
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
-  sha256: 4964ef04532cce861183176123287df387db41329ad24a7256518b1ec1bb99b9
-  md5: d943970fbb63d8d9e6f5d805f2a6fbdf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1932101
-  timestamp: 1764009859395
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
-  sha256: f756ae4ab74fea66ac0f7b687e5ff72a736521e5d30c2959f5e06bb26b43bb92
-  md5: cb6fcb4bb58138dc49beda6d90d2f4cb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1771859
-  timestamp: 1764009871699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
-  sha256: e18c0428812b74200603b8944868ad2ba753a30e1d5be86a44e84b560ad95bfb
-  md5: fb4b0939fbc6cce6be885131224f9c35
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1726048
-  timestamp: 1764009904442
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.41.5-py313h114bc41_1.conda
   sha256: 926de8c3cf42c9eea67f7fb075331172c3399c10f7fd0d94b4f942b298eb4301
   md5: 0b2da722db0f7799fd9537438d241594
@@ -8666,66 +11255,6 @@ packages:
   license_family: MIT
   size: 1922906
   timestamp: 1764010123974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
-  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
-  md5: 52b991b3676ad69221ac4efe952ea622
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - google-cloud-secret-manager>=2.23.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  - pyyaml >=6.0.1
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  license: MIT
-  license_family: MIT
-  size: 151041
-  timestamp: 1764165180924
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
-  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
-  md5: 8bcdca4304da9f754bfb1f5839f796dc
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - azure-identity >=1.16.0
-  - tomli >=2.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - pyyaml >=6.0.1
-  - google-cloud-secret-manager>=2.23.1
-  license: MIT
-  license_family: MIT
-  size: 150714
-  timestamp: 1764165157426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
-  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
-  md5: 4bc0da3d9e06af7ce644b3901790c1ee
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  - google-cloud-secret-manager>=2.23.1
-  - pyyaml >=6.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  license: MIT
-  license_family: MIT
-  size: 150650
-  timestamp: 1764165172452
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
   sha256: 41e0f59c3321217f4aa6014c3411daec4264f4ea2483ac4711b90accdc8ae080
   md5: 9be00e22c3dd90cc9dd9e183021866db
@@ -8746,36 +11275,6 @@ packages:
   license_family: MIT
   size: 150711
   timestamp: 1764165274424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
-  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
-  md5: ccea3f7c3ca8da985a55fbc042ad8d82
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4943174
-  timestamp: 1775127040649
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
-  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
-  md5: 1e4f8926de2d91ff108ecf1f8d30371f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4941418
-  timestamp: 1775127034860
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
-  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
-  md5: 1a096beb854aaa14d863b4da60533f79
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4967892
-  timestamp: 1775127065874
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.20.0-py313haa95532_0.conda
   sha256: 55eb323f6032fe8c04b3336316f03080de2f147a32cc8485a4bf2b3b44cebbb9
   md5: ac3a0314796552bc697699b09c014e71
@@ -8788,42 +11287,6 @@ packages:
   license_family: BSD
   size: 5003268
   timestamp: 1775127093941
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
-  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
-  md5: 3cbe7080967f615cd88efd025391b662
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 102773
-  timestamp: 1773773809562
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
-  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
-  md5: 9f01b187aede17a6e8b192f35472b652
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103005
-  timestamp: 1773773803703
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
-  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
-  md5: 208f064869aaa98b2340cc60eb64c58b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103272
-  timestamp: 1773773829773
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
   sha256: 7aef9d733577597c67e2e122e275063bb1b62289943dde8fc2053e052b4669c4
   md5: ea6817e7fbafb39b117e5d6c30f40a54
@@ -8836,66 +11299,6 @@ packages:
   license_family: MIT
   size: 102610
   timestamp: 1773773869078
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
-  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
-  md5: c7bc813891134328cf9262beac3465db
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 479484
-  timestamp: 1763629905351
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
-  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
-  md5: fd8423aa2c161f1355d9eb5e53958096
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 377280
-  timestamp: 1763651408167
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
-  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
-  md5: 41e5a9f1fb430fad7e10a9db74000502
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26218
-  timestamp: 1773985120703
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
-  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
-  md5: 90a46389b262fac93bd471f2fc0ea5ff
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25832
-  timestamp: 1773985116510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
-  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
-  md5: 505cfc77c635faa08a4a889e1c6c8a10
-  depends:
-  - pyobjc-framework-cocoa
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26139
-  timestamp: 1773985028336
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyperclip-1.11.0-py313haa95532_0.conda
   sha256: fcb763479633b4cc7d05a20cc43670537bf7c4e9c5e473f796860a08104e92c0
   md5: 7aa1773bcce0f593f10a123a140c14db
@@ -8906,36 +11309,6 @@ packages:
   license_family: BSD
   size: 25926
   timestamp: 1773985260113
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
-  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
-  md5: e1ab9ffa1588856f0bdbb204322568c4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35801
-  timestamp: 1761753024312
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
-  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
-  md5: 43da0d039f7b195466a8be650fa38424
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35803
-  timestamp: 1761753028895
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
-  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
-  md5: 16bf831da5d9b80789ca8c06f958ae2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 36057
-  timestamp: 1761753032083
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
   sha256: 80a495f4af262ca1119720a007eab7dda13008f48ba1a9e0a0b0003638dc71aa
   md5: fbfa708fb7dba50f62e0363778296f29
@@ -8947,81 +11320,6 @@ packages:
   license_family: BSD
   size: 35859
   timestamp: 1761753068122
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
-  build_number: 100
-  sha256: 558a087f71909db8c04f634af023c94d128305f1b313560bf6ed9bb404f731bf
-  md5: f0c9d56e080ab6f2838d1626225cdd37
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.35.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 33182243
-  timestamp: 1771950585257
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
-  build_number: 100
-  sha256: 3440eaa5799c8adb5cf8973c0181f114b116ba9b3ef44a9ff31fbb50575a2243
-  md5: 1d5ed28a2ac1369d7d94b834e8d3a505
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.35.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 31723170
-  timestamp: 1771950827906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
-  build_number: 100
-  sha256: cdb79b470fdce5061bfcc0188800e92361f24668d79b212d057240b0ff5ffc7a
-  md5: 19a38ad6775e08a4774572c2bbf2f187
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 13569673
-  timestamp: 1771949586042
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.12-h39c999c_100_cp313.conda
   build_number: 100
   sha256: 72ed8ba8d7ddb639d9c49b8ac6580f8e4a07ef9b70ed6e3c9bc9fa759b917195
@@ -9045,39 +11343,6 @@ packages:
   license_family: PSF
   size: 16714237
   timestamp: 1771949289066
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
-  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
-  md5: a844b3df0b11b33f4742841d25146b6c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313830
-  timestamp: 1728385377316
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
-  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
-  md5: 061428165f4369719796769975341cf7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 315827
-  timestamp: 1728405669914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
-  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
-  md5: 2ac600a5ed014f3b8fe2996b213a68e6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313686
-  timestamp: 1728585595371
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
   sha256: 76a01e3051b5ff8157a5018de495b6f1ca1adaf8854c984a15bb59c7940f1a09
   md5: 43a3d00b9e02e3dea2bdcfec026286ac
@@ -9089,42 +11354,6 @@ packages:
   license_family: BSD
   size: 314702
   timestamp: 1729038434598
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
-  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
-  md5: 6aa550906f91d13d1371c07e9cb5c5c3
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51623
-  timestamp: 1768559707638
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
-  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
-  md5: e07c79278a8a508e83e42d176ab595be
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51868
-  timestamp: 1768559706782
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
-  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
-  md5: 69ed706ac95df59f56b448091f4c40fa
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51905
-  timestamp: 1768559713789
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
   sha256: 13d615a42829d3c12dc481c69ab5f1116c3199e288f41254349a06271ce4e9fb
   md5: 072ed01dfef3ee838397aca7daca4909
@@ -9137,36 +11366,6 @@ packages:
   license_family: BSD
   size: 76112
   timestamp: 1768559797418
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
-  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
-  md5: 213fed7b509c30119154cf77a958aa7d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253447
-  timestamp: 1763718602538
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
-  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
-  md5: b8dc8f719d9a94474d335a89ff1ab0a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253530
-  timestamp: 1763718606784
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
-  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
-  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253652
-  timestamp: 1763718722391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
   sha256: 82a7013143a81abbf1c7657bf8b808bf0dc0a8e3a4b985eda5ad1c57526341e4
   md5: f8d83d25272d9810a1b8f8fc36d6d6b2
@@ -9177,36 +11376,6 @@ packages:
   license_family: BSD
   size: 254671
   timestamp: 1763718769611
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.22-py313h06a4308_0.conda
-  sha256: 1698108e7f224df70f6514dc9bb833975b5c3f47345a4e1282db18e3598b5700
-  md5: aa89c2ed9a05853082cd19c20ba08656
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63807
-  timestamp: 1770213120083
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.22-py313hd43f75c_0.conda
-  sha256: f868a7e78c5c2a474306668060bceed1f06b6a95e0525c0c34560dff68316759
-  md5: b936e94e4dc4c1841fa1cfd250cb3ab1
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63443
-  timestamp: 1770213004301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.22-py313hca03da5_0.conda
-  sha256: 1193284d818979968ff3ea025db81dead8b7ce6a25bc8ee8fb7ea88a863f228a
-  md5: 664d7612270a36fe3894eb84777ae034
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63072
-  timestamp: 1770212979157
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.22-py313haa95532_0.conda
   sha256: 25a5bf78f4123af6f5e67139d69c90b8a2317a25686ee8439284c0e9eba3065a
   md5: 7cafce0e85a94c8dd39fc1d34147d291
@@ -9217,36 +11386,6 @@ packages:
   license_family: Apache
   size: 62835
   timestamp: 1770213065957
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
-  md5: 5af1bf885def2fa779b0bb002e53651b
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6157
-  timestamp: 1764349599777
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
-  md5: fb2966848729243e63cc897cb90f1eda
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6101
-  timestamp: 1764349598421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
-  md5: 12e362aabff119a51f51ac3c0f3d0a84
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6010
-  timestamp: 1764349560639
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
   build_number: 3
   sha256: d0a5b4e854c76a4ff354a9ce22725cff8986afff92e3fccca14a02171fccd56e
@@ -9257,36 +11396,6 @@ packages:
   license_family: BSD
   size: 6092
   timestamp: 1764349785264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
-  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
-  md5: f700a9cc4e35fd699b4df403f8f14148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 224571
-  timestamp: 1773043070463
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
-  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
-  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 223054
-  timestamp: 1773043038462
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
-  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
-  md5: 7faf2150ef3d3493e3554582fec52fcb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 226666
-  timestamp: 1773042949673
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
   sha256: c56ad8b43d5b1c0839d9bb87ddbb1b969c3591d67df173fa416e38d094c8d81e
   md5: e2698e9bf539b4e68b9b7fde985f7cdc
@@ -9320,44 +11429,6 @@ packages:
   license_family: BSD
   size: 55951
   timestamp: 1768296662106
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
-  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
-  md5: 2384f037ab798b6ce6097c717a8758dc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 253759
-  timestamp: 1763465523432
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
-  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
-  md5: a9b067a53f219bf9ed2a4583154facf9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 245388
-  timestamp: 1763465541517
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
-  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
-  md5: 5ea183aac23f4bbe41412f200a70d09d
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 237854
-  timestamp: 1763465528485
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py313hb9a58be_0.conda
   sha256: cdf7b48afb00e8f1c75b8009bf288015f3f894925807350c412d2b40505ff71b
   md5: 99d3b0d7895f14c833020bae2637fbd0
@@ -9372,33 +11443,6 @@ packages:
   license_family: MIT
   size: 232090
   timestamp: 1763465571269
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
-  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
-  md5: 631d76b2ec86efd85d6266113f7b20d5
-  depends:
-  - libre2-11 2025.11.05 h3356fce_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26001
-  timestamp: 1770390441796
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
-  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
-  md5: bb43fdeb5e1bc6595d63be00f22eaf00
-  depends:
-  - libre2-11 2025.11.05 h1b0d54c_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25969
-  timestamp: 1770390562916
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
-  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
-  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
-  depends:
-  - libre2-11 2025.11.05 hce96306_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26013
-  timestamp: 1770390441654
 - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hca2749c_1.conda
   sha256: 37ed6c029f2d0ca481bd36dd1a46be9c56d6aefd3af67238aad08a4058078cb1
   md5: 7b2b70a3962203de30cb3f7d4a21e759
@@ -9408,36 +11452,6 @@ packages:
   license_family: BSD
   size: 218680
   timestamp: 1770390656414
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
-  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
-  md5: 33b7455bfa1462c42bbc9a0535070313
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19959
-  timestamp: 1760613452708
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
-  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
-  md5: d2228764ccb4ad95813f44effcaaa38a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19961
-  timestamp: 1760613342830
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
-  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
-  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 20018
-  timestamp: 1760613321490
 - conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
   sha256: ce9cb1907f5ad2f1da9a073bf941532fcae38754ee519092d675ed2632c15eb0
   md5: 2686c6ca4329a9d6a587103c986e7026
@@ -9448,73 +11462,6 @@ packages:
   license_family: MIT
   size: 20322
   timestamp: 1760613512213
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
-  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
-  md5: 8578e006d4ef5cb98a6cda232b3490f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 481826
-  timestamp: 1754485653893
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
-  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
-  md5: f04b3cb7ab28e886ceb012e4e9626e82
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 509455
-  timestamp: 1754485781954
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
-  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
-  md5: fed853901ec41684b9e08b0c7ee4d7f0
-  depends:
-  - __osx >=11.1
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 475276
-  timestamp: 1754485689285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
-  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
-  md5: ce6e467c7e671a9214bc5d118b8e24a7
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82123
-  timestamp: 1762536905383
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
-  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
-  md5: f1cd02f5cac4c78dd00805f81f7b66d8
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82590
-  timestamp: 1762536906694
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
-  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
-  md5: 3fa52decbfabf965e84fd38bfb2e268f
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82518
-  timestamp: 1762536906534
 - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
   sha256: 175d71ed03e9e70ec164fe1f944955859f1e94b78bd068131737366f52863348
   md5: 45abed89b4fa72b0b16dc01408537551
@@ -9527,31 +11474,6 @@ packages:
   license_family: MIT
   size: 82654
   timestamp: 1762536944331
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.4-h6a678d5_2.conda
-  sha256: 3c9233dc26c1e4264966c5b95ab7cb80748153ae1c3de688a503d9f84c888210
-  md5: 3c6dbc6c60b3897222d79359343e90fa
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 29681
-  timestamp: 1714680903817
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.4-h419075a_2.conda
-  sha256: 6b1fdbf185a6df47d04b841618860735efcc5cb6729835a7d381af0576743d44
-  md5: 50bf464f48566d71a2778149c54d9fb1
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 30679
-  timestamp: 1714680903704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.4-h313beb8_2.conda
-  sha256: c762e27a07ece0e9977ae96f454ed40c4bef396d9f0c0fe3e7fb8059945b6d4d
-  md5: 91a2f6f75e6c6614f43ddc8ac2b3e0aa
-  license: MIT
-  license_family: MIT
-  size: 28562
-  timestamp: 1714680923465
 - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.4-hd77b12b_2.conda
   sha256: 1244464650edae7ee4a7361e2bff996d40f41a984ce824fb96c911151aa0e7df
   md5: 0145436bf5111660b686d3ad7f1b4235
@@ -9562,38 +11484,6 @@ packages:
   license_family: MIT
   size: 41178
   timestamp: 1714681024765
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.4-h6a678d5_2.conda
-  sha256: 7211f85590295c8dc29622fe02514f081a3a25dcc2dafcc741365ddb5aedee95
-  md5: b03aa4903158279f003e7032ab9f5601
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - reproc 14.2.4 h6a678d5_2
-  license: MIT
-  license_family: MIT
-  size: 21248
-  timestamp: 1714680919761
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.4-h419075a_2.conda
-  sha256: 7637fbc980328f813717563f123a8d8f8f2da24920e35e1984f2fd860c9cec5c
-  md5: d4a07ee63f2fded787246f3eb2d2157c
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - reproc 14.2.4 h419075a_2
-  license: MIT
-  license_family: MIT
-  size: 21136
-  timestamp: 1714680918050
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.4-h313beb8_2.conda
-  sha256: 86078c391e11c380a58e83825cd9f3e0498e0866e0aa2b77ba8fe6cce49e5274
-  md5: dde005914879790985acd3af3bf84e65
-  depends:
-  - libcxx >=14.0.6
-  - reproc 14.2.4 h313beb8_2
-  license: MIT
-  license_family: MIT
-  size: 21399
-  timestamp: 1714680948045
 - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.4-hd77b12b_2.conda
   sha256: 977af37a7ae564f8b244b6406fc44db97a17649c7265fffadafba9b927ff77ac
   md5: 34c1b673ec90d3c79cfb1677505ae5c8
@@ -9605,57 +11495,6 @@ packages:
   license_family: MIT
   size: 35033
   timestamp: 1714681086506
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
-  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
-  md5: 120fcdc3014753b33a63db5930b7a085
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170579
-  timestamp: 1775066095969
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
-  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
-  md5: a7bcec6c82277f3990f35708bd05d660
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 171420
-  timestamp: 1775066082442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
-  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
-  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170039
-  timestamp: 1775066216803
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.33.1-py313haa95532_0.conda
   sha256: 2e3287357fab55e326b1d2ed0a4a648647e2ad1ea1851c1da2a98059427558b0
   md5: db2c3d5b826ca6275015bfaaf007188e
@@ -9673,39 +11512,6 @@ packages:
   license_family: Apache
   size: 170995
   timestamp: 1775066185516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
-  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
-  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88122
-  timestamp: 1728411680534
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
-  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
-  md5: 3f4000830e7a25be1df38114d361b976
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88285
-  timestamp: 1728500408740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
-  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
-  md5: 85f9714b8bf50cf6f9c75deb5441bba8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88498
-  timestamp: 1731721373383
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
   sha256: 522043089fc1642c8c8798864bdeaad6b7ddcdbfee8a3083fc31bdcc02577166
   md5: b11a903414ef47b3faed42691b1d2c9d
@@ -9717,48 +11523,6 @@ packages:
   license_family: Apache
   size: 89136
   timestamp: 1731731373752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
-  sha256: 4006abedbb05553a7f667566d23afbac4beea2097a96d0508c629b044affde0c
-  md5: f4775d8f7f987cff7f067c7a47c66723
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 604815
-  timestamp: 1760375652641
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
-  sha256: 3f941bc0664875e48deba64e64686f44b75b29d323063ec504a9e40c6b8c621c
-  md5: 097a66ceed127b2918383880bed077d2
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 603684
-  timestamp: 1760375647067
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
-  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
-  md5: ffc0d1741d0d0dbff07518323feb64d8
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 603836
-  timestamp: 1760375502207
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-14.2.0-py313haa95532_0.conda
   sha256: 54308fc64559dac4eb2f486594c826aaa7ba33d984392c6ee59850491c494a4b
   md5: 098632335698839505bc680c928fb38f
@@ -9773,42 +11537,6 @@ packages:
   license_family: MIT
   size: 604180
   timestamp: 1760375703489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
-  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
-  md5: 42d308b4487e6a58261a971eb689044b
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33936
-  timestamp: 1771961295227
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
-  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
-  md5: 167fe8ee5af593667148b74a02090717
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33721
-  timestamp: 1771961162662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
-  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
-  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33777
-  timestamp: 1771961170073
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-rst-1.3.2-py313haa95532_0.conda
   sha256: ad249f5c8aae6b75219fad602950c0287295a1b6baf118de85ee83afe1caa9e4
   md5: 0331fdc656de0c90b60866c109b7c686
@@ -9821,41 +11549,6 @@ packages:
   license_family: MIT
   size: 33623
   timestamp: 1771961216902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
-  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
-  md5: 9630d019be2bb127699a375157124a0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 346701
-  timestamp: 1762366536075
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
-  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
-  md5: 7f93cb69d835d6256cc68d0c22843159
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 335795
-  timestamp: 1762366544737
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
-  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
-  md5: 150c83ebdcae2067ae5c34a05c1da4ed
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 311962
-  timestamp: 1762366565780
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
   sha256: e9d4ae95e182d385fad599b171f7dbdf125a385566cd551e5ae579aa6699a9f0
   md5: 3253a635462ed5652fb9f5241e201d69
@@ -9869,50 +11562,6 @@ packages:
   license_family: MIT
   size: 219848
   timestamp: 1762366911453
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
-  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
-  md5: dc961556c7bbe4e2aa959e36ab816dcd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271868
-  timestamp: 1762535994695
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
-  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
-  md5: 28b23d252e0d230044637b0f8f88cca6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271533
-  timestamp: 1762535980215
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
-  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
-  md5: b292e4688f8ac6f1c97f1f3e895f5cff
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271430
-  timestamp: 1762535976251
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
   sha256: 4e8a117ed84fdf47dd2ef8ce7c6395af0a1310845917b4087aa98ec045796454
   md5: 97843e1c3c45660d8aa2c6dd6a7d1fc2
@@ -9929,41 +11578,6 @@ packages:
   license_family: MIT
   size: 271852
   timestamp: 1762536109923
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
-  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
-  md5: dad8d758af9c2b4369776c601407d9bd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 136835
-  timestamp: 1762530306911
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
-  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
-  md5: 26960af9de364b5745c254d1a6890c45
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 127958
-  timestamp: 1762530151153
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
-  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
-  md5: ca9e7978a1057363f0c36d975b764dcb
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 114492
-  timestamp: 1762530107760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.14-py313hb9a58be_0.conda
   sha256: 3ca28bf6841518b5004d899bd726b3f0230fd1ebfee34a9c336e6dc0cb41523c
   md5: cac6a4b727d18eb086ea401e817043af
@@ -9977,62 +11591,6 @@ packages:
   license_family: MIT
   size: 108685
   timestamp: 1762530153943
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
-  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
-  md5: 6ce9737188317c940d461c09c18d0ab3
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31382
-  timestamp: 1775127026347
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
-  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
-  md5: 529575cd8e6b7becb44a50d0d35009f0
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31316
-  timestamp: 1775127025036
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
-  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
-  md5: 985226bbcb23ebc859128ca676ad6321
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45387
-  timestamp: 1761903210853
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
-  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
-  md5: c9d0d757b916ddfd019821dbbc02a0d9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45447
-  timestamp: 1761903130898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
-  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
-  md5: 8b4a9bf142beac7513382b0a84ce51f5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45786
-  timestamp: 1761903046636
 - conda: https://repo.anaconda.com/pkgs/main/win-64/semver-3.0.4-py313haa95532_0.conda
   sha256: 5158570e5a5891716906743ce9eebe1a0572143dffe808ecba634e5a2c0b3859
   md5: 2dbcf40ddf66f02858c49c67ce0fd953
@@ -10043,36 +11601,6 @@ packages:
   license_family: BSD
   size: 70112
   timestamp: 1761903400398
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
-  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
-  md5: 08038e054ee9e8419ea6aa3fd04455ea
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1665385
-  timestamp: 1775048728528
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
-  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
-  md5: 10081f3addefc88e8127e68448bf9f6d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1666759
-  timestamp: 1775048722771
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
-  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
-  md5: c396551324d88dfb8c688affa5226c2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1669346
-  timestamp: 1775048820327
 - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-82.0.1-py313haa95532_0.conda
   sha256: 8c047064c40aa8a1c02c2488a7466178b71e87f5fce2ca9b95c96acc60d434b0
   md5: c5e8aa64b4745bdbadc0d37754385ccd
@@ -10083,36 +11611,6 @@ packages:
   license_family: MIT
   size: 1666057
   timestamp: 1775048790435
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
-  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
-  md5: 843241073919fc2c912f6ed85d14681d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23136
-  timestamp: 1761912223128
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
-  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
-  md5: d32e4a1ec001c6cef1aae68c11480c55
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23120
-  timestamp: 1761912222490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
-  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
-  md5: 58fe2f1c6896f6e26cea231b74e3888c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 22962
-  timestamp: 1761912224859
 - conda: https://repo.anaconda.com/pkgs/main/win-64/shellingham-1.5.4-py313haa95532_0.conda
   sha256: 1f6a915225fb3e8712d8734cae5276eb4527f93f5051f79269c1e1e4d03cd9e5
   md5: 48a11caef15ab91bf7360541a0842d05
@@ -10123,35 +11621,6 @@ packages:
   license_family: OTHER
   size: 23375
   timestamp: 1761912263432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
-  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
-  md5: 7b2a4b5be590071e1b4dce77b413d26a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 264262
-  timestamp: 1734048099531
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
-  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
-  md5: 0cefa22396b339a17597faad550d9582
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 226027
-  timestamp: 1734048100065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
-  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
-  md5: 443db5b88521ce0e2aaeb77bcf8fb488
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 220407
-  timestamp: 1734048107599
 - conda: https://repo.anaconda.com/pkgs/main/win-64/simdjson-3.10.1-h214f63a_0.conda
   sha256: fc942285ef1ed85c6ae955752e7ebadda95161eefc560c8e034d0d56f33110e1
   md5: e89a4c728f54ef6e0d7845fd1992af58
@@ -10162,36 +11631,6 @@ packages:
   license_family: Apache
   size: 281697
   timestamp: 1734048180938
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
-  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
-  md5: 648ce63d75b826e85fb8801c8b4b4e44
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37483
-  timestamp: 1744271525796
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
-  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
-  md5: 626970a8b8398716c9b9f9025eafd307
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37500
-  timestamp: 1744271573927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
-  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
-  md5: 4af6f9244bd475289f3410b1c8880ed9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 39474
-  timestamp: 1744271575294
 - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py313haa95532_0.conda
   sha256: fe16c893061086d4882b77d91b95efa937a831ce78bd3eb17cb18c99539b8232
   md5: e7fc4d83bea7ee99038d43c773df475f
@@ -10202,36 +11641,6 @@ packages:
   license_family: MIT
   size: 38706
   timestamp: 1744271651700
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
-  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
-  md5: face17589cf2b386d76cc870234dfe6e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17447
-  timestamp: 1764329206740
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
-  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
-  md5: 219c67c8ff19787a64b06c2517d063e9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17506
-  timestamp: 1764329173905
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
-  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
-  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17410
-  timestamp: 1764329171349
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
   sha256: 256d04f9d78737274877cd1fb9d7b15ef9efa940737cba71701ab20f9555322a
   md5: ec4cfcc2fe1e1b4325af67997d46ba36
@@ -10242,47 +11651,6 @@ packages:
   license_family: Other
   size: 17469
   timestamp: 1764329260587
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
-  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
-  md5: c7b847a43363d2d77724b9ea04881088
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1265119
-  timestamp: 1773313781324
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
-  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
-  md5: 55600c8be72a7624ebd63e54ed72cbe0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1281272
-  timestamp: 1773313781654
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
-  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
-  md5: cf083b0b25fff8ddab995ac001076f38
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1182590
-  timestamp: 1773314600429
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
   sha256: d9d5f8b3ba4afcf43baca9386ae69f3b7b0f1d30f35ced10bc52d61fe0d1cd28
   md5: b273f421592da633715a1c28058d0ea9
@@ -10294,42 +11662,6 @@ packages:
   license_family: Other
   size: 938682
   timestamp: 1773313787688
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
-  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
-  md5: 1fb18f68f15d21748310b2a09ea2f923
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21821
-  timestamp: 1745413175232
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
-  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
-  md5: 1596a495a1f3def74862ce0efcc8281e
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21754
-  timestamp: 1745413132458
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
-  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
-  md5: 685d7b964cfdfd152fb5ddc0951b16d2
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 23284
-  timestamp: 1745413263670
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
   sha256: 9f666e8156f111864ed9db7cfc4ade7408c9ca70f7f2b83f21bb17028715b6e0
   md5: cdb1d606ebfdb4a999b3936644911c34
@@ -10342,39 +11674,6 @@ packages:
   license_family: BSD
   size: 22693
   timestamp: 1745413221013
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.47.3-py313h06a4308_0.conda
-  sha256: f8d1b5a04bc9094bdc37f10bf227477dd3d1d7c02b5f41be1c91515b58649abb
-  md5: d75839b48c8d42e3e863de59994c4f96
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176882
-  timestamp: 1756910754331
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.47.3-py313hd43f75c_0.conda
-  sha256: 1143a28c21d0c234bf292910fd32f471cac3617850dc930f9760c8743fdab6bb
-  md5: 4e7e8a7d8b32b54e6fe2a5bc1ae2df44
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176653
-  timestamp: 1756910709929
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.47.3-py313hca03da5_0.conda
-  sha256: 4e340c9a1a336a863e70ddeedfac8407e5753b6ca77496f17d992c137361514a
-  md5: e17a539f880afd365a5ff1a388ec6605
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 177175
-  timestamp: 1756910711562
 - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.47.3-py313haa95532_0.conda
   sha256: 47ab748d8923e946c1371b1f0a9512fa93ccedacc387a6a10bbee8c52f85f43f
   md5: 59708fc1ba21fea3beff24556d600b6d
@@ -10386,39 +11685,6 @@ packages:
   license_family: BSD
   size: 177278
   timestamp: 1756910740826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
-  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
-  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3610181
-  timestamp: 1755243907117
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
-  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
-  md5: 6a7f42565108e00d27f68f4ae5751c53
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3717438
-  timestamp: 1755243976411
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
-  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
-  md5: d1329e6c7292f448cdeed21290dd1035
-  depends:
-  - __osx >=11.1
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3448719
-  timestamp: 1755244020166
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
   sha256: 2f7e9d06b513bcabce6d9ae195e45ccf94fd249edfefc591a5430a9f6f92a7fa
   md5: ddff7b6a72958ef802f40a735e505474
@@ -10431,45 +11697,6 @@ packages:
   license_family: BSD
   size: 3700492
   timestamp: 1755244051664
-- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
-  md5: cda05f5f6d8509529d1a2743288d197a
-  depends:
-  - python >=2.7
-  license: MIT
-  license_family: MIT
-  size: 20302
-  timestamp: 1616166645426
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
-  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
-  md5: 782987d420694bdc4a207a16db446a56
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82730
-  timestamp: 1768296500871
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
-  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
-  md5: d5ba67844244cfccfa37b1b23ec83b23
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82633
-  timestamp: 1768296495852
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
-  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
-  md5: 65d4e75c4c995d35de71b4e16174828c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82474
-  timestamp: 1768297453889
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
   sha256: cfd820f3b7c2cb7e7ff53c7110fc11d45220724457831c4b7b44e10f24b4e081
   md5: bf2d1a34135ca0731780c7b012fa5c89
@@ -10480,36 +11707,6 @@ packages:
   license_family: MIT
   size: 82570
   timestamp: 1768296694724
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
-  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
-  md5: d625085e004f964c54b88a3c6c5e8d7e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189342
-  timestamp: 1762896696002
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
-  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
-  md5: 8949c7ff2861d1b903cee84c0607eacf
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 188584
-  timestamp: 1762896685732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
-  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
-  md5: 9199e3c9a0451d04eff558d461dd1b2c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189601
-  timestamp: 1762896659686
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
   sha256: 5ab0840c91097eb033eb73a06cae0dee6317379b1c15cff4fe9672168488d28b
   md5: c5c83cb181bee0abb42aa29669eecee6
@@ -10520,42 +11717,6 @@ packages:
   license_family: MIT
   size: 189958
   timestamp: 1762896691761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
-  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
-  md5: 17b9f23e939b55ab9cab471b694a79d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 161112
-  timestamp: 1771398721582
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
-  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
-  md5: 54a2c4b9c33935687b977159f85bb4cb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160713
-  timestamp: 1771398718073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
-  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
-  md5: af4d88d628ea31190ed1432bba93b9c2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160792
-  timestamp: 1771398721170
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
   sha256: d3fe275f6dbc5bd68277660f7cbc07ced89a4fb5198a35ce2c32bc5d02eaa042
   md5: a797878a96f1b422ec8eee84371459f2
@@ -10569,36 +11730,6 @@ packages:
   license_family: MOZILLA
   size: 185961
   timestamp: 1771398813387
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
-  sha256: 0e7167d3723f10bfade1a0b6c3c59829c2bf9705d8f3ffd57bdebdc3b6ddf1ba
-  md5: e3ab7e8538a252ccb235f1cf218bda52
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216170
-  timestamp: 1728385119935
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
-  sha256: ab62d2a4692749c680612ab3330fea299ff9245a550a9d0a07bebc969b5435ba
-  md5: 7df7fc6bcb911d97032699617ee74718
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 212695
-  timestamp: 1728405381017
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
-  sha256: c06d6a4a9b21b72720bbbe2bcb0d850290df50925360cdc744115e1894f5176b
-  md5: 176fa6f06b48bfbbe763addd30ff154f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 213397
-  timestamp: 1728585495815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py313haa95532_0.conda
   sha256: 9617cced1f3dda7b511a1b19fce74ec6126de327febd3cbc096f1393b4253562
   md5: 0a77cf43cb292b62f1021ec2f59b809c
@@ -10609,36 +11740,6 @@ packages:
   license_family: BSD
   size: 214295
   timestamp: 1729038177233
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.1-py313h06a4308_1.conda
-  sha256: 5236b0311bb9dc1b8643fed1666c2ff465225d055e14f7730ca43e63258c6257
-  md5: f365c6753a35068503a4fba9a29953ff
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49373
-  timestamp: 1762520921980
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.1-py313hd43f75c_1.conda
-  sha256: ff9d5e072d130624fe642a1005d9bdf27a4c0775b0eea072b38b9e6a605de83d
-  md5: 8900fdf0ddd06efe24eb8f7c6794ccb4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49415
-  timestamp: 1762520920919
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.1-py313hca03da5_1.conda
-  sha256: 678639cde456bae6e4a11ce9118be17eebb4113963eb7aca2be86bd425d64e59
-  md5: c65542bf580047dbffdedaf763057c77
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49457
-  timestamp: 1762520944435
 - conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.1-py313haa95532_1.conda
   sha256: e3cdd87c4b0acadd89a849d52e28b2624a3029ff88ba75a77a74bfec6e037135
   md5: 02621c34f9d5bed45c55831d62a45ae7
@@ -10649,48 +11750,6 @@ packages:
   license_family: MIT
   size: 49487
   timestamp: 1762521065061
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
-  sha256: abf3e9b5820c78d1ca3d41b91f9b7b67d13d3e6c3f2892cc10f6f2361b3f0c3f
-  md5: d9b03aa4048c711087209d7c35e3fb32
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313h06a4308_1
-  constrains:
-  - typer-cli 0.20.0.*
-  - typer-slim 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157493
-  timestamp: 1771513026151
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
-  sha256: 72528b21b18f32ce743af2e3e2bc1518935cde1cdf36dd46fd0189e98ef3901c
-  md5: a404eaf65b18781d5e5d0f3a02db930b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313hd43f75c_1
-  constrains:
-  - typer-slim 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157663
-  timestamp: 1771513020641
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
-  sha256: fe035489f4bed2ab2fa0f51ae50faaf7c9b7390252b86123cbae4d3e45e178df
-  md5: 2a00d5da027f2f72dfd4b05c178afb29
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313hca03da5_1
-  constrains:
-  - typer-slim 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157900
-  timestamp: 1771513056344
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.20.0-py313haa95532_1.conda
   sha256: bf5f44ef827b63bdfaefef50ae2eca43e9ba0d0dc478a51deec0ef9fee8815b2
   md5: dfab5f80445eb8659daef0ba9527f95f
@@ -10705,57 +11764,6 @@ packages:
   license_family: MIT
   size: 182475
   timestamp: 1771513176865
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
-  sha256: 31e03fddda42d42d36db861c134ea402e4a7abe20a69a7a2b5bb07d42530737b
-  md5: 1d5785a482a13f84097ba02722141e5d
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - shellingham >=1.3.0
-  - rich >=10.11.0
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 112535
-  timestamp: 1771513011655
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
-  sha256: 7c1d7f40115ceba0cc000135f2e88a4dc41ca26615984bf01803f42de7e13647
-  md5: 06f7840d8233d7d3815c803d8950d653
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - shellingham >=1.3.0
-  - rich >=10.11.0
-  - typer-cli 0.20.0.*
-  - typer 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 112583
-  timestamp: 1771513006666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
-  sha256: 3e3e58ea2dabbc9ebe99e5a83d360c33642de0485fa07bcfa4f4bb1fa870f58b
-  md5: eaad783ddbeddae5d991cf850033e284
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - rich >=10.11.0
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  size: 112806
-  timestamp: 1771513038567
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-0.20.0-py313haa95532_1.conda
   sha256: dd4e5f1bc66d19d4294dd0730671f7e3a0fe6bdc5c5ab863846edd88b13b06e9
   md5: 8ec4fad99a2260241e793af8d8ef2369
@@ -10773,54 +11781,6 @@ packages:
   license_family: MIT
   size: 112460
   timestamp: 1771513097234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
-  sha256: b8a7d942b5032ecb3fd4faa83c7f51aa290d38773eb74195d7df136998aef8b6
-  md5: 9dd2ed87dd542c2ccde13c6e2e29a311
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313h06a4308_1
-  constrains:
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7309
-  timestamp: 1771513016825
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
-  sha256: 4695a00df558018887f458bd70b04c672d30d114b900444bfe845a577d8d1302
-  md5: 74f2f9f2479e83b49c21a310182f04d8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313hd43f75c_1
-  constrains:
-  - typer-cli 0.20.0.*
-  - typer 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7307
-  timestamp: 1771513011450
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
-  sha256: f10f6c39573b002cd7ed525c97e3a1033525b17e2ca9f635c7965ad1578e5d98
-  md5: 9d8e87a1f5725cf60bba4ec5094b80ae
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313hca03da5_1
-  constrains:
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7235
-  timestamp: 1771513045167
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-standard-0.20.0-py313haa95532_1.conda
   sha256: 05bc257bcdc83b244bbd10915692690463fc8b27e40abb67115df64faaa79fc1
   md5: 928952e95121b247487ae696bac105fd
@@ -10837,39 +11797,6 @@ packages:
   license_family: MIT
   size: 7252
   timestamp: 1771513106030
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
-  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
-  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313h06a4308_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11238
-  timestamp: 1756280930223
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
-  md5: 055d37ff4e41c9b9e33d2bb8919c263b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hd43f75c_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11203
-  timestamp: 1756280951293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
-  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
-  md5: 22b46f0e6d389d4199ffaa317e9c9a05
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hca03da5_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 12434
-  timestamp: 1756281597870
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
   sha256: 3503a6100d19cd88fcc28c21d6e3517f78e77f4541408266f0d6ffc2010a6ed0
   md5: b9d604ca2915d5b5c2e71c56eddcf39e
@@ -10881,39 +11808,6 @@ packages:
   license_family: PSF
   size: 12368
   timestamp: 1756281409751
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
-  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
-  md5: b5ea08882d6d5cca3e38a27a3575e85c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32310
-  timestamp: 1760614182019
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
-  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
-  md5: ff4e707bcf34fee0e2065cf2487e2103
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32401
-  timestamp: 1760614185275
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
-  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
-  md5: 1398c39b86119164f19498b6fbcfdb69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32465
-  timestamp: 1760614190333
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
   sha256: 2d10e45ad212588bd03eded99708a7d2dc50f4353577c890e82a28e6e3593f2a
   md5: e20a2281ead8112e87233f7ced446b0d
@@ -10925,36 +11819,6 @@ packages:
   license_family: MIT
   size: 32527
   timestamp: 1760614225492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
-  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
-  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 104756
-  timestamp: 1756280924315
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
-  md5: 017a18fc16caf581ce26bac0ad6f9efb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 101647
-  timestamp: 1756280944673
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
-  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
-  md5: 3c37609330dd4baeb0f4842f02cb783e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 106009
-  timestamp: 1756281579411
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
   sha256: 7ffee67192fba083f61c95f197fc119cb77ef83528d5d18ed2f63a881e46c0b9
   md5: 0e3cbe58bfd973d09298bcbf2de72675
@@ -10965,13 +11829,6 @@ packages:
   license_family: PSF
   size: 103139
   timestamp: 1756281400010
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
-  sha256: bab9c667cb352cdbbc895b4aa8c867221e2e98d5310d884e494540c0b5c1efce
-  md5: b46d6837d6e1ceabdf40378de048c581
-  license: CC-PDDC OR BSD-3-Clause
-  license_family: BSD
-  size: 120000
-  timestamp: 1772652196967
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
   sha256: 9dfca4fb23f20e62a48b9c52e2fdf4d0d34bb31eb6a930c2195fcd10651b3cc3
   md5: 15e1b10231d7d236520501fcfb440f31
@@ -10980,36 +11837,6 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 634816
   timestamp: 1752158202557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
-  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
-  md5: ad4d17d499c69cca7e35518f53419f5c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24140
-  timestamp: 1774276104417
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
-  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
-  md5: e857fd0d00de0e82669ff9e06d27f6dd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24215
-  timestamp: 1774276085005
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
-  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
-  md5: 7c281290dab4999400a1e12be880c3a2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24287
-  timestamp: 1774276373831
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
   sha256: 19b9ca9d334f4dad46930fad8dbd029817e78e1b5b1e4571fa703cdd196ece8b
   md5: 1b5b33b6f59be43d466b89eca9058e3f
@@ -11020,51 +11847,6 @@ packages:
   license_family: MIT
   size: 24294
   timestamp: 1774276137392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
-  sha256: 450d16974ba2405a26ad7da3a2a2dc4f395246427d3f3471520f7a0810e57e74
-  md5: 23108bceb7bbce3e449c9c55ecbaa296
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - backports.zstd >=1.0.0
-  - h2 >=4,<5
-  license: MIT
-  license_family: MIT
-  size: 357351
-  timestamp: 1767810287147
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
-  sha256: 82275c3c5f7e5eab48d74089cc207d4aa692f4a2efd30d4e992d1fd2d7775cca
-  md5: d7dea689ca62516ce02639d4663d1c53
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - h2 >=4,<5
-  - backports.zstd >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 357777
-  timestamp: 1767810287557
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
-  sha256: 375349eeb47983e6e2b2d2608f7141d948e5396e2906b087781d4f49df8dad0c
-  md5: 464328fc7f4e77667c63d5284e866e85
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - h2 >=4,<5
-  - backports.zstd >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 357592
-  timestamp: 1767810426391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
   sha256: f4d385f2f8c1803164a156f5122bde7d345be80b485827e2046562e1cf307da2
   md5: 991be321d1493e7325cf42a491eb01d9
@@ -11080,42 +11862,6 @@ packages:
   license_family: MIT
   size: 358116
   timestamp: 1767810523479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
-  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
-  md5: 302fdbeea413b0dc179b3ea16886718e
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141937
-  timestamp: 1768226450635
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
-  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
-  md5: ebabc185d4b18349d7bf0d9f5c3d2901
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140643
-  timestamp: 1768226452652
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
-  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
-  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 142181
-  timestamp: 1768226456487
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-0.40.0-py313haa95532_0.conda
   sha256: 79a3d79f156b4e3c2c0403dd306673d0ce0eab9fe826ce222fcd278e25736412
   md5: 892ba822f39d820e448a427969b75326
@@ -11128,57 +11874,6 @@ packages:
   license_family: BSD
   size: 167281
   timestamp: 1768226570499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
-  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
-  md5: 2e099756135a2ef67be288cb2d8c3119
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313h06a4308_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39548
-  timestamp: 1768226455792
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
-  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
-  md5: cb02ecced70ccf3114a942f060eb4f66
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hd43f75c_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39602
-  timestamp: 1768226458187
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
-  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
-  md5: eea1461696459cc24a16b5a689281400
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hca03da5_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39438
-  timestamp: 1768226463310
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-standard-0.40.0-py313haa95532_0.conda
   sha256: bf489bb11dd95158312c6b4691d73f1b1a639203cfa9f16e1b0cc5c50b9bb8f8
   md5: 6d196786ef6b84ab5630c064a6163ac1
@@ -11196,50 +11891,6 @@ packages:
   license_family: BSD
   size: 39668
   timestamp: 1768226581896
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
-  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
-  md5: c28e5468c6d8844e76d22ac7baea58e4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 665707
-  timestamp: 1762175545430
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
-  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
-  md5: 27e470f3b095fe3116358db877c2a2ea
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 612267
-  timestamp: 1762175558240
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
-  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
-  md5: 62098dfc2ae82083a56bfd7bc319cf0e
-  depends:
-  - __osx >=12.1
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 545986
-  timestamp: 1762175544791
 - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_10.conda
   sha256: d427b27e553a5caa78284a995ff9c3720b0f213a0e650fe9d3b54b4b4a65f241
   md5: 064c529f6f598fb2225446f76687a170
@@ -11269,44 +11920,6 @@ packages:
   license_family: BSD
   size: 19526
   timestamp: 1752199762272
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.1.1-py313h828f358_1.conda
-  sha256: 8ba2673045897d4b473dd974281b5d17db2e3cd42feec3a57dace7ca5a2faae2
-  md5: 9a7b7a4267a510d59d226cd2c271e9cd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 431640
-  timestamp: 1767984676303
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.1.1-py313h5331b00_1.conda
-  sha256: 1c63f47cdd8a02e84a0eac4310a93e386ca83c30c066d698a02e0ffa472e5593
-  md5: b60abe6911b141fc8469ee8852c5b1cc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 421473
-  timestamp: 1767984729070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.1.1-py313h931abed_1.conda
-  sha256: 53edfc478b14716b82ac71ee21940a4d0512e6af5a5426cccdc1f67ac32d03fb
-  md5: 3ef9c9cd73f6f7bd7cb9ec85cf3440aa
-  depends:
-  - __osx >=12.1
-  - anyio >=3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 375190
-  timestamp: 1767984700820
 - conda: https://repo.anaconda.com/pkgs/main/win-64/watchfiles-1.1.1-py313h114bc41_1.conda
   sha256: dc3c74fd7093bffff637f079d3034dc370e15e3a53b2b106e8eb4f963496bfcf
   md5: 18d5cb6b1af206d5279c66db0cb1fefb
@@ -11321,38 +11934,6 @@ packages:
   license_family: MIT
   size: 316002
   timestamp: 1767985067119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
-  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
-  md5: 946018cc418258ab8d35ed63099a3181
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 361630
-  timestamp: 1751974452259
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
-  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
-  md5: d6b2c092cb970c634a4b1376a8c212b6
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 368295
-  timestamp: 1751974662854
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
-  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
-  md5: ec80386b367f09af4b44b3824e29acce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 363811
-  timestamp: 1751974819165
 - conda: https://repo.anaconda.com/pkgs/main/win-64/websockets-15.0.1-py313h827c3e9_0.conda
   sha256: 1422f7434ce43647a3336ce4703d6a57905b6ffaf9906a5809fa09cc4fb06bbe
   md5: 05f2ea39368835a4209afca69a5b479c
@@ -11365,39 +11946,6 @@ packages:
   license_family: BSD
   size: 402372
   timestamp: 1751974975676
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
-  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
-  md5: 6730c94b00e7d802f421acd3a435af84
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70377
-  timestamp: 1769450261731
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
-  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
-  md5: caf0597b40222d6f17f745bd54636cea
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70703
-  timestamp: 1769450262181
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
-  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
-  md5: 0d4dafde912fdee412dadf279d688eb5
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70617
-  timestamp: 1769450358672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.46.3-py313haa95532_0.conda
   sha256: 8206b8d3b204549064bb11d50b812cf283f898444ade26f2bcde765424980575
   md5: 5d0ad25154aadbe531052f5aebb2e9f5
@@ -11418,38 +11966,6 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10272
   timestamp: 1761746316414
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
-  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
-  md5: 446fbd19ad7929dd70635f0303c5047b
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67121
-  timestamp: 1736540936116
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
-  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
-  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67625
-  timestamp: 1736540966215
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
-  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
-  md5: d75550f3641901250eaa43ed71dc40d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 65365
-  timestamp: 1736541780222
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.17.0-py313h827c3e9_0.conda
   sha256: bb5df055aa57eb6b5f9d90cfe6d13c40c6437f4da0bf3611188e8380cceeab3d
   md5: 280ad1ae053ab8dee8a864e78ddf501d
@@ -11462,315 +11978,6 @@ packages:
   license_family: BSD
   size: 70322
   timestamp: 1736543533940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
-  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
-  md5: 8d5b22b094b6802334d7c8316c4091ce
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23000
-  timestamp: 1771372478643
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
-  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
-  md5: 750a7b171e663c39f6ecc0771452514a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23909
-  timestamp: 1771372468468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
-  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
-  md5: 7a684ffa744044240b3061ad28531930
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 58122
-  timestamp: 1746171563556
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
-  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
-  md5: 4f190efcbddae546e15d54f3f0314b96
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 59357
-  timestamp: 1746171572210
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
-  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
-  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26341
-  timestamp: 1746172168013
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
-  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
-  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26965
-  timestamp: 1746172174098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
-  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
-  md5: 6298b27afae6f49f03765b2a03df2fcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 916212
-  timestamp: 1746110020649
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
-  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
-  md5: e87565f2b050d575ee056f472d062383
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 950329
-  timestamp: 1746110056137
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
-  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
-  md5: a8005a9f6eb903e113cd5363e8a11459
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 13582
-  timestamp: 1745958707989
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
-  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
-  md5: 96f0df92ef31ad0aaf27b6b373e4f510
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 14118
-  timestamp: 1745958715370
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
-  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
-  md5: c284a09ddfba81d9c4e740110f09ea06
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19260
-  timestamp: 1745992279492
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
-  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
-  md5: 5bfda69ee113cfc8e38e0214c078ef4e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19895
-  timestamp: 1745992295156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
-  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
-  md5: d810521a7b4a177fb3d1152cf84a778d
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 49889
-  timestamp: 1746169291297
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
-  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
-  md5: 607d46e3586e0c7b93a4495e0fe52db2
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 50277
-  timestamp: 1746169296094
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
-  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
-  md5: d95e8903fc0067086f153d04b8cbe578
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 95151
-  timestamp: 1746431898579
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
-  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
-  md5: f5e59a8d2737934ac40c9bf645a75c52
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 100170
-  timestamp: 1746431911997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
-  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
-  md5: 79d7d6794c6adbc537fc98f94e204270
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 409903
-  timestamp: 1746172685149
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
-  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
-  md5: c4b133535086cbaaf2403b18dc377e4a
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 417862
-  timestamp: 1746172689660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
-  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
-  md5: 412a0d97a7a51d23326e57226189da92
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-xextproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-renderproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 594175
-  timestamp: 1746046234466
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
-  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
-  md5: 46b530510556e0b1830c40b5ac625f0e
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-renderproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-xextproto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 595620
-  timestamp: 1746046239552
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
-  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
-  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 635646
-  timestamp: 1772548381644
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
-  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
-  md5: 0d2e76f65075404a9c26010882e7a786
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 643308
-  timestamp: 1772548369777
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
-  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
-  md5: bc7f39bd763f6957ec91046f0e67a9f3
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 269216
-  timestamp: 1772548381049
 - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
   sha256: e09005f52c41234213bd52ebd07092d945855b6d631dd709dcf35dbc71a15c63
   md5: 70e604035b6c97b915114912f047fb2a
@@ -11782,28 +11989,6 @@ packages:
   license_family: GPL2
   size: 271653
   timestamp: 1772548477626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
-  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
-  md5: 39fdbf4db769e494ffb06d95680c83d8
-  depends:
-  - libgcc-ng >=7.3.0
-  license: MIT
-  size: 76992
-  timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
-  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
-  md5: 588d487b103786708d10c1800d048fd4
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  size: 77652
-  timestamp: 1619009841594
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
-  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
-  md5: 23a9bda10db68f27fac5c379466c98b7
-  license: MIT
-  size: 73088
-  timestamp: 1629137313522
 - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
   sha256: e197edaa90488491bd6e0eaa51329d2d93242c6acd7d0aa7b0351d4b24412368
   md5: 959a63017c520ef9d345bd82ab344e3e
@@ -11813,35 +11998,6 @@ packages:
   license: MIT
   size: 63112
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.8.0-h6a678d5_1.conda
-  sha256: 47beed31dd48cbe0041f221e5b4521f2bd3d907b5dcc74cabfae9346c2ba5784
-  md5: 015d2d74ad3c8e53eec3358637433718
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 621367
-  timestamp: 1714510789193
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.8.0-h419075a_1.conda
-  sha256: 85eff1a70501daf5e228b6f2f326506043886db106c03d170b0f931cb55b695b
-  md5: 51a2369fb0d068241603303f704835db
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 607901
-  timestamp: 1714510851512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.8.0-h313beb8_1.conda
-  sha256: 116aa14d2455e97e892141e57bb215b747c09caa4d34de289bfcc6bd962cb507
-  md5: 788e42390f4b031fb47b547797baff69
-  depends:
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 484110
-  timestamp: 1714510972284
 - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.8.0-hd77b12b_1.conda
   sha256: 0cc485708dd5d8d00b8c9293f4c0a854adfdf8ca48b512afc1ece5764751177b
   md5: f90bd3c9e348fc821d2699721773225f
@@ -11852,36 +12008,6 @@ packages:
   license_family: MIT
   size: 2166174
   timestamp: 1714514387587
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
-  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
-  md5: 0c22474f16e65bd9b52fd3b8d60a0372
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32106
-  timestamp: 1763977880529
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
-  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
-  md5: 89dedf7658549815d9e8d5456231932b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32299
-  timestamp: 1763977879242
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
-  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
-  md5: 1b87c5130b5fd6d1738e28799f8b8236
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32097
-  timestamp: 1763977879589
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py313haa95532_0.conda
   sha256: e1fabe5d67279888410b53ad3fe26f02d6c82cb3f4124e07b08e7988815cde31
   md5: 58f9bf466a66b75fee3e9522803e26f8
@@ -11892,37 +12018,6 @@ packages:
   license_family: MIT
   size: 32592
   timestamp: 1763978011708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
-  sha256: cf30f83189a30b12a9239f132ea0ce676fa822a52045adb0f9ff9b3b4d79ead6
-  md5: 9f3a877e5e0fa0fb39253a59ff824861
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libzlib 1.3.1 hb25bd0a_0
-  license: Zlib
-  license_family: OTHER
-  size: 98150
-  timestamp: 1756475939641
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
-  sha256: db213b9f69ccaf2457daabc1a92a4ce0c7aab6bba8145a2e349812cd6f0b41b4
-  md5: 58ccfae41b6e3ad4fd6961071d450f6a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libzlib 1.3.1 h998d150_0
-  license: Zlib
-  license_family: OTHER
-  size: 105760
-  timestamp: 1756475948207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
-  sha256: 0af76c0fbf1697cfd54ada59547e8d086ab113b6dfcc9360aab573a6eb711771
-  md5: eb0fb89b08890d755421c26fae5a8909
-  depends:
-  - __osx >=11.1
-  - libzlib 1.3.1 h5f15de7_0
-  license: Zlib
-  license_family: OTHER
-  size: 78512
-  timestamp: 1756475938331
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.conda
   sha256: 116120d38011eea43cbeeb70e00b0eaa3b1c0a3f470df09aadb0d0b66aebbf60
   md5: 4db9b3fbefe915ffb9eef8c812a98c6a
@@ -11935,50 +12030,6 @@ packages:
   license_family: OTHER
   size: 115567
   timestamp: 1756476083170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
-  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
-  md5: 78685aca3b481cf213b92abfbe0b2b21
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 422402
-  timestamp: 1758189113863
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
-  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
-  md5: 8d4a8433cf437f7ecc5aafa9874c2012
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 396870
-  timestamp: 1758189118512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
-  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
-  md5: b282b2aecb718102ee0bb3848514689a
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 349977
-  timestamp: 1758189118260
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
   sha256: ecc86fd8a56adb8e6cfc2f6ede240b93350cdbf7382662c6ffb12f526e4dff03
   md5: 2fcbc03acf75dedbb17fec7ef2ba5803
@@ -11995,46 +12046,6 @@ packages:
   license_family: BSD
   size: 337202
   timestamp: 1758189153500
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
-  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
-  md5: 93b0e546434bfb874aeefd6bb6cf40bb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 622604
-  timestamp: 1758039176606
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
-  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
-  md5: abc05ce4daceeb1fa321b365cb847975
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 594707
-  timestamp: 1758039173244
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
-  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
-  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 471230
-  timestamp: 1758039171969
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
   sha256: c822ed29c20166934ef9c9e29b863bc382b2c3c602ac1f3a62e9af2c0495a74c
   md5: fd829528313216f62505dd7a281230ea

--- a/tool-specs/anaconda-cli/pixi.lock
+++ b/tool-specs/anaconda-cli/pixi.lock
@@ -20,7 +20,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-conda-0.1.11-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-core-0.1.11-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-utilities-0.1.11-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
@@ -256,7 +256,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
@@ -498,7 +498,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
@@ -708,7 +708,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
@@ -1072,9 +1072,9 @@ packages:
   license_family: Proprietary
   size: 161158
   timestamp: 1773868125336
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.0-py313h06a4308_0.conda
-  sha256: 05c88390cbccc5899245d3f64f1bc0d4c70bdabc181a566f8f6c0b1dfc42834f
-  md5: 18445f9c01ae774d10af183aaf947e65
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.1-py313h06a4308_0.conda
+  sha256: e5110723ad643d2aa1f35eab1262a36140dcd031fef0aed5e218148e0051b70d
+  md5: 0135828396adb3cb229ca6a6ef7ccaa7
   depends:
   - anaconda-anon-usage
   - anaconda-auth >=0.13.0,<1.0.0
@@ -1089,8 +1089,8 @@ packages:
   - rich >=13.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 75022
-  timestamp: 1779920833758
+  size: 75075
+  timestamp: 1780062413079
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
   sha256: 0cd6732f7a3f8c4f2911c6bc963a5d5fcd6aeb061a408842d5b6207a6a20aa77
   md5: d8c5512c00cfaa0c16b6b2c51d866378
@@ -4037,9 +4037,9 @@ packages:
   license_family: Proprietary
   size: 160774
   timestamp: 1773868123073
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
-  sha256: bb6cea8523fef86fdea911c9aa1a952f9a69b0f21e769263a7240e81be64693c
-  md5: 7cb0f3e63900985c9bbd872a4d0f2123
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.1-py313hd43f75c_0.conda
+  sha256: 645c82048a8a88715654fe12ceb8129a3b7e32b92b77f99b9506cf2970d0fa4b
+  md5: d6e0121611b5f2b607243474e4d5b059
   depends:
   - anaconda-anon-usage
   - anaconda-auth >=0.13.0,<1.0.0
@@ -4054,8 +4054,8 @@ packages:
   - rich >=13.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 75605
-  timestamp: 1779920836271
+  size: 75772
+  timestamp: 1780062412357
 - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
   sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
   md5: aab07c0ab08553546780a3a40f8f2cec
@@ -7062,9 +7062,9 @@ packages:
   license_family: Proprietary
   size: 162392
   timestamp: 1773868150264
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
-  sha256: c4ddc9e821fc73d2febaa69445773a2d1e566197beb9ae76b217a09fec75a3d5
-  md5: 4fccbb8b017a20c662308ad20a1e72fe
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.1-py313hca03da5_0.conda
+  sha256: 7ab3e15eac10410c126524599e5990a28f379c37a3da4ecf27d88278cfd8b4c2
+  md5: 112d00c441d60f4398011c37b74547d5
   depends:
   - anaconda-anon-usage
   - anaconda-auth >=0.13.0,<1.0.0
@@ -7079,8 +7079,8 @@ packages:
   - rich >=13.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 75562
-  timestamp: 1779920861440
+  size: 75917
+  timestamp: 1780062437196
 - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
   sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
   md5: 9916fa1108527ee314251aec8a0c7353
@@ -9636,9 +9636,9 @@ packages:
   license_family: Proprietary
   size: 160509
   timestamp: 1773868198156
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
-  sha256: 4aee689864b9fb410377657a00567a91a8684a5c65d9d6f652334b01712a479c
-  md5: fdbf822269394ba6e2e0eabd16a007d6
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.1-py313haa95532_0.conda
+  sha256: 54ebcbd61bc8d9028e36fa707d19ed6761dab7f3d3376912c2d884a0aab6715b
+  md5: ccd17efbcd4b3ef56b09a7a129088c97
   depends:
   - anaconda-anon-usage
   - anaconda-auth >=0.13.0,<1.0.0
@@ -9653,8 +9653,8 @@ packages:
   - rich >=13.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 100191
-  timestamp: 1779920913902
+  size: 100193
+  timestamp: 1780062496652
 - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
   sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
   md5: 8d4b877231bde39bd3ef1270fb015389

--- a/tool-specs/anaconda-cli/pixi.lock
+++ b/tool-specs/anaconda-cli/pixi.lock
@@ -1,19 +1,17 @@
-version: 7
-platforms:
-- name: linux-64
-- name: linux-aarch64
-- name: osx-arm64
-- name: win-64
+version: 6
 environments:
   default:
     channels:
     - url: https://repo.anaconda.com/pkgs/main/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-52_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
@@ -25,6 +23,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
@@ -32,19 +31,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.34.6-hd44998d_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.3.19-h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.5.14-h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-6.2.2-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.5.20-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.6-py313h04fe016_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.7-py313h04fe016_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
@@ -53,10 +54,10 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.7-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/environs-11.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.5-h7354ed3_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.128.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.8.1-h7354ed3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.135.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastmcp-3.1.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-11.2.0-hca5f364_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-12.1.0-h44f220b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
@@ -66,14 +67,15 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-78.3-h84d19a5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.14-h5eee18b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.15.0-hbcba0ee_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
@@ -85,59 +87,58 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.2-h3ec8f01_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.7-hb3cce40_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.19.0-ha05a353_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.20.0-hd8fa685_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.5-h7354ed3_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.8.1-h7354ed3_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.8-hc5d346e_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_8.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_8.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-h860b5fb_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313h3f77f5b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-he97f470_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313heb26620_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.67.1-h697f920_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.69.0-hc59f8b6_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_8.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_8.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.9-h2c43086_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.14.6-hf2a51f9_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-h47b2149_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-11.0.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.30.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.6-h1b28b03_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
@@ -150,6 +151,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
@@ -157,21 +159,22 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.13.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.46.4-py313h6e1b9ff_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.13-hb7b561f_100_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.22-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.29-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
@@ -179,11 +182,11 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.4-h6a678d5_2.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.4-h6a678d5_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.7-h7bdf020_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.7-h7bdf020_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-15.0.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
@@ -197,21 +200,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.47.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.52.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.1-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.15.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.4-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.25.1-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.7.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
@@ -231,25 +234,17 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.8.0-h6a678d5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.9.0-he852c71_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-h47b2149_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       linux-aarch64:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-52_gnu.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
@@ -261,6 +256,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
@@ -268,19 +264,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.3.19-hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.5.14-hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.5.20-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.6-py313haa502f6_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.7-py313haa502f6_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
@@ -289,10 +287,10 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.5-h5b11e9f_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.128.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.8.1-h5b11e9f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.135.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastmcp-3.1.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-11.2.0-hc5e0126_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-12.1.0-h8e5a627_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
@@ -302,14 +300,15 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-73.1-h419075a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-78.3-h184064b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.14-h998d150_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.15.0-h588a716_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
@@ -321,59 +320,58 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.2-h9e3fb69_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.7-h7866cb9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.19.0-hd99d008_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.20.0-h7563a4b_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.5-h5b11e9f_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.8.1-h5b11e9f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.8-h89d793c_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_8.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_8.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-hc4b5eec_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h9fbafe8_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-h5c8e501_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h8125cf1_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.67.1-h9561ae0_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.69.0-h2dcec1c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_8.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_8.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.13.9-h729a2f8_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.14.6-hfdc530d_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h27118de_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-11.0.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.30.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.6-h39c9139_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
@@ -386,6 +384,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
@@ -393,21 +392,22 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.13.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.46.4-py313hef68074_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.13-h0f2f12d_100_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.22-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.29-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
@@ -415,11 +415,11 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.4-h419075a_2.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.4-h419075a_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.7-h301ae1c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.7-h301ae1c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-15.0.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
@@ -433,21 +433,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.47.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.52.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.1-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.15.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.4-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.25.1-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.7.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
@@ -467,31 +467,15 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.8.0-h419075a_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.9.0-hcd08bf0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h27118de_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
@@ -503,6 +487,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
@@ -510,18 +495,20 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.3.19-hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.5.14-hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.5.20-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.6-py313hae07363_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.7-py313hae07363_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
@@ -530,22 +517,23 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.128.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.135.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastmcp-3.1.1-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-11.2.0-h643473a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-12.1.0-hc20ec9e_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h0087489_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h86cef2d_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h50c8ec2_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h61de102_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.15.0-h9db958f_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
@@ -560,49 +548,54 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-hcc4682f_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-hcc4682f_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.16.0-h01d3526_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-h7b764f5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-h7b764f5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.20.0-h033922a_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.5-h50f4ffc_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-hd3943a6_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-hd3943a6_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.8.1-h50f4ffc_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.8-hcfc0b96_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-h7b764f5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-h7b764f5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h55097f8_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h55097f8_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-hcdddc3d_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h7b764f5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h7b764f5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkrb5-1.22.1-hbbdc3aa_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-h4b9b42c_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.69.0-he427349_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.4-h2acab8a_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.6-h1ea6aa3_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-hb4cf58c_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lmdb-0.9.31-h79febb2_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-11.0.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.30.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.6-ha0b305a_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
@@ -615,17 +608,19 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.13.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.46.4-py313h3983f12_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
@@ -633,11 +628,11 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.13-ha8cd034_100_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.22-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.29-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
@@ -645,8 +640,8 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.4-h313beb8_2.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.4-h313beb8_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.7-h279499b_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.7-h279499b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
@@ -662,21 +657,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.47.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.52.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.1-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.15.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.4-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.25.1-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.7.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
@@ -686,22 +681,15 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.8.0-h313beb8_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.9.0-h9fe17f6_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-hb4cf58c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
@@ -713,6 +701,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
@@ -720,19 +709,21 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.3.19-haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.5.14-haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.5.20-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.6-py313hbfe00f4_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.7-py313hbfe00f4_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
@@ -741,9 +732,9 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.128.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.135.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/fastmcp-3.1.1-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-11.2.0-h58b7f6e_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-12.1.0-ha349831_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/frozendict-2.4.6-py313h02ab6af_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/googleapis-common-protos-1.72.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.78.0-py313ha1f0e13_0.conda
@@ -751,7 +742,7 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/httptools-0.7.1-py313h02ab6af_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
@@ -767,41 +758,41 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20260107.0-cxx17_hc587421_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.2-h6c023e8_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.7-h8d653b7_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.20.0-h9440e04_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.5-hd7fb8db_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.8.1-hd7fb8db_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.8-h2b21627_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.78.0-hecd3d80_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.18-hc89ec93_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libkrb5-1.22.1-h3d06f0e_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hc213065_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h364efb6_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hf4f7140_3.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h0016b16_3.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.5-h65d7223_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-h797e85b_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libsolv-0.7.30-h23a355e_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.14.6-h42c6e62_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h1c6eee0_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/luajit-2.1-h1c6eee0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/lupa-2.6-py313h1c6eee0_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/marshmallow-3.19.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-1.26.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.12-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/menuinst-2.4.2-py313h885b0b7_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-11.0.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py313h5da7b33_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/nlohmann_json-3.11.2-h6c2663c_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.14.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.30.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/openapi-pydantic-0.5.1-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.5-hbb43b14_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.6-hbb43b14_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-api-1.38.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313haa95532_0.conda
@@ -814,27 +805,29 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.24.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.41.5-py313h114bc41_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.13.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.46.4-py313h51239a8_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.20.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pyperclip-1.11.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.12-h39c999c_100_cp313.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.13-h39c999c_100_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.22-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.29-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py313h885b0b7_0.conda
@@ -843,11 +836,11 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hca2749c_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.4-hd77b12b_2.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.4-hd77b12b_2.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.7-h557c29b_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.7-h557c29b_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.33.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-14.2.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-15.0.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-rst-1.3.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
@@ -860,27 +853,27 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.47.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.52.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.1-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.20.0-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-0.20.0-py313haa95532_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-standard-0.20.0-py313haa95532_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.15.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.4-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.25.1-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.7.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-0.40.0-py313haa95532_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-standard-0.40.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_10.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_12.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_12.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_12.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/watchfiles-1.1.1-py313h114bc41_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/websockets-15.0.1-py313h827c3e9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.46.3-py313haa95532_0.conda
@@ -888,9 +881,9 @@ environments:
       - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.17.0-py313h827c3e9_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.8.0-hd77b12b_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.9.0-h9081779_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py313haa95532_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h1c6eee0_1.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
       - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
 packages:
@@ -899,17 +892,28 @@ packages:
   md5: c3473ff8bdb3d124ed5ff11ec380d6f9
   size: 3473
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.conda
-  sha256: 576011048d23f2e03372263493c5529f802286ff53e8426df99a5b11cc2572f3
-  md5: 71d281e9c2192cb3fa425655a8defb85
-  depends:
-  - _libgcc_mutex 0.1 main
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
+  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
+  md5: b272288d02db5520249ca7870c2287b4
+  license: None
+  size: 2491
+  timestamp: 1617219512888
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-52_gnu.conda
+  build_number: 52
+  sha256: 2f2c16a33f51ba032e8d4929b4d2e9173d81931d8d280a4a4a85a2412e8bdaf0
+  md5: 8c74a3d91bfc4b484c91ed7201f84fba
   license: BSD-3-Clause
-  size: 21315
-  timestamp: 1652859733309
+  license_family: BSD
+  size: 6672
+  timestamp: 1779131107752
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-52_gnu.conda
+  build_number: 52
+  sha256: a565f285cdcb14894ba4e8a081fcec0ce7a3b9636d3fe7be709c849438b08b79
+  md5: f367f6af1c675137019bcded877b4a59
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6626
+  timestamp: 1779131108070
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiofiles-25.1.0-py313h06a4308_0.conda
   sha256: a7d0c79a1946344c8878079b89d7c054d71e4ff4b5cea04ec392b24ec785cd93
   md5: c2c8e35353fa943fa74108dd431a7b9f
@@ -920,6 +924,36 @@ packages:
   license_family: Apache
   size: 35419
   timestamp: 1773069249301
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
+  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
+  md5: 6327e33161b8e0ae8b501af0b07ee435
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35447
+  timestamp: 1773069243126
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
+  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
+  md5: 1784bef0a518f47b0cb442e02b75ce84
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35320
+  timestamp: 1773069152139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
+  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
+  md5: c62bd3bff5cb11570247115c1ab81225
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 35318
+  timestamp: 1773069363087
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-ai-0.5.0-py313h06a4308_1.conda
   sha256: 22acee4a47176055648cbe19f0ca8d9ee29ac8dec54d7279e0b4572bb00bffd2
   md5: 68ae0d156d8f42f20253ab6936a58180
@@ -944,6 +978,89 @@ packages:
   license_family: BSD
   size: 117028
   timestamp: 1773844617250
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
+  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
+  md5: a8de75045d038d62c3553bdb1a2bf2b3
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - langchain-openai >=0.2.8
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116895
+  timestamp: 1773844596952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
+  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
+  md5: 88dc2eae5116b824692db6bb9b443eed
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - pydantic-ai >=1.50
+  - llm >=0.22
+  - mcp >=1.26
+  - langchain-openai >=0.2.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116841
+  timestamp: 1773844602363
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
+  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
+  md5: c486692f9df9720276afb556abff5361
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-cli-base >=0.8.1
+  - openai
+  - packaging
+  - platformdirs
+  - pydantic >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich
+  - ruamel.yaml
+  - typer
+  constrains:
+  - mcp >=1.26
+  - pydantic-ai >=1.50
+  - langchain-openai >=0.2.8
+  - llm >=0.22
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116690
+  timestamp: 1773844804490
+- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
+  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
+  md5: c78d47374611a8e86f7a9817f3768160
+  depends:
+  - python >=3.8
+  constrains:
+  - conda >=23.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19864
+  timestamp: 1774907942644
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-auth-0.14.4-py313h06a4308_0.conda
   sha256: c52fe534ed3a4e6cf09289d60bf6c458c7150f82c0bd00c791a02985dc1f2c98
   md5: 7c9db0780c2764d1b9a8965b58d07d99
@@ -969,6 +1086,81 @@ packages:
   license_family: BSD
   size: 127651
   timestamp: 1777996211774
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
+  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
+  md5: cc86d0a53de1c9d4559f84313d92f08d
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda-token >=0.7.0
+  - conda >=23.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127355
+  timestamp: 1777996210212
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
+  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
+  md5: be96323ace383458edf5ef71f8e72654
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127712
+  timestamp: 1777996231900
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
+  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
+  md5: 5f4b80f4355b922b23fdd3456c6d4001
+  depends:
+  - anaconda-cli-base >=0.8.1
+  - cryptography >=3.4.0
+  - httpx
+  - keyring
+  - pkce
+  - pydantic
+  - pyjwt
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  - requests
+  - semver <4
+  - anaconda-anon-usage >=0.7.2
+  constrains:
+  - anaconda-cloud-auth >=0.8
+  - conda >=23.9.0
+  - conda-token >=0.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152577
+  timestamp: 1777996277515
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-cli-base-0.8.2-py313h06a4308_0.conda
   sha256: 6ea3ced350e4d3f744774ba3bc5aa6a5eff3751d0ddd39ac6496868efbd78226
   md5: a256fa8ae4cf05d1cfb990cfee0b7976
@@ -992,6 +1184,75 @@ packages:
   license_family: BSD
   size: 62178
   timestamp: 1775469271573
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
+  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
+  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62286
+  timestamp: 1775469252673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
+  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
+  md5: 52656bda190a7f2bec974f508a9f35f2
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-cloud-cli >=0.3.0
+  - anaconda-auth >=0.12.0
+  - anaconda-client >=1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62048
+  timestamp: 1775469312642
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
+  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
+  md5: 5717d515db735fe7167bd3b5ea7bdc50
+  depends:
+  - click
+  - packaging >=23.0
+  - pydantic >=2.12
+  - pydantic-settings >=2.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - readchar
+  - rich
+  - tomli
+  - tomlkit
+  - typer >=0.17
+  constrains:
+  - anaconda-client >=1.13.0
+  - anaconda-auth >=0.12.0
+  - anaconda-cloud-cli >=0.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86912
+  timestamp: 1775469436561
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.14.1-py313h06a4308_0.conda
   sha256: 4a979bb0b48ad2712884695a3056453fbc5208acfc6a250aa3ed049831263f5e
   md5: 7233ba45150b5530456f5da5b9054d48
@@ -1020,6 +1281,90 @@ packages:
   license_family: BSD
   size: 845691
   timestamp: 1772491237524
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
+  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
+  md5: 0b644ecae935ac975164247e9f4d981d
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 845333
+  timestamp: 1772491214305
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
+  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
+  md5: c2a25adb6831401a65a5cdb63f88ba27
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 846994
+  timestamp: 1772491115479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
+  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
+  md5: e10dea7c74568841ed1cd5d8ec12ca92
+  depends:
+  - anaconda-anon-usage >=0.7.3
+  - anaconda-auth >=0.12.3
+  - anaconda-cli-base >=0.7.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.13,<3.14.0a0
+  - python-dateutil >=2.6.1
+  - python_abi 3.13.* *_cp313
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  constrains:
+  - anaconda-project >=0.9.1
+  - pillow >=10.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 870768
+  timestamp: 1772491405834
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-conda-0.1.11-py313h06a4308_0.conda
   sha256: acca75e8798b376e92646a8b5d7b262b215ec947e01dae4742c212b23d44abcc
   md5: af3167e083aefe1a08c832819e9256e7
@@ -1040,6 +1385,66 @@ packages:
   license_family: Other
   size: 160999
   timestamp: 1773935004052
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
+  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
+  md5: bfb5d8d4df085842d8c0b2e056b9257f
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161380
+  timestamp: 1773934997584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
+  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
+  md5: ed7020be4e2288dff58f60f7bf106fa9
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 162438
+  timestamp: 1773935019675
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
+  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
+  md5: 643c72f55e9de9926eabd069edbf2322
+  depends:
+  - anaconda-connector-core 0.1.11
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - conda >=25.11.1,<26.3.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - menuinst >=2
+  - orjson >=3.11.4
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.32.5,<3.0.0a0
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 161935
+  timestamp: 1773935085468
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-core-0.1.11-py313h06a4308_0.conda
   sha256: 683e0c239c7efa04fb6bc7523dd61a2005278d6eee3c9c084708075c27c10b77
   md5: 73c3d30b01b18ada722168b8a163afb3
@@ -1056,6 +1461,54 @@ packages:
   license_family: Other
   size: 169433
   timestamp: 1773871645177
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
+  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
+  md5: 7112210d85ff777ac172307690b79f45
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 168446
+  timestamp: 1773871519885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
+  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
+  md5: a9010a6c725f4a11001406492d49f35e
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 169752
+  timestamp: 1773871547623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
+  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
+  md5: c2ebc9fa966f6b08ea187fa807641415
+  depends:
+  - anaconda-connector-utilities 0.1.11
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Other
+  size: 226857
+  timestamp: 1773871887979
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-connector-utilities-0.1.11-py313h06a4308_0.conda
   sha256: 9d64a3304c848ba7e5639ad99e3d513b3390ce38c1ae7d9371a4f09d9fc0564c
   md5: 9e0c6279430723e71d9b46aa80c1a66f
@@ -1072,6 +1525,54 @@ packages:
   license_family: Proprietary
   size: 161158
   timestamp: 1773868125336
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
+  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
+  md5: 213c7a858140be70244c210c31e4da04
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160774
+  timestamp: 1773868123073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
+  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
+  md5: eeca273b542009d5cd4e022bd2cb827d
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 162392
+  timestamp: 1773868150264
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
+  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
+  md5: 6f2969069844333afb09ed91b701abe0
+  depends:
+  - attrs >=25.4.0
+  - frozendict >=2.4.6,<3.0.0a0
+  - more-itertools >=10.8.0
+  - packaging >=25.0
+  - pydantic >=2.12.4,<3.0.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.15.0,<5.0.0a0
+  license: Proprietary
+  license_family: Proprietary
+  size: 160509
+  timestamp: 1773868198156
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-mcp-1.1.0-py313h06a4308_0.conda
   sha256: 05c88390cbccc5899245d3f64f1bc0d4c70bdabc181a566f8f6c0b1dfc42834f
   md5: 18445f9c01ae774d10af183aaf947e65
@@ -1091,6 +1592,63 @@ packages:
   license_family: BSD
   size: 75022
   timestamp: 1779920833758
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
+  sha256: bb6cea8523fef86fdea911c9aa1a952f9a69b0f21e769263a7240e81be64693c
+  md5: 7cb0f3e63900985c9bbd872a4d0f2123
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75605
+  timestamp: 1779920836271
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
+  sha256: c4ddc9e821fc73d2febaa69445773a2d1e566197beb9ae76b217a09fec75a3d5
+  md5: 4fccbb8b017a20c662308ad20a1e72fe
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75562
+  timestamp: 1779920861440
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
+  sha256: 4aee689864b9fb410377657a00567a91a8684a5c65d9d6f652334b01712a479c
+  md5: fdbf822269394ba6e2e0eabd16a007d6
+  depends:
+  - anaconda-anon-usage
+  - anaconda-auth >=0.13.0,<1.0.0
+  - anaconda-cli-base >=0.8.1,<1.0.0
+  - anaconda-opentelemetry >=0.8.1,<1.2.0
+  - click >=8.1.0,<9.0.0
+  - environments-mcp-server >=1.0.2,<2.0.0
+  - mcp-compose >=0.1.12,<2.0.0
+  - platformdirs >=4.0.0,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100191
+  timestamp: 1779920913902
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-opentelemetry-1.1.0-py313h06a4308_0.conda
   sha256: 0cd6732f7a3f8c4f2911c6bc963a5d5fcd6aeb061a408842d5b6207a6a20aa77
   md5: d8c5512c00cfaa0c16b6b2c51d866378
@@ -1111,6 +1669,66 @@ packages:
   license_family: APACHE
   size: 82788
   timestamp: 1776808534361
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
+  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
+  md5: aab07c0ab08553546780a3a40f8f2cec
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82829
+  timestamp: 1776808540195
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
+  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
+  md5: 9916fa1108527ee314251aec8a0c7353
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 83086
+  timestamp: 1776808490341
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
+  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
+  md5: 8d4b877231bde39bd3ef1270fb015389
+  depends:
+  - anaconda-anon-usage
+  - grpcio >=1.71.0
+  - opentelemetry-api 1.38.0
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
+  - opentelemetry-exporter-otlp-proto-http 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=6.0.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 82692
+  timestamp: 1776808693739
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-doc-0.0.4-py313h06a4308_0.conda
   sha256: 436b89319aa90a7338c308e0779c595276ae01430febf7968e8f40c5ae17a456
   md5: 6ceee906e5cc1dae03776e7c64e56877
@@ -1121,6 +1739,36 @@ packages:
   license_family: MIT
   size: 11432
   timestamp: 1763372671839
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
+  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
+  md5: 37fbf9726b0439b29bba0e1cf52ae35c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11421
+  timestamp: 1763372675300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
+  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
+  md5: f39857a71feb6e39da9739228f340a78
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11405
+  timestamp: 1763372676418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
+  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
+  md5: 250197e0edb4f89e9d3199c32fcecd5d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 11465
+  timestamp: 1763372717011
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/annotated-types-0.6.0-py313h06a4308_1.conda
   sha256: 382f07779f01e3a6621b963ebd8f01b1759fd71c64cb8d47b4b1da17451e07a4
   md5: 3d0213cea41b88c15fdf1ed04eba799c
@@ -1131,6 +1779,36 @@ packages:
   license_family: MIT
   size: 26097
   timestamp: 1761744946758
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
+  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
+  md5: 108a8bcd136312e83793f5cda2f350fb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26012
+  timestamp: 1761744922996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
+  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
+  md5: c0c2fb9483677bb657eda6d491e5f29c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 25909
+  timestamp: 1761744968164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
+  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
+  md5: 2c7171d6d58b9364b4406ab1c85ee50b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26185
+  timestamp: 1761745147069
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.12.1-py313h06a4308_0.conda
   sha256: f14560ae804db5d9289a4ddec171cbbacf78dd49b4a640f21fd0829ee55b333f
   md5: fcc4b2673d3d0b0a203bf1496a694ec3
@@ -1144,6 +1822,53 @@ packages:
   license_family: MIT
   size: 317979
   timestamp: 1773134446379
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
+  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
+  md5: 910687ebf7746e8562300e8f1996edc6
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318118
+  timestamp: 1773134422321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
+  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
+  md5: 7e400853597f6d7237e927baa6706aa7
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1773134435123
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
+  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
+  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
+  depends:
+  - idna >=2.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - trio >=0.32.0
+  license: MIT
+  license_family: MIT
+  size: 318164
+  timestamp: 1773134551978
+- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
+  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
+  md5: c0ad195970a65c174b997011ac13f2f8
+  depends:
+  - python >=3.7
+  license: MIT OR Apache-2.0
+  size: 49261
+  timestamp: 1758125010311
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-26.1.0-py313h0c820a0_0.conda
   sha256: 0c54f6998dfa0ce079af488624d12f1541ae5e4c77eadbb728f01c89d24a419e
   md5: 7abefd1bcc7f971ebe2e905b54d3d9af
@@ -1154,6 +1879,36 @@ packages:
   license_family: MIT
   size: 180870
   timestamp: 1774959670748
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
+  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
+  md5: 711f61b5492b94625605422dd8e326ed
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180516
+  timestamp: 1774959654156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
+  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
+  md5: bafc36567bd5432aea186b203ccbe80d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 180639
+  timestamp: 1774959652662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
+  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
+  md5: 2a3be388a9418ec78c921662e816d826
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 181026
+  timestamp: 1774959795526
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/authlib-1.6.9-py313h06a4308_0.conda
   sha256: eca5799ea6fe42c404d575fe3e6a1296ab4a77477338e4844e3ce55cfb92d51e
   md5: 8b691d36a48bb3b11af5acca7ef5f3b7
@@ -1168,6 +1923,48 @@ packages:
   license_family: BSD
   size: 446172
   timestamp: 1775206363270
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
+  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
+  md5: 3bee8eb5a01e45d657bc7edc508dcde4
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 445207
+  timestamp: 1775206365399
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
+  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
+  md5: a76eeaf70ce3bead86b2c5da38121a69
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446875
+  timestamp: 1775206378569
+- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
+  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
+  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
+  depends:
+  - cryptography >=3.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  constrains:
+  - pycryptodomex >=3.10,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 448508
+  timestamp: 1775206412930
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/beartype-0.22.9-py313h06a4308_0.conda
   sha256: 12e6857595968ad28911cf185f7696365ff92eaa4a9ad9cead223a7332a3a6bb
   md5: 468a6120b4db27b9d6de4aa86e6c6a45
@@ -1178,6 +1975,36 @@ packages:
   license_family: MIT
   size: 1486546
   timestamp: 1772489320625
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
+  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
+  md5: 63457f5636c2230e585b265ea721c2f8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1484918
+  timestamp: 1772489319478
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
+  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
+  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488689
+  timestamp: 1772489325506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
+  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
+  md5: f38f1b967e522121f347c6e53e50386e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1488599
+  timestamp: 1772489378490
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/boltons-25.0.0-py313h06a4308_0.conda
   sha256: 248e6cb425de676a39915d1c241e0434d9ec8b19d27771f7132907519f7fbc77
   md5: afd30cc40ab0edf4e246b901c8eca725
@@ -1188,6 +2015,36 @@ packages:
   license_family: BSD
   size: 522428
   timestamp: 1751383912748
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
+  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
+  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 522348
+  timestamp: 1751383856268
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
+  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
+  md5: a5b55c281bf03fadccc2b9fb5e6c567d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 524228
+  timestamp: 1751383887927
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
+  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
+  md5: 78e0f7a51d811d64b0d0fa4e886458f2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523882
+  timestamp: 1751383878776
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.2.0.0-py313h7354ed3_0.conda
   sha256: 1d13694da029eb587dcdce691e4a6a1590ac5de65f0cde234fff849fd7985168
   md5: d309f82c145a73fedf7bc6930f689dba
@@ -1202,6 +2059,47 @@ packages:
   license_family: MIT
   size: 381299
   timestamp: 1764961365931
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
+  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
+  md5: 9dd92861bec232ccdf7869b0b05b453b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 385446
+  timestamp: 1764961345156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
+  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
+  md5: 4f002093422042d948885e06821f150b
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17.0
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375456
+  timestamp: 1764961201718
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
+  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
+  md5: 964620a4cb8353969963fbb7b045b01c
+  depends:
+  - cffi >=1.17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 355904
+  timestamp: 1764961470388
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.conda
   sha256: 235f266d5f9c3c61748bb1af0eff21bc7ed2a2a356b97ff28d9c1135039b08b0
   md5: f21a3ff51c1b271977f53ce956a69297
@@ -1211,6 +2109,32 @@ packages:
   license_family: BSD
   size: 268384
   timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
+  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
+  md5: f580b2013db742598b2d59875bccf774
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 215406
+  timestamp: 1714510578082
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
+  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
+  md5: 27a1ffbd30ff6427c112a733410e2f57
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 132212
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
+  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
+  md5: 33e784123d565c38e68945f07b461282
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 91870
+  timestamp: 1714511182837
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.34.6-hd44998d_0.conda
   sha256: a5bdd98c8c2ef2bbe52b0fb018ddda3e62f91b2f96089e66e903052e1e91498e
   md5: e16f3bb02771b2e37ea421a3f8ee1ebb
@@ -1222,13 +2146,66 @@ packages:
   license_family: MIT
   size: 206586
   timestamp: 1769077678178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.3.19-h06a4308_0.conda
-  sha256: 8a9aef8816cff77cfde5d9d90e45b67653bf5099b0f7c221cf0746da3461d95b
-  md5: 291793559c71f945283cdb33962e7761
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
+  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
+  md5: 6e3e5f38a8efcb439d36f091baa23034
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 217449
+  timestamp: 1769077676509
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
+  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
+  md5: ceb5c473b56eb1b79fd079f6b0d029df
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 177571
+  timestamp: 1769077680758
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
+  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
+  md5: f6f293f1ec437a5a362252af20d31e50
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 203491
+  timestamp: 1769077840032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2026.5.14-h06a4308_0.conda
+  sha256: 5950470e038010db93938a18891cacf9878e2b0929396754529b01485213f9aa
+  md5: 16c8384e6e546a181720f7f2f2da717b
   license: MPL-2.0
   license_family: Other
-  size: 128969
-  timestamp: 1774365804711
+  size: 109982
+  timestamp: 1779369544071
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.5.14-hd43f75c_0.conda
+  sha256: 1952de6b37c0a04ff26b9e719e842742fd20d3d90cff7e6ae71d59f6eacd8b35
+  md5: 53fbdd199058951543bd02ea5f55290c
+  license: MPL-2.0
+  license_family: Other
+  size: 109983
+  timestamp: 1779369526496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.5.14-hca03da5_0.conda
+  sha256: fbec6b4a50724693297bc99d16b5f455267d24d10780dee40214d11822d6a3b3
+  md5: 4fc63c7213f26bca8f8e1a561b08df0e
+  license: MPL-2.0
+  license_family: Other
+  size: 110299
+  timestamp: 1779369421717
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.5.14-haa95532_0.conda
+  sha256: cd677eba8e5005c16d6c0926b3a6ee54e4a0a466bb1ae8071e6fc49cbd65ad29
+  md5: 120259e1e9fba21a245cfe2a632332c0
+  license: MPL-2.0
+  license_family: Other
+  size: 110063
+  timestamp: 1779369808140
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-6.2.2-py313h06a4308_0.conda
   sha256: 1f940a1c17e8fec366dfeee42f16adb2226caee1fc7a14cffa9ba69f024b3d72
   md5: fff0be0678af050cf070caf6112afb73
@@ -1239,16 +2216,76 @@ packages:
   license_family: MIT
   size: 41231
   timestamp: 1764867398576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py313h06a4308_0.conda
-  sha256: dca4a436b34e5ab1f62a2dbbd0989e03e7ef375288c10f0b3bc95f1614095dba
-  md5: 76d1efd083cb0251ec8295c355adb1e2
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
+  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
+  md5: 1d25e042eebc783ff4804fc9c42852d2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41563
+  timestamp: 1764867403876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
+  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
+  md5: bb47e0b8fa0f637b245c34b5b357a5d4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41149
+  timestamp: 1764867366355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
+  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
+  md5: 9ce972c71a87d4d90534a24d77e99cb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 41594
+  timestamp: 1764867445911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.5.20-py313h06a4308_0.conda
+  sha256: 3139ce7e371fed80ff4185cb2bfd742e6b06162057100210d3a80e6c001304ef
+  md5: 47167ed1d781ecd386dac1a51c1617a8
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: MPL-2.0
   license_family: Other
-  size: 152128
-  timestamp: 1767659200360
+  size: 134466
+  timestamp: 1779370435067
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.5.20-py313hd43f75c_0.conda
+  sha256: ad0482b93275e69f0992fce82aa568a364bcd508ed5cf89a8147d60b17ddb5e2
+  md5: 06ec246514aaf39ce1b2962db79f2c69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134424
+  timestamp: 1779370393603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.5.20-py313hca03da5_0.conda
+  sha256: 22ceda465617efdfe3648420c9ae89c786148e955c3fc88643eae95dddf90df0
+  md5: 93a7a1245eb7e35a665f0d84ca941feb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134103
+  timestamp: 1779370319413
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.5.20-py313haa95532_0.conda
+  sha256: c00dca94da0cba08243b42c58fe5f896b7661095febcda0d4fe5fb9757e1b9a7
+  md5: 080f8f5683481a20991f10dc4ea654a6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0
+  license_family: Other
+  size: 134382
+  timestamp: 1779370678439
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-2.0.0-py313h4eded50_1.conda
   sha256: a16eafa37a73eb521aef93e9760f44be8f0180f9ff3e5bccbf2de8f6e762e9a0
   md5: 48989473c291f70b074ba57b48d4eda5
@@ -1263,6 +2300,47 @@ packages:
   license_family: MIT
   size: 295376
   timestamp: 1761832800589
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
+  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
+  md5: d010d105070e615750bbb51b8f2b17f5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 317809
+  timestamp: 1761832800132
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
+  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
+  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
+  depends:
+  - __osx >=12.1
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 288576
+  timestamp: 1761832806745
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
+  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
+  md5: d1e9e395ff8688288d67b89e896c2b6c
+  depends:
+  - pycparser
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 299121
+  timestamp: 1761832847099
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py313h06a4308_0.conda
   sha256: d84312b64791eac1dad798c86110a0ac53e7d980d6d4c5d32f60ebbb82e4eb4b
   md5: 36134f1eb9574beab525f137faa53cd7
@@ -1273,6 +2351,36 @@ packages:
   license_family: MIT
   size: 100520
   timestamp: 1761744847216
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
+  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
+  md5: c89d95c43d07b658088bb12631ce9132
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100336
+  timestamp: 1761744908393
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
+  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
+  md5: 6301ec890b186cbe5d8243254450651e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 100213
+  timestamp: 1761744861372
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
+  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
+  md5: 9e4732d3d22b2cf01fc408696e8ebd41
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 124770
+  timestamp: 1761745054105
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py313h06a4308_1.conda
   sha256: c743088f34421989511925c4fd47bd2d1627e0d47a9ce17ac522971456559dbf
   md5: cd0c96b38e17a2b268d15d0b22da55b3
@@ -1283,6 +2391,47 @@ packages:
   license_family: BSD
   size: 327716
   timestamp: 1764332274729
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
+  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
+  md5: 7813f91a66f3a442e803469cf76e3e1c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328923
+  timestamp: 1764332280328
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
+  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
+  md5: 7ac45ddb190136a57ad9b02e7e365ec0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328813
+  timestamp: 1764332257562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
+  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
+  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
+  depends:
+  - colorama
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328826
+  timestamp: 1764332409785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
+  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
+  md5: b73ebc8eb01ba1e79ad34303e2975694
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55002
+  timestamp: 1729036609433
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-26.1.1-py313h06a4308_0.conda
   sha256: 7fa70086625233a494e92418fb58591f43e2c6309cb4c082e3fd778a0280c506
   md5: c47ffd5c56a75b1b62855a3c8e430889
@@ -1318,6 +2467,126 @@ packages:
   license_family: BSD
   size: 1273463
   timestamp: 1771402226765
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
+  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
+  md5: efb9dc33b510e1c882b597d994f6ab3d
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-env >=2.6
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1270780
+  timestamp: 1771402352584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
+  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
+  md5: 1fbe06ba53189032094abfe761e965ce
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-build >=25.9
+  - conda-env >=2.6
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275763
+  timestamp: 1771402227023
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
+  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
+  md5: 301f7c7830bdf835d4fcf93e0122da7a
+  depends:
+  - archspec >=0.2.3
+  - boltons >=23.0.0
+  - charset-normalizer
+  - conda-libmamba-solver >=25.4.0
+  - conda-package-handling >=2.2.0
+  - distro >=1.5.0
+  - frozendict >=2.4.2
+  - jsonpatch >=1.32
+  - menuinst >=2
+  - packaging >=23.0
+  - platformdirs >=3.10.0
+  - pluggy >=1.0.0
+  - pycosat >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.28.0,<3
+  - ruamel.yaml >=0.11.14,<0.19
+  - setuptools >=60.0.0
+  - tqdm >=4
+  - truststore >=0.8.0
+  - zstandard >=0.19.0
+  constrains:
+  - conda-env >=2.6
+  - conda-build >=25.9
+  - conda-content-trust >=0.1.1
+  - conda-anaconda-telemetry >=0.3.0
+  - conda-anaconda-tos >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275313
+  timestamp: 1771402340575
+- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.2-pyh3785b3c_0.conda
+  sha256: 10f62f9acf24c5abff2b172d90c65e5e6fbdfd5d228014969282ce180de30c3d
+  md5: 4a5e3c023bdfc52f653d8ecd03daafd2
+  depends:
+  - boltons >=23.0.0
+  - conda >=26.1
+  - libmambapy >=2
+  - msgpack-python >=1.1.1
+  - python >=3.10
+  - requests >=2.28.0,<3.0.0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58289
+  timestamp: 1778687024589
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.4.0-py313h06a4308_1.conda
   sha256: d1e652dbd4390b12bcf938ece3e85636c12ab54d91a25de7dd1ac8ca84b1b8b1
   md5: 8df01d8631f16021fe6e7f0093de07db
@@ -1330,6 +2599,42 @@ packages:
   license_family: BSD
   size: 284840
   timestamp: 1762366426064
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
+  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
+  md5: 6577f526b527308e4bf66a7bdef0e7fe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285635
+  timestamp: 1762366425854
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
+  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
+  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285376
+  timestamp: 1762366427916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
+  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
+  md5: 0bf62b2027e8a656a86e1c4a7e71142c
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 309759
+  timestamp: 1762366569467
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.12.0-py313h06a4308_1.conda
   sha256: 8d1ff42b4560986c9d46ef2114cd77ae791ec4400a5ba4eb9a4b22ad540466c1
   md5: 56c2a9c6a706a12193c0b98ef951b4b6
@@ -1342,6 +2647,42 @@ packages:
   license_family: BSD
   size: 38518
   timestamp: 1762361653472
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
+  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
+  md5: 313fca7b4d867f8b06df3140548f9440
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38256
+  timestamp: 1762361650200
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
+  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
+  md5: 01a0bc32a49fd331d514dfd64446fb1e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38499
+  timestamp: 1762361650835
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
+  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
+  md5: d9081bd54908ac92135e6fb20d0aade2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38102
+  timestamp: 1762361726254
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cpp-expected-1.1.0-hdb19cb5_0.conda
   sha256: 8718137ba3afc2eb8eb986e17442968aec45b32bbd746b64bc239c3019ec7216
   md5: 3a195bcf47b691adb4a635a8b7f396f7
@@ -1352,9 +2693,38 @@ packages:
   license_family: CC
   size: 132687
   timestamp: 1734039334436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.6-py313h04fe016_1.conda
-  sha256: 16dd4718288c67aecf5206931b47879ee4faedb057d914a278716569f9a6b537
-  md5: cd18893d2e2a58f20ae7ab9133e172d9
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
+  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
+  md5: 06c2848c6311674e19391d4b81b3188a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: CC0-1.0
+  license_family: CC
+  size: 132686
+  timestamp: 1734039347698
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
+  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
+  md5: 9a83af67c17d1c760cd7aff545ef7e0f
+  depends:
+  - libcxx >=14.0.6
+  license: CC0-1.0
+  license_family: CC
+  size: 134133
+  timestamp: 1734039345192
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
+  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
+  md5: 67a55401db50a1d6bde2b153a74bcb07
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: CC0-1.0
+  license_family: CC
+  size: 133944
+  timestamp: 1734039396266
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-46.0.7-py313h04fe016_0.conda
+  sha256: 75204f831ba33196179fc03b036ef28e5a7692fcade74340280553bca86aaecc
+  md5: 317e0398d4abaeac3831ebf9031bfb56
   depends:
   - __glibc >=2.28,<3.0.a0
   - cffi >=2.0.0
@@ -1366,8 +2736,56 @@ packages:
   - pyopenssl >=23.0.0
   license: Apache-2.0 OR BSD-3-Clause
   license_family: OTHER
-  size: 1705099
-  timestamp: 1775166014972
+  size: 1704316
+  timestamp: 1775672149374
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.7-py313haa502f6_0.conda
+  sha256: 3ed601727cd363adb4659bcf6d1355f089ab03c51316b0cd9b44878689691797
+  md5: 6278e4fbbb0c256dba21cf6d8786a1ba
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=2.0.0
+  - libgcc >=14
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1684534
+  timestamp: 1775672140512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.7-py313hae07363_0.conda
+  sha256: a8a8c9a21c602dc4b5e165e763cd91a93c0a0c26cafaa3449cd2b71f1153cf24
+  md5: 2ed446dca3be7460703b133a979a88e5
+  depends:
+  - __osx >=12.1
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1585026
+  timestamp: 1775672122040
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.7-py313hbfe00f4_0.conda
+  sha256: 6ef8d801080710183ab192071940fed2d81c468bb25352a7cf69acc554053268
+  md5: 437bbfadf68c247ade554ede99116d43
+  depends:
+  - cffi >=2.0.0
+  - openssl >=3.5.5,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - pyopenssl >=23.0.0
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: OTHER
+  size: 1480593
+  timestamp: 1775672660391
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyclopts-4.6.0-py313h06a4308_0.conda
   sha256: ae53fd9454d789e5d815340cf2fc2dc08890e7d49a5709c3b990c923a58e8c05
   md5: 470893a428fe943c25311711c34b8912
@@ -1382,6 +2800,48 @@ packages:
   license_family: Apache
   size: 392859
   timestamp: 1772065044827
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
+  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
+  md5: 8f3083bd30c06eace150fbf4ff5acd33
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392308
+  timestamp: 1772065019547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
+  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
+  md5: 85c2e5e0e00bcd63d85871b80f060b1b
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 392115
+  timestamp: 1772064911124
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
+  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
+  md5: db173ac83b3843bec70a8b2070881460
+  depends:
+  - attrs >=23.1.0
+  - docstring_parser >=0.15,<4.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.6.0
+  - rich-rst >=1.3.1,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 448738
+  timestamp: 1772065243755
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.16.2-h5bd4931_0.conda
   sha256: ff936d58ce18451f18cba16a8ade9365199a6321d4eb1c60c1eb1d8e3932c65b
   md5: 4c4aef417b613e7111d90cf2348b231a
@@ -1395,6 +2855,27 @@ packages:
   license_family: GPL
   size: 1259937
   timestamp: 1756144852972
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
+  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
+  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
+  depends:
+  - expat >=2.7.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1275876
+  timestamp: 1756144876643
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
+  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
+  md5: d912068b0729930972adcaac338882c0
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 23826
+  timestamp: 1615228158573
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/distro-1.9.0-py313h06a4308_0.conda
   sha256: 57e25d204f2e891ab2f68a776b9e21cc681adfe089ea35a18aa05e5aa950a4c7
   md5: 1fd7ab065e9958e7bbd4d3fbf175742b
@@ -1405,6 +2886,36 @@ packages:
   license_family: Apache
   size: 37917
   timestamp: 1728396132498
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
+  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
+  md5: 77f95d4b0a5bf1b775dda3372544dbeb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37699
+  timestamp: 1728480059192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
+  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
+  md5: 5e948f3d746f13d209bd09a9d2fb7758
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38129
+  timestamp: 1728591870413
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
+  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
+  md5: 9a502db95e7e272d1b7ed53f03dafab2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 63476
+  timestamp: 1729059201537
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/dnspython-2.8.0-py313h06a4308_0.conda
   sha256: 76ed0f399394a99c99f89ea8525b89f50412a75d0230d99b07137f6f9bdc117f
   md5: d9d17b8c0998984fbde4103a0113fb34
@@ -1423,6 +2934,61 @@ packages:
   license_family: OTHER
   size: 665462
   timestamp: 1763718275784
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
+  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
+  md5: 23079a69d0ac19cf9f264cfc36dfaf67
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  license: ISC
+  license_family: OTHER
+  size: 666622
+  timestamp: 1763718283404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
+  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
+  md5: 83b6045550ea3f3984ad063b58c44f83
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpx >=0.28.0
+  - httpcore >=1.0.0
+  - cryptography >=45
+  - h2 >=4.2.0
+  - trio >=0.30
+  - idna >=3.10
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 667571
+  timestamp: 1763718279384
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
+  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
+  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  - trio >=0.30
+  - idna >=3.10
+  - wmi >=1.5.1
+  - cryptography >=45
+  - h2 >=4.2.0
+  - aioquic >=1.2.0
+  license: ISC
+  license_family: OTHER
+  size: 666555
+  timestamp: 1763718371551
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docstring_parser-0.17.0-py313h06a4308_0.conda
   sha256: 4b99a2d38d4324cff99f21bcf1b938e25f178e5f22615b0dc8b6a7c6f17a0774
   md5: be1740cddc233f9ab333989a30091afb
@@ -1433,6 +2999,36 @@ packages:
   license_family: MIT
   size: 96105
   timestamp: 1766163640372
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
+  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
+  md5: 3a916231ebb779a7c2d5230fca7a2792
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96633
+  timestamp: 1766163709520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
+  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
+  md5: 84ceb2792085acb3459abeedb47f888d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96396
+  timestamp: 1766163600127
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
+  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
+  md5: 6c03175c12338ebc8273659a72c462ce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 96782
+  timestamp: 1766163871411
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/docutils-0.21.2-py313h06a4308_1.conda
   sha256: f07ce74ab05c47d99351bf2a8f40721f8211c3cc33a4db95f5f9d946b0ba3584
   md5: e9073a661561fdcd74f47e5e1116d686
@@ -1443,6 +3039,36 @@ packages:
   license_family: Other
   size: 938474
   timestamp: 1761746639546
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
+  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
+  md5: c73024412ae68d6afa90b3bfca1a3b28
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 939239
+  timestamp: 1761746641765
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
+  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
+  md5: 54a125d07b398d692c81bcad8c0fc6df
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 940136
+  timestamp: 1761746670106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
+  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
+  md5: bbfbf4a353f2adbd724998ab6083802f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  license_family: Other
+  size: 1014370
+  timestamp: 1761746691814
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/email-validator-2.3.0-py313h06a4308_0.conda
   sha256: e9010e12bc5ec063fada7c7f93908ebaee19f8c00fbcb42a6293e9854a92f54b
   md5: 147defdb8eb1d949155ba6dfcd33dfb7
@@ -1455,6 +3081,42 @@ packages:
   license_family: OTHER
   size: 66155
   timestamp: 1758610271322
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
+  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
+  md5: 4f6a93a269938d34f89e6c56b07905a1
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 65683
+  timestamp: 1758610280179
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
+  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
+  md5: c1112f1321fda31b8b182c011bd25f39
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 66105
+  timestamp: 1758610134265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
+  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
+  md5: 0aec5daa5284e9e3967c95a79f775012
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Unlicense
+  license_family: OTHER
+  size: 90963
+  timestamp: 1758610340546
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/environments-mcp-server-1.0.7-py313h06a4308_0.conda
   sha256: 34a464a65059b8878aca3cbc996597285cee847cd5ded1a121951126b2d30706
   md5: 919252a39e7e6b88c0d2f10af26c81e0
@@ -1479,6 +3141,78 @@ packages:
   license_family: BSD
   size: 66976
   timestamp: 1779916005740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
+  sha256: 4d498a91280bc6dc6d9d0108f1f7fbf3cc732014b522621ee0ce2ee1dea24b8e
+  md5: d2c9e173a97f6bbc2bc18c77796c5a6f
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66788
+  timestamp: 1779915955594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
+  sha256: 9ef08d154b7f88a5e232804d55aff2ff14c57693d4de856fdb6840ea97937034
+  md5: 2644ebe94b48d6c7e0b179c30807dfbd
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67101
+  timestamp: 1779916082564
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
+  sha256: fb3ce799f193bcb6e33061ad6f975654b06f3342c3c10a72664f9cfb23ac5c4d
+  md5: b7b2eed90ced3af325d06a98dfa4c4b0
+  depends:
+  - anaconda-auth >=0.13.0
+  - anaconda-connector-conda >=0.1.11,<0.2.0a0
+  - anaconda-connector-core >=0.1.11,<0.2.0a0
+  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
+  - click >=8.1,<9.0
+  - conda >=25.11.0,<26.2.0
+  - environs >=9.0,<12.0
+  - fastmcp >=2.12
+  - httpx >=0.24,<1.0
+  - lupa >=2.6,<3.0
+  - opentelemetry-instrumentation >=0.51b0,<5.59b0
+  - orjson >=3.11.5,<3.12
+  - pip >=25.0.0,<27.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typer >=0.7,<1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91692
+  timestamp: 1779916032565
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/environs-11.2.1-py313h06a4308_0.conda
   sha256: 3f42e89e9e231d76b622db947fe92ea894610c0b47dc05c672248a3de542e70d
   md5: 44df1fdd5286369932065aa827ed55cd
@@ -1491,6 +3225,42 @@ packages:
   license_family: MIT
   size: 37166
   timestamp: 1774388511813
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
+  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
+  md5: b34fd0d10946da439f9b357e3d42e1f5
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37088
+  timestamp: 1774388461266
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
+  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
+  md5: a1db257019eb3930e461aa5626be2c0e
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37392
+  timestamp: 1774388481869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
+  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
+  md5: f61420d4421c1f5c8ecb2d0cac6a910c
+  depends:
+  - marshmallow >=3.13.0,<4
+  - python >=3.13,<3.14.0a0
+  - python-dotenv
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37648
+  timestamp: 1774388523034
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py313h06a4308_0.conda
   sha256: ce30b8b076188b90cca5b053884631f7c9ecd669b023bdbe77b0b4aae4df3192
   md5: ca4915b2c8f67574d512d40f117617a1
@@ -1501,45 +3271,172 @@ packages:
   license_family: MIT
   size: 48909
   timestamp: 1761560358064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.5-h7354ed3_0.conda
-  sha256: ca2c5e649f35a9bdf6af0db5c596ebe060f5f6136417285348ab8e1eaa2f1dfa
-  md5: 26ee2ccb746d7d06dfc5f83f906bd650
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
+  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
+  md5: 23b284ce11d60c82ef766dbfc024277c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49018
+  timestamp: 1761560361917
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
+  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
+  md5: cd68188eea25cf618d3ed80a746e34cd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 48744
+  timestamp: 1761560378218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
+  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
+  md5: be5485351f1313fc4628d30117e0fdd5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 49233
+  timestamp: 1761560536661
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.8.1-h7354ed3_0.conda
+  sha256: e878cbb8688295d31fbae7980505e404fc93dda7da53b83272b0252d461f4338
+  md5: 45f62162756790fa5fc2ccb7b4efa1ad
   depends:
   - __glibc >=2.28,<3.0.a0
-  - libexpat 2.7.5 h7354ed3_0
+  - libexpat 2.8.1 h7354ed3_0
   - libgcc >=14
   - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 24686
-  timestamp: 1774555959871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.128.0-py313h06a4308_0.conda
-  sha256: 2e67b70f7c75b738fe9cee99e8f2426fc78e9e28a1fa39688553ff4d49b9a039
-  md5: 58fb538a4ee5225beaed597d3525a75e
+  size: 24824
+  timestamp: 1779874385684
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.8.1-h5b11e9f_0.conda
+  sha256: 3e40b271ec47e077ca4d204cbf65a2240a33ec163c4860cc350d0f268af30915
+  md5: 774839ce2af756baca243ee77e2b04d5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libexpat 2.8.1 h5b11e9f_0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 25948
+  timestamp: 1779874409953
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastapi-core-0.135.4-py313h06a4308_0.conda
+  sha256: 5e2374da4a5adc8b3c7dc7d403dffcace21af420bf1a1c807559c2b0b4c9f86e
+  md5: 48955966edbdf46f308f52aa594d0394
   depends:
   - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
+  - pydantic >=2.9.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
+  - starlette >=0.46.0
   - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
   constrains:
-  - jinja2 >=3.1.5
-  - itsdangerous >=1.1.0
-  - orjson >=3.2.1
-  - pydantic-extra-types >=2.0.0
-  - fastapi-cli >=0.0.8
-  - httpx >=0.23.0,<1.0.0
-  - pyyaml >=5.3.1
-  - python-multipart >=0.0.18
   - pydantic-settings >=2.0.0
   - email-validator >=2.0.0
+  - orjson >=3.2.1
+  - fastapi-cli >=0.0.8
+  - httpx >=0.23.0,<1.0.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - pydantic-extra-types >=2.0.0
+  - pyyaml >=5.3.1
+  - jinja2 >=3.1.5
+  - python-multipart >=0.0.18
   - uvicorn-standard >=0.12.0
+  - itsdangerous >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 212566
+  timestamp: 1779213502962
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.135.4-py313hd43f75c_0.conda
+  sha256: a554a080bc41268cc230f109343d1e5463162f067d1b43be38262d722e5f1e23
+  md5: 8356bfc6cd2e6e10ee94e5c728bd12b2
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - pydantic-settings >=2.0.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - fastapi-cli >=0.0.8
+  - uvicorn-standard >=0.12.0
+  - pydantic-extra-types >=2.0.0
+  - itsdangerous >=1.1.0
+  - orjson >=3.2.1
+  - jinja2 >=3.1.5
+  - httpx >=0.23.0,<1.0.0
+  - python-multipart >=0.0.18
+  - email-validator >=2.0.0
+  - pyyaml >=5.3.1
+  license: MIT
+  license_family: MIT
+  size: 213160
+  timestamp: 1779213485286
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.135.4-py313hca03da5_0.conda
+  sha256: 1b9e6662b9cfd28296990a27bba731fdaf168e0c7eaf5018cb55755b3b97a15d
+  md5: 5c3422f980014c560b2dda3a93c3fc18
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - jinja2 >=3.1.5
+  - email-validator >=2.0.0
+  - fastapi-cli >=0.0.8
+  - itsdangerous >=1.1.0
+  - python-multipart >=0.0.18
+  - uvicorn-standard >=0.12.0
+  - pyyaml >=5.3.1
+  - pydantic-extra-types >=2.0.0
+  - httpx >=0.23.0,<1.0.0
+  - orjson >=3.2.1
+  - pydantic-settings >=2.0.0
   - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
   license: MIT
   license_family: MIT
-  size: 195578
-  timestamp: 1768401129399
+  size: 213782
+  timestamp: 1779213508607
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.135.4-py313haa95532_0.conda
+  sha256: 6991d1ff653f28d473c3faa78b56dddbe7484e97a8d08533c4b0b6210b73f5d1
+  md5: 08d621ddb70b614c33a8847c48b30cad
+  depends:
+  - annotated-doc >=0.0.2
+  - pydantic >=2.9.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.46.0
+  - typing-extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  constrains:
+  - pydantic-settings >=2.0.0
+  - itsdangerous >=1.1.0
+  - python-multipart >=0.0.18
+  - email-validator >=2.0.0
+  - uvicorn-standard >=0.12.0
+  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
+  - pyyaml >=5.3.1
+  - httpx >=0.23.0,<1.0.0
+  - fastapi-cli >=0.0.8
+  - orjson >=3.2.1
+  - jinja2 >=3.1.5
+  - pydantic-extra-types >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 270617
+  timestamp: 1779213555162
 - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastmcp-3.1.1-py313h06a4308_0.conda
   sha256: a7a9431f336fd35f1002ece0009ebd72bce46618c4cc1a488205ee8ab8ec6516
   md5: 715ed31b021b666ddf86d091f58d455e
@@ -1584,2926 +3481,6 @@ packages:
   license_family: Apache
   size: 1060147
   timestamp: 1774377863253
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-11.2.0-hca5f364_0.conda
-  sha256: 851afd6890164c6894572c275a7d3fb87dac4ce8b3760925febb2c3779306275
-  md5: 0615a40b477dd3a4488d67cd422a1365
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 206513
-  timestamp: 1754990938922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
-  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
-  md5: 26dfe875df9973e0e98ec5add063e00e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39148
-  timestamp: 1761750688493
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
-  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
-  md5: df53b928c3a9dd53c7f4e87cc03e03d2
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h6a67909_0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libasprintf-devel 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libgettextpo-devel 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 535333
-  timestamp: 1772045309664
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
-  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
-  md5: ac944526cc2d27ffa3c44a42cd86f46d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3777431
-  timestamp: 1772045279414
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
-  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
-  md5: 91b9170766e7040dedc182d913a7ff89
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171370
-  timestamp: 1770382383126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
-  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
-  md5: 9b8c1795cc878775116cd01cea2ddad8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 h79c45ec_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 877844
-  timestamp: 1770755209168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
-  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
-  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64750
-  timestamp: 1761931277052
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
-  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
-  md5: 77016551f9607c23c6243632bf100507
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127896
-  timestamp: 1748526107673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
-  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
-  md5: 4b7c5319a6df6513319768f73969098c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 101585
-  timestamp: 1763634777574
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
-  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
-  md5: d25af3a5cbefe54951cb3dc369b945bb
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=8.0.0,<9.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - zstandard >=0.18.0
-  - socksio >=1.0.0,<2.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217558
-  timestamp: 1760447364823
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.0-py313h06a4308_0.conda
-  sha256: 323856b6498b26b978b3c553b8ed4965002b940574032057f8818c1b63954bf0
-  md5: 55a43a7e939a3fcc4987774478a735ee
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16656
-  timestamp: 1735845644279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.conda
-  sha256: f60e8a4b965ba50214f5a7a24308c060860fa5062d9d69d581287a520006abba
-  md5: 6d09df641fc23f7d277a04dc7ea32dd4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 27195861
-  timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
-  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
-  md5: c8b25d0fe19ba1a7319a0221e7615265
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 202882
-  timestamp: 1761911998666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
-  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
-  md5: e3d3dc1bd7e26bef582f874fbb4c543c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71396
-  timestamp: 1772097118324
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.14-h5eee18b_1.conda
-  sha256: e76928987010e8d60fe7e2edbbf733643ed16f17eb9cbcd96bc4dcb2d823dec2
-  md5: 852537d568f5ed410a100d65424039dc
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 38170
-  timestamp: 1705704612984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
-  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
-  md5: c4ea3f7208a811b569bbeae8c42c5b2d
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19952
-  timestamp: 1755516354462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
-  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
-  md5: 54a430923247a921a5c57e330e04549f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17104
-  timestamp: 1769477866762
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
-  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
-  md5: 9572b85d5f84049bc36867f49d498520
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23712
-  timestamp: 1768389384997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
-  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
-  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 304593
-  timestamp: 1762897374551
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
-  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
-  md5: 8cb4b1755a4a8fd6a57883863236ef2b
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36479
-  timestamp: 1728399618377
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
-  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
-  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18979
-  timestamp: 1774432898196
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
-  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
-  md5: 259205480d74c969b6bbd3c48662291e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30490
-  timestamp: 1774283018435
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
-  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
-  md5: 7125606e211300f51b43b14c7039c163
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198245
-  timestamp: 1767955393666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
-  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
-  md5: dea8a1c280fb8cb391be3b459d8dfac1
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52614
-  timestamp: 1772640999029
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
-  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
-  md5: 2dbc150b61f12b744cf873c285f4a418
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17079
-  timestamp: 1762788451045
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
-  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
-  md5: 292a4c15bbd54feba358997e6d1b35db
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96597
-  timestamp: 1764588298747
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
-  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
-  md5: 6d505a62b565ff3d80d5a6662a83d54a
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-mypy >=1.0.1
-  - shtab >=1.1.0
-  - pytest-enabler >=3.4
-  - pytest-checkdocs >=2.4
-  license: MIT
-  license_family: MIT
-  size: 82797
-  timestamp: 1763637203264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
-  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
-  md5: c563bb71f4df90fc3b92cde204827564
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 742162
-  timestamp: 1773255564362
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
-  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
-  md5: 569d92e1732a69adff57813342a9c316
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - libabseil-static =20260107.0=cxx17*
-  - abseil-cpp =20260107.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384532
-  timestamp: 1770384636226
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.2-h3ec8f01_0.conda
-  sha256: 47b727b2add2529ee9f983fefda5307a728941e95f48b467119865ef17ec417c
-  md5: 7e646e7deafe4482bb0b9525ab748132
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libxml2 >=2.13.8,<2.14.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.18,<4.0a0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 875632
-  timestamp: 1761151790516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
-  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
-  md5: 9fe17fea3f12a5dcc483b89f48e361da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52393
-  timestamp: 1772045241614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
-  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
-  md5: 114f7a7ae6d01b7f5d568439769857f7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 hf2ab22a_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33684
-  timestamp: 1772045249959
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
-  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
-  md5: cdc0bbfec0c99b30d435b22341a716b0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78282
-  timestamp: 1762363571278
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
-  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
-  md5: 7cad8348df1c96bf2f0a697806d1b3b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 33634
-  timestamp: 1762363575967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
-  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
-  md5: 854af1d6af8b3565fa8c7edb2141a2de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 h32cd6e7_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 279951
-  timestamp: 1762363583050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.19.0-ha05a353_0.conda
-  sha256: d485833f2828450de36e7abf46645b05c56a72175c2d42e1963c92dce9fce2f6
-  md5: bf3bea70fcf78aa1ad48e76976bc67c0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.67.1,<1.68.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 499620
-  timestamp: 1774299460402
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
-  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
-  md5: 5065620db4393fb549f30114a33897d1
-  depends:
-  - libgcc-ng >=7.5.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 114011
-  timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.7.5-h7354ed3_0.conda
-  sha256: cda922c9f09bfa17933d55849b9232416872b068018ab89580e379d5487a2c14
-  md5: 67c73f16b2eb58c1c73d5a3dc1645d14
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 125091
-  timestamp: 1774555957601
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.conda
-  sha256: b0e7fe2e5d498bc5a2c57cf942701bba8f22ec55de55e092ffbffc40b816df88
-  md5: 70646cc713f0c43926cfdcfe9b695fe0
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 144691
-  timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_7.conda
-  sha256: baf9d8d16e2a8ae7a4d1b80f2c1a932deaca1a87c677a370f6ab4688482db47b
-  md5: 01fb1b8725fc7f66312b9d409758917a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_7
-  - libgomp 15.2.0 h4751f2c_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 825084
-  timestamp: 1762772576461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_7.conda
-  sha256: 3a3678f17a8916777d03b83f19f673107b4a9bf55366234dcfa42edbd5173123
-  md5: 2783efb2502b9caa7f08e25fd54df899
-  depends:
-  - libgcc 15.2.0 h69a1729_7
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28356
-  timestamp: 1762772577850
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
-  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
-  md5: 775a5698ec2a0aa6e2435b86418b563f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 190134
-  timestamp: 1772045245717
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
-  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
-  md5: 5766eead346251db288d5b13c3dffd6f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 hf2ab22a_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36248
-  timestamp: 1772045253856
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-15.2.0-h4751f2c_7.conda
-  sha256: 835e44371812c91563a00dec8bc98c460f8b9f33f50543244bc8774c446a2172
-  md5: 82025ed6da944bd419d42d9b1ff116aa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 446183
-  timestamp: 1762772542830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
-  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
-  md5: 91b626db75392fc7254aaad8dc9a9850
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7252351
-  timestamp: 1770755115633
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
-  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
-  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 789520
-  timestamp: 1771491869505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
-  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
-  md5: 7ab70b332bb2df9ce90a1567126b5d2a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 82352
-  timestamp: 1760364378431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
-  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
-  md5: 3fd122ff074ed6bed89994053feb1fe3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 804625
-  timestamp: 1775137912599
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-h860b5fb_1.conda
-  sha256: 87776624e4882955942a61799db0cafd19e5ab26874ddcb99cca2d66a4ea287d
-  md5: c9351e4b3b09fbe3c3bba5526acbf19c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2061828
-  timestamp: 1763111696644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313h3f77f5b_1.conda
-  sha256: feedf8857d483851cf41a5ff9d625ea9c100194d54a974259072e215a3f86307
-  md5: a974c724de77f79cd7e926116fd861df
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=11.2.0,<12.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libmamba 2.3.2 h860b5fb_1
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 663170
-  timestamp: 1763111784452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
-  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
-  md5: feb10f42b1a7b523acbf85461be41a3e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 88085
-  timestamp: 1726088449399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.67.1-h697f920_0.conda
-  sha256: 73b3c00697e9a1a5693e9ff70f7995dc27ac11a72524cb9fd71b60b6da480a1d
-  md5: c509cea724fbc22300e5ce9ced97d569
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.5,<2.0a0
-  - c-ares >=1.7.5
-  - jansson >=2.14,<3.0a0
-  - jansson >=2.5
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libstdcxx-ng
-  - libxml2 >=2.13.9,<2.14.0a0
-  - libxml2 >=2.6.26
-  - openssl >=1.1.1
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zlib >=1.2.3
-  license: MIT
-  license_family: MIT
-  size: 651583
-  timestamp: 1762785235166
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
-  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
-  md5: 0801fbfd982d1a0de5cc895fed83a19c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3703875
-  timestamp: 1770634775371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
-  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
-  md5: 0767b8ade520f4927ff9d5866d783f6b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210465
-  timestamp: 1770390434417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
-  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
-  md5: 0d547d53349f3fcf4a20c9a207c08a3b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 465860
-  timestamp: 1760357067289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
-  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
-  md5: dd68c24355431c0543339dda1404129d
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 315187
-  timestamp: 1732891131339
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_7.conda
-  sha256: 747474162ae421d680ab3374d8b11158701206d4a9c4a8f9de557dd6fc13345a
-  md5: 7dc7ec61ceea5de17f3e2c4c5f442fc6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 h69a1729_7
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3903663
-  timestamp: 1762772586621
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_7.conda
-  sha256: 7a39becf3c7dd6016d4b6d24587071cda2afefcdf2886ad16572095261c87b90
-  md5: cf200522c0b13d64bf81035358d05f5b
-  depends:
-  - libstdcxx 15.2.0 h39759b7_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28429
-  timestamp: 1762772606373
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
-  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
-  md5: e79c628574f0ed3b60bd63e6d78501a1
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 671850
-  timestamp: 1777465777755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
-  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
-  md5: 4a6a2354414c9080327274aa514e5299
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28110
-  timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
-  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
-  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 901634
-  timestamp: 1772644974924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
-  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
-  md5: fdf0d380fa3809a301e2dbc0d5183883
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 440690
-  timestamp: 1746022211479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.9-h2c43086_0.conda
-  sha256: 9bb90ed726ba5868488184f03aa1c18fe654e00aa36b570a16a66c3d350a868b
-  md5: 72d5d2d627dd9b7780781e7aa6a12689
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 684847
-  timestamp: 1761768971660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-hb25bd0a_0.conda
-  sha256: 2e0a3ea3aba7ffaa9c2ce9b267b34b12859f93bde8e62cedcbbab6144776568f
-  md5: 338ee51e19ee211b7fc994d4ba88c631
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 60697
-  timestamp: 1756475934898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
-  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
-  md5: 1468bc20414b0fa8eb1b18d3a916039f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 480121
-  timestamp: 1754999718088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
-  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
-  md5: 6f3445d61b923a4e22a50b4ede3c1865
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 377746
-  timestamp: 1775637820996
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
-  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
-  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 150496
-  timestamp: 1775657630843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
-  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
-  md5: 2ee58861f2b92b868ce761abb831819d
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 159495
-  timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_1.conda
-  sha256: bfed5539652f10a2c344501a4d9928856b50d323fdd390c578fd08e856b7d648
-  md5: f515d22e3c87bcf86d4cd5c877bc34cd
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - sphinx-book-theme >=1,<2
-  - commonmark >=0.9,<0.10
-  - panflute >=2.3,<2.4
-  - markdown >=3.4,<3.9
-  - mistletoe >=1.0,<2.0
-  - mistune >=3.0,<4.0
-  - linkify-it-py >=1,<3
-  license: MIT
-  license_family: MIT
-  size: 242668
-  timestamp: 1767001668294
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
-  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
-  md5: 28351e7fd716ee4b3baef571be119b98
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151241
-  timestamp: 1728403996163
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
-  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
-  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - python-dotenv >=1.0.0
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 428184
-  timestamp: 1771960075711
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
-  sha256: b6ca5bd3f708610801723deb09a29941cb47061832659de55b414f0496bab3b6
-  md5: e909ab91f515181fff72f312cbe1dcb1
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  - opentelemetry-api >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 346906
-  timestamp: 1779919393059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
-  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
-  md5: 39da6986b50a3eb3cbf60c9883f4b92e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26871
-  timestamp: 1758552191170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
-  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
-  md5: 3c19869ee69743cd3e6ed44610f7b845
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257750
-  timestamp: 1765382387320
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-10.8.0-py313h06a4308_0.conda
-  sha256: a6da3706af1a527f98e4db5e9e492836d9315825ee99336230865493ae4ee0a6
-  md5: bd0dee4808dd6acb561fce514a345c3d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 167359
-  timestamp: 1761121509531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
-  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
-  md5: b1fb5c763a2d3e15e633e84bccf52ce4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 123032
-  timestamp: 1750958840666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
-  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
-  md5: b9ee8adce00b801f3767671675300a6f
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 154942
-  timestamp: 1728385601732
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
-  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
-  md5: 0abfc090299da4bb031b84c64309757b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1137647
-  timestamp: 1753947487644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
-  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
-  md5: 36890f7abd98066b607211b1773e6343
-  license: MIT
-  license_family: MIT
-  size: 127326
-  timestamp: 1680082329609
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.14.0-py313h06a4308_0.conda
-  sha256: 0b5bf6306956956c8346844723db74144b3d278bdb62cec34a0a74d3595f5b5d
-  md5: 718b1fc51e7c834eab78ed742d720a45
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - pandas-stubs >=1.1.0.11
-  - pandas >=1.2.3
-  - httpx_aiohttp >=0.1.9
-  - sounddevice >=0.5.1
-  - websockets >=13,<16
-  license: Apache-2.0
-  license_family: Apache
-  size: 1048147
-  timestamp: 1767167972500
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
-  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
-  md5: d842c01c08579c4398dc5b15a0bd875d
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79899
-  timestamp: 1763721155768
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.5-h1b28b03_0.conda
-  sha256: 0dcbe182b4b5270e2c5b35ec90418ae7e2de7a925f8617fdc939dee732a21b8b
-  md5: 96c41caadc229cc56c4fbcb26bb5b8cd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 5818141
-  timestamp: 1772119658375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
-  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
-  md5: 8310c25ce1847aee276a9e2617388f46
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101271
-  timestamp: 1763996098531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
-  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
-  md5: ea9c98e0799195320c546768f562f351
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37782
-  timestamp: 1764236782492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
-  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
-  md5: 4c6786f5a20a0d5705c77a18d97eebec
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43650
-  timestamp: 1764254904983
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
-  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
-  md5: de2d09e81412c0288e94586569f8276c
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33381
-  timestamp: 1764254429958
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
-  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
-  md5: a9aa9b02edaa6e129374ae281b4ace66
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 58002
-  timestamp: 1764084155711
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
-  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
-  md5: e36ceb40f2e628e2b6d4bb62032539a1
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57320
-  timestamp: 1764164412130
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
-  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
-  md5: 2a77251102af2651654e23f12c0e58c6
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 274299
-  timestamp: 1764073186249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
-  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
-  md5: e794cf7621bbe67d177b7e279cd6d610
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 179330
-  timestamp: 1764062875253
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
-  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
-  md5: 76bffd8af6e6a162a1e7af69b9b800d7
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 337138
-  timestamp: 1771945983540
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
-  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
-  md5: 0f7d4f61c3851a0d436b96e9cb02c393
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200822
-  timestamp: 1775004135549
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
-  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
-  md5: da78932ffefe7e3f780f75672b3f8b36
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51265
-  timestamp: 1772567686795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
-  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
-  md5: 49c2031dcebd085e49c3aff84479e314
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1289658
-  timestamp: 1759825800150
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
-  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
-  md5: a1e79da30a6c62c6398e9bb990ee9ed6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9162
-  timestamp: 1728388115083
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
-  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
-  md5: e1705a98bf3338281b413e1fc8484a12
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54729
-  timestamp: 1773652981831
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
-  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
-  md5: 5c71fdece7639940072a849417bff8da
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47969
-  timestamp: 1776972936162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
-  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
-  md5: 7664f08981772ba49fef33294a096a18
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170398
-  timestamp: 1772733409298
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
-  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
-  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 570052
-  timestamp: 1770660764829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
-  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
-  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550941
-  timestamp: 1761896477134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
-  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
-  md5: 973a642312d2a28927aaf5b477c67250
-  depends:
-  - libgcc-ng >=7.2.0
-  license: MIT
-  license_family: MIT
-  size: 5360
-  timestamp: 1505733967605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_0.conda
-  sha256: 1342d17b10c8d4c2a1299e64c2e9e9b3bb21f5d20a340f8fd95bc19bd484b652
-  md5: 615b5f8a0a168480d9c09adda1c4d690
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - pytz >=2025.2
-  - pydantic >=2.11.9
-  - keyring >=25.6.0
-  - asyncpg >=0.30.0
-  - hvac >=2.3.0
-  - rocksdict >=0.3.24
-  - elasticsearch >=8.0.0
-  - diskcache >=5.0.0
-  - cryptography >=45.0.0
-  - aiohttp>=3.12
-  - types-aiobotocore-s3 >=2.16.0
-  - pymongo >=4.0.0
-  - python-duckdb >=1.1.1
-  - dbus-python >=1.4.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - types-hvac >=2.3.0
-  - pathvalidate >=3.3.1
-  - aioboto3 >=13.3.0
-  - aiomcache >=0.8.0
-  - redis-py >=4.3.0
-  - cachetools >=5.0.0
-  - valkey-glide >=2.1.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 258923
-  timestamp: 1774282532566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
-  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
-  md5: 60ea7416e08d78563e31d16c333bd57f
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 93055
-  timestamp: 1736868559715
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
-  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
-  md5: 3b8ea90c558c424f123c1fc6069c9fa6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155521
-  timestamp: 1774959763398
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.12.5-py313h06a4308_0.conda
-  sha256: 6c081cbd4131236658531e64370f14aabd59335a63a6b78360505bf8ba06e885
-  md5: 95234214667460a6e4eb9cd44c5facba
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1107018
-  timestamp: 1773134413559
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.41.5-py313h498d7c9_1.conda
-  sha256: 4964ef04532cce861183176123287df387db41329ad24a7256518b1ec1bb99b9
-  md5: d943970fbb63d8d9e6f5d805f2a6fbdf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1932101
-  timestamp: 1764009859395
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
-  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
-  md5: 52b991b3676ad69221ac4efe952ea622
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - google-cloud-secret-manager>=2.23.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  - pyyaml >=6.0.1
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  license: MIT
-  license_family: MIT
-  size: 151041
-  timestamp: 1764165180924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
-  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
-  md5: ccea3f7c3ca8da985a55fbc042ad8d82
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4943174
-  timestamp: 1775127040649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
-  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
-  md5: 3cbe7080967f615cd88efd025391b662
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 102773
-  timestamp: 1773773809562
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
-  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
-  md5: 41e5a9f1fb430fad7e10a9db74000502
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26218
-  timestamp: 1773985120703
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
-  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
-  md5: e1ab9ffa1588856f0bdbb204322568c4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35801
-  timestamp: 1761753024312
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.12-hb7b561f_100_cp313.conda
-  build_number: 100
-  sha256: 558a087f71909db8c04f634af023c94d128305f1b313560bf6ed9bb404f731bf
-  md5: f0c9d56e080ab6f2838d1626225cdd37
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.35.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 33182243
-  timestamp: 1771950585257
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
-  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
-  md5: a844b3df0b11b33f4742841d25146b6c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313830
-  timestamp: 1728385377316
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
-  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
-  md5: 6aa550906f91d13d1371c07e9cb5c5c3
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51623
-  timestamp: 1768559707638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
-  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
-  md5: 213fed7b509c30119154cf77a958aa7d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253447
-  timestamp: 1763718602538
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.22-py313h06a4308_0.conda
-  sha256: 1698108e7f224df70f6514dc9bb833975b5c3f47345a4e1282db18e3598b5700
-  md5: aa89c2ed9a05853082cd19c20ba08656
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63807
-  timestamp: 1770213120083
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
-  md5: 5af1bf885def2fa779b0bb002e53651b
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6157
-  timestamp: 1764349599777
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
-  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
-  md5: f700a9cc4e35fd699b4df403f8f14148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 224571
-  timestamp: 1773043070463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
-  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
-  md5: 2384f037ab798b6ce6097c717a8758dc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 253759
-  timestamp: 1763465523432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
-  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
-  md5: 631d76b2ec86efd85d6266113f7b20d5
-  depends:
-  - libre2-11 2025.11.05 h3356fce_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26001
-  timestamp: 1770390441796
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
-  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
-  md5: 33b7455bfa1462c42bbc9a0535070313
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19959
-  timestamp: 1760613452708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
-  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
-  md5: 8578e006d4ef5cb98a6cda232b3490f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 481826
-  timestamp: 1754485653893
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
-  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
-  md5: ce6e467c7e671a9214bc5d118b8e24a7
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82123
-  timestamp: 1762536905383
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.4-h6a678d5_2.conda
-  sha256: 3c9233dc26c1e4264966c5b95ab7cb80748153ae1c3de688a503d9f84c888210
-  md5: 3c6dbc6c60b3897222d79359343e90fa
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 29681
-  timestamp: 1714680903817
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.4-h6a678d5_2.conda
-  sha256: 7211f85590295c8dc29622fe02514f081a3a25dcc2dafcc741365ddb5aedee95
-  md5: b03aa4903158279f003e7032ab9f5601
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - reproc 14.2.4 h6a678d5_2
-  license: MIT
-  license_family: MIT
-  size: 21248
-  timestamp: 1714680919761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
-  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
-  md5: 120fcdc3014753b33a63db5930b7a085
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170579
-  timestamp: 1775066095969
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
-  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
-  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88122
-  timestamp: 1728411680534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-14.2.0-py313h06a4308_0.conda
-  sha256: 4006abedbb05553a7f667566d23afbac4beea2097a96d0508c629b044affde0c
-  md5: f4775d8f7f987cff7f067c7a47c66723
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 604815
-  timestamp: 1760375652641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
-  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
-  md5: 42d308b4487e6a58261a971eb689044b
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33936
-  timestamp: 1771961295227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
-  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
-  md5: 9630d019be2bb127699a375157124a0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 346701
-  timestamp: 1762366536075
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
-  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
-  md5: dc961556c7bbe4e2aa959e36ab816dcd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271868
-  timestamp: 1762535994695
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
-  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
-  md5: dad8d758af9c2b4369776c601407d9bd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 136835
-  timestamp: 1762530306911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
-  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
-  md5: 6ce9737188317c940d461c09c18d0ab3
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31382
-  timestamp: 1775127026347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
-  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
-  md5: 985226bbcb23ebc859128ca676ad6321
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45387
-  timestamp: 1761903210853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
-  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
-  md5: 08038e054ee9e8419ea6aa3fd04455ea
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1665385
-  timestamp: 1775048728528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
-  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
-  md5: 843241073919fc2c912f6ed85d14681d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23136
-  timestamp: 1761912223128
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
-  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
-  md5: 7b2a4b5be590071e1b4dce77b413d26a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 264262
-  timestamp: 1734048099531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
-  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
-  md5: 648ce63d75b826e85fb8801c8b4b4e44
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37483
-  timestamp: 1744271525796
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
-  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
-  md5: face17589cf2b386d76cc870234dfe6e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17447
-  timestamp: 1764329206740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
-  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
-  md5: c7b847a43363d2d77724b9ea04881088
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1265119
-  timestamp: 1773313781324
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
-  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
-  md5: 1fb18f68f15d21748310b2a09ea2f923
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21821
-  timestamp: 1745413175232
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.47.3-py313h06a4308_0.conda
-  sha256: f8d1b5a04bc9094bdc37f10bf227477dd3d1d7c02b5f41be1c91515b58649abb
-  md5: d75839b48c8d42e3e863de59994c4f96
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176882
-  timestamp: 1756910754331
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
-  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
-  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3610181
-  timestamp: 1755243907117
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
-  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
-  md5: 782987d420694bdc4a207a16db446a56
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82730
-  timestamp: 1768296500871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
-  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
-  md5: d625085e004f964c54b88a3c6c5e8d7e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189342
-  timestamp: 1762896696002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
-  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
-  md5: 17b9f23e939b55ab9cab471b694a79d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 161112
-  timestamp: 1771398721582
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py313h06a4308_0.conda
-  sha256: 0e7167d3723f10bfade1a0b6c3c59829c2bf9705d8f3ffd57bdebdc3b6ddf1ba
-  md5: e3ab7e8538a252ccb235f1cf218bda52
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216170
-  timestamp: 1728385119935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.1-py313h06a4308_1.conda
-  sha256: 5236b0311bb9dc1b8643fed1666c2ff465225d055e14f7730ca43e63258c6257
-  md5: f365c6753a35068503a4fba9a29953ff
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49373
-  timestamp: 1762520921980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.20.0-py313h06a4308_1.conda
-  sha256: abf3e9b5820c78d1ca3d41b91f9b7b67d13d3e6c3f2892cc10f6f2361b3f0c3f
-  md5: d9b03aa4048c711087209d7c35e3fb32
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313h06a4308_1
-  constrains:
-  - typer-cli 0.20.0.*
-  - typer-slim 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157493
-  timestamp: 1771513026151
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-0.20.0-py313h06a4308_1.conda
-  sha256: 31e03fddda42d42d36db861c134ea402e4a7abe20a69a7a2b5bb07d42530737b
-  md5: 1d5785a482a13f84097ba02722141e5d
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - shellingham >=1.3.0
-  - rich >=10.11.0
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 112535
-  timestamp: 1771513011655
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-slim-standard-0.20.0-py313h06a4308_1.conda
-  sha256: b8a7d942b5032ecb3fd4faa83c7f51aa290d38773eb74195d7df136998aef8b6
-  md5: 9dd2ed87dd542c2ccde13c6e2e29a311
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313h06a4308_1
-  constrains:
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7309
-  timestamp: 1771513016825
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
-  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
-  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313h06a4308_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11238
-  timestamp: 1756280930223
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
-  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
-  md5: b5ea08882d6d5cca3e38a27a3575e85c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32310
-  timestamp: 1760614182019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
-  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
-  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 104756
-  timestamp: 1756280924315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
-  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
-  md5: ad4d17d499c69cca7e35518f53419f5c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24140
-  timestamp: 1774276104417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.6.3-py313h06a4308_0.conda
-  sha256: 450d16974ba2405a26ad7da3a2a2dc4f395246427d3f3471520f7a0810e57e74
-  md5: 23108bceb7bbce3e449c9c55ecbaa296
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - backports.zstd >=1.0.0
-  - h2 >=4,<5
-  license: MIT
-  license_family: MIT
-  size: 357351
-  timestamp: 1767810287147
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
-  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
-  md5: 302fdbeea413b0dc179b3ea16886718e
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141937
-  timestamp: 1768226450635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
-  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
-  md5: 2e099756135a2ef67be288cb2d8c3119
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313h06a4308_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39548
-  timestamp: 1768226455792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
-  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
-  md5: c28e5468c6d8844e76d22ac7baea58e4
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 665707
-  timestamp: 1762175545430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.1.1-py313h828f358_1.conda
-  sha256: 8ba2673045897d4b473dd974281b5d17db2e3cd42feec3a57dace7ca5a2faae2
-  md5: 9a7b7a4267a510d59d226cd2c271e9cd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 431640
-  timestamp: 1767984676303
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
-  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
-  md5: 946018cc418258ab8d35ed63099a3181
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 361630
-  timestamp: 1751974452259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
-  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
-  md5: 6730c94b00e7d802f421acd3a435af84
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70377
-  timestamp: 1769450261731
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
-  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
-  md5: 446fbd19ad7929dd70635f0303c5047b
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67121
-  timestamp: 1736540936116
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
-  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
-  md5: 8d5b22b094b6802334d7c8316c4091ce
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23000
-  timestamp: 1771372478643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
-  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
-  md5: 7a684ffa744044240b3061ad28531930
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 58122
-  timestamp: 1746171563556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
-  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
-  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26341
-  timestamp: 1746172168013
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
-  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
-  md5: 6298b27afae6f49f03765b2a03df2fcb
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 916212
-  timestamp: 1746110020649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
-  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
-  md5: a8005a9f6eb903e113cd5363e8a11459
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 13582
-  timestamp: 1745958707989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
-  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
-  md5: c284a09ddfba81d9c4e740110f09ea06
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19260
-  timestamp: 1745992279492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
-  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
-  md5: d810521a7b4a177fb3d1152cf84a778d
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 49889
-  timestamp: 1746169291297
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
-  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
-  md5: d95e8903fc0067086f153d04b8cbe578
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 95151
-  timestamp: 1746431898579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
-  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
-  md5: 79d7d6794c6adbc537fc98f94e204270
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 409903
-  timestamp: 1746172685149
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
-  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
-  md5: 412a0d97a7a51d23326e57226189da92
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-xextproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-renderproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 594175
-  timestamp: 1746046234466
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
-  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
-  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 635646
-  timestamp: 1772548381644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
-  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
-  md5: 39fdbf4db769e494ffb06d95680c83d8
-  depends:
-  - libgcc-ng >=7.3.0
-  license: MIT
-  size: 76992
-  timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.8.0-h6a678d5_1.conda
-  sha256: 47beed31dd48cbe0041f221e5b4521f2bd3d907b5dcc74cabfae9346c2ba5784
-  md5: 015d2d74ad3c8e53eec3358637433718
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 621367
-  timestamp: 1714510789193
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
-  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
-  md5: 0c22474f16e65bd9b52fd3b8d60a0372
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32106
-  timestamp: 1763977880529
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-hb25bd0a_0.conda
-  sha256: cf30f83189a30b12a9239f132ea0ce676fa822a52045adb0f9ff9b3b4d79ead6
-  md5: 9f3a877e5e0fa0fb39253a59ff824861
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libzlib 1.3.1 hb25bd0a_0
-  license: Zlib
-  license_family: OTHER
-  size: 98150
-  timestamp: 1756475939641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
-  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
-  md5: 78685aca3b481cf213b92abfbe0b2b21
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 422402
-  timestamp: 1758189113863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
-  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
-  md5: 93b0e546434bfb874aeefd6bb6cf40bb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 622604
-  timestamp: 1758039176606
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_libgcc_mutex-0.1-main.conda
-  sha256: 41e43dedb2e5805d15b60d0e337f625c6308b49ec94e1c7a2b34a62257ab850f
-  md5: b272288d02db5520249ca7870c2287b4
-  license: None
-  size: 2491
-  timestamp: 1617219512888
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/_openmp_mutex-5.1-51_gnu.conda
-  build_number: 51
-  sha256: 70892a5efb5803b565ba889b5479b6e866a0fabce3a7d2f648e494a9e7bff49b
-  md5: 66329dd81c60123e0d7c4c39b7ee7afe
-  depends:
-  - _libgcc_mutex 0.1 main
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
-  license: BSD-3-Clause
-  size: 1427721
-  timestamp: 1621385842900
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/aiofiles-25.1.0-py313hd43f75c_0.conda
-  sha256: 24898c55fcdb702a3804f862bb9e9f38d472ed334ebc89ab29075228ae0c442d
-  md5: 6327e33161b8e0ae8b501af0b07ee435
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35447
-  timestamp: 1773069243126
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-ai-0.5.0-py313hd43f75c_1.conda
-  sha256: 3acd30c8e89cf25fae5cd6076040bb15bb0bce6b6b38e6cf9aaf7ea55a02ce14
-  md5: a8de75045d038d62c3553bdb1a2bf2b3
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - langchain-openai >=0.2.8
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116895
-  timestamp: 1773844596952
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-auth-0.14.4-py313hd43f75c_0.conda
-  sha256: 841bdc2be16b56d58c495bfa923455316da0f92f415d318965c710cf26b5585b
-  md5: cc86d0a53de1c9d4559f84313d92f08d
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda-token >=0.7.0
-  - conda >=23.9.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127355
-  timestamp: 1777996210212
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-cli-base-0.8.2-py313hd43f75c_0.conda
-  sha256: 28626c38cf07a0536b6ff857df93174b614bbab282647635ddafb332516da702
-  md5: 0caf94c72f3e4e2b96f2124a29b1f17c
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62286
-  timestamp: 1775469252673
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-client-1.14.1-py313hd43f75c_0.conda
-  sha256: 70495831572571fb441eab2f150f30d60fecd2c6afef104261315d168aa2a5bc
-  md5: 0b644ecae935ac975164247e9f4d981d
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 845333
-  timestamp: 1772491214305
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-conda-0.1.11-py313hd43f75c_0.conda
-  sha256: 0060a280a06618c8dc15ed2fdbfe401471c4d29981c7eafa78095344a74cce2c
-  md5: bfb5d8d4df085842d8c0b2e056b9257f
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161380
-  timestamp: 1773934997584
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-core-0.1.11-py313hd43f75c_0.conda
-  sha256: a0aa9cce135bf2adaa066beac602d4597b15ad8cae86fca1e3fc746aae30fb6f
-  md5: 7112210d85ff777ac172307690b79f45
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 168446
-  timestamp: 1773871519885
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-connector-utilities-0.1.11-py313hd43f75c_0.conda
-  sha256: 703688d606b9aa02d5f612f8bb7bbd3bc2c84c79624ec6eeec993f6872085e93
-  md5: 213c7a858140be70244c210c31e4da04
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160774
-  timestamp: 1773868123073
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-mcp-1.1.0-py313hd43f75c_0.conda
-  sha256: bb6cea8523fef86fdea911c9aa1a952f9a69b0f21e769263a7240e81be64693c
-  md5: 7cb0f3e63900985c9bbd872a4d0f2123
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 75605
-  timestamp: 1779920836271
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anaconda-opentelemetry-1.1.0-py313hd43f75c_0.conda
-  sha256: 51e17a33a7ce7f80dfe8d9586a2a27d8d9a5e53eff4a07476cf62e55101c381e
-  md5: aab07c0ab08553546780a3a40f8f2cec
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82829
-  timestamp: 1776808540195
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-doc-0.0.4-py313hd43f75c_0.conda
-  sha256: f7d89f7dc779752d9441a8bb8253ab0920a9abca82f59728b7ab1222ecfed09e
-  md5: 37fbf9726b0439b29bba0e1cf52ae35c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11421
-  timestamp: 1763372675300
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/annotated-types-0.6.0-py313hd43f75c_1.conda
-  sha256: 15b9529bb8203632502c42ff0a2aeaaf20dd8c1de007834c5e7bd7956aa40c19
-  md5: 108a8bcd136312e83793f5cda2f350fb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26012
-  timestamp: 1761744922996
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/anyio-4.12.1-py313hd43f75c_0.conda
-  sha256: cfcb121fffb9969aecd5d7420d297f70e7c163236170ba16f88fa70a01cd6d5a
-  md5: 910687ebf7746e8562300e8f1996edc6
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318118
-  timestamp: 1773134422321
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/attrs-26.1.0-py313h89b2311_0.conda
-  sha256: 676ecb2919b6347efa1f086620930e827228c4852bad62f1b7ddca57ea9e4ac7
-  md5: 711f61b5492b94625605422dd8e326ed
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180516
-  timestamp: 1774959654156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/authlib-1.6.9-py313hd43f75c_0.conda
-  sha256: ad581cbd43141fc73dbbd0d96fc160115ac51d74322924cc227ec1fb1ee7f941
-  md5: 3bee8eb5a01e45d657bc7edc508dcde4
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 445207
-  timestamp: 1775206365399
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/beartype-0.22.9-py313hd43f75c_0.conda
-  sha256: ac4f2bb52268835c48e11e55e45f6e81a0604aac819a66f3e27a40da5d4148d2
-  md5: 63457f5636c2230e585b265ea721c2f8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1484918
-  timestamp: 1772489319478
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/boltons-25.0.0-py313hd43f75c_0.conda
-  sha256: d00ede3fc4122b25889446f787c4904fa363ca1a176a4575e14f2b94f1bf5445
-  md5: 1b01e9e6de64afa506ca4a894ecd9bb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 522348
-  timestamp: 1751383856268
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/brotlicffi-1.2.0.0-py313h5b11e9f_0.conda
-  sha256: cf00a3ed8f43fe2f2f31c074685f8e20fa96b5687d137ff161a24768fa54ed1e
-  md5: 9dd92861bec232ccdf7869b0b05b453b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17.0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 385446
-  timestamp: 1764961345156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/bzip2-1.0.8-h998d150_6.conda
-  sha256: ce168a001a8243588f8b127c40b866abcdd932733f0ab430cbf66dafbea297be
-  md5: f580b2013db742598b2d59875bccf774
-  depends:
-  - libgcc-ng >=11.2.0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 215406
-  timestamp: 1714510578082
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/c-ares-1.34.6-h0985719_0.conda
-  sha256: b1c67bf09db7d68e844c1b4db6b478ff69a0c00986ad60c24f94e5a417bf51ae
-  md5: 6e3e5f38a8efcb439d36f091baa23034
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 217449
-  timestamp: 1769077676509
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ca-certificates-2026.3.19-hd43f75c_0.conda
-  sha256: 3e384eff3151ac56bddedb0e283b8fd48e5f0f01467b46cbf6246323f2e213c2
-  md5: 51d892f6d58c233a961bb88a72a80d16
-  license: MPL-2.0
-  license_family: Other
-  size: 128939
-  timestamp: 1774365802467
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cachetools-6.2.2-py313hd43f75c_0.conda
-  sha256: eeeb2c9eddf8bbe94869055350265557a21f4c83fd8f56da2feb09821e6d6af3
-  md5: 1d25e042eebc783ff4804fc9c42852d2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41563
-  timestamp: 1764867403876
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/certifi-2026.01.04-py313hd43f75c_0.conda
-  sha256: a3de2871ed01954e278c620333e134398b609eb2b40a065b5f285c33e8980ac3
-  md5: da57c7bf0bbdf1849008dbe93d75643a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151899
-  timestamp: 1767659159197
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cffi-2.0.0-py313h2d8c4a8_1.conda
-  sha256: 219c90ba19e11ac6410e1da4b18f2ec6a6f4880deca29c6d7bba3228ff792601
-  md5: d010d105070e615750bbb51b8f2b17f5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 317809
-  timestamp: 1761832800132
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/charset-normalizer-3.4.4-py313hd43f75c_0.conda
-  sha256: 1beec840bca8dec97d0db6e01b879a0a7c641a74b8c8c45764810ebca0566d35
-  md5: c89d95c43d07b658088bb12631ce9132
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100336
-  timestamp: 1761744908393
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/click-8.2.1-py313hd43f75c_1.conda
-  sha256: a87292699cffa58eb1d866543dd618d59268b8e3b0480db742882751d47b1c4a
-  md5: 7813f91a66f3a442e803469cf76e3e1c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328923
-  timestamp: 1764332280328
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-26.1.1-py313hd43f75c_0.conda
-  sha256: 547b746f6e420971f5b99860e0ea6bdbd8e610a5131a4d6a70a35392abe0aaee
-  md5: efb9dc33b510e1c882b597d994f6ab3d
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-env >=2.6
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1270780
-  timestamp: 1771402352584
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-handling-2.4.0-py313hd43f75c_1.conda
-  sha256: 6bdcf37984bd50c875510e19c82e4dde8501f3bc926a0b41097280b240f0ef68
-  md5: 6577f526b527308e4bf66a7bdef0e7fe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285635
-  timestamp: 1762366425854
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/conda-package-streaming-0.12.0-py313hd43f75c_1.conda
-  sha256: c9c5362d656e30df415170c9fca96539371e9837ee38e8d3be9e645947329c2c
-  md5: 313fca7b4d867f8b06df3140548f9440
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38256
-  timestamp: 1762361650200
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cpp-expected-1.1.0-hb8fdbf2_0.conda
-  sha256: d5396c004cebbb05c60844cc4dd23e9ee0cd2896b70b8867719f80c7c04d37e6
-  md5: 06c2848c6311674e19391d4b81b3188a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: CC0-1.0
-  license_family: CC
-  size: 132686
-  timestamp: 1734039347698
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cryptography-46.0.6-py313haa502f6_1.conda
-  sha256: ea8a8929b26ce11b136093b49ed47842617d235262abce14275a08b8733fa8dc
-  md5: 15cce1cf3010a45c2282a7c0a04a39ed
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=2.0.0
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1685129
-  timestamp: 1775165946454
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/cyclopts-4.6.0-py313hd43f75c_0.conda
-  sha256: 612dfafb4222dade89af8047527a194e59aa412dc1bc8f2647411c2b1c85b08a
-  md5: 8f3083bd30c06eace150fbf4ff5acd33
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392308
-  timestamp: 1772065019547
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dbus-1.16.2-h6a16351_0.conda
-  sha256: fd1aac52c9c80cbc5f56d8f0286b4f3a972b25ad785e64464f2eeb0f783f29c3
-  md5: 6a7d865ed36eeecaaaf64a27519a3c7d
-  depends:
-  - expat >=2.7.1,<3.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1275876
-  timestamp: 1756144876643
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/distro-1.9.0-py313hd43f75c_0.conda
-  sha256: d86ac5f58acd43e7c5c5e5a9b24f128e7f498f65c72db101c5638ebc407af88e
-  md5: 77f95d4b0a5bf1b775dda3372544dbeb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37699
-  timestamp: 1728480059192
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/dnspython-2.8.0-py313hd43f75c_0.conda
-  sha256: 2d504bb4e1b99774167a66443967be24901fb38560853059b4713c33c6ea702d
-  md5: 23079a69d0ac19cf9f264cfc36dfaf67
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  license: ISC
-  license_family: OTHER
-  size: 666622
-  timestamp: 1763718283404
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docstring_parser-0.17.0-py313hd43f75c_0.conda
-  sha256: e4796183d9ef7cd7478cb9ffeb012d2e9d6d87261873db125e0b7b0dff74c33b
-  md5: 3a916231ebb779a7c2d5230fca7a2792
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96633
-  timestamp: 1766163709520
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/docutils-0.21.2-py313hd43f75c_1.conda
-  sha256: 063d0799ddda2232c84ad44270dd4e341023ec4849c66cc53988e8c9d5058232
-  md5: c73024412ae68d6afa90b3bfca1a3b28
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 939239
-  timestamp: 1761746641765
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/email-validator-2.3.0-py313hd43f75c_0.conda
-  sha256: 623f055ec775595db9039943c00901acfa6db333ca2a0f3cf0098753c6a9fa9c
-  md5: 4f6a93a269938d34f89e6c56b07905a1
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 65683
-  timestamp: 1758610280179
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environments-mcp-server-1.0.7-py313hd43f75c_0.conda
-  sha256: 4d498a91280bc6dc6d9d0108f1f7fbf3cc732014b522621ee0ce2ee1dea24b8e
-  md5: d2c9e173a97f6bbc2bc18c77796c5a6f
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 66788
-  timestamp: 1779915955594
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/environs-11.2.1-py313hd43f75c_0.conda
-  sha256: 00ca376574bf29cb44e81a34b81dc0e07cc62b930c3ecb6b05e5e8b5304ccb37
-  md5: b34fd0d10946da439f9b357e3d42e1f5
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37088
-  timestamp: 1774388461266
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/exceptiongroup-1.3.0-py313hd43f75c_0.conda
-  sha256: 62b4235831562290f9c88f9b79eed918496bb6b0bf24ca03347bb1ec167b82ac
-  md5: 23b284ce11d60c82ef766dbfc024277c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49018
-  timestamp: 1761560361917
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/expat-2.7.5-h5b11e9f_0.conda
-  sha256: 7a040dac98974da19f3ad8c62349c3e2e99295671c35716da917e3ae42f42c88
-  md5: 90d02a912cfb7f3bea1f0107c5276c2a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libexpat 2.7.5 h5b11e9f_0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 25656
-  timestamp: 1774555880096
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastapi-core-0.128.0-py313hd43f75c_0.conda
-  sha256: 10831bcd9e780eff2e3a1045d11d77eefaf38028eb9e1926291ceac5b9bb8d43
-  md5: e426f9ebee861421e9b7c984bb64a10f
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - httpx >=0.23.0,<1.0.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - email-validator >=2.0.0
-  - jinja2 >=3.1.5
-  - pyyaml >=5.3.1
-  - fastapi-cli >=0.0.8
-  - python-multipart >=0.0.18
-  - orjson >=3.2.1
-  - pydantic-extra-types >=2.0.0
-  - pydantic-settings >=2.0.0
-  - itsdangerous >=1.1.0
-  - uvicorn-standard >=0.12.0
-  license: MIT
-  license_family: MIT
-  size: 195510
-  timestamp: 1768401128402
 - conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fastmcp-3.1.1-py313hd43f75c_0.conda
   sha256: 25541e8c2d463538a366efe3768a9bc2c410d9d7b62c78023bedd113d05244ae
   md5: 890b979716890bda333d2b8da4e9df67
@@ -4548,2956 +3525,6 @@ packages:
   license_family: Apache
   size: 1057392
   timestamp: 1774377861488
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-11.2.0-hc5e0126_0.conda
-  sha256: 71d2a7ed8e4eceefbc6711d95295ba2a616de464a1e357282865bb631cd2ee58
-  md5: c7d95da4afe9887b02a792a5707a4bba
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 206105
-  timestamp: 1754990985187
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
-  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
-  md5: 8d10823536cc83aca7475e92af48e733
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 38822
-  timestamp: 1761750688451
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
-  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
-  md5: 29ce6f4467466ef1155fd8485c41b52c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext-tools 0.25.1 h304d29d_0
-  - libasprintf 0.25.1 h8121631_0
-  - libasprintf-devel 0.25.1 h8121631_0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libgettextpo-devel 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 529353
-  timestamp: 1772045298146
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
-  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
-  md5: c0f5a28ad7e3facdc8181ef762970499
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3969299
-  timestamp: 1772045273194
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
-  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
-  md5: 5a519fab2daa903499d90bef420c0c8b
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 170581
-  timestamp: 1770382377233
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
-  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
-  md5: 4648b65bcb134c3764a9e64f6e6953d8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.0 hec5afc2_0
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 831478
-  timestamp: 1770755033862
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
-  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
-  md5: 4786f45bc40fd0fb4b60c05d19e32179
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64484
-  timestamp: 1761931284057
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
-  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
-  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127463
-  timestamp: 1748526158318
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
-  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
-  md5: e4fc275a391afef3d78ec4149d5ad589
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 98508
-  timestamp: 1763634792733
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
-  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
-  md5: 63a3ec07509610236d9ad578a3b625aa
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - zstandard >=0.18.0
-  - click >=8.0.0,<9.0.0a0
-  - pygments >=2.0.0,<3.0.0a0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216526
-  timestamp: 1760447362829
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.0-py313hd43f75c_0.conda
-  sha256: c6954bcac5ea4799c6e7ae83e1a19b58df39819793109a2bf69ebfe4c33a4727
-  md5: db176a960a159bcfd981f1c16d4f3d88
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16571
-  timestamp: 1735845498447
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-73.1-h419075a_0.conda
-  sha256: 666aa21f839d88ebafb9804da64076a61b081c0d390c2f57150400080cce9e41
-  md5: cb0845107bfb0b019a07516080fd9431
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 27496589
-  timestamp: 1692293356718
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
-  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
-  md5: 93b126011717941f140fd04b6dd6d37b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203848
-  timestamp: 1761912000622
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
-  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
-  md5: 465aead5c1e7b7a585ebb676781545a1
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 71748
-  timestamp: 1772097105461
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.14-h998d150_1.conda
-  sha256: 4e8c5fbfee25074df634337a5d30841fc88bb5feedb89a02c138f85d5e7b54f5
-  md5: e0a9db0de5a436a8fa92f72bd09617c9
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 42724
-  timestamp: 1705704607717
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
-  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
-  md5: 281677614ab4b309ddb5afd24c80cd26
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19436
-  timestamp: 1755516386420
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
-  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
-  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17035
-  timestamp: 1769477854229
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
-  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
-  md5: 3fc0a300184c6cfbbb48735e637b6f00
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 23679
-  timestamp: 1768389385039
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
-  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
-  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 298136
-  timestamp: 1762897357507
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
-  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
-  md5: 9930fc2e22ba90d25992765ac140be02
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36927
-  timestamp: 1728480664723
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
-  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
-  md5: 793eb8901926bede7a6eebdce28cf6a0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19083
-  timestamp: 1774432919346
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
-  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
-  md5: 4660f274a8ff963e92cb29db01b37c91
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30439
-  timestamp: 1774283011961
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
-  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
-  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198026
-  timestamp: 1767955403846
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
-  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
-  md5: 022e69a93795b21be36f997e24f2b341
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52583
-  timestamp: 1772640996503
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
-  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
-  md5: da59899cde4411bae19ae5f15aebe373
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 16920
-  timestamp: 1762788449938
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
-  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
-  md5: f303bbea09244d08acd0fad083bbd6eb
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 96552
-  timestamp: 1764588304837
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
-  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
-  md5: c96025bac150402baa006c878d604992
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - jeepney >=0.4.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - secretstorage >=3.2
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-mypy >=1.0.1
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  license: MIT
-  license_family: MIT
-  size: 82677
-  timestamp: 1763637208740
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
-  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
-  md5: 833bdaaca975deb8a858597241ecd5c9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  constrains:
-  - binutils_impl_linux-aarch64 2.44
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 783012
-  timestamp: 1773255553164
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
-  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
-  md5: 50deebc10eb4d612f1bb35aa92538797
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1402413
-  timestamp: 1770384640911
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.2-h9e3fb69_0.conda
-  sha256: 2e066b7f308658f772bd453b4e151ba43e7e1e9aef40fb80a88fd1a9d3f1e8d5
-  md5: f1e2109005623363f0bca6854a0e9a10
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libxml2 >=2.13.8,<2.14.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.18,<4.0a0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1002269
-  timestamp: 1761151803239
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
-  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
-  md5: 898dd823b7a53a708a69d86847903b0e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.1-or-later
-  size: 52342
-  timestamp: 1772045233389
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
-  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
-  md5: 7b561a37cd2af9c7c194c2090e419ee3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libasprintf 0.25.1 h8121631_0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 33644
-  timestamp: 1772045246611
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
-  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
-  md5: 607b0beebe5e0c3643f2fceee006d15e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 78099
-  timestamp: 1762363467361
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
-  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
-  md5: 805855f8193938731ccba31427eaa37c
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 31209
-  timestamp: 1762363472701
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
-  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
-  md5: bfc1f2cb23c1f160079289f797e97756
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon 1.2.0 he9a0769_0
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 286206
-  timestamp: 1762363480172
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.19.0-hd99d008_0.conda
-  sha256: 8cd359cab520aec169feb0cfe08503d4efc878c324071b9a666c9a8d2afaca6c
-  md5: 923a7d9c10712dfc997e685ea445dc94
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libgcc >=14
-  - libidn2 >=2,<3.0a0
-  - libkrb5 >=1.22.1,<1.23.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.67.1,<1.68.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 516746
-  timestamp: 1774299451585
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
-  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
-  md5: 230e8093b929e64244f2c7e181705802
-  depends:
-  - libgcc-ng >=10.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 115539
-  timestamp: 1619012635485
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.7.5-h5b11e9f_0.conda
-  sha256: e50822f322079932eb4ff6c806f7ea7043260bb1e4afd4ff74f258f06fa0a954
-  md5: 13c85e5a1e3397428462cb9c364abd16
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 118612
-  timestamp: 1774555877019
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.4-h419075a_1.conda
-  sha256: 18fd986f0ef7f6a59c363e5305d06fe3f20509c39e3393fef60d722316828992
-  md5: 34c197394030fa553d97fc902585ee9b
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 143394
-  timestamp: 1714483284040
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_7.conda
-  sha256: 06ae831ca00e09a65ba8b5536e8b728be3eb909e0cf041ebcc542b92fa4bc969
-  md5: a31a8c63a5fe7234863f8e9dd2b20901
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_7
-  - libgomp 15.2.0 hf47c802_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 511039
-  timestamp: 1762772353789
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_7.conda
-  sha256: e672543a5f8d8ae30c7feab3ba57a2960c46756ca24fb027e3f6284a88d44acb
-  md5: e7d01ec71523a231b0d3b83f33a2dd21
-  depends:
-  - libgcc 15.2.0 hc18542e_7
-  - _libgcc_mutex * main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28446
-  timestamp: 1762772355060
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
-  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
-  md5: 3c39fd72e5a005e81c78cefe0f4b0464
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 214938
-  timestamp: 1772045240107
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
-  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
-  md5: 60521b8fbf132abc3846a700f33374cf
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libgettextpo 0.25.1 h8121631_0
-  - libiconv >=1.18,<2.0a0
-  license: GPL-3.0-or-later
-  size: 36215
-  timestamp: 1772045253063
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgomp-15.2.0-hf47c802_7.conda
-  sha256: 69eeb9a1342df1ba18d0fa994ebf3a43a653cf48a006b8778682cf032cf1e565
-  md5: 3403656472f38870e65c29aa6065e00e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 449546
-  timestamp: 1762772309007
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
-  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
-  md5: eb5839753b2b8904f6d7107d6240ef23
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6933116
-  timestamp: 1770754985299
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
-  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
-  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 778215
-  timestamp: 1771491870922
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
-  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
-  md5: 5bd529c1efa0251f0cebe7f84a504f69
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - gettext >=0.21.0,<1.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 119389
-  timestamp: 1760364375350
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
-  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
-  md5: 690464725d117c8ec5194f57b56525b5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - lmdb
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - krb5 1.22.1
-  license: MIT
-  license_family: MIT
-  size: 845865
-  timestamp: 1775137916299
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-hc4b5eec_1.conda
-  sha256: 3a06ed5da101445a72bbed867abcbb43b9cf05bf54ce9b6c40382554ca06991b
-  md5: b05e5a9cc5fc7b166d37b3859c4034bc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libsolv >=0.7.30,<0.8.0a0
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1989864
-  timestamp: 1763111663378
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h9fbafe8_1.conda
-  sha256: 266d4763906b5811fc8af23ec7b69b8b2b40b3588ec5999a199df4020d49db27
-  md5: d2269de613080d5a54a306aeed65cdfe
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - fmt >=11.2.0,<12.0a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - libmamba 2.3.2 hc4b5eec_1
-  - libstdcxx
-  - libstdcxx-ng >=11.2.0
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 574461
-  timestamp: 1763111749830
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
-  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
-  md5: 8bd7f4c495a81af4914c899949e52542
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 125873
-  timestamp: 1726088467322
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.67.1-h9561ae0_0.conda
-  sha256: 130c8e0aa79b541c473b701a6cb598e5200e0ce02735485ce1aab85e66a3c141
-  md5: 0a0b516b0f968b856717d559944efbac
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - c-ares >=1.34.5,<2.0a0
-  - c-ares >=1.7.5
-  - jansson >=2.14,<3.0a0
-  - jansson >=2.5
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - libgcc >=15
-  - libstdcxx >=15
-  - libstdcxx-ng
-  - libxml2 >=2.13.9,<2.14.0a0
-  - libxml2 >=2.6.26
-  - openssl >=1.1.1
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zlib >=1.2.3
-  license: MIT
-  license_family: MIT
-  size: 667251
-  timestamp: 1762785214718
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
-  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
-  md5: aa2d494311b59791b542ceedfc12ff2e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3507714
-  timestamp: 1770634686006
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
-  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
-  md5: 2d6e1172997c845d903d346b97494c07
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203733
-  timestamp: 1770390557525
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
-  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
-  md5: 40c52830df19329c37dd2f093eb944de
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 471404
-  timestamp: 1760357069476
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
-  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
-  md5: a88e620d4eafd7f199a0502433e5e0c0
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 332414
-  timestamp: 1732891127645
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_7.conda
-  sha256: 13c51fceabb26176b862042f079e74bc6bfc527a658dfd76d184bfb4c0cf5e90
-  md5: 90938778a2b6d4ba5c618b6e95b07a4b
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc 15.2.0 hc18542e_7
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3832701
-  timestamp: 1762772364181
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_7.conda
-  sha256: 928ee09e47b0ec7a7125e36a604e157ae24724117dd20706e1875e3bfb273f8f
-  md5: 34e6c37bb398595bc67ef229f5e60c80
-  depends:
-  - libstdcxx 15.2.0 h9538471_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 28507
-  timestamp: 1762772385720
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
-  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
-  md5: a99663395dab887607b2e5a854389721
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 676495
-  timestamp: 1777465771156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
-  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
-  md5: 59cd225a7659291aa716c6cdae7e1363
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 30035
-  timestamp: 1668082742967
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
-  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
-  md5: 52b484c9618823592d2c26632724dafd
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 594684
-  timestamp: 1772644989262
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
-  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
-  md5: 28e00a696fd74b7550b7d1b8698e10af
-  depends:
-  - libgcc-ng >=11.2.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdmcp >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 443363
-  timestamp: 1746022227484
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.13.9-h729a2f8_0.conda
-  sha256: 4934f41e2776b11efab87b9e1cd28c2aa150ec6c4ba0df1ee61dbab23462d288
-  md5: ad018fbdca2c6fd5edb874ea572bb089
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 720922
-  timestamp: 1761768979409
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h998d150_0.conda
-  sha256: 8dd49d0fe4a8a309e1aa22f96ff61d203eb719710436737042f6d0336635e18f
-  md5: 7d92046a5eb7a64af7ffbd0bc5ae7366
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 66950
-  timestamp: 1756475943009
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
-  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
-  md5: ff7911a6103418a2c907d8c0262dd7f2
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 414985
-  timestamp: 1754999724928
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
-  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
-  md5: 77eab2a2d275f56e722b1aad11532fd3
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 376687
-  timestamp: 1775637816376
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
-  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
-  md5: 8a1c323359558fc4a4df9191aa6d00fa
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 143384
-  timestamp: 1775657550865
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
-  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
-  md5: 70c4ab9462183ac4af60852d2a79fbf6
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 185496
-  timestamp: 1714510593467
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_1.conda
-  sha256: a05d920a2e8fb12ed3778262c5f089533dee6b6288e2424738ec1e7aeab95287
-  md5: 39f85b75ecca46ab04ffaed82496e0fd
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - mistune >=3.0,<4.0
-  - linkify-it-py >=1,<3
-  - panflute >=2.3,<2.4
-  - commonmark >=0.9,<0.10
-  - sphinx-book-theme >=1,<2
-  - mistletoe >=1.0,<2.0
-  - markdown >=3.4,<3.9
-  license: MIT
-  license_family: MIT
-  size: 242704
-  timestamp: 1767001694138
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
-  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
-  md5: 1225f726844496e3564e4b2d6c539763
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 151130
-  timestamp: 1728498536715
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
-  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
-  md5: b7268fc357df1edc377e4a02b5c5c115
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - typer >=0.16.0
-  - python-dotenv >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 430285
-  timestamp: 1771960065247
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
-  sha256: 830eba7a3d482bf580428ca3df9e79092d6e84525916de57e8a71ba188401ad7
-  md5: 500ea279af0692936f7d51b378eb25ba
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  - opentelemetry-api >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 347389
-  timestamp: 1779919403644
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
-  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
-  md5: 5ab5b1fc729b44eb2872d740d95c495d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26724
-  timestamp: 1758552208116
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
-  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
-  md5: 0514a2f7425fe0559d98b6593f8c936d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257086
-  timestamp: 1765382393281
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-10.8.0-py313hd43f75c_0.conda
-  sha256: 1f321a79e93054e15a30b78ef59a169d2c48bb81411304bdd5a08f9a6103b48f
-  md5: d8aa86705b3aa00966554fd8d3d6e3d4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 168226
-  timestamp: 1761121492722
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
-  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
-  md5: 90c7270744a7c8abdf51b5fecf7a9c14
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 120613
-  timestamp: 1750958715349
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
-  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
-  md5: 4d635e1fed6b6841ae3db1e0377a7712
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 153354
-  timestamp: 1728405954288
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
-  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
-  md5: 7a1863281d1b73c33d04a3709fda9bda
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1203577
-  timestamp: 1753947513381
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
-  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
-  md5: 9e9d478b40d0e254cd3b448f92f47e8c
-  license: MIT
-  license_family: MIT
-  size: 127337
-  timestamp: 1680082426492
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.14.0-py313hd43f75c_0.conda
-  sha256: cbf21b326814a1d043b8ca3c5f5d5fec6cfc082e31d4a2e3a4b66a1837352a33
-  md5: 1f863d45456e44fda9e9d01e6ecf3679
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - websockets >=13,<16
-  - httpx_aiohttp >=0.1.9
-  - pandas-stubs >=1.1.0.11
-  - pandas >=1.2.3
-  - sounddevice >=0.5.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1039763
-  timestamp: 1767167972967
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
-  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
-  md5: 583ab7940537e3387afa8c18b28eeb1c
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 79849
-  timestamp: 1763721155450
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.5-h39c9139_0.conda
-  sha256: 8fadf5dae2d6cf940ab38fa58d964325032fcb1f5105783e928ec3068841168a
-  md5: d3628d798e959fc4dcb6f5521f98c9da
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 5672689
-  timestamp: 1772119615171
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
-  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
-  md5: 85b624fe49b39de9fbe86b79144cb7c4
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 100915
-  timestamp: 1763996095398
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
-  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
-  md5: fab7d6c7cd4ebefb06eada5bee45916c
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 37829
-  timestamp: 1764236793947
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
-  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
-  md5: 211d4704424ad214a215cf0378e685cf
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43410
-  timestamp: 1764254906556
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
-  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
-  md5: 928d47e0634131263d53b97b8359431f
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33553
-  timestamp: 1764254406341
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
-  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
-  md5: aae5f23a1a4a2c152ee68f16d380ff15
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57805
-  timestamp: 1764084154068
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
-  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
-  md5: a93dfba7f5563c3430eb842ff88b7cb7
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57059
-  timestamp: 1764164411916
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
-  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
-  md5: 0ce00548bf7f2bc4d0cca918a84a3989
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275046
-  timestamp: 1764073129503
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
-  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
-  md5: f14b38ac757bcb80c206d16fb2e55592
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 177920
-  timestamp: 1764062882890
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
-  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
-  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 334755
-  timestamp: 1771945967596
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
-  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
-  md5: ba91769862d81cb2c29f4918aae1a245
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 198468
-  timestamp: 1775004133206
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
-  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
-  md5: 730f7454d70a81d991ac05e09c699166
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51488
-  timestamp: 1772567675008
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
-  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
-  md5: d2a1b973881c8c0493bf1fd7b62a2918
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 1177858
-  timestamp: 1759825801409
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
-  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
-  md5: ed391ccc6d6caaccedd5250fdeb48807
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9176
-  timestamp: 1728408515784
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
-  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
-  md5: cdff168e8e1d6bbfced0f9ce18a6534a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54735
-  timestamp: 1773652976404
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
-  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
-  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47904
-  timestamp: 1776972854196
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
-  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
-  md5: 08a8181515e8bdce86ee017bb1153d69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170028
-  timestamp: 1772733403459
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
-  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
-  md5: c65088b4df85204138e7899b7bb677c5
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 579494
-  timestamp: 1770660753322
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
-  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
-  md5: 55e55bb476470a157cf4b81f44283436
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 550478
-  timestamp: 1761896485773
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
-  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
-  md5: bd26b7e13996984230e8ec67f3ebd4c7
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  license_family: MIT
-  size: 7035
-  timestamp: 1615912729649
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_0.conda
-  sha256: f1bc44d14e47248ac41cd19f4248eefd19e0c8c653def8ebe34da121aac143f9
-  md5: 41d9139e9cf072086e73d2b8674a161c
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - valkey-glide >=2.1.0
-  - hvac >=2.3.0
-  - cryptography >=45.0.0
-  - aioboto3 >=13.3.0
-  - types-hvac >=2.3.0
-  - types-aiobotocore-s3 >=2.16.0
-  - pymongo >=4.0.0
-  - python-duckdb >=1.1.1
-  - cachetools >=5.0.0
-  - diskcache >=5.0.0
-  - keyring >=25.6.0
-  - rocksdict >=0.3.24
-  - pydantic >=2.11.9
-  - pathvalidate >=3.3.1
-  - dbus-python >=1.4.0
-  - elasticsearch >=8.0.0
-  - pytz >=2025.2
-  - aiohttp>=3.12
-  - redis-py >=4.3.0
-  - aiomcache >=0.8.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - asyncpg >=0.30.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 258279
-  timestamp: 1774282530353
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
-  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
-  md5: 574f6176492ab5f26a379307c7377a30
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92719
-  timestamp: 1736868553560
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
-  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
-  md5: 03fd00dba51a683e8d01f74ec63a1fec
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 156035
-  timestamp: 1774959750947
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.12.5-py313hd43f75c_0.conda
-  sha256: 075b85319122a84033ed5e8671a404878daad18d896f69b8a7e5b946f1463667
-  md5: 02a133da4f575464a6424b568d582954
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1107670
-  timestamp: 1773134406974
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.41.5-py313hff451be_1.conda
-  sha256: f756ae4ab74fea66ac0f7b687e5ff72a736521e5d30c2959f5e06bb26b43bb92
-  md5: cb6fcb4bb58138dc49beda6d90d2f4cb
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1771859
-  timestamp: 1764009871699
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
-  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
-  md5: 8bcdca4304da9f754bfb1f5839f796dc
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - azure-identity >=1.16.0
-  - tomli >=2.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - pyyaml >=6.0.1
-  - google-cloud-secret-manager>=2.23.1
-  license: MIT
-  license_family: MIT
-  size: 150714
-  timestamp: 1764165157426
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
-  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
-  md5: 1e4f8926de2d91ff108ecf1f8d30371f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4941418
-  timestamp: 1775127034860
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
-  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
-  md5: 9f01b187aede17a6e8b192f35472b652
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103005
-  timestamp: 1773773803703
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
-  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
-  md5: 90a46389b262fac93bd471f2fc0ea5ff
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - xclip
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25832
-  timestamp: 1773985116510
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
-  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
-  md5: 43da0d039f7b195466a8be650fa38424
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35803
-  timestamp: 1761753028895
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.12-h0f2f12d_100_cp313.conda
-  build_number: 100
-  sha256: 3440eaa5799c8adb5cf8973c0181f114b116ba9b3ef44a9ff31fbb50575a2243
-  md5: 1d5ed28a2ac1369d7d94b834e8d3a505
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.35.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=14
-  - libmpdec >=4.0.0,<5.0a0
-  - libuuid >=1.41.5,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 31723170
-  timestamp: 1771950827906
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
-  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
-  md5: 061428165f4369719796769975341cf7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 315827
-  timestamp: 1728405669914
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
-  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
-  md5: e07c79278a8a508e83e42d176ab595be
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51868
-  timestamp: 1768559706782
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
-  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
-  md5: b8dc8f719d9a94474d335a89ff1ab0a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253530
-  timestamp: 1763718606784
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.22-py313hd43f75c_0.conda
-  sha256: f868a7e78c5c2a474306668060bceed1f06b6a95e0525c0c34560dff68316759
-  md5: b936e94e4dc4c1841fa1cfd250cb3ab1
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63443
-  timestamp: 1770213004301
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
-  md5: fb2966848729243e63cc897cb90f1eda
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6101
-  timestamp: 1764349598421
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
-  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
-  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 223054
-  timestamp: 1773043038462
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
-  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
-  md5: a9b067a53f219bf9ed2a4583154facf9
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 245388
-  timestamp: 1763465541517
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
-  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
-  md5: bb43fdeb5e1bc6595d63be00f22eaf00
-  depends:
-  - libre2-11 2025.11.05 h1b0d54c_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25969
-  timestamp: 1770390562916
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
-  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
-  md5: d2228764ccb4ad95813f44effcaaa38a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 19961
-  timestamp: 1760613342830
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
-  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
-  md5: f04b3cb7ab28e886ceb012e4e9626e82
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 509455
-  timestamp: 1754485781954
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
-  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
-  md5: f1cd02f5cac4c78dd00805f81f7b66d8
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82590
-  timestamp: 1762536906694
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.4-h419075a_2.conda
-  sha256: 6b1fdbf185a6df47d04b841618860735efcc5cb6729835a7d381af0576743d44
-  md5: 50bf464f48566d71a2778149c54d9fb1
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 30679
-  timestamp: 1714680903704
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.4-h419075a_2.conda
-  sha256: 7637fbc980328f813717563f123a8d8f8f2da24920e35e1984f2fd860c9cec5c
-  md5: d4a07ee63f2fded787246f3eb2d2157c
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - reproc 14.2.4 h419075a_2
-  license: MIT
-  license_family: MIT
-  size: 21136
-  timestamp: 1714680918050
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
-  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
-  md5: a7bcec6c82277f3990f35708bd05d660
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 171420
-  timestamp: 1775066082442
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
-  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
-  md5: 3f4000830e7a25be1df38114d361b976
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88285
-  timestamp: 1728500408740
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-14.2.0-py313hd43f75c_0.conda
-  sha256: 3f941bc0664875e48deba64e64686f44b75b29d323063ec504a9e40c6b8c621c
-  md5: 097a66ceed127b2918383880bed077d2
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 603684
-  timestamp: 1760375647067
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
-  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
-  md5: 167fe8ee5af593667148b74a02090717
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33721
-  timestamp: 1771961162662
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
-  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
-  md5: 7f93cb69d835d6256cc68d0c22843159
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 335795
-  timestamp: 1762366544737
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
-  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
-  md5: 28b23d252e0d230044637b0f8f88cca6
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271533
-  timestamp: 1762535980215
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
-  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
-  md5: 26960af9de364b5745c254d1a6890c45
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 127958
-  timestamp: 1762530151153
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
-  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
-  md5: 529575cd8e6b7becb44a50d0d35009f0
-  depends:
-  - cryptography >=2.0
-  - dbus >=1.16.2,<2.0a0
-  - jeepney >=0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 31316
-  timestamp: 1775127025036
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
-  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
-  md5: c9d0d757b916ddfd019821dbbc02a0d9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45447
-  timestamp: 1761903130898
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
-  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
-  md5: 10081f3addefc88e8127e68448bf9f6d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1666759
-  timestamp: 1775048722771
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
-  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
-  md5: d32e4a1ec001c6cef1aae68c11480c55
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 23120
-  timestamp: 1761912222490
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
-  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
-  md5: 0cefa22396b339a17597faad550d9582
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 226027
-  timestamp: 1734048100065
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
-  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
-  md5: 626970a8b8398716c9b9f9025eafd307
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37500
-  timestamp: 1744271573927
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
-  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
-  md5: 219c67c8ff19787a64b06c2517d063e9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17506
-  timestamp: 1764329173905
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
-  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
-  md5: 55600c8be72a7624ebd63e54ed72cbe0
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1281272
-  timestamp: 1773313781654
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
-  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
-  md5: 1596a495a1f3def74862ce0efcc8281e
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21754
-  timestamp: 1745413132458
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.47.3-py313hd43f75c_0.conda
-  sha256: 1143a28c21d0c234bf292910fd32f471cac3617850dc930f9760c8743fdab6bb
-  md5: 4e7e8a7d8b32b54e6fe2a5bc1ae2df44
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 176653
-  timestamp: 1756910709929
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
-  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
-  md5: 6a7f42565108e00d27f68f4ae5751c53
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3717438
-  timestamp: 1755243976411
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
-  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
-  md5: d5ba67844244cfccfa37b1b23ec83b23
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82633
-  timestamp: 1768296495852
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
-  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
-  md5: 8949c7ff2861d1b903cee84c0607eacf
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 188584
-  timestamp: 1762896685732
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
-  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
-  md5: 54a2c4b9c33935687b977159f85bb4cb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160713
-  timestamp: 1771398718073
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.14.3-py313hd43f75c_0.conda
-  sha256: ab62d2a4692749c680612ab3330fea299ff9245a550a9d0a07bebc969b5435ba
-  md5: 7df7fc6bcb911d97032699617ee74718
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 212695
-  timestamp: 1728405381017
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.1-py313hd43f75c_1.conda
-  sha256: ff9d5e072d130624fe642a1005d9bdf27a4c0775b0eea072b38b9e6a605de83d
-  md5: 8900fdf0ddd06efe24eb8f7c6794ccb4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49415
-  timestamp: 1762520920919
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.20.0-py313hd43f75c_1.conda
-  sha256: 72528b21b18f32ce743af2e3e2bc1518935cde1cdf36dd46fd0189e98ef3901c
-  md5: a404eaf65b18781d5e5d0f3a02db930b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313hd43f75c_1
-  constrains:
-  - typer-slim 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157663
-  timestamp: 1771513020641
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-0.20.0-py313hd43f75c_1.conda
-  sha256: 7c1d7f40115ceba0cc000135f2e88a4dc41ca26615984bf01803f42de7e13647
-  md5: 06f7840d8233d7d3815c803d8950d653
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - shellingham >=1.3.0
-  - rich >=10.11.0
-  - typer-cli 0.20.0.*
-  - typer 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 112583
-  timestamp: 1771513006666
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-slim-standard-0.20.0-py313hd43f75c_1.conda
-  sha256: 4695a00df558018887f458bd70b04c672d30d114b900444bfe845a577d8d1302
-  md5: 74f2f9f2479e83b49c21a310182f04d8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313hd43f75c_1
-  constrains:
-  - typer-cli 0.20.0.*
-  - typer 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7307
-  timestamp: 1771513011450
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
-  md5: 055d37ff4e41c9b9e33d2bb8919c263b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hd43f75c_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 11203
-  timestamp: 1756280951293
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
-  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
-  md5: ff4e707bcf34fee0e2065cf2487e2103
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32401
-  timestamp: 1760614185275
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
-  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
-  md5: 017a18fc16caf581ce26bac0ad6f9efb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 101647
-  timestamp: 1756280944673
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
-  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
-  md5: e857fd0d00de0e82669ff9e06d27f6dd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24215
-  timestamp: 1774276085005
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.6.3-py313hd43f75c_0.conda
-  sha256: 82275c3c5f7e5eab48d74089cc207d4aa692f4a2efd30d4e992d1fd2d7775cca
-  md5: d7dea689ca62516ce02639d4663d1c53
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - h2 >=4,<5
-  - backports.zstd >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 357777
-  timestamp: 1767810287557
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
-  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
-  md5: ebabc185d4b18349d7bf0d9f5c3d2901
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140643
-  timestamp: 1768226452652
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
-  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
-  md5: cb02ecced70ccf3114a942f060eb4f66
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hd43f75c_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39602
-  timestamp: 1768226458187
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
-  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
-  md5: 27e470f3b095fe3116358db877c2a2ea
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 612267
-  timestamp: 1762175558240
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.1.1-py313h5331b00_1.conda
-  sha256: 1c63f47cdd8a02e84a0eac4310a93e386ca83c30c066d698a02e0ffa472e5593
-  md5: b60abe6911b141fc8469ee8852c5b1cc
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 421473
-  timestamp: 1767984729070
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
-  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
-  md5: d6b2c092cb970c634a4b1376a8c212b6
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 368295
-  timestamp: 1751974662854
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
-  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
-  md5: caf0597b40222d6f17f745bd54636cea
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70703
-  timestamp: 1769450262181
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
-  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
-  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 67625
-  timestamp: 1736540966215
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
-  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
-  md5: 750a7b171e663c39f6ecc0771452514a
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxmu >=1.2.1,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 23909
-  timestamp: 1771372468468
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
-  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
-  md5: 4f190efcbddae546e15d54f3f0314b96
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 59357
-  timestamp: 1746171572210
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
-  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
-  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
-  depends:
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 26965
-  timestamp: 1746172174098
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
-  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
-  md5: e87565f2b050d575ee056f472d062383
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto >=2024.1
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 950329
-  timestamp: 1746110056137
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
-  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
-  md5: 96f0df92ef31ad0aaf27b6b373e4f510
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 14118
-  timestamp: 1745958715370
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
-  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
-  md5: 5bfda69ee113cfc8e38e0214c078ef4e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 19895
-  timestamp: 1745992295156
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
-  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
-  md5: 607d46e3586e0c7b93a4495e0fe52db2
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 50277
-  timestamp: 1746169296094
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
-  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
-  md5: f5e59a8d2737934ac40c9bf645a75c52
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 100170
-  timestamp: 1746431911997
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
-  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
-  md5: c4b133535086cbaaf2403b18dc377e4a
-  depends:
-  - libgcc-ng >=11.2.0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-xorgproto >=2024.1,<2025.0a0
-  license: MIT
-  license_family: MIT
-  size: 417862
-  timestamp: 1746172689660
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
-  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
-  md5: 46b530510556e0b1830c40b5ac625f0e
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - xorg-renderproto <0.0.0a
-  - xorg-xineramaproto <0.0.0a
-  - xorg-dri3proto <0.0.0a
-  - xorg-inputproto <0.0.0a
-  - xorg-scrnsaverproto <0.0.0a
-  - xorg-xf86vidmodeproto <0.0.0a
-  - xorg-dpmsproto <0.0.0a
-  - xorg-dmxproto <0.0.0a
-  - xorg-damageproto <0.0.0a
-  - xorg-xf86driproto <0.0.0a
-  - xorg-bigreqsproto <0.0.0a
-  - xorg-kbproto <0.0.0a
-  - xorg-randrproto <0.0.0a
-  - xorg-xf86dgaproto <0.0.0a
-  - xorg-fontsproto <0.0.0a
-  - xorg-presentproto <0.0.0a
-  - xorg-xwaylandproto <0.0.0a
-  - xorg-applewmproto <0.0.0a
-  - xorg-recordproto <0.0.0a
-  - xorg-resourceproto <0.0.0a
-  - xorg-xf86bigfontproto <0.0.0a
-  - xorg-xextproto <0.0.0a
-  - xorg-fixesproto <0.0.0a
-  - xorg-glproto <0.0.0a
-  - xorg-dri2proto <0.0.0a
-  - xorg-videoproto <0.0.0a
-  - xorg-xcmiscproto <0.0.0a
-  - xorg-xproto <0.0.0a
-  - xorg-compositeproto <0.0.0a
-  license: MIT
-  license_family: MIT
-  size: 595620
-  timestamp: 1746046239552
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
-  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
-  md5: 0d2e76f65075404a9c26010882e7a786
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 643308
-  timestamp: 1772548369777
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
-  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
-  md5: 588d487b103786708d10c1800d048fd4
-  depends:
-  - libgcc-ng >=10.2.0
-  license: MIT
-  size: 77652
-  timestamp: 1619009841594
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.8.0-h419075a_1.conda
-  sha256: 85eff1a70501daf5e228b6f2f326506043886db106c03d170b0f931cb55b695b
-  md5: 51a2369fb0d068241603303f704835db
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 607901
-  timestamp: 1714510851512
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
-  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
-  md5: 89dedf7658549815d9e8d5456231932b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32299
-  timestamp: 1763977879242
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h998d150_0.conda
-  sha256: db213b9f69ccaf2457daabc1a92a4ce0c7aab6bba8145a2e349812cd6f0b41b4
-  md5: 58ccfae41b6e3ad4fd6961071d450f6a
-  depends:
-  - libgcc-ng >=11.2.0
-  - libzlib 1.3.1 h998d150_0
-  license: Zlib
-  license_family: OTHER
-  size: 105760
-  timestamp: 1756475948207
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
-  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
-  md5: 8d4a8433cf437f7ecc5aafa9874c2012
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - cffi >=1.17
-  - libgcc-ng >=11.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 396870
-  timestamp: 1758189118512
-- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
-  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
-  md5: abc05ce4daceeb1fa321b365cb847975
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 594707
-  timestamp: 1758039173244
-- conda: https://repo.anaconda.com/pkgs/main/noarch/anaconda-anon-usage-0.7.6-pyhb46e38b_100.conda
-  sha256: 403ef7e93dee117ffb1dca2d0f032fc3a4449381ec88c6726e3066d57171e8ce
-  md5: c78d47374611a8e86f7a9817f3768160
-  depends:
-  - python >=3.8
-  constrains:
-  - conda >=23.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19864
-  timestamp: 1774907942644
-- conda: https://repo.anaconda.com/pkgs/main/noarch/archspec-0.2.5-pyhd3eb1b0_0.conda
-  sha256: d7c38d818d5f88e636de5d9fba2365be56f3230ee2656ab3b552c1e4bbd07668
-  md5: c0ad195970a65c174b997011ac13f2f8
-  depends:
-  - python >=3.7
-  license: MIT OR Apache-2.0
-  size: 49261
-  timestamp: 1758125010311
-- conda: https://repo.anaconda.com/pkgs/main/noarch/conda-libmamba-solver-26.4.1-pyh3785b3c_0.conda
-  sha256: ae098ebc94df3b64f449052c4f2c765187a3e30e4981362d7a52fb802930f357
-  md5: 3e467ddfbd4e40a574474ae928f7a423
-  depends:
-  - boltons >=23.0.0
-  - conda >=26.1
-  - libmambapy >=2
-  - msgpack-python >=1.1.1
-  - python >=3.10
-  - requests >=2.28.0,<3.0.0
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 58057
-  timestamp: 1777900169394
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.conda
-  sha256: d5ccad2e614ba3f953c202a42270fe0cfdaf6c5071311a3accf28446c49a6c5b
-  md5: d912068b0729930972adcaac338882c0
-  depends:
-  - python
-  license: PSF 2.0
-  license_family: PSF
-  size: 23826
-  timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
-  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
-  md5: f115ef0af90b59f35ef56743955979a4
-  depends:
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 39004
-  timestamp: 1627537099507
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
-  sha256: a3ffa3423f3a1c2a5184fd3e83c4555c9b6d627b0ed2e101b2ab615d585c1f40
-  md5: 694138f71ea48d078f301a9a701bbc62
-  depends:
-  - python >=3.9,<3.14.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 1178932
-  timestamp: 1774988902802
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
-  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
-  md5: 7f0df6639fdf60ccd3045ee6faedd32f
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14215
-  timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
-  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
-  md5: cda05f5f6d8509529d1a2743288d197a
-  depends:
-  - python >=2.7
-  license: MIT
-  license_family: MIT
-  size: 20302
-  timestamp: 1616166645426
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026a-he532380_0.conda
-  sha256: bab9c667cb352cdbbc895b4aa8c867221e2e98d5310d884e494540c0b5c1efce
-  md5: b46d6837d6e1ceabdf40378de048c581
-  license: CC-PDDC OR BSD-3-Clause
-  license_family: BSD
-  size: 120000
-  timestamp: 1772652196967
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiofiles-25.1.0-py313hca03da5_0.conda
-  sha256: 5aa9f42006e01226e83667a432fc975dacd55071dd5dad52d543b6f29897320c
-  md5: 1784bef0a518f47b0cb442e02b75ce84
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35320
-  timestamp: 1773069152139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-ai-0.5.0-py313hca03da5_1.conda
-  sha256: 6eed03cd506bb5c525b53cd93da86aa5dea5f0699910320c06f800dad739d49b
-  md5: 88dc2eae5116b824692db6bb9b443eed
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - pydantic-ai >=1.50
-  - llm >=0.22
-  - mcp >=1.26
-  - langchain-openai >=0.2.8
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116841
-  timestamp: 1773844602363
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-auth-0.14.4-py313hca03da5_0.conda
-  sha256: 8979c9ada6c2ad367a365eada8d29413aa29c5b3156e03b53bf1dd6bf90f162f
-  md5: be96323ace383458edf5ef71f8e72654
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 127712
-  timestamp: 1777996231900
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-cli-base-0.8.2-py313hca03da5_0.conda
-  sha256: 7d167f87416f41947373de051a3f964981ebc5de34fa300a7ac0f05a5e9f431b
-  md5: 52656bda190a7f2bec974f508a9f35f2
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-cloud-cli >=0.3.0
-  - anaconda-auth >=0.12.0
-  - anaconda-client >=1.13.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62048
-  timestamp: 1775469312642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.14.1-py313hca03da5_0.conda
-  sha256: 460e0fd57f9f66267397f52483738a9e43e11d97114cca466230422ff4c4f6bf
-  md5: c2a25adb6831401a65a5cdb63f88ba27
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 846994
-  timestamp: 1772491115479
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-conda-0.1.11-py313hca03da5_0.conda
-  sha256: 1a92fa1c3e787e305d016528cc1fef8e428359c25555d22a5930b809e3b99694
-  md5: ed7020be4e2288dff58f60f7bf106fa9
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 162438
-  timestamp: 1773935019675
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-core-0.1.11-py313hca03da5_0.conda
-  sha256: 597d428b1c632edbb878ed5e0bc0d4290985cc0d14a30ee515c5065d8400f819
-  md5: a9010a6c725f4a11001406492d49f35e
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 169752
-  timestamp: 1773871547623
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-connector-utilities-0.1.11-py313hca03da5_0.conda
-  sha256: 7c44338d8b53ca0b59113fcfd5497acc04bd747021d8b16acb35d1a8ab2d5e7f
-  md5: eeca273b542009d5cd4e022bd2cb827d
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 162392
-  timestamp: 1773868150264
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-mcp-1.1.0-py313hca03da5_0.conda
-  sha256: c4ddc9e821fc73d2febaa69445773a2d1e566197beb9ae76b217a09fec75a3d5
-  md5: 4fccbb8b017a20c662308ad20a1e72fe
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 75562
-  timestamp: 1779920861440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-opentelemetry-1.1.0-py313hca03da5_0.conda
-  sha256: 9d42f2977265e80eb250f006b3ead63d597c360dfc33e4b8fc1a1cb9dfe29abf
-  md5: 9916fa1108527ee314251aec8a0c7353
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 83086
-  timestamp: 1776808490341
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-doc-0.0.4-py313hca03da5_0.conda
-  sha256: 4b5b6b6f011a13a77e2f360a72440c07c1e8c1c82fcd6ebd400bfd713a8353ee
-  md5: f39857a71feb6e39da9739228f340a78
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11405
-  timestamp: 1763372676418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/annotated-types-0.6.0-py313hca03da5_1.conda
-  sha256: c3073a3025838c527211012e3943a613f50c1fa1a258dc52f6c21d81aab0993e
-  md5: c0c2fb9483677bb657eda6d491e5f29c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 25909
-  timestamp: 1761744968164
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.12.1-py313hca03da5_0.conda
-  sha256: d752e4d46e5dc6e4cf3a0c6ffa3cc553af159f394a21509aaf854e4d8494bedd
-  md5: 7e400853597f6d7237e927baa6706aa7
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 317912
-  timestamp: 1773134435123
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-26.1.0-py313h0d18f5d_0.conda
-  sha256: 4a28308d2cfe39dcbab454fb35bb7c2c7bff31288cedda1a1c36019a514373c1
-  md5: bafc36567bd5432aea186b203ccbe80d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 180639
-  timestamp: 1774959652662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/authlib-1.6.9-py313hca03da5_0.conda
-  sha256: feb837043ad74651b797c3cb57ed444e82935adb1a6dc10a6671378ccb9023fa
-  md5: a76eeaf70ce3bead86b2c5da38121a69
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 446875
-  timestamp: 1775206378569
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beartype-0.22.9-py313hca03da5_0.conda
-  sha256: 67a2792c6037d3e5e0f9f13b01ef509ed5ec83121e317c3975215c0b3135b927
-  md5: 1a59f6f0d4e897cc1c89fe533bb70b58
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488689
-  timestamp: 1772489325506
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boltons-25.0.0-py313hca03da5_0.conda
-  sha256: 7a9a5c1d2d873909deb55958405c3226b078c1aae3ce879b45339c684fde4d9d
-  md5: a5b55c281bf03fadccc2b9fb5e6c567d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 524228
-  timestamp: 1751383887927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py313h50f4ffc_0.conda
-  sha256: 0b67ba7cd4a8cc17d1b21b9a9ac14f48199ab219366cbdd3fd0ad7e2faadb6ff
-  md5: 4f002093422042d948885e06821f150b
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17.0
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 375456
-  timestamp: 1764961201718
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.conda
-  sha256: a99e7ae89274837bfa706a7f8bcb970520d909a84b9fa1d63ddce1305d96121c
-  md5: 27a1ffbd30ff6427c112a733410e2f57
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 132212
-  timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.6-hfe05a68_0.conda
-  sha256: 2947839d4751f848f54672ddc231667b03f2d3ad4979c2bca4911f09de67fe5a
-  md5: ceb5c473b56eb1b79fd079f6b0d029df
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: MIT
-  license_family: MIT
-  size: 177571
-  timestamp: 1769077680758
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2026.3.19-hca03da5_0.conda
-  sha256: 8a14f3cf9c266735eaa01a6879185e5a0518d0377f76d760633c7698e3cab036
-  md5: a7e9cfcf108c1488853b1d205e5ae380
-  license: MPL-2.0
-  license_family: Other
-  size: 129019
-  timestamp: 1774365821682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-6.2.2-py313hca03da5_0.conda
-  sha256: 56e687962b2af4574ef8f32614be430cee982679eff82cb3ef44a6b7ed9b8971
-  md5: bb47e0b8fa0f637b245c34b5b357a5d4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41149
-  timestamp: 1764867366355
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py313hca03da5_0.conda
-  sha256: 839ea683a30bfd322076dceafaa8752882feebb654afe9ddd8595e71db99faa1
-  md5: 65d56422e29c425a3a91c8e1c17888d0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151748
-  timestamp: 1767659160370
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py313h73c2a22_1.conda
-  sha256: 0ebe4f5cda560fa048bfc03018f5a38c55f4966c0b3c145154f4e4f00a7bbdaa
-  md5: 3b8705f4c0c5bd099d1061f34c2ef78d
-  depends:
-  - __osx >=12.1
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 288576
-  timestamp: 1761832806745
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py313hca03da5_0.conda
-  sha256: 240ae310bc1c58a1061816b1b4751407f7841c0da8ef1c09babd9860f39a180a
-  md5: 6301ec890b186cbe5d8243254450651e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 100213
-  timestamp: 1761744861372
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py313hca03da5_1.conda
-  sha256: 8375ddb41ba02c49944570c7925beb8d66852392293ee5d57842c4e9d36b425b
-  md5: 7ac45ddb190136a57ad9b02e7e365ec0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328813
-  timestamp: 1764332257562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-26.1.1-py313hca03da5_0.conda
-  sha256: 7cdfede20aa1efa424187822ee901dd9ebfc5de5ff78089d432682affea587a1
-  md5: 1fbe06ba53189032094abfe761e965ce
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-build >=25.9
-  - conda-env >=2.6
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275763
-  timestamp: 1771402227023
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.4.0-py313hca03da5_1.conda
-  sha256: 0e7ae6a4e9eda628de32dc45bfc552e5a8c7c79224e134e3fe3579e933af82c6
-  md5: 99d586bc84e70ee5e8415cfb63cc4cfe
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285376
-  timestamp: 1762366427916
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.12.0-py313hca03da5_1.conda
-  sha256: 167d9c3bfd693c347a43c4b006c1379f1ff94588ee818ed231d801ad63a65f34
-  md5: 01a0bc32a49fd331d514dfd64446fb1e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38499
-  timestamp: 1762361650835
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cpp-expected-1.1.0-h48ca7d4_0.conda
-  sha256: 6639ca3fc92dd98178c78ac917ea864b475821ce55a617f9e636f618ffdce7f1
-  md5: 9a83af67c17d1c760cd7aff545ef7e0f
-  depends:
-  - libcxx >=14.0.6
-  license: CC0-1.0
-  license_family: CC
-  size: 134133
-  timestamp: 1734039345192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-46.0.6-py313hae07363_1.conda
-  sha256: 98fb481ec4aaa2986a1e3db853e4b72423a6ca0fe6ab9be9bc0d9ed79a412d11
-  md5: 3ac69dec44f28472bec0a94ce8dc44cd
-  depends:
-  - __osx >=12.1
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1583766
-  timestamp: 1775167156757
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cyclopts-4.6.0-py313hca03da5_0.conda
-  sha256: b9885b2c8fb86069bdd37bede22d0333d967a995bf6cbbb3c2d722dd99508b5a
-  md5: 85c2e5e0e00bcd63d85871b80f060b1b
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 392115
-  timestamp: 1772064911124
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distro-1.9.0-py313hca03da5_0.conda
-  sha256: 8be5c0b3ea659bcdb3ee629792e972625d6d4d21d54184591ae53dd4aa02a242
-  md5: 5e948f3d746f13d209bd09a9d2fb7758
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38129
-  timestamp: 1728591870413
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dnspython-2.8.0-py313hca03da5_0.conda
-  sha256: ca5c1490879fc58367f4e2fa1de4715a20ac08520a5738951914eaa408bc8954
-  md5: 83b6045550ea3f3984ad063b58c44f83
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpx >=0.28.0
-  - httpcore >=1.0.0
-  - cryptography >=45
-  - h2 >=4.2.0
-  - trio >=0.30
-  - idna >=3.10
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 667571
-  timestamp: 1763718279384
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docstring_parser-0.17.0-py313hca03da5_0.conda
-  sha256: 520959d57e5577ca4748c4f317bfd3f3126490fa1511135b3c5fed04138ccb24
-  md5: 84ceb2792085acb3459abeedb47f888d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96396
-  timestamp: 1766163600127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/docutils-0.21.2-py313hca03da5_1.conda
-  sha256: 41c01237183aed7e1e3c10a3163708d93a7917a8d70facbc2730b611557d4e05
-  md5: 54a125d07b398d692c81bcad8c0fc6df
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 940136
-  timestamp: 1761746670106
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/email-validator-2.3.0-py313hca03da5_0.conda
-  sha256: 43d60a9d88165bc8601a7e39f4eb6ed36a88acea8bbcdc8922b30b00bcfd448a
-  md5: c1112f1321fda31b8b182c011bd25f39
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 66105
-  timestamp: 1758610134265
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environments-mcp-server-1.0.7-py313hca03da5_0.conda
-  sha256: 9ef08d154b7f88a5e232804d55aff2ff14c57693d4de856fdb6840ea97937034
-  md5: 2644ebe94b48d6c7e0b179c30807dfbd
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 67101
-  timestamp: 1779916082564
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/environs-11.2.1-py313hca03da5_0.conda
-  sha256: 3bc1da73459da2c0d2c5c24ef277788a99d8a2192cf4686fb72df33701048e26
-  md5: a1db257019eb3930e461aa5626be2c0e
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37392
-  timestamp: 1774388481869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py313hca03da5_0.conda
-  sha256: 6d9d356a2ba3efb6b501c5f2cf23e8f11c2a753ce58e853204c2d9b59c6345be
-  md5: cd68188eea25cf618d3ed80a746e34cd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 48744
-  timestamp: 1761560378218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastapi-core-0.128.0-py313hca03da5_0.conda
-  sha256: 6fb3db76bfeb30e28707b52a5056e512bd42f96c731b4ef437a2bea5d35da208
-  md5: 944377cd6e1d22c9079dc7d605de20ec
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - uvicorn-standard >=0.12.0
-  - fastapi-cli >=0.0.8
-  - pydantic-settings >=2.0.0
-  - pyyaml >=5.3.1
-  - orjson >=3.2.1
-  - email-validator >=2.0.0
-  - pydantic-extra-types >=2.0.0
-  - httpx >=0.23.0,<1.0.0
-  - itsdangerous >=1.1.0
-  - python-multipart >=0.0.18
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - jinja2 >=3.1.5
-  license: MIT
-  license_family: MIT
-  size: 196018
-  timestamp: 1768401131556
 - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastmcp-3.1.1-py313hca03da5_0.conda
   sha256: fcdac29589ed776f311b521b563f41b81553bf176cd7c3489c7dd62e84f98721
   md5: 306acc6065d62af1f39051a6a4457fab
@@ -7542,2557 +3569,6 @@ packages:
   license_family: Apache
   size: 1062410
   timestamp: 1774377883971
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-11.2.0-h643473a_0.conda
-  sha256: 4a5fc475d626338504ac2f9947936c511151712b3d98f41e14091cbdbbcbecdc
-  md5: 4658ef48e7980c9c02455e16fb874492
-  depends:
-  - __osx >=11.1
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 192134
-  timestamp: 1754990881142
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
-  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
-  md5: 662529f545d783dc4148ad30f1110b51
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 39679
-  timestamp: 1761750693438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h0087489_1.conda
-  sha256: 474dfdcd92ff2f76346f259e988a41d413e731558fdb515dc5b623bf89cbf897
-  md5: e348dbb8c6f1a03b14e13b5ec06128a8
-  depends:
-  - __osx >=12.1
-  - gettext-tools 0.25.1 h86cef2d_1
-  - libasprintf 0.25.1 hcc4682f_1
-  - libasprintf-devel 0.25.1 hcc4682f_1
-  - libcxx >=20
-  - libgettextpo 0.25.1 hd3943a6_1
-  - libgettextpo-devel 0.25.1 hd3943a6_1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  - libintl-devel 0.25.1 h55097f8_1
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 541343
-  timestamp: 1777366825427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h86cef2d_1.conda
-  sha256: c49c5eb435c4a15367dcc722dab90ba8fe15a0ac7ab7ed01f8255e3448b18cad
-  md5: 002abaa93cfa4d989a91122d55719ed6
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  - libxml2 2.14.4.*
-  - libxml2 >=2.14.4,<2.15.0a0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-or-later
-  size: 3469625
-  timestamp: 1777366802264
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
-  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
-  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
-  depends:
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - grpcio >=1.44.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 171931
-  timestamp: 1770382381497
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
-  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
-  md5: db94ba50dcc724b61f6f51982822577b
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libgrpc 1.78.0 h7694377_0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 761674
-  timestamp: 1770754627213
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
-  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
-  md5: 38e110c2ae2fb67d3ef1abfc786498f9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 64806
-  timestamp: 1761931279662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
-  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
-  md5: 6d33385bdc014731d4369f0d0e09af73
-  depends:
-  - certifi
-  - h11 >=0.16
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 129364
-  timestamp: 1748526183257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
-  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
-  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 92280
-  timestamp: 1763634775883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
-  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
-  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pygments >=2.0.0,<3.0.0a0
-  - zstandard >=0.18.0
-  - h2 >=3.0.0,<5.0.0a0
-  - socksio >=1.0.0,<2.0.0a0
-  - click >=8.0.0,<9.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217168
-  timestamp: 1760447208891
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.0-py313hca03da5_0.conda
-  sha256: 3b36d113033fbd06873ec3a42a43593655ed8b9d676cc5b4b9dac2472a4c158a
-  md5: cb105fd0a4a87512800bc9d5a6ad99b7
-  depends:
-  - httpx
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 16865
-  timestamp: 1735845800331
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
-  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
-  md5: 48dcf4bb007f44e187fe29b1120e0ef9
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 23865757
-  timestamp: 1777922195678
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
-  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
-  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203509
-  timestamp: 1761912023966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
-  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
-  md5: 711d5bcfff34a45210902f5ef91c3ec6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zipp >=3.20
-  license: Apache-2.0
-  license_family: APACHE
-  size: 72439
-  timestamp: 1772099900987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
-  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
-  md5: f4e4bcf521aa18ee57d0607ad48f284c
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 21271
-  timestamp: 1755516531252
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
-  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
-  md5: 0a89e92618b4328787ef72b0d94d8808
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 17072
-  timestamp: 1769477856721
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
-  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
-  md5: 7174017dd1ce6c709a2b1d87156deb56
-  depends:
-  - more-itertools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24174
-  timestamp: 1768389389007
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
-  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
-  md5: ef1c78fa12751c0d455245582d1cb49b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 268149
-  timestamp: 1762897357212
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
-  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
-  md5: 9e1af96e93b8278ec9029f1bd38f4517
-  depends:
-  - jsonpointer >=1.9
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 37185
-  timestamp: 1728594571279
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
-  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
-  md5: 552bd935bf55a9099c7d2910a8d56391
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19004
-  timestamp: 1774432907812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
-  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
-  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 30409
-  timestamp: 1774283033815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
-  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
-  md5: 0be71be35e5503bdecfebf75f1fa55c0
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 198501
-  timestamp: 1767955687618
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
-  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
-  md5: bd5d17c69a377489445f1cac4b1390e7
-  depends:
-  - pathable >=0.5.0,<0.6.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - referencing <0.38.0
-  constrains:
-  - requests >=2.31.0,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52745
-  timestamp: 1772641022505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
-  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
-  md5: 6cfee2660e901231d2fe274f02afeaf8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - referencing >=0.31.0
-  license: MIT
-  license_family: MIT
-  size: 17167
-  timestamp: 1762788437806
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
-  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
-  md5: a691a010a6df73533294e436b2edb780
-  depends:
-  - platformdirs >=2.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 97019
-  timestamp: 1764588302845
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
-  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
-  md5: d19d185ec9fd87908b74303c8e38893f
-  depends:
-  - jaraco.classes
-  - jaraco.context
-  - jaraco.functools
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - pytest-checkdocs >=2.4
-  - pytest-enabler >=3.4
-  - shtab >=1.1.0
-  - pytest-mypy >=1.0.1
-  license: MIT
-  license_family: MIT
-  size: 83253
-  timestamp: 1763637330760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
-  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
-  md5: 112093c65f205a89992cf9cfc7120f41
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - abseil-cpp =20260107.0
-  - libabseil-static =20260107.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1224935
-  timestamp: 1770384634202
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
-  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
-  md5: 9368c8128813db74810effc28a6d0de2
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - libxml2 >=2.14.4,<2.15.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.8.2,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 783208
-  timestamp: 1777387020815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-hcc4682f_1.conda
-  sha256: 92490f2d7a793173adc3fc6ea31fedcceedf36e03bd60ae0ed0054a8db58ec4c
-  md5: d2a53560d3ed522db0e42c3359b5b485
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  license: LGPL-2.1-or-later
-  size: 50062
-  timestamp: 1777366750809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-hcc4682f_1.conda
-  sha256: 68c83c6e80279aa8fe0bb2b0166ff7e445ed5e20284103ebc7efdc95d2b3f889
-  md5: 30b14cd969c3443791d9a02cc3670915
-  depends:
-  - __osx >=12.1
-  - libasprintf 0.25.1 hcc4682f_1
-  license: LGPL-2.1-or-later
-  size: 33791
-  timestamp: 1777366761731
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.16.0-h01d3526_0.conda
-  sha256: b5fcc7e7382bca42ce86b3038ae03b9ebaa6ea69b581079a16d973c5f33c44fa
-  md5: 80e6e03e9a967b1c89975845e0596756
-  depends:
-  - __osx >=12.1
-  - libidn2 >=2,<3.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.57.0,<2.0a0
-  - libssh2 >=1.11.1
-  - libssh2 >=1.11.1,<2.0a0
-  - openssl >=3.0.18,<4.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 390969
-  timestamp: 1761555409156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
-  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
-  md5: 344e08f75d799c1e5b57441a2a4c357d
-  depends:
-  - __osx >=12.1
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 316282
-  timestamp: 1775479658335
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
-  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
-  md5: 00cac99189c361c3b2cbf506ae6cc718
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106490
-  timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.5-h50f4ffc_0.conda
-  sha256: aa8a1edb1076afd0c3f1881dc4cd57ab58c8d7a3289ac39ca103504d2c956c73
-  md5: 39948de0b74df7103d32d9eeab59cb3b
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 110894
-  timestamp: 1774555845024
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.conda
-  sha256: 800216cb554d0beaf970fe7c3efeee7974bb76576c1c5e0ae070c57fca2bba93
-  md5: 2bec9ee4b1214a3c3e2d1f2e18725daf
-  license: MIT
-  license_family: MIT
-  size: 122887
-  timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-hd3943a6_1.conda
-  sha256: a79bc3262177055c8d4a367ac61975756942db5c4e97d319d167dd6c1fc3362c
-  md5: 008a4033018ea9ef9bac5a49af7b52ff
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: GPL-3.0-or-later
-  size: 176696
-  timestamp: 1777366767819
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-hd3943a6_1.conda
-  sha256: 87541ceaad5c717a8814b4d2dbae5051778af0e36b5afc5b1e3f1d152a786200
-  md5: b268ecbfe62a0030b050a4a04cac014b
-  depends:
-  - __osx >=12.1
-  - libgettextpo 0.25.1 hd3943a6_1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: GPL-3.0-or-later
-  size: 36399
-  timestamp: 1777366777968
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
-  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
-  md5: 39336ad943dcc5f88ad31e32f1c4c66a
-  depends:
-  - __osx >=12.1
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5,<2026.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4848994
-  timestamp: 1770754583246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
-  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
-  md5: efcf143adafc878192a4ab5252f4cacb
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-only
-  size: 749113
-  timestamp: 1771491894949
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
-  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
-  md5: 4caba2988c52534c6ba5e88afebba106
-  depends:
-  - __osx >=12.1
-  - gettext >=0.21.0,<1.0a0
-  - libiconv >=1.16,<2.0a0
-  - libunistring >=1,<2.0a0
-  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
-  license_family: OTHER
-  size: 114873
-  timestamp: 1760364408172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h55097f8_1.conda
-  sha256: c968c240abbf7cb8e716b6e46c000e41080431d43e9c9288dc27a9cb974edd63
-  md5: d2a79ee17b6db1b6c7dc3319c79fde05
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 84226
-  timestamp: 1777366756740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h55097f8_1.conda
-  sha256: 055656e5c2ec8cbdb9d89a2a48ff11a4e7d0480483920c123077eb4bc25d252e
-  md5: 792d607bddde98d9bebc7ec853f8b271
-  depends:
-  - __osx >=12.1
-  - libiconv >=1.18,<2.0a0
-  - libintl 0.25.1 h55097f8_1
-  license: LGPL-2.1-or-later
-  size: 38922
-  timestamp: 1777366772836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-hcdddc3d_1.conda
-  sha256: 4a9771ab23729aea3d9a9736c2f6ff1eb548d7dd5737934e8b571b7e31593552
-  md5: 7cd60c4d398e629da02f85ca1c9c6620
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
-  - libcxx >=19
-  - libsolv >=0.7.30,<0.8.0a0
-  - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
-  - reproc >=14.2,<15.0a0
-  - reproc-cpp >=14.2,<15.0a0
-  - simdjson >=3.10.1,<3.11.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1466323
-  timestamp: 1763111449765
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_1.conda
-  sha256: c297878fcf3baf04de81875eac275dce4cd1a19017ee68fc9364aae53068f7ea
-  md5: 8af2f87a53f6ee1d4396e609402e6dac
-  depends:
-  - __osx >=12.1
-  - fmt >=11.2.0,<12.0a0
-  - libcxx >=19
-  - libmamba 2.3.2 hcdddc3d_1
-  - pybind11-abi 5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 587576
-  timestamp: 1763111506082
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
-  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
-  md5: 7b01d2d5e276a24dd44e7846406656ed
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 70527
-  timestamp: 1726088461517
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.conda
-  sha256: 6f26e84b4452251879cf8d12af77833202736d6081eebd5fa8757cfa7eac67aa
-  md5: 32eac5d9a166c3cbce9b6dfef765b138
-  depends:
-  - c-ares >=1.19.1,<2.0a0
-  - c-ares >=1.7.5
-  - libcxx >=14.0.6
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - openssl >=3.0.11,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 648894
-  timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
-  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
-  md5: d45781f34f4b8e74d5b279e2e5d82c25
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2735206
-  timestamp: 1770634426661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
-  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
-  md5: 44b6b0d291189d289f38fa7bba97d117
-  depends:
-  - __osx >=12.1
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=20
-  constrains:
-  - re2 2025-11-05 *_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 164100
-  timestamp: 1770390432249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
-  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
-  md5: f39e89f9206a2366089b09a7cd209cf5
-  depends:
-  - __osx >=12.1
-  - libcxx >=17
-  - pcre2 >=10.46,<10.47.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 383544
-  timestamp: 1760357075048
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
-  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
-  md5: b5aa2854a5872c57538743b4a85a731d
-  depends:
-  - openssl >=3.0.15,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 298763
-  timestamp: 1732891144732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
-  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
-  md5: c457b6d1695d1b5b054632d2d5895517
-  depends:
-  - __osx >=12.1
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 644497
-  timestamp: 1777466299217
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
-  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
-  md5: 5b151376f98c09831d6bd730ca7794c8
-  depends:
-  - __osx >=12.1
-  license: MIT
-  license_family: MIT
-  size: 418963
-  timestamp: 1772645021860
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.4-h2acab8a_1.conda
-  sha256: 1ec937aa6abde15942f00e9d7ec2b6e2082144e0502ff83e962e4a6a4033886a
-  md5: 87ae8fd271f57247baa0a1a7eea23ab8
-  depends:
-  - __osx >=12.1
-  - icu >=78.3,<79.0a0
-  - libiconv >=1.16,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.8.2,<6.0a0
-  license: MIT
-  license_family: MIT
-  size: 557636
-  timestamp: 1778064229309
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.conda
-  sha256: a51872f0fc7ccc4e448babffc9361a3544efe4fce31af0c63a4bb17e9f047615
-  md5: 5a533023e8ce9cae4f939e5eb9eceef7
-  depends:
-  - __osx >=11.1
-  constrains:
-  - zlib 1.3.1
-  license: Zlib
-  license_family: OTHER
-  size: 47901
-  timestamp: 1756475936697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
-  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
-  md5: e535d29ea97147f0f6fb78a5a40c389e
-  depends:
-  - __osx >=12.1
-  constrains:
-  - lua <5.1|>=5.2
-  license: MIT
-  license_family: MIT
-  size: 374612
-  timestamp: 1775637687250
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
-  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
-  md5: 8b33a63dd414c362bc478d44fa6cad6b
-  depends:
-  - __osx >=12.1
-  - luajit >=2.1,<3.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 122459
-  timestamp: 1775657525476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
-  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
-  md5: 82202ff2e94bc301fd9c790556506bb7
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 160308
-  timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_1.conda
-  sha256: c8277cdfdc835839eb6c2acc162ca1f8d4357e13c32d842b282dc9654fff5e6f
-  md5: 2114d29335579a39de598a3208576547
-  depends:
-  - mdurl >=0.1,<0.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - mdit-py-plugins >=0.5.0
-  - mistune >=3.0,<4.0
-  - mistletoe >=1.0,<2.0
-  - sphinx-book-theme >=1,<2
-  - markdown >=3.4,<3.9
-  - commonmark >=0.9,<0.10
-  - panflute >=2.3,<2.4
-  - linkify-it-py >=1,<3
-  license: MIT
-  license_family: MIT
-  size: 243627
-  timestamp: 1767001669424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
-  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
-  md5: 4c3e970508e6cb3ad65579fb6b576143
-  depends:
-  - packaging >=17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 149478
-  timestamp: 1728598048738
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
-  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
-  md5: 04ba8f0bfa78cef0456aeff11cfd1308
-  depends:
-  - anyio >=4.5
-  - httpx >=0.27.1
-  - httpx-sse >=0.4
-  - jsonschema >=4.20.0
-  - pydantic >=2.11.0,<3.0.0
-  - pydantic-settings >=2.5.2
-  - pyjwt >=2.10.1
-  - python >=3.13,<3.14.0a0
-  - python-multipart >=0.0.9
-  - python_abi 3.13.* *_cp313
-  - rich >=13.9.4
-  - sse-starlette >=1.6.1
-  - starlette >=0.27
-  - uvicorn >=0.31.1
-  constrains:
-  - websockets >=15.0.1
-  - python-dotenv >=1.0.0
-  - typer >=0.16.0
-  license: MIT
-  license_family: MIT
-  size: 432541
-  timestamp: 1771960072114
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
-  sha256: 7dcb7ab7f6c3c0fd9301a4c760120e6bacd48762aee3269f304bea64e569ce91
-  md5: 9cd2d7945fcb775737365c00913343e4
-  depends:
-  - cryptography >=41.0.0
-  - fastapi-core >=0.104.0
-  - httpx >=0.25.0
-  - importlib-metadata >=4.8.0
-  - mcp >=1.2.1
-  - prometheus_client
-  - psutil >=5.9.0
-  - pydantic >=2
-  - pyjwt >=2.8.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=1.0.0
-  - python_abi 3.13.* *_cp313
-  - sse-starlette >=1.8.0
-  - toml >=0.10.2
-  - typer
-  - typing-extensions >=4
-  - uvicorn-standard >=0.24.0
-  constrains:
-  - opentelemetry-exporter-otlp-proto-http >=1.20.0
-  - opentelemetry-api >=1.20.0
-  - opentelemetry-sdk >=1.20.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 347924
-  timestamp: 1779919417576
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
-  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
-  md5: cc0fbba5b4ee07d4f979149d050c864a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26834
-  timestamp: 1758552196391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
-  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
-  md5: e5a706e1b73efa80d1ec1f23256e3b86
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause AND MIT
-  license_family: BSD
-  size: 257932
-  timestamp: 1765382400100
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-10.8.0-py313hca03da5_0.conda
-  sha256: b9ab925d227d92daf0e76666bdfcd602197fce4a13ff2ae3792b86712ecce3ad
-  md5: ba0fd81d15324ef0abfb4110b83d82cc
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 166259
-  timestamp: 1761121562080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
-  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
-  md5: 58664c7ab05f2559e22bc3030c90bd2a
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 113263
-  timestamp: 1750958887102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
-  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
-  md5: 98737e4835cef677dbf6fa0d9d364968
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.13,<3.14.0a0
-  - python-fastjsonschema >=2.15
-  - python_abi 3.13.* *_cp313
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 155808
-  timestamp: 1728586024156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
-  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
-  md5: d8a28b593d36653bec90bd2d78c7538b
-  depends:
-  - __osx >=11.1
-  license: MIT AND X11
-  license_family: MIT
-  size: 906808
-  timestamp: 1753947535285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
-  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
-  md5: 5cc48a403acb53596382724e41f99a6b
-  license: MIT
-  license_family: MIT
-  size: 128547
-  timestamp: 1680082112201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.14.0-py313hca03da5_0.conda
-  sha256: e669bbd6b577ee3e09db578293c262c37bc631beab5a6887c1944f9e56745b81
-  md5: 73458dbb241114ed06a5b561f7b048e5
-  depends:
-  - anyio >=3.5.0,<5
-  - distro >=1.7.0,<2
-  - httpx >=0.23.0,<1
-  - jiter >=0.10.0,<1
-  - pydantic >=1.9.0,<3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - sniffio
-  - tqdm >4
-  - typing-extensions >=4.11,<5
-  constrains:
-  - websockets >=13,<16
-  - pandas-stubs >=1.1.0.11
-  - httpx_aiohttp >=0.1.9
-  - sounddevice >=0.5.1
-  - pandas >=1.2.3
-  license: Apache-2.0
-  license_family: Apache
-  size: 1050444
-  timestamp: 1767167836275
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
-  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
-  md5: b2bded54c66346cf90e89ea7e65d80f6
-  depends:
-  - pydantic >=1.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 80685
-  timestamp: 1763721157221
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.5-ha0b305a_0.conda
-  sha256: 92cd3b69b02e8ca149bd387cfb168ba07d1d4f91f0921af5a280271c7aae1cad
-  md5: 1ff1b3ba66cd97c9be2819d012d58df4
-  depends:
-  - __osx >=12.1
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 4948202
-  timestamp: 1772119560161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
-  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
-  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
-  depends:
-  - importlib-metadata >=6.0,<8.8.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 101534
-  timestamp: 1763996094518
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
-  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
-  md5: dd551f29b6694f41a405d347e5b7641e
-  depends:
-  - opentelemetry-proto 1.38.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 38099
-  timestamp: 1764236649957
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
-  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
-  md5: 9b13a4cb589d5fc73e302f66b526c922
-  depends:
-  - googleapis-common-protos >=1.57,<2
-  - grpcio >=1.66.2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 43323
-  timestamp: 1764254973641
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
-  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
-  md5: e65ca1299e5e4ca5f515faa509bd23ae
-  depends:
-  - googleapis-common-protos >=1.52,<2
-  - opentelemetry-api >=1.15,<2
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.7,<3
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 33433
-  timestamp: 1764254395627
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
-  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
-  md5: 59267a3e2c335ee1d45d703dfaee30f7
-  depends:
-  - opentelemetry-api ~=1.4
-  - opentelemetry-semantic-conventions 0.59b0
-  - packaging >=18.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - wrapt >=1.0.0,<2.0.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 57708
-  timestamp: 1764084154910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
-  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
-  md5: c2f0aecc8a2ea835b91a7897ab121f5c
-  depends:
-  - protobuf >=5.0,<7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 57335
-  timestamp: 1764164412952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
-  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
-  md5: c5fda39e599753e09a32115eb8330bac
-  depends:
-  - opentelemetry-api 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 275773
-  timestamp: 1764073043306
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
-  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
-  md5: 677be6639bad152b927832a09d639b72
-  depends:
-  - opentelemetry-api 1.38.0.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 180260
-  timestamp: 1764062877653
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
-  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
-  md5: 304016a5b391759778800af9f24e1332
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0 AND (Apache-2.0 OR MIT)
-  license_family: OTHER
-  size: 305477
-  timestamp: 1771946048520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
-  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
-  md5: 16eee0ba12a1721ab94eb4f87517b5e2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 200339
-  timestamp: 1775004034672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
-  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
-  md5: edb4dc7d24225792e537e7db178ab7a5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 51842
-  timestamp: 1772567682290
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
-  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
-  md5: dc957a9fa85669b0f6ce65ea9343fd8f
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: BSD-3-Clause WITH PCRE2-exception
-  license_family: BSD
-  size: 901944
-  timestamp: 1759825795666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
-  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
-  md5: 5c6344029e52293764fd4f88d6216c07
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 9307
-  timestamp: 1728592695690
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
-  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
-  md5: f9e7cc4e6d37a4efe63452519464e148
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 54951
-  timestamp: 1773653001076
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
-  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
-  md5: 3550efa655956e28eb7282c3210bb015
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 47964
-  timestamp: 1776972833748
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
-  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
-  md5: f686d9126128ed3d50046833a1b555a9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 170595
-  timestamp: 1772733427973
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
-  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
-  md5: 70879a51504dda5aff5034450b11a84a
-  depends:
-  - __osx >=12.1
-  - libcxx >=20
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 461761
-  timestamp: 1770660566466
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
-  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
-  md5: 6bc6a220a229abae6afa80ccf4c3b06b
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 561023
-  timestamp: 1761896362276
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_0.conda
-  sha256: eeb86bfc9db2ecb4bfe8852460295b5dcd37d244ab302d67a920e18a98478646
-  md5: 08a6f7bf52ab151c245dd7dd816df303
-  depends:
-  - beartype >=0.20.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.15.0
-  constrains:
-  - types-aiobotocore-s3 >=2.16.0
-  - dbus-python >=1.4.0
-  - pytz >=2025.2
-  - aiomcache >=0.8.0
-  - python-duckdb >=1.1.1
-  - elasticsearch >=8.0.0
-  - redis-py >=4.3.0
-  - hvac >=2.3.0
-  - asyncpg >=0.30.0
-  - pydantic >=2.11.9
-  - cryptography >=45.0.0
-  - diskcache >=5.0.0
-  - types-hvac >=2.3.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - aiohttp>=3.12
-  - rocksdict >=0.3.24
-  - pymongo >=4.0.0
-  - valkey-glide >=2.1.0
-  - cachetools >=5.0.0
-  - pathvalidate >=3.3.1
-  - aioboto3 >=13.3.0
-  - keyring >=25.6.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 260440
-  timestamp: 1774282548095
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
-  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
-  md5: 2ee55b934de679d2f73bd0f3840f1dfd
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 90639
-  timestamp: 1736868507679
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
-  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
-  md5: 63924165d4c0b49b018d6c6c742d5666
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140335
-  timestamp: 1774959697268
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.12.5-py313hca03da5_0.conda
-  sha256: 263e4a340ba4b6425eca95b681181941bd060686daab3864062870e7d39fe7b5
-  md5: dffaab726a9b2000756aaebc6da806d7
-  depends:
-  - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  constrains:
-  - email-validator >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 1108443
-  timestamp: 1773134360203
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.41.5-py313h931abed_1.conda
-  sha256: e18c0428812b74200603b8944868ad2ba753a30e1d5be86a44e84b560ad95bfb
-  md5: fb4b0939fbc6cce6be885131224f9c35
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.14.1
-  license: MIT
-  license_family: MIT
-  size: 1726048
-  timestamp: 1764009904442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
-  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
-  md5: 4bc0da3d9e06af7ce644b3901790c1ee
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.21.0
-  - python_abi 3.13.* *_cp313
-  - typing-inspection >=0.4.0
-  constrains:
-  - boto3>=1.35.0
-  - tomli >=2.0.1
-  - google-cloud-secret-manager>=2.23.1
-  - pyyaml >=6.0.1
-  - azure-keyvault-secrets >=4.8.0
-  - azure-identity >=1.16.0
-  license: MIT
-  license_family: MIT
-  size: 150650
-  timestamp: 1764165172452
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
-  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
-  md5: 1a096beb854aaa14d863b4da60533f79
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4967892
-  timestamp: 1775127065874
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
-  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
-  md5: 208f064869aaa98b2340cc60eb64c58b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - cryptography >=3.4.0
-  license: MIT
-  license_family: MIT
-  size: 103272
-  timestamp: 1773773829773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
-  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
-  md5: c7bc813891134328cf9262beac3465db
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 479484
-  timestamp: 1763629905351
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
-  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
-  md5: fd8423aa2c161f1355d9eb5e53958096
-  depends:
-  - __osx >=12.1
-  - libffi 3.4.*
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 377280
-  timestamp: 1763651408167
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
-  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
-  md5: 505cfc77c635faa08a4a889e1c6c8a10
-  depends:
-  - pyobjc-framework-cocoa
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26139
-  timestamp: 1773985028336
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
-  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
-  md5: 16bf831da5d9b80789ca8c06f958ae2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 36057
-  timestamp: 1761753032083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.12-ha8cd034_100_cp313.conda
-  build_number: 100
-  sha256: cdb79b470fdce5061bfcc0188800e92361f24668d79b212d057240b0ff5ffc7a
-  md5: 19a38ad6775e08a4774572c2bbf2f187
-  depends:
-  - __osx >=12.1
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.19,<4.0a0
-  - python_abi * *_cp313
-  - readline >=8.2,<9.0a0
-  - sqlite >=3.50.2,<4.0a0
-  - tk >=8.6.15,<8.7.0a0
-  - tzdata
-  - xz >=5.6.4,<6.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 13569673
-  timestamp: 1771949586042
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
-  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
-  md5: 2ac600a5ed014f3b8fe2996b213a68e6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - six >=1.5
-  license: BSD-3-Clause and Apache-2.0
-  license_family: BSD
-  size: 313686
-  timestamp: 1728585595371
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
-  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
-  md5: 69ed706ac95df59f56b448091f4c40fa
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - click >=5.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 51905
-  timestamp: 1768559713789
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
-  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
-  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 253652
-  timestamp: 1763718722391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.22-py313hca03da5_0.conda
-  sha256: 1193284d818979968ff3ea025db81dead8b7ce6a25bc8ee8fb7ea88a863f228a
-  md5: 664d7612270a36fe3894eb84777ae034
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63072
-  timestamp: 1770212979157
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
-  build_number: 3
-  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
-  md5: 12e362aabff119a51f51ac3c0f3d0a84
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6010
-  timestamp: 1764349560639
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
-  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
-  md5: 7faf2150ef3d3493e3554582fec52fcb
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 226666
-  timestamp: 1773042949673
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
-  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
-  md5: 5ea183aac23f4bbe41412f200a70d09d
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 237854
-  timestamp: 1763465528485
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
-  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
-  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
-  depends:
-  - libre2-11 2025.11.05 hce96306_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26013
-  timestamp: 1770390441654
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
-  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
-  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 20018
-  timestamp: 1760613321490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
-  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
-  md5: fed853901ec41684b9e08b0c7ee4d7f0
-  depends:
-  - __osx >=11.1
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 475276
-  timestamp: 1754485689285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
-  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
-  md5: 3fa52decbfabf965e84fd38bfb2e268f
-  depends:
-  - attrs >=22.2.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 82518
-  timestamp: 1762536906534
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.4-h313beb8_2.conda
-  sha256: c762e27a07ece0e9977ae96f454ed40c4bef396d9f0c0fe3e7fb8059945b6d4d
-  md5: 91a2f6f75e6c6614f43ddc8ac2b3e0aa
-  license: MIT
-  license_family: MIT
-  size: 28562
-  timestamp: 1714680923465
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.4-h313beb8_2.conda
-  sha256: 86078c391e11c380a58e83825cd9f3e0498e0866e0aa2b77ba8fe6cce49e5274
-  md5: dde005914879790985acd3af3bf84e65
-  depends:
-  - libcxx >=14.0.6
-  - reproc 14.2.4 h313beb8_2
-  license: MIT
-  license_family: MIT
-  size: 21399
-  timestamp: 1714680948045
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
-  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
-  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
-  depends:
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - urllib3 >=1.26,<3
-  constrains:
-  - chardet >=3.0.2,<8
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 170039
-  timestamp: 1775066216803
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
-  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
-  md5: 85f9714b8bf50cf6f9c75deb5441bba8
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.0.1,<3.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 88498
-  timestamp: 1731721373383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
-  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
-  md5: ffc0d1741d0d0dbff07518323feb64d8
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=7.5.1,<9
-  license: MIT
-  license_family: MIT
-  size: 603836
-  timestamp: 1760375502207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
-  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
-  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
-  depends:
-  - docutils
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=12.0.0
-  license: MIT
-  license_family: MIT
-  size: 33777
-  timestamp: 1771961170073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
-  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
-  md5: 150c83ebdcae2067ae5c34a05c1da4ed
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 311962
-  timestamp: 1762366565780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
-  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
-  md5: b292e4688f8ac6f1c97f1f3e895f5cff
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ruamel.yaml.clib >=0.2.7
-  constrains:
-  - ruamel.yaml.jinja2 >=0.2
-  license: MIT
-  license_family: MIT
-  size: 271430
-  timestamp: 1762535976251
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
-  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
-  md5: ca9e7978a1057363f0c36d975b764dcb
-  depends:
-  - __osx >=12.1
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 114492
-  timestamp: 1762530107760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
-  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
-  md5: 8b4a9bf142beac7513382b0a84ce51f5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45786
-  timestamp: 1761903046636
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
-  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
-  md5: c396551324d88dfb8c688affa5226c2f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1669346
-  timestamp: 1775048820327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
-  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
-  md5: 58fe2f1c6896f6e26cea231b74e3888c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: ISC
-  license_family: OTHER
-  size: 22962
-  timestamp: 1761912224859
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
-  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
-  md5: 443db5b88521ce0e2aaeb77bcf8fb488
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 220407
-  timestamp: 1734048107599
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
-  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
-  md5: 4af6f9244bd475289f3410b1c8880ed9
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 39474
-  timestamp: 1744271575294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
-  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
-  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17410
-  timestamp: 1764329171349
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
-  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
-  md5: cf083b0b25fff8ddab995ac001076f38
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  - zlib >=1.3.1,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1182590
-  timestamp: 1773314600429
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
-  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
-  md5: 685d7b964cfdfd152fb5ddc0951b16d2
-  depends:
-  - anyio >=4.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.41.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 23284
-  timestamp: 1745413263670
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.47.3-py313hca03da5_0.conda
-  sha256: 4e340c9a1a336a863e70ddeedfac8407e5753b6ca77496f17d992c137361514a
-  md5: e17a539f880afd365a5ff1a388ec6605
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 177175
-  timestamp: 1756910711562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
-  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
-  md5: d1329e6c7292f448cdeed21290dd1035
-  depends:
-  - __osx >=11.1
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3448719
-  timestamp: 1755244020166
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
-  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
-  md5: 65d4e75c4c995d35de71b4e16174828c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 82474
-  timestamp: 1768297453889
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
-  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
-  md5: 9199e3c9a0451d04eff558d461dd1b2c
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 189601
-  timestamp: 1762896659686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
-  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
-  md5: af4d88d628ea31190ed1432bba93b9c2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 160792
-  timestamp: 1771398721170
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py313hca03da5_0.conda
-  sha256: c06d6a4a9b21b72720bbbe2bcb0d850290df50925360cdc744115e1894f5176b
-  md5: 176fa6f06b48bfbbe763addd30ff154f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 213397
-  timestamp: 1728585495815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.1-py313hca03da5_1.conda
-  sha256: 678639cde456bae6e4a11ce9118be17eebb4113963eb7aca2be86bd425d64e59
-  md5: c65542bf580047dbffdedaf763057c77
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49457
-  timestamp: 1762520944435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.20.0-py313hca03da5_1.conda
-  sha256: fe035489f4bed2ab2fa0f51ae50faaf7c9b7390252b86123cbae4d3e45e178df
-  md5: 2a00d5da027f2f72dfd4b05c178afb29
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313hca03da5_1
-  constrains:
-  - typer-slim 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 157900
-  timestamp: 1771513056344
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-0.20.0-py313hca03da5_1.conda
-  sha256: 3e3e58ea2dabbc9ebe99e5a83d360c33642de0485fa07bcfa4f4bb1fa870f58b
-  md5: eaad783ddbeddae5d991cf850033e284
-  depends:
-  - click >=8.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
-  - rich >=10.11.0
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  size: 112806
-  timestamp: 1771513038567
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-slim-standard-0.20.0-py313hca03da5_1.conda
-  sha256: f10f6c39573b002cd7ed525c97e3a1033525b17e2ca9f635c7965ad1578e5d98
-  md5: 9d8e87a1f5725cf60bba4ec5094b80ae
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313hca03da5_1
-  constrains:
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7235
-  timestamp: 1771513045167
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
-  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
-  md5: 22b46f0e6d389d4199ffaa317e9c9a05
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions 4.15.0 py313hca03da5_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 12434
-  timestamp: 1756281597870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
-  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
-  md5: 1398c39b86119164f19498b6fbcfdb69
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 32465
-  timestamp: 1760614190333
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
-  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
-  md5: 3c37609330dd4baeb0f4842f02cb783e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: PSF-2.0
-  license_family: PSF
-  size: 106009
-  timestamp: 1756281579411
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
-  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
-  md5: 7c281290dab4999400a1e12be880c3a2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 24287
-  timestamp: 1774276373831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py313hca03da5_0.conda
-  sha256: 375349eeb47983e6e2b2d2608f7141d948e5396e2906b087781d4f49df8dad0c
-  md5: 464328fc7f4e77667c63d5284e866e85
-  depends:
-  - brotlicffi >=1.2.0
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - h2 >=4,<5
-  - backports.zstd >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 357592
-  timestamp: 1767810426391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
-  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
-  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 142181
-  timestamp: 1768226456487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
-  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
-  md5: eea1461696459cc24a16b5a689281400
-  depends:
-  - httptools >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python-dotenv >=0.13
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=5.1
-  - uvicorn 0.40.0 py313hca03da5_0
-  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
-  - watchfiles >=0.13
-  - websockets >=10.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39438
-  timestamp: 1768226463310
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
-  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
-  md5: 62098dfc2ae82083a56bfd7bc319cf0e
-  depends:
-  - __osx >=12.1
-  - libuv >=1.48.0,<2.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - python >=3.8.1
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 545986
-  timestamp: 1762175544791
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.1.1-py313h931abed_1.conda
-  sha256: 53edfc478b14716b82ac71ee21940a4d0512e6af5a5426cccdc1f67ac32d03fb
-  md5: 3ef9c9cd73f6f7bd7cb9ec85cf3440aa
-  depends:
-  - __osx >=12.1
-  - anyio >=3.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 375190
-  timestamp: 1767984700820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
-  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
-  md5: ec80386b367f09af4b44b3824e29acce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 363811
-  timestamp: 1751974819165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
-  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
-  md5: 0d4dafde912fdee412dadf279d688eb5
-  depends:
-  - packaging >=24.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 70617
-  timestamp: 1769450358672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
-  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
-  md5: d75550f3641901250eaa43ed71dc40d7
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 65365
-  timestamp: 1736541780222
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
-  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
-  md5: bc7f39bd763f6957ec91046f0e67a9f3
-  depends:
-  - __osx >=12.1
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 269216
-  timestamp: 1772548381049
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
-  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
-  md5: 23a9bda10db68f27fac5c379466c98b7
-  license: MIT
-  size: 73088
-  timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.8.0-h313beb8_1.conda
-  sha256: 116aa14d2455e97e892141e57bb215b747c09caa4d34de289bfcc6bd962cb507
-  md5: 788e42390f4b031fb47b547797baff69
-  depends:
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 484110
-  timestamp: 1714510972284
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
-  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
-  md5: 1b87c5130b5fd6d1738e28799f8b8236
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 32097
-  timestamp: 1763977879589
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.conda
-  sha256: 0af76c0fbf1697cfd54ada59547e8d086ab113b6dfcc9360aab573a6eb711771
-  md5: eb0fb89b08890d755421c26fae5a8909
-  depends:
-  - __osx >=11.1
-  - libzlib 1.3.1 h5f15de7_0
-  license: Zlib
-  license_family: OTHER
-  size: 78512
-  timestamp: 1756475938331
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
-  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
-  md5: b282b2aecb718102ee0bb3848514689a
-  depends:
-  - __osx >=12.1
-  - cffi >=1.17
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstd >=1.5.7,<1.5.8.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 349977
-  timestamp: 1758189118260
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
-  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
-  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
-  depends:
-  - __osx >=12.1
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.6.4,<6.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 471230
-  timestamp: 1758039171969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiofiles-25.1.0-py313haa95532_0.conda
-  sha256: 087a169289930dc85225ea20bdf1cde6d9218e2e451eef869d3f616fb246d0d5
-  md5: c62bd3bff5cb11570247115c1ab81225
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 35318
-  timestamp: 1773069363087
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-ai-0.5.0-py313haa95532_1.conda
-  sha256: 572d0d70c90e013894912041337d2d5daf466f70e13dd723c2299488c4097a85
-  md5: c486692f9df9720276afb556abff5361
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-cli-base >=0.8.1
-  - openai
-  - packaging
-  - platformdirs
-  - pydantic >=2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich
-  - ruamel.yaml
-  - typer
-  constrains:
-  - mcp >=1.26
-  - pydantic-ai >=1.50
-  - langchain-openai >=0.2.8
-  - llm >=0.22
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116690
-  timestamp: 1773844804490
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-auth-0.14.4-py313haa95532_0.conda
-  sha256: a608187369836eb258a224d0d6490cc1aff1960d620d281327c5b778468bc43b
-  md5: 5f4b80f4355b922b23fdd3456c6d4001
-  depends:
-  - anaconda-cli-base >=0.8.1
-  - cryptography >=3.4.0
-  - httpx
-  - keyring
-  - pkce
-  - pydantic
-  - pyjwt
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  - requests
-  - semver <4
-  - anaconda-anon-usage >=0.7.2
-  constrains:
-  - anaconda-cloud-auth >=0.8
-  - conda >=23.9.0
-  - conda-token >=0.7.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 152577
-  timestamp: 1777996277515
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-cli-base-0.8.2-py313haa95532_0.conda
-  sha256: cf508cd7fc76dc48d8a53935c0365029900f6a338b07b0bdd142ccf61f6a9eb7
-  md5: 5717d515db735fe7167bd3b5ea7bdc50
-  depends:
-  - click
-  - packaging >=23.0
-  - pydantic >=2.12
-  - pydantic-settings >=2.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - readchar
-  - rich
-  - tomli
-  - tomlkit
-  - typer >=0.17
-  constrains:
-  - anaconda-client >=1.13.0
-  - anaconda-auth >=0.12.0
-  - anaconda-cloud-cli >=0.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86912
-  timestamp: 1775469436561
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.14.1-py313haa95532_0.conda
-  sha256: f9ca0870258b6617e701aab351a61c24b4297b30211a426f8c002003e6af47da
-  md5: e10dea7c74568841ed1cd5d8ec12ca92
-  depends:
-  - anaconda-anon-usage >=0.7.3
-  - anaconda-auth >=0.12.3
-  - anaconda-cli-base >=0.7.0
-  - conda-package-handling >=1.7.3
-  - defusedxml >=0.7.1
-  - nbformat >=4.4.0
-  - platformdirs >=3.10.0,<5.0
-  - python >=3.13,<3.14.0a0
-  - python-dateutil >=2.6.1
-  - python_abi 3.13.* *_cp313
-  - pytz >=2021.3
-  - pyyaml >=3.12
-  - requests >=2.20.0
-  - requests-toolbelt >=0.9.1
-  - setuptools >=58.0.4
-  - tqdm >=4.56.0
-  - urllib3 >=1.26.4
-  constrains:
-  - anaconda-project >=0.9.1
-  - pillow >=10.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 870768
-  timestamp: 1772491405834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-conda-0.1.11-py313haa95532_0.conda
-  sha256: 9173b05ad2a5a3eada3b344a697dc6cf2ef92a38e8e81692710eb1635ad646b0
-  md5: 643c72f55e9de9926eabd069edbf2322
-  depends:
-  - anaconda-connector-core 0.1.11
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - conda >=25.11.1,<26.3.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - menuinst >=2
-  - orjson >=3.11.4
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.32.5,<3.0.0a0
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 161935
-  timestamp: 1773935085468
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-core-0.1.11-py313haa95532_0.conda
-  sha256: 010bd2bafe22c03378d0ec0ff9bd79f4020bf6157f2069b988fa566217e72015
-  md5: c2ebc9fa966f6b08ea187fa807641415
-  depends:
-  - anaconda-connector-utilities 0.1.11
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Other
-  size: 226857
-  timestamp: 1773871887979
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-connector-utilities-0.1.11-py313haa95532_0.conda
-  sha256: 891f6458e9076676889da0fc670e57b436900e65c31dd22db61209a51e93da41
-  md5: 6f2969069844333afb09ed91b701abe0
-  depends:
-  - attrs >=25.4.0
-  - frozendict >=2.4.6,<3.0.0a0
-  - more-itertools >=10.8.0
-  - packaging >=25.0
-  - pydantic >=2.12.4,<3.0.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.15.0,<5.0.0a0
-  license: Proprietary
-  license_family: Proprietary
-  size: 160509
-  timestamp: 1773868198156
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-mcp-1.1.0-py313haa95532_0.conda
-  sha256: 4aee689864b9fb410377657a00567a91a8684a5c65d9d6f652334b01712a479c
-  md5: fdbf822269394ba6e2e0eabd16a007d6
-  depends:
-  - anaconda-anon-usage
-  - anaconda-auth >=0.13.0,<1.0.0
-  - anaconda-cli-base >=0.8.1,<1.0.0
-  - anaconda-opentelemetry >=0.8.1,<1.2.0
-  - click >=8.1.0,<9.0.0
-  - environments-mcp-server >=1.0.2,<2.0.0
-  - mcp-compose >=0.1.12,<2.0.0
-  - platformdirs >=4.0.0,<5
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 100191
-  timestamp: 1779920913902
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-opentelemetry-1.1.0-py313haa95532_0.conda
-  sha256: 9ef1e52cdb418a6a4051625f1e24499dc88d5ec73ee314cec82f0ac33d263567
-  md5: 8d4b877231bde39bd3ef1270fb015389
-  depends:
-  - anaconda-anon-usage
-  - grpcio >=1.71.0
-  - opentelemetry-api 1.38.0
-  - opentelemetry-exporter-otlp-proto-common 1.38.0
-  - opentelemetry-exporter-otlp-proto-grpc 1.38.0
-  - opentelemetry-exporter-otlp-proto-http 1.38.0
-  - opentelemetry-proto 1.38.0
-  - opentelemetry-sdk 1.38.0
-  - opentelemetry-semantic-conventions 0.59b0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - pyyaml >=6.0.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 82692
-  timestamp: 1776808693739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-doc-0.0.4-py313haa95532_0.conda
-  sha256: 281cbe4ddcbf8a123083a60f5b09da78d45b8b6b16c73366b241bfc54b356e49
-  md5: 250197e0edb4f89e9d3199c32fcecd5d
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 11465
-  timestamp: 1763372717011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/annotated-types-0.6.0-py313haa95532_1.conda
-  sha256: 7aeb1d587bd7ad0faad1bbb3c5e5a0a4a584fc6c226fa33682e60aa76fc2ddb2
-  md5: 2c7171d6d58b9364b4406ab1c85ee50b
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 26185
-  timestamp: 1761745147069
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.12.1-py313haa95532_0.conda
-  sha256: 51ad4b3ea68d808dd29deef0c3b83e4be8535b968e6627f2b294d61d0c01c1de
-  md5: 68c07c0dd57fb3631e0b44bbcc6ec85d
-  depends:
-  - idna >=2.8
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - trio >=0.32.0
-  license: MIT
-  license_family: MIT
-  size: 318164
-  timestamp: 1773134551978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-26.1.0-py313h35db113_0.conda
-  sha256: 75212793a492f1fc407da8e50ea62b036c592215db4f2df7a1f534a7ee0388ba
-  md5: 2a3be388a9418ec78c921662e816d826
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 181026
-  timestamp: 1774959795526
-- conda: https://repo.anaconda.com/pkgs/main/win-64/authlib-1.6.9-py313haa95532_0.conda
-  sha256: 57522c736e6a8ec998c52cded95142de69c7d7caa060deb4f7f731b7b9dfc28a
-  md5: 3759df6b7fe2dfaec9fefa4dbaa3a066
-  depends:
-  - cryptography >=3.2
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  constrains:
-  - pycryptodomex >=3.10,<4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 448508
-  timestamp: 1775206412930
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beartype-0.22.9-py313haa95532_0.conda
-  sha256: b8997e24a26186b7954102f5ae98ab9a6bb32fac484003827ba76162b65a34c4
-  md5: f38f1b967e522121f347c6e53e50386e
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 1488599
-  timestamp: 1772489378490
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boltons-25.0.0-py313haa95532_0.conda
-  sha256: c695504d0b210c758b9952a8f6accd217588ffa3bad87eccff5d8db1870e0893
-  md5: 78e0f7a51d811d64b0d0fa4e886458f2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 523882
-  timestamp: 1751383878776
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py313h885b0b7_0.conda
-  sha256: 3a204226b3a57b3312473f6f101bb067eb3d986e5b2373b421d1ec6c71160891
-  md5: 964620a4cb8353969963fbb7b045b01c
-  depends:
-  - cffi >=1.17.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 355904
-  timestamp: 1764961470388
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.conda
-  sha256: 4e30c9bfd4501555b0859c863e95ea044290babf3bf190b9d4fb38b06cf15c3c
-  md5: 33e784123d565c38e68945f07b461282
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 91870
-  timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.6-h2c209ce_0.conda
-  sha256: ec9844734fb774cb96c1fbcb60c1864fb26d05d7551722f5b08a7763eb0e0dae
-  md5: f6f293f1ec437a5a362252af20d31e50
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  size: 203491
-  timestamp: 1769077840032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2026.3.19-haa95532_0.conda
-  sha256: 922ec2dc939cf5a6790a391d5164952ab4c3802ab882fad71da361888a20ad81
-  md5: 646f2cc64c282566396335d4e352a3b4
-  license: MPL-2.0
-  license_family: Other
-  size: 128933
-  timestamp: 1774365840323
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-6.2.2-py313haa95532_0.conda
-  sha256: d530d9093a9cd9812e2f0a6e46fada0ccc02293fc67133d4d8bcea8f9ef6d311
-  md5: 9ce972c71a87d4d90534a24d77e99cb0
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41594
-  timestamp: 1764867445911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py313haa95532_0.conda
-  sha256: cc1f29494f63fed7d925e545e1f8c47f51e8e06f856b4d15a40925c07e81fed5
-  md5: 5808bf0191f70eb95f0cc7d7faf7eaea
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MPL-2.0
-  license_family: Other
-  size: 151549
-  timestamp: 1767659399196
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py313h02ab6af_1.conda
-  sha256: ec04f70cf11c0ea55deea4c011e40a54e44346e3c1083f2489d695332da2cbee
-  md5: d1e9e395ff8688288d67b89e896c2b6c
-  depends:
-  - pycparser
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  license: MIT
-  license_family: MIT
-  size: 299121
-  timestamp: 1761832847099
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py313haa95532_0.conda
-  sha256: 1f52dabe12c1494d797baaa83a335a136263fd751e2330da82765a4b499e9ab7
-  md5: 9e4732d3d22b2cf01fc408696e8ebd41
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 124770
-  timestamp: 1761745054105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py313haa95532_1.conda
-  sha256: cd3f6faec56670975522d5a3ff658a93fab1591320e345c3556603d7642df0b5
-  md5: 17865c3c6a7a80bb226bf7a8e1b0a34e
-  depends:
-  - colorama
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 328826
-  timestamp: 1764332409785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py313haa95532_0.conda
-  sha256: 44e29288f710fcc69fce9b58faa6493d514d5cff2cbabea16e22bb0572a3d666
-  md5: b73ebc8eb01ba1e79ad34303e2975694
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55002
-  timestamp: 1729036609433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-26.1.1-py313haa95532_0.conda
-  sha256: 6cb15ee40c7e2e1a7866ab9f3a3d95e64f654c80f23cdda46a7caf208e22e67d
-  md5: 301f7c7830bdf835d4fcf93e0122da7a
-  depends:
-  - archspec >=0.2.3
-  - boltons >=23.0.0
-  - charset-normalizer
-  - conda-libmamba-solver >=25.4.0
-  - conda-package-handling >=2.2.0
-  - distro >=1.5.0
-  - frozendict >=2.4.2
-  - jsonpatch >=1.32
-  - menuinst >=2
-  - packaging >=23.0
-  - platformdirs >=3.10.0
-  - pluggy >=1.0.0
-  - pycosat >=0.6.3
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests >=2.28.0,<3
-  - ruamel.yaml >=0.11.14,<0.19
-  - setuptools >=60.0.0
-  - tqdm >=4
-  - truststore >=0.8.0
-  - zstandard >=0.19.0
-  constrains:
-  - conda-env >=2.6
-  - conda-build >=25.9
-  - conda-content-trust >=0.1.1
-  - conda-anaconda-telemetry >=0.3.0
-  - conda-anaconda-tos >=0.2.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1275313
-  timestamp: 1771402340575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.4.0-py313haa95532_1.conda
-  sha256: d8db448f913dbd860b9d6e71ce4b6868fdc974630c4a3a297f1ba9c24a806931
-  md5: 0bf62b2027e8a656a86e1c4a7e71142c
-  depends:
-  - conda-package-streaming >=0.9.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 309759
-  timestamp: 1762366569467
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.12.0-py313haa95532_1.conda
-  sha256: c3b44038bc84ea3711e3995be45e1b5ad0107090b0f94a7ac5238f3c22e5b67a
-  md5: d9081bd54908ac92135e6fb20d0aade2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - requests
-  - zstandard >=0.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38102
-  timestamp: 1762361726254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cpp-expected-1.1.0-h214f63a_0.conda
-  sha256: 73e2ef3800ff5659c111f073e8e2f802d48483c78ea8781cdf5ed34fae6de2a2
-  md5: 67a55401db50a1d6bde2b153a74bcb07
-  depends:
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.29.30133,<15.0a0
-  license: CC0-1.0
-  license_family: CC
-  size: 133944
-  timestamp: 1734039396266
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-46.0.6-py313hbfe00f4_1.conda
-  sha256: 6ffe06d9e0fdc259fa0ff6637c9a5d1e5cf63956cd14ac2b773e02ce55432327
-  md5: 60bf04e1104890a8841e4517a028cf6c
-  depends:
-  - cffi >=2.0.0
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  constrains:
-  - pyopenssl >=23.0.0
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  size: 1481930
-  timestamp: 1775166420995
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cyclopts-4.6.0-py313haa95532_0.conda
-  sha256: c8ec7be1b1f8cc6520ce2fa13c1229b051783e2bc4a6b38d4ca53d1d280973c5
-  md5: db173ac83b3843bec70a8b2070881460
-  depends:
-  - attrs >=23.1.0
-  - docstring_parser >=0.15,<4.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - rich >=13.6.0
-  - rich-rst >=1.3.1,<2.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 448738
-  timestamp: 1772065243755
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distro-1.9.0-py313haa95532_0.conda
-  sha256: 5311c77bcb8f33552594b6743fab3944374085ee53626755813ba015cf71b10d
-  md5: 9a502db95e7e272d1b7ed53f03dafab2
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 63476
-  timestamp: 1729059201537
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dnspython-2.8.0-py313haa95532_0.conda
-  sha256: 92b7c17be101f6dd62e41104856fbb1202859c17f7070eae04f6a0adba757328
-  md5: 3aff8e6fb522c2b8f4d79eccffa655d6
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  - trio >=0.30
-  - idna >=3.10
-  - wmi >=1.5.1
-  - cryptography >=45
-  - h2 >=4.2.0
-  - aioquic >=1.2.0
-  license: ISC
-  license_family: OTHER
-  size: 666555
-  timestamp: 1763718371551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docstring_parser-0.17.0-py313haa95532_0.conda
-  sha256: 56e0b4b7e7a14eaa7c32a623bfd6ca16c4c6e4be69a023a0f02a087a2910eb86
-  md5: 6c03175c12338ebc8273659a72c462ce
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 96782
-  timestamp: 1766163871411
-- conda: https://repo.anaconda.com/pkgs/main/win-64/docutils-0.21.2-py313haa95532_1.conda
-  sha256: b09c30bf098b97bd82239e0ae256965b73ab9a704d19497fb2363f6038a5be7b
-  md5: bbfbf4a353f2adbd724998ab6083802f
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  license_family: Other
-  size: 1014370
-  timestamp: 1761746691814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/email-validator-2.3.0-py313haa95532_0.conda
-  sha256: a436a1c5afb37b46a4e0d67d05827a00b6cd6b93552e1ed5244a46049f6639af
-  md5: 0aec5daa5284e9e3967c95a79f775012
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Unlicense
-  license_family: OTHER
-  size: 90963
-  timestamp: 1758610340546
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environments-mcp-server-1.0.7-py313haa95532_0.conda
-  sha256: fb3ce799f193bcb6e33061ad6f975654b06f3342c3c10a72664f9cfb23ac5c4d
-  md5: b7b2eed90ced3af325d06a98dfa4c4b0
-  depends:
-  - anaconda-auth >=0.13.0
-  - anaconda-connector-conda >=0.1.11,<0.2.0a0
-  - anaconda-connector-core >=0.1.11,<0.2.0a0
-  - anaconda-connector-utilities >=0.1.11,<0.2.0a0
-  - click >=8.1,<9.0
-  - conda >=25.11.0,<26.2.0
-  - environs >=9.0,<12.0
-  - fastmcp >=2.12
-  - httpx >=0.24,<1.0
-  - lupa >=2.6,<3.0
-  - opentelemetry-instrumentation >=0.51b0,<5.59b0
-  - orjson >=3.11.5,<3.12
-  - pip >=25.0.0,<27.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - typer >=0.7,<1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 91692
-  timestamp: 1779916032565
-- conda: https://repo.anaconda.com/pkgs/main/win-64/environs-11.2.1-py313haa95532_0.conda
-  sha256: 9564138f2a45f63cc948536a86f77c87c4bc5683e133bfe96ddb36c9d3b19130
-  md5: f61420d4421c1f5c8ecb2d0cac6a910c
-  depends:
-  - marshmallow >=3.13.0,<4
-  - python >=3.13,<3.14.0a0
-  - python-dotenv
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 37648
-  timestamp: 1774388523034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py313haa95532_0.conda
-  sha256: 5eac2b622c840f3e9cbfa6faf28d6fdea3ee8dc1c87942e8d52a123b65d7a92e
-  md5: be5485351f1313fc4628d30117e0fdd5
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 49233
-  timestamp: 1761560536661
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastapi-core-0.128.0-py313haa95532_0.conda
-  sha256: 0f0185034ee22e4d7e4cd27a7422be8dec68f67ea42c2c9a3dfe0d29d8c21da9
-  md5: 27ac4e0463fbab1360fe56504c95396e
-  depends:
-  - annotated-doc >=0.0.2
-  - pydantic >=2.7.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - starlette >=0.40.0,<0.51.0
-  - typing-extensions >=4.8.0
-  constrains:
-  - pyyaml >=5.3.1
-  - uvicorn-standard >=0.12.0
-  - ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0
-  - fastapi-cli >=0.0.8
-  - python-multipart >=0.0.18
-  - email-validator >=2.0.0
-  - orjson >=3.2.1
-  - pydantic-extra-types >=2.0.0
-  - itsdangerous >=1.1.0
-  - httpx >=0.23.0,<1.0.0
-  - jinja2 >=3.1.5
-  - pydantic-settings >=2.0.0
-  license: MIT
-  license_family: MIT
-  size: 253473
-  timestamp: 1768401259271
 - conda: https://repo.anaconda.com/pkgs/main/win-64/fastmcp-3.1.1-py313haa95532_0.conda
   sha256: e2ac0a58de7fbad8d04788f6cbd9411d8ad4887e20c090270677807dbff6e4a5
   md5: 37a1c03b4d1c38f1844c89147df17bca
@@ -10137,17 +3613,84 @@ packages:
   license_family: Apache
   size: 1086285
   timestamp: 1774377928366
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-11.2.0-h58b7f6e_0.conda
-  sha256: 34df803b78d9c5b23674c0663b505980025afbc6098d8fb53cb9b6c1b4b33082
-  md5: de02359dfe1a0b71736085f1e65508f1
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fmt-12.1.0-h44f220b_0.conda
+  sha256: 75206a86cdcdb0752db803e8ab8b27589d376413f16f8b280f8864b27702636d
+  md5: dd4be9ab91074ac1e2bc78719cf51496
   depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 209011
-  timestamp: 1754991152830
+  size: 196493
+  timestamp: 1772639967801
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/fmt-12.1.0-h8e5a627_0.conda
+  sha256: aa7b58e9c755e962d12389a5c8ca40360f23e8acbcc4f40b7d71eacd5def830d
+  md5: 4f7d44864ddd9385f19d54f6bd1c16c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 195404
+  timestamp: 1772639972853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fmt-12.1.0-hc20ec9e_0.conda
+  sha256: 2eef880a6cc5d890b18714f4cdf533d291d35c45670921fd99d62e8413b585a1
+  md5: 4222bb0bb9d851b64a8163104f07d8b8
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 178313
+  timestamp: 1772640095208
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fmt-12.1.0-ha349831_0.conda
+  sha256: 5dd4c4ad9a4557c783980ca135e10ec6de1c150b9df3a4099efc8982922de509
+  md5: 17ae3f100dfdbf5fd1291f5d42c37913
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 194070
+  timestamp: 1772640043830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozendict-2.4.6-py313hee96239_0.conda
+  sha256: bbd8544cebc4a43a7c92898ffed3d4e668c236dbd3e7c6307758c31b75f0e3d3
+  md5: 26dfe875df9973e0e98ec5add063e00e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39148
+  timestamp: 1761750688493
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/frozendict-2.4.6-py313ha28494d_0.conda
+  sha256: f7e99b716ea48840fa7d8c27e4fc10df0399ec5e94e3068b2956eb99d891d845
+  md5: 8d10823536cc83aca7475e92af48e733
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 38822
+  timestamp: 1761750688451
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozendict-2.4.6-py313haa24f5a_0.conda
+  sha256: a04a4d19f35edd518d645c0b86dd3c68772df87abdcf1b6d210c2cfa4697ee69
+  md5: 662529f545d783dc4148ad30f1110b51
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 39679
+  timestamp: 1761750693438
 - conda: https://repo.anaconda.com/pkgs/main/win-64/frozendict-2.4.6-py313h02ab6af_0.conda
   sha256: 95ee413c83df0269fea089be2bf2fa7c1761a986d213f1c6926d4bd904176180
   md5: 16d7e8878fbec9e9856e9b7b3a7d41cb
@@ -10161,6 +3704,127 @@ packages:
   license_family: LGPL
   size: 39675
   timestamp: 1761750775394
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-0.25.1-h92eb808_0.conda
+  sha256: 1a83e26f502a98bce1348b67f61e8ada17304080be574e743a434ccbefc8c142
+  md5: df53b928c3a9dd53c7f4e87cc03e03d2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h6a67909_0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libasprintf-devel 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libgettextpo-devel 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 535333
+  timestamp: 1772045309664
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-0.25.1-h0561090_0.conda
+  sha256: db174b7069cbf5ab649ba23a4de1b3a8df1630a1633d51335c8b119b420ba3cf
+  md5: 29ce6f4467466ef1155fd8485c41b52c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext-tools 0.25.1 h304d29d_0
+  - libasprintf 0.25.1 h8121631_0
+  - libasprintf-devel 0.25.1 h8121631_0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libgettextpo-devel 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 529353
+  timestamp: 1772045298146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.25.1-h50c8ec2_0.conda
+  sha256: 40d943c93b3530d872e0d984fe79570debae6cb8f6b8b715a83043fd349f9815
+  md5: 019e4c074d5db31938a582141e0d8af1
+  depends:
+  - __osx >=12.1
+  - gettext-tools 0.25.1 h61de102_0
+  - libasprintf 0.25.1 h7b764f5_0
+  - libasprintf-devel 0.25.1 h7b764f5_0
+  - libcxx >=20
+  - libgettextpo 0.25.1 h7b764f5_0
+  - libgettextpo-devel 0.25.1 h7b764f5_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  - libintl-devel 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 540523
+  timestamp: 1772045399083
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gettext-tools-0.25.1-h6a67909_0.conda
+  sha256: 040af24b30b7928def70ffc1fb0deb502156796993a26d95aeb3df90b92b755c
+  md5: ac944526cc2d27ffa3c44a42cd86f46d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3777431
+  timestamp: 1772045279414
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/gettext-tools-0.25.1-h304d29d_0.conda
+  sha256: 5ead76545610e4aaa089c7be388ae84d18a62c721c739ba4abf56e6ff86374af
+  md5: c0f5a28ad7e3facdc8181ef762970499
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3969299
+  timestamp: 1772045273194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-tools-0.25.1-h61de102_0.conda
+  sha256: d32649817c09e50b6fac1fe0ff33423e62e72603548486a31e4b4a4bcf21a62e
+  md5: 114bc0088ee0fb1bc617315c0cc35682
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-or-later
+  size: 3473993
+  timestamp: 1772045376052
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/googleapis-common-protos-1.72.0-py313h06a4308_0.conda
+  sha256: 6868564ed619b9d81b3824d5e7876e7d015757cb6a6c47deb54e7ef7d4904e1e
+  md5: 91b9170766e7040dedc182d913a7ff89
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171370
+  timestamp: 1770382383126
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/googleapis-common-protos-1.72.0-py313hd43f75c_0.conda
+  sha256: f9c172a39d1c96af1fd2f58a06ecdb2aa0107bcb4270f39e4ded097f2d40a245
+  md5: 5a519fab2daa903499d90bef420c0c8b
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 170581
+  timestamp: 1770382377233
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/googleapis-common-protos-1.72.0-py313hca03da5_0.conda
+  sha256: ef182325ad8e33360907fd2f07d259d5d0755f0e75be94de5e90f10b6d99de9c
+  md5: dbbce5fa2e62a7607fb0f2a014e0cfb1
+  depends:
+  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - grpcio >=1.44.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 171931
+  timestamp: 1770382381497
 - conda: https://repo.anaconda.com/pkgs/main/win-64/googleapis-common-protos-1.72.0-py313haa95532_0.conda
   sha256: 3ba8735bb797cd4a59c3cfda4fdb4402e8195c3ff73e1c1a4741481cca316570
   md5: f0f53c3478e98fa4a70424c9841b9663
@@ -10174,6 +3838,56 @@ packages:
   license_family: APACHE
   size: 172940
   timestamp: 1770382461709
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.78.0-py313h281d4e4_0.conda
+  sha256: a6be0ec0b8d695dd77a7260cfb5f7d81dfdab34d654329a45349195b0159f411
+  md5: 9b8c1795cc878775116cd01cea2ddad8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 h79c45ec_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 877844
+  timestamp: 1770755209168
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/grpcio-1.78.0-py313h646149a_0.conda
+  sha256: 4ac1d0f9f6ebece698f9bd1fcee8ad0644a8383d3046e6ccf8d50dc63c8267fb
+  md5: 4648b65bcb134c3764a9e64f6e6953d8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libgrpc 1.78.0 hec5afc2_0
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 831478
+  timestamp: 1770755033862
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.78.0-py313h1d739a6_0.conda
+  sha256: b6186b6d42dd6884d5666629e11673a1e3e8418551b3bf40ceca43627ed6c4b1
+  md5: db94ba50dcc724b61f6f51982822577b
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libgrpc 1.78.0 h7694377_0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.12,<5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 761674
+  timestamp: 1770754627213
 - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.78.0-py313ha1f0e13_0.conda
   sha256: 7d6c1bab6553c858ebb29bfdd9c113e99ec8c6076582b718451bfe6f596d5826
   md5: 1667c992706d53ffdc6f05e3577c607d
@@ -10191,6 +3905,36 @@ packages:
   license_family: APACHE
   size: 727985
   timestamp: 1770755894751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.16.0-py313h06a4308_1.conda
+  sha256: 96dcaec2513ff1034fc52b8b13e5500d41b05671d85f8bff24895bf807129812
+  md5: 64c98017f4f5b701ed2b2f20d5e9ea4c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64750
+  timestamp: 1761931277052
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/h11-0.16.0-py313hd43f75c_1.conda
+  sha256: f096b0379734307c844040e26d8a8193291244076843a992371b23eb927ace25
+  md5: 4786f45bc40fd0fb4b60c05d19e32179
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64484
+  timestamp: 1761931284057
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.16.0-py313hca03da5_1.conda
+  sha256: 6e90b3482d77fd6289188186a453b2be6dee73859e73c09f595774de02b0183e
+  md5: 38e110c2ae2fb67d3ef1abfc786498f9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 64806
+  timestamp: 1761931279662
 - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.16.0-py313haa95532_1.conda
   sha256: 81e22d7167caf13f505697c0a182d428576d865c67b2f5ef0655201527302a9b
   md5: a97fdc66e5c3a6fcb5f8818f4606f22f
@@ -10201,6 +3945,42 @@ packages:
   license_family: MIT
   size: 64663
   timestamp: 1761931421750
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.9-py313h06a4308_0.conda
+  sha256: 43cf7bc5c9c8a5a7470c5b7c6b1ad0f67319bf4de5b958d7c1e7027e63029cc4
+  md5: 77016551f9607c23c6243632bf100507
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127896
+  timestamp: 1748526107673
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpcore-1.0.9-py313hd43f75c_0.conda
+  sha256: 43d8020a0b441b52d620e5f3d500f117be23a5ce22346035cc4817eb08622462
+  md5: 03260c9cc30bdb7167dbb8aeb4a2db1b
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127463
+  timestamp: 1748526158318
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.9-py313hca03da5_0.conda
+  sha256: 29c6b4fe1102058af3c395fdf33dedc1ecaac6335759a2d0bed39dcb667e06a2
+  md5: 6d33385bdc014731d4369f0d0e09af73
+  depends:
+  - certifi
+  - h11 >=0.16
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129364
+  timestamp: 1748526183257
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.9-py313haa95532_0.conda
   sha256: d500fb5bedabbb40813f548184b7fa6f3fd92893209c0762777d8b7926e94af2
   md5: 2262f0f3863efb10f8f4442438401a8d
@@ -10213,6 +3993,41 @@ packages:
   license_family: BSD
   size: 131010
   timestamp: 1748526313503
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httptools-0.7.1-py313h47b2149_0.conda
+  sha256: 7b348b0b131f69d320a6f0d2e478a878c33d549796f3d64e0fe1423e9390425c
+  md5: 4b7c5319a6df6513319768f73969098c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 101585
+  timestamp: 1763634777574
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httptools-0.7.1-py313h27118de_0.conda
+  sha256: 0c591a1de157a9c529ef86eedc8be6f11002477aade17ec574ef5ea3cc635bec
+  md5: e4fc275a391afef3d78ec4149d5ad589
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 98508
+  timestamp: 1763634792733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httptools-0.7.1-py313haa24f5a_0.conda
+  sha256: cf86c5c248c66a1fdb7494111e5516396efb8468772402e2641b28b1e62afb44
+  md5: 8c908d696cfb916e2f2a6ac1f1a9b476
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92280
+  timestamp: 1763634775883
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httptools-0.7.1-py313h02ab6af_0.conda
   sha256: e8b67d7608f23cf46b932ebff40fe59ee3d71e0a03ae805662adb2b9391fc2ed
   md5: 1cfe4a9cca6beb28dd5870ef564a73dc
@@ -10226,6 +4041,66 @@ packages:
   license_family: MIT
   size: 84545
   timestamp: 1763634955246
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.28.1-py313h06a4308_1.conda
+  sha256: ea875a1564f96bd1fdbaf82e6fa51d829f099b7f69a5a9e76c5ea9d5483d9288
+  md5: d25af3a5cbefe54951cb3dc369b945bb
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=8.0.0,<9.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - zstandard >=0.18.0
+  - socksio >=1.0.0,<2.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217558
+  timestamp: 1760447364823
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-0.28.1-py313hd43f75c_1.conda
+  sha256: ee474a5b631ad6875ec0fb11aa5cc7e65f193c20564ec9e5f539725acffa8121
+  md5: 63a3ec07509610236d9ad578a3b625aa
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - zstandard >=0.18.0
+  - click >=8.0.0,<9.0.0a0
+  - pygments >=2.0.0,<3.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216526
+  timestamp: 1760447362829
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.28.1-py313hca03da5_1.conda
+  sha256: 4b9579b31971d46a31710d7cb6740c03a61a37f0c1e181113eb3ec1556d3c707
+  md5: 363b8e8b1d1fed3355d8aafdc00c35a8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pygments >=2.0.0,<3.0.0a0
+  - zstandard >=0.18.0
+  - h2 >=3.0.0,<5.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217168
+  timestamp: 1760447208891
 - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.28.1-py313haa95532_1.conda
   sha256: 110311c08a60e70198900b6aa5a35e7b1f2175bd3109e0a56610b75d0ea3f20f
   md5: 55a5ebf53109994a5ac8a2f802bd8f43
@@ -10246,17 +4121,111 @@ packages:
   license_family: BSD
   size: 242095
   timestamp: 1760447587973
-- conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.0-py313haa95532_0.conda
-  sha256: be0e01deed35e9d81f96eb543e8dc8973f1cd2c8810426fa4e544279a29e480a
-  md5: e37085d0059052288a703a850ebcbf71
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-sse-0.4.3-py313h06a4308_0.conda
+  sha256: 2839f29be1c271227df948b1afec5fd344e90a69a52f3c2500f5cbcf5c5e6089
+  md5: d935fe60ceefba9d9ef09f9da74f318e
   depends:
   - httpx
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 17881
-  timestamp: 1735853319955
+  size: 23252
+  timestamp: 1779705422223
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/httpx-sse-0.4.3-py313hd43f75c_0.conda
+  sha256: 32f20f7e8b5835ab651597744fc608b9bcbd77638bd6937854ecb13e92ab2a15
+  md5: bb6b82c3e0c456cbcc0aec5dfbcc3afc
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23420
+  timestamp: 1779705412194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-sse-0.4.3-py313hca03da5_0.conda
+  sha256: 6c02369fd41c73a1bf806c52d32fa3733786872f81580b25fe034a020b5bc947
+  md5: 318fe0ce85ba910b160151492742c849
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23465
+  timestamp: 1779705367664
+- conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-sse-0.4.3-py313haa95532_0.conda
+  sha256: 1d8c0b1aa3081aa37a7c7e80cc7a4e53342188c6d2568dd4b12cf45cf9202e6a
+  md5: 865f4caec9445359c1ad492b9fe91ec5
+  depends:
+  - httpx
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23567
+  timestamp: 1779705561106
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-78.3-h84d19a5_0.conda
+  sha256: b4a4f7bbc3722e658cd1d21c37c4d7b4c7e89a48233bc2b90d430c9ce4a65859
+  md5: b3cca90607d3b176e49048756e89296e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 24357919
+  timestamp: 1777922220477
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/icu-78.3-h184064b_0.conda
+  sha256: a8bbd0804c4ea74a6de8231f27a913a730b3a5e9cf65664d46b9ad5f6cc59fe2
+  md5: 0da5f35ada86b8ac25eb864edd8189ff
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 24630174
+  timestamp: 1777922213958
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-78.3-hb00977c_0.conda
+  sha256: 8dd5131eccd5c7ad312437d6534f97dc7c7acb2ddf5506c543d1bddf72ab8640
+  md5: 48dcf4bb007f44e187fe29b1120e0ef9
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 23865757
+  timestamp: 1777922195678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py313h06a4308_0.conda
+  sha256: 2cbd75d6f8a108b989d3f580ffc40fbee43349e272794d1227fb11fe31191196
+  md5: c8b25d0fe19ba1a7319a0221e7615265
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202882
+  timestamp: 1761911998666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/idna-3.11-py313hd43f75c_0.conda
+  sha256: 2fcd3b20cbdfb7a0420f4c2f61909542259d744e42c12fdf76b4088b10059019
+  md5: 93b126011717941f140fd04b6dd6d37b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203848
+  timestamp: 1761912000622
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py313hca03da5_0.conda
+  sha256: bdb342e9e185cebf1f33d858ead48f6594829d014e1008a818b4ee3b8ce8b3dd
+  md5: 9840df0ca7f12f0d58576f9fa33ef0fc
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203509
+  timestamp: 1761912023966
 - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py313haa95532_0.conda
   sha256: 8264d301462d3eb44c813da4c4e092fc2f32b257ef5692a00573ac4c0346d920
   md5: 426a9add5ed691e72c893059ee0485fd
@@ -10267,6 +4236,39 @@ packages:
   license_family: BSD
   size: 203986
   timestamp: 1761912082836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.1-py313h06a4308_0.conda
+  sha256: 07e7ba32fc0ca0acbce844c20140b7c39823106e811005bb45d924363172f255
+  md5: e3d3dc1bd7e26bef582f874fbb4c543c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71396
+  timestamp: 1772097118324
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/importlib-metadata-8.7.1-py313hd43f75c_0.conda
+  sha256: 70c1ae18c8d2c962221cb73305357ba343c27e96ba0a2a63e267b68304c4b7e5
+  md5: 465aead5c1e7b7a585ebb676781545a1
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 71748
+  timestamp: 1772097105461
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.1-py313hca03da5_0.conda
+  sha256: debcd046ce94a9d5c1354954203417b70f4fb276826f13a563e1b33ae0bd58fb
+  md5: 711d5bcfff34a45210902f5ef91c3ec6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72439
+  timestamp: 1772099900987
 - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.1-py313haa95532_0.conda
   sha256: e31d3af9ae2a8a60d0ab46045ca1c3103bd5c1b878197ad3dbbf42db732bf41f
   md5: f806d7a4777a4c76c01b630b4fdb3732
@@ -10278,6 +4280,68 @@ packages:
   license_family: APACHE
   size: 72171
   timestamp: 1772097268508
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jansson-2.15.0-hbcba0ee_0.conda
+  sha256: f00270fce560124e2ac09e83130d0128b510d4bfb7143fd85ea70bea6b828d86
+  md5: fa3f5a347af7dc8c8db48c54fe5a2ae2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 66361
+  timestamp: 1779458360191
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jansson-2.15.0-h588a716_0.conda
+  sha256: bc4f597d0a8c76d0ceffb22028757f45ab551149ed9700d1eb58449f774df3c7
+  md5: 732df9ad011a787c27b4ad59698a68eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 69453
+  timestamp: 1779458327726
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.15.0-h9db958f_0.conda
+  sha256: c71158d76a0575cded1b6d698245b06b48cd9d6d50556c32e64d405a01c69b5c
+  md5: 618eef6415d2646740fe6b59538585c9
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 60223
+  timestamp: 1779458360360
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.classes-3.4.0-py313h06a4308_0.conda
+  sha256: 74c2d4abcff4a9dcce44b7a2180bf08b834cfc72ac9745ff318fb44b27c93516
+  md5: c4ea3f7208a811b569bbeae8c42c5b2d
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19952
+  timestamp: 1755516354462
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.classes-3.4.0-py313hd43f75c_0.conda
+  sha256: a95219d2781fce181f7185ee219d14200e5e81acfd6284c5df5a826b6f524d76
+  md5: 281677614ab4b309ddb5afd24c80cd26
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19436
+  timestamp: 1755516386420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.classes-3.4.0-py313hca03da5_0.conda
+  sha256: b0cdf7c33f4c61d0143590b15616e19a3c104203d6507b5c5363ee70b78b8a29
+  md5: f4e4bcf521aa18ee57d0607ad48f284c
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 21271
+  timestamp: 1755516531252
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.classes-3.4.0-py313haa95532_0.conda
   sha256: 7eb0c4ee04a96ad65ae0c51d58ad17d5203b76ddcd2d4702503a50127434fd27
   md5: a8fd08b7543a5b778d2e2c29c5aa88e9
@@ -10289,6 +4353,36 @@ packages:
   license_family: MIT
   size: 21078
   timestamp: 1755516602917
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.context-6.1.0-py313h06a4308_0.conda
+  sha256: ef4eebc2a04a062e54a6d4c318f70b88a737cb48706b2e9b1ec1f12cd0e24214
+  md5: 54a430923247a921a5c57e330e04549f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17104
+  timestamp: 1769477866762
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.context-6.1.0-py313hd43f75c_0.conda
+  sha256: edd3821909b3ae014625c64165c12fd35e539dbece19a5886ce884ce0d592362
+  md5: 7e58d4d035e2a5da3a932e1ce90c8f46
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17035
+  timestamp: 1769477854229
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.context-6.1.0-py313hca03da5_0.conda
+  sha256: 7a62f07477d22eee6924bff0b9f9243c9cf43abb1e6ffda42e12cacc80063d88
+  md5: 0a89e92618b4328787ef72b0d94d8808
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 17072
+  timestamp: 1769477856721
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.context-6.1.0-py313haa95532_0.conda
   sha256: 50f96dd6dc6cfefe9eb81802fdcaec8f1776e723ac8a43d825902e3d1f53e363
   md5: 75a2698e16470e6c8ca5a80decb040f3
@@ -10299,6 +4393,39 @@ packages:
   license_family: MIT
   size: 16899
   timestamp: 1769477938631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jaraco.functools-4.4.0-py313h06a4308_0.conda
+  sha256: cd3eca2672458d798fc63a1e9293f61866c8f0d797fc2f4e10fe2f3503f0a4b2
+  md5: 9572b85d5f84049bc36867f49d498520
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23712
+  timestamp: 1768389384997
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jaraco.functools-4.4.0-py313hd43f75c_0.conda
+  sha256: 7e3f95db3babff2f8b51f58d2805c325117e02385feab2e62880211722133bee
+  md5: 3fc0a300184c6cfbbb48735e637b6f00
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 23679
+  timestamp: 1768389385039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jaraco.functools-4.4.0-py313hca03da5_0.conda
+  sha256: 5b0d10767b5645eff4bc711220046f12d1b2c38cdf5529b2138c0237748f4cd8
+  md5: 7174017dd1ce6c709a2b1d87156deb56
+  depends:
+  - more-itertools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24174
+  timestamp: 1768389389007
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jaraco.functools-4.4.0-py313haa95532_0.conda
   sha256: d6495ad19759532a27e73055a1f13de378af550ff07878543e252b76c095660c
   md5: 25711ebee8c977aa282a9aa5ceea0817
@@ -10310,6 +4437,52 @@ packages:
   license_family: MIT
   size: 24310
   timestamp: 1768389476340
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jeepney-0.7.1-pyhd3eb1b0_0.conda
+  sha256: a74312540427eb9b5b613afe7fdfbd1b271530e177c94d186e2aeea907e50522
+  md5: f115ef0af90b59f35ef56743955979a4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 39004
+  timestamp: 1627537099507
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jiter-0.12.0-py313h498d7c9_0.conda
+  sha256: 98334c04dc2970dee14630c45fc0682c61da00472c6d0c87ce205261f4a03d7b
+  md5: b3bdb36f756b6055ce7b5e9535c6e7eb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 304593
+  timestamp: 1762897374551
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jiter-0.12.0-py313hff451be_0.conda
+  sha256: 47d0318362f050fb09e84f23c31efc2ff9873e1699e32b1fa771118d178a1253
+  md5: 78cac99f7ea800abcf0bcd09b8e1b7cb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 298136
+  timestamp: 1762897357507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jiter-0.12.0-py313h931abed_0.conda
+  sha256: 2a5ef24718129f8bcbb068e17bb22e1a2f5e53b5fe1ab5ea310383db670964a6
+  md5: ef1c78fa12751c0d455245582d1cb49b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 268149
+  timestamp: 1762897357212
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jiter-0.12.0-py313h114bc41_0.conda
   sha256: f39d48b2e608459feb932a21598c24ab04c9c32099a6aab94d5a08d7002aa082
   md5: e4a8ded259e4807efe3f846cbc713b75
@@ -10323,6 +4496,39 @@ packages:
   license_family: MIT
   size: 181327
   timestamp: 1762897503347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpatch-1.33-py313h06a4308_1.conda
+  sha256: a84eba19b44745aa7892ed30a461b4da6b315e93b50d468de72486d0a8a9f892
+  md5: 8cb4b1755a4a8fd6a57883863236ef2b
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36479
+  timestamp: 1728399618377
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpatch-1.33-py313hd43f75c_1.conda
+  sha256: 25ce8b958c589c634c9f85bfd8a63ae1cb385ae7ed1b2955f7a60337a196ab72
+  md5: 9930fc2e22ba90d25992765ac140be02
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36927
+  timestamp: 1728480664723
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpatch-1.33-py313hca03da5_1.conda
+  sha256: c36bf14810eb4e6d0cdfbdfae3495ed7e17f695196fa485a8aa0fb254ca39716
+  md5: 9e1af96e93b8278ec9029f1bd38f4517
+  depends:
+  - jsonpointer >=1.9
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37185
+  timestamp: 1728594571279
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpatch-1.33-py313haa95532_1.conda
   sha256: d25504515f356dc8c06dbf73ce598ba7b327431edf6ca1b06fa9a184a786ea04
   md5: 8c5fff5a1d8d36890bc5a297c1445785
@@ -10334,6 +4540,36 @@ packages:
   license_family: BSD
   size: 61903
   timestamp: 1729054823125
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonpointer-3.1.1-py313h06a4308_0.conda
+  sha256: 4004b09332ddfe32e7d0cf306566885c8a430d59eb092ff3bd5a4796d7da7125
+  md5: 05a451fa72cfd0f7c870a4d9cbe59c1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18979
+  timestamp: 1774432898196
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonpointer-3.1.1-py313hd43f75c_0.conda
+  sha256: 6b8f3a1cd9da65de2a28295ae91e9e4b8f9ed7748de0d5bc08fb0c1b9ffad3cf
+  md5: 793eb8901926bede7a6eebdce28cf6a0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19083
+  timestamp: 1774432919346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonpointer-3.1.1-py313hca03da5_0.conda
+  sha256: 35137f60ddb5c7adc8ab028b5035b1f265e0bcbec2ab859da413654da7d190c7
+  md5: 552bd935bf55a9099c7d2910a8d56391
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19004
+  timestamp: 1774432907812
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonpointer-3.1.1-py313haa95532_0.conda
   sha256: d0cc264fcb1555ed5e2fea4cbcbef11c2fbdec97b003625b784229aa5255f483
   md5: 75eab033c2afaa3732443501ce5c69a9
@@ -10344,6 +4580,36 @@ packages:
   license_family: BSD
   size: 43602
   timestamp: 1774433242550
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonref-1.1.0-py313h06a4308_0.conda
+  sha256: d2e912d3e5f5f7addf4996a8b661ec04b03e40a00811cb87db47ea5498af20cb
+  md5: 259205480d74c969b6bbd3c48662291e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30490
+  timestamp: 1774283018435
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonref-1.1.0-py313hd43f75c_0.conda
+  sha256: 3e80486504b14df6b698a54884515acb34e911e9d278e1f3ceafe665df60dfaa
+  md5: 4660f274a8ff963e92cb29db01b37c91
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30439
+  timestamp: 1774283011961
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonref-1.1.0-py313hca03da5_0.conda
+  sha256: 10d892d81e3216ef1231d941b814001b512b35fec628ed40e541829cc44e0531
+  md5: 5d6b05040c4bb4fcb5f46d525526e9b4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 30409
+  timestamp: 1774283033815
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonref-1.1.0-py313haa95532_0.conda
   sha256: 873027cd600f7bcb3955afff88d739dce468fb97711f984b2aa6daf9228970f4
   md5: 765f2516c806c0efce4302fb729a0c47
@@ -10354,6 +4620,48 @@ packages:
   license_family: MIT
   size: 30266
   timestamp: 1774283061640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py313h06a4308_0.conda
+  sha256: 8ad9ba853000a4454989dd92ac0061f21bd65aa771fd109ed3868a62e5d9192b
+  md5: 7125606e211300f51b43b14c7039c163
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198245
+  timestamp: 1767955393666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-4.25.1-py313hd43f75c_0.conda
+  sha256: c93f28e048b022670b19942a66ea9973b4c3e7ea43a95c38a661397a4e20ed42
+  md5: bfea8a2ab7a160ffc1ee1aeb725f198c
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198026
+  timestamp: 1767955403846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py313hca03da5_0.conda
+  sha256: 4d02aa59742ee485e5cd99108fdf28f4770253f24507ce22781daa687a48a490
+  md5: 0be71be35e5503bdecfebf75f1fa55c0
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 198501
+  timestamp: 1767955687618
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py313haa95532_0.conda
   sha256: 74712222c6722333c45a9e2b745af71fe2739ab5a6b0ed805b6f716103576821
   md5: 97042d9d769c8b7527882ae7edaba05a
@@ -10368,6 +4676,51 @@ packages:
   license_family: MIT
   size: 223147
   timestamp: 1767955635122
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-path-0.4.5-py313h06a4308_0.conda
+  sha256: fb8bf70cd13655e39b748b624d8e88f9449c07c9bf8f6ebd4b4cbeb5e306cdf7
+  md5: dea8a1c280fb8cb391be3b459d8dfac1
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52614
+  timestamp: 1772640999029
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-path-0.4.5-py313hd43f75c_0.conda
+  sha256: 82d26f42da003fcddae5742787de5d6f722f7c79bdb9b73b227e45c7345e4b80
+  md5: 022e69a93795b21be36f997e24f2b341
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52583
+  timestamp: 1772640996503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-path-0.4.5-py313hca03da5_0.conda
+  sha256: 12ddca1b88f4bcca55d143e098d7db549237c6bdd1cb66ab5db6e6cdaf3588d8
+  md5: bd5d17c69a377489445f1cac4b1390e7
+  depends:
+  - pathable >=0.5.0,<0.6.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - referencing <0.38.0
+  constrains:
+  - requests >=2.31.0,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52745
+  timestamp: 1772641022505
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-path-0.4.5-py313haa95532_0.conda
   sha256: d91c2b3156c53733cf5544a44d15fa79e0ecc688383c4c821dc2ee5979e4ef11
   md5: a8451b4e6b9ea3c5b515f06b9ba91e23
@@ -10383,6 +4736,39 @@ packages:
   license_family: Apache
   size: 52421
   timestamp: 1772641050217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py313h06a4308_0.conda
+  sha256: c555be705e9285d896da3ecec9852a0c1dd6fd286a8fd4bd8f72171636222b0d
+  md5: 2dbc150b61f12b744cf873c285f4a418
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17079
+  timestamp: 1762788451045
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jsonschema-specifications-2025.9.1-py313hd43f75c_0.conda
+  sha256: c815265f54b83cd17fbe1c192b32d3fa6fbe1a619fbbaef5924f4d154dedf92c
+  md5: da59899cde4411bae19ae5f15aebe373
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16920
+  timestamp: 1762788449938
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py313hca03da5_0.conda
+  sha256: fc8064c9bd507c1eaa571c2834e8f0f2a935a35a71ffc107c12c6e1f0bc88221
+  md5: 6cfee2660e901231d2fe274f02afeaf8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 17167
+  timestamp: 1762788437806
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py313haa95532_0.conda
   sha256: 28620856a54ef6885be4360f5b85633685ddb4d88b2a43b57c7bdffc19335e09
   md5: 5c075ecdc29eda1f025dfdc4e0f6efcb
@@ -10394,6 +4780,42 @@ packages:
   license_family: MIT
   size: 17206
   timestamp: 1762788650578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py313h06a4308_0.conda
+  sha256: a1e2cf45948cb3f2ea3ed2ca9d04607add3144d616931ad4dc0fbbfe2fc1359a
+  md5: 292a4c15bbd54feba358997e6d1b35db
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96597
+  timestamp: 1764588298747
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/jupyter_core-5.9.1-py313hd43f75c_0.conda
+  sha256: 16e1650b5527aa52bf2ca81058e42ff54ec17c83230c8a69b3cf2b17c8e67b76
+  md5: f303bbea09244d08acd0fad083bbd6eb
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96552
+  timestamp: 1764588304837
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py313hca03da5_0.conda
+  sha256: b565732d61d5438d4a1bd4a1e0d8d2bd41b77fdb908d7d8dd221a05eba3a9f26
+  md5: a691a010a6df73533294e436b2edb780
+  depends:
+  - platformdirs >=2.5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97019
+  timestamp: 1764588302845
 - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py313haa95532_0.conda
   sha256: ffaafa66cf38b5ac02048ded1a6998ac2b83bc65712b6bc7947c93b78da71bb8
   md5: 3b95819d01e50e21001764a85f9afe81
@@ -10407,6 +4829,64 @@ packages:
   license_family: BSD
   size: 121625
   timestamp: 1764588393434
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/keyring-25.7.0-py313h06a4308_0.conda
+  sha256: 549e460fd45bddce3a1492dbb1af7b227e0428318b4accf8c08209a5d96b38ed
+  md5: 6d505a62b565ff3d80d5a6662a83d54a
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-mypy >=1.0.1
+  - shtab >=1.1.0
+  - pytest-enabler >=3.4
+  - pytest-checkdocs >=2.4
+  license: MIT
+  license_family: MIT
+  size: 82797
+  timestamp: 1763637203264
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/keyring-25.7.0-py313hd43f75c_0.conda
+  sha256: 03024b2f38afa6bd7f7c9e5738a5659178d4d4f67b959bd6255f4a25160da560
+  md5: c96025bac150402baa006c878d604992
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - secretstorage >=3.2
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-mypy >=1.0.1
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 82677
+  timestamp: 1763637208740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keyring-25.7.0-py313hca03da5_0.conda
+  sha256: f80404cbc9871c92d481a52e565cc9cc7636cec451804b7eefea1f039359fca7
+  md5: d19d185ec9fd87908b74303c8e38893f
+  depends:
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - pytest-checkdocs >=2.4
+  - pytest-enabler >=3.4
+  - shtab >=1.1.0
+  - pytest-mypy >=1.0.1
+  license: MIT
+  license_family: MIT
+  size: 83253
+  timestamp: 1763637330760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/keyring-25.7.0-py313haa95532_0.conda
   sha256: bea45ee837d9962996ba5bc05ed0d9e87e8d711cee9156bc2b649dadace14879
   md5: 793935b26a9203a0e14d442c5edfe91c
@@ -10426,6 +4906,69 @@ packages:
   license_family: MIT
   size: 108233
   timestamp: 1763637248210
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.44-h9e0c5a2_3.conda
+  sha256: 4a4875ab4354d4a1bf1695850efad8787d7063387ed6b5aec5ecb659869e2590
+  md5: c563bb71f4df90fc3b92cde204827564
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 742162
+  timestamp: 1773255564362
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ld_impl_linux-aarch64-2.44-h97084ae_3.conda
+  sha256: 81a10d3fe92406c81cc4f106ecb4e12f6e57ce02e5fdba53e69bb34a3f61e5c2
+  md5: 833bdaaca975deb8a858597241ecd5c9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  constrains:
+  - binutils_impl_linux-aarch64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 783012
+  timestamp: 1773255553164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20260107.0-cxx17_h6199ee8_0.conda
+  sha256: 879d45ca2f128a6dd01555413fcbb499b324108ecd3322c13bbff61bb893d114
+  md5: 569d92e1732a69adff57813342a9c316
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libabseil-static =20260107.0=cxx17*
+  - abseil-cpp =20260107.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1384532
+  timestamp: 1770384636226
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libabseil-20260107.0-cxx17_h65ea6a0_0.conda
+  sha256: b3d015553a364f0d799ec3c9424571ed9f2580c5bd76f6a9dbf928820dba891f
+  md5: 50deebc10eb4d612f1bb35aa92538797
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1402413
+  timestamp: 1770384640911
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20260107.0-cxx17_hdc7b58b_0.conda
+  sha256: 72f7b39e0ccfd730c21593655ab4587f7c44489fe4a90f315e025e684eac3d45
+  md5: 112093c65f205a89992cf9cfc7120f41
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - abseil-cpp =20260107.0
+  - libabseil-static =20260107.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1224935
+  timestamp: 1770384634202
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20260107.0-cxx17_hc587421_0.conda
   sha256: 3f445c4b66ad27ed9c46b1d30f0aae9789fa739dbe8156c9ca9aa31b375fcd88
   md5: 54f8fe8d7b66347164bbf3544bbe9172
@@ -10440,25 +4983,162 @@ packages:
   license_family: Apache
   size: 1913462
   timestamp: 1770384749003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.2-h6c023e8_0.conda
-  sha256: 35427e640b7852c894f568384a36e07e27ef70d3b4f2ac3e6b658d7dcdf0f5a1
-  md5: 775fe9d0f2f8c22ac9e3a56d2b0f327a
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libarchive-3.8.7-hb3cce40_0.conda
+  sha256: b53751f828019d420954c263c600f18658990cdb70808db407d710a26d5fb697
+  md5: 6c2434e636c663e6cd532d44143588d0
   depends:
+  - __glibc >=2.28,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.16,<2.0a0
-  - libxml2 >=2.13.8,<2.14.0a0
+  - libgcc >=14
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.18,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  - xz >=5.6.4,<6.0a0
-  - zlib >=1.2.13,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - openssl >=3.5.6,<4.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 1860635
-  timestamp: 1761152150940
+  size: 887782
+  timestamp: 1777386329226
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libarchive-3.8.7-h7866cb9_0.conda
+  sha256: 3916a720df2f472c3a953bd8a4f97f9e61e4d21c44f79036f8aa3beca9edd0c5
+  md5: dae6a149f7aab01e0db2b27a7efd6c98
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.5.6,<4.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 946062
+  timestamp: 1777386313184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libarchive-3.8.7-h81558fc_0.conda
+  sha256: 054ef8241a20fe22aaed3514160603fe0fe8aff3637a1c9b058c1fedd2bd0831
+  md5: 9368c8128813db74810effc28a6d0de2
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 783208
+  timestamp: 1777387020815
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libarchive-3.8.7-h8d653b7_0.conda
+  sha256: 729af533e54088cebda836851067d401f93ff3d9dea22957da9ed7e9513779cb
+  md5: 75939536c3ad6fc7145090a812b0bf1f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.5.6,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - xz >=5.8.2,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 844167
+  timestamp: 1777386529375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-0.25.1-hf2ab22a_0.conda
+  sha256: b2f3a2a452022b990a76205957145a567b5aba86910fc20c4e2f853b4687132c
+  md5: 9fe17fea3f12a5dcc483b89f48e361da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52393
+  timestamp: 1772045241614
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-0.25.1-h8121631_0.conda
+  sha256: c924c28f5d6f8cf1640e39ac4e4de0df38ecea4c96b6b62e9d591bd6d64fa5bc
+  md5: 898dd823b7a53a708a69d86847903b0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  size: 52342
+  timestamp: 1772045233389
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-0.25.1-h7b764f5_0.conda
+  sha256: a3295db57bc22c78f922c0ee121ac8dbb0c8dae55a190d248e053075700ce902
+  md5: 6003a1343b04c750a86f6efa2f572aed
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: LGPL-2.1-or-later
+  size: 50271
+  timestamp: 1772045324221
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libasprintf-devel-0.25.1-hf2ab22a_0.conda
+  sha256: a2652c79b33be9f2d2ea0a98dbb5f0b63b16598b4b16600f15f89d98655a1a6f
+  md5: 114f7a7ae6d01b7f5d568439769857f7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 hf2ab22a_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33684
+  timestamp: 1772045249959
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libasprintf-devel-0.25.1-h8121631_0.conda
+  sha256: c110ce6ac4c804889002f0645aeb94ed343a18ada361c74cb04df990a79d89b0
+  md5: 7b561a37cd2af9c7c194c2090e419ee3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libasprintf 0.25.1 h8121631_0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 33644
+  timestamp: 1772045246611
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libasprintf-devel-0.25.1-h7b764f5_0.conda
+  sha256: 0aae2a9792cc32bab39ddac313c2af30276f95065ea98b6451d500ac72e5c46b
+  md5: 31af545e511849b35da42d6fb49795e6
+  depends:
+  - __osx >=12.1
+  - libasprintf 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later
+  size: 33878
+  timestamp: 1772045335253
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.2.0-h32cd6e7_0.conda
+  sha256: a389948434028846cd8a844a0fda48e2dbff9d639563c8cee643f754d30a90cd
+  md5: cdc0bbfec0c99b30d435b22341a716b0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78282
+  timestamp: 1762363571278
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlicommon-1.2.0-he9a0769_0.conda
+  sha256: cac28e3396bf85b57eac6bcacba440e0ad7520d2d7de5539e1196cd3b0ae39fb
+  md5: 607b0beebe5e0c3643f2fceee006d15e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78099
+  timestamp: 1762363467361
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.conda
+  sha256: 6384ef4189390c3831c74d7c370947c0dcb130bbede2c2f384cf831fd8050254
+  md5: 9f83d2c2497e71ef4b3578fbd78bc673
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 77225
+  timestamp: 1762363445823
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.conda
   sha256: 515b14efb88b6a184c3a228df9d735a60505a77d6d0d85ca2efe3fdf26135f7c
   md5: d9c1dc58106b14e5173de685e8593dde
@@ -10470,6 +5150,38 @@ packages:
   license_family: MIT
   size: 87952
   timestamp: 1762363782214
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.2.0-ha2c5f68_0.conda
+  sha256: 475bcf1824c93184cd4f2091481a5e6da5d593c5fc466a53c449e14aa30e850d
+  md5: 7cad8348df1c96bf2f0a697806d1b3b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 33634
+  timestamp: 1762363575967
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlidec-1.2.0-h541720b_0.conda
+  sha256: feada6607f1553123ea75b4568d0ffb0e341e8b36e9ab750b2008c1dc86ad26b
+  md5: 805855f8193938731ccba31427eaa37c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 31209
+  timestamp: 1762363472701
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.conda
+  sha256: 9db56cd97049b73274301c2b9fc8ddb5e103f8c68b3b2a4c04d245c4e5b6fef5
+  md5: 8d41fd7da1d9d44b9ba39ab833f66605
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 27444
+  timestamp: 1762363457191
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.conda
   sha256: 6b9147b66d9807378598c27fc5fff2e3eb3eaa807036d0c18c0d90778f612260
   md5: 6571166b6a690d451fbf6500c4ffba2e
@@ -10482,6 +5194,38 @@ packages:
   license_family: MIT
   size: 40440
   timestamp: 1762363799309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.2.0-h2e96acb_0.conda
+  sha256: 31c153a8165bef6673fb460b9dd4cb6ed4904585cc455ab827282044fcfcce95
+  md5: 854af1d6af8b3565fa8c7edb2141a2de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 h32cd6e7_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 279951
+  timestamp: 1762363583050
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libbrotlienc-1.2.0-h1377268_0.conda
+  sha256: 15339597609bf4c673c4aeb33e41ac58e2f08b08ad4a9fe00c477eaca1a4f056
+  md5: bfc1f2cb23c1f160079289f797e97756
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon 1.2.0 he9a0769_0
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 286206
+  timestamp: 1762363480172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.conda
+  sha256: 4c70015a24a73ce6559c98b59c35d960661326e6fd218e5aa3d074b9ab34441f
+  md5: ae2005cd80e3d845fe71ab43f4dadd73
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 294292
+  timestamp: 1762363468368
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.conda
   sha256: 5ff2563603fe5f0114da382bc0de34b060751a6aea9690f919fd20fdf448c3be
   md5: f2b21ddeba6f3dc5b3206b6913128cc8
@@ -10494,6 +5238,71 @@ packages:
   license_family: MIT
   size: 259203
   timestamp: 1762363815702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.20.0-hd8fa685_1.conda
+  sha256: 558a029dd317c9610f257fd73a210917c76c6d6ec5de1471ae3d432d6f3fc277
+  md5: 0bce5ed9e5696f46b16b074cf643265e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 502712
+  timestamp: 1777909373160
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libcurl-8.20.0-h7563a4b_1.conda
+  sha256: 1f602c45ac9a23c025ab7d4cabaa9a700d4290030d3b6a3a0d895e45f2b37bdb
+  md5: 30adc3614fcd17e672ee6edb8ad7f4c6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 519428
+  timestamp: 1777909391095
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.20.0-h033922a_1.conda
+  sha256: 326fbb0c80960cbc989eb48910ea7e5a4376f709e3737279c21df80b0780c634
+  md5: f8cb177ffaea62f25e41174bf7ee97ba
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libidn2 >=2,<3.0a0
+  - libkrb5 >=1.22.1,<1.23.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.69.0,<1.70.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 405787
+  timestamp: 1777909422116
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.20.0-h9440e04_1.conda
   sha256: 9e17afa766dccfafffb5a32fd80c81f89c23b40d22c518cb9ee4b89bcd4cf6ab
   md5: ab923b442ef1342c787c7dc3242118b0
@@ -10513,29 +5322,301 @@ packages:
   license_family: MIT
   size: 451035
   timestamp: 1777909579462
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.5-hd7fb8db_0.conda
-  sha256: e30d43671816e39e4b1d49120cd25ee0a38080f207bc7e230c8abf4eeae347f5
-  md5: ea2ebdfc4a16a5cbc06d09a374f62f34
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-22.1.2-hf894667_0.conda
+  sha256: 7c72e11f71def84a9737daddc3a8b5828a77db918dbbfdf087cd86cfc6ec2fc2
+  md5: 344e08f75d799c1e5b57441a2a4c357d
+  depends:
+  - __osx >=12.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 316282
+  timestamp: 1775479658335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.conda
+  sha256: 75f04cf201848d58df127caf9f316f71e1103b28e00b5add9b0c8025e52d7569
+  md5: 5065620db4393fb549f30114a33897d1
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 114011
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libev-4.33-hfd63f10_1.conda
+  sha256: 48db4f9854b48cf3bf113d2870d95bd9587c5cd40a34638f850c7fbc944be95f
+  md5: 230e8093b929e64244f2c7e181705802
+  depends:
+  - libgcc-ng >=10.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115539
+  timestamp: 1619012635485
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.conda
+  sha256: 553d09ddd69a6efb5bcf6cc225ef27c573f5df27199dd03ecbcf006ec844beaa
+  md5: 00cac99189c361c3b2cbf506ae6cc718
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106490
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libexpat-2.8.1-h7354ed3_0.conda
+  sha256: 57a21ae2dba96d6418a06c0631d36ba16d290840bed8fade3b5feeb527cfc3d2
+  md5: b9cac11f36e352a3c78662310d88ee91
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 126462
+  timestamp: 1779874382476
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libexpat-2.8.1-h5b11e9f_0.conda
+  sha256: a08e2c5d1229d1dde5bd6ef44fa933b61fef6f33a7b1fd1b7a346e46244537f7
+  md5: 2b2a39542506c31ba21df82aafee564d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 120742
+  timestamp: 1779874407783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.8.1-h50f4ffc_0.conda
+  sha256: 9ebbfa7b71762954befc42968df4b7728845ab7add2dcb5a8bf4ab033950eb71
+  md5: c21c46d2abc33b9cdc13d8154df31e39
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 112959
+  timestamp: 1779874356035
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.8.1-hd7fb8db_0.conda
+  sha256: 25046714ee1942c1e28b61335ef07d483f16c86baa4fe7150b06fc6f1b2c2791
+  md5: d237326a5202bcb08333c8431ff77c68
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   constrains:
-  - expat 2.7.5.*
+  - expat 2.8.1.*
   license: MIT
   license_family: MIT
-  size: 123312
-  timestamp: 1774555907563
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.conda
-  sha256: 43a437fde4c064b2f1be2342a7bc6edccbc13da6a4fb8a44d87e4e6e34c54b63
-  md5: 9807b377e11739ae3e920e10e607e460
+  size: 125019
+  timestamp: 1779874537343
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.8-hc5d346e_2.conda
+  sha256: e3fbc1100922e09b9e472ae1e92d0b83438e559f4817a55da34288890e56a087
+  md5: f87fb1388f53485d805e355356566519
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 124747
-  timestamp: 1714484319443
+  size: 139680
+  timestamp: 1777296450587
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libffi-3.4.8-h89d793c_2.conda
+  sha256: 56ee541a21e585e93f12656207573904360862a3833f4cfdaa421926fe9eb165
+  md5: dd2e20b9a0d36cf7ac77f33519a92d43
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 135199
+  timestamp: 1777296435963
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.8-hcfc0b96_2.conda
+  sha256: 2cb0390c3c0ef4078230cfd95030013a59d3f48ace554b7406ee50fd85cfbf4c
+  md5: a491d121dadb72e44774af37f9737e96
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 118699
+  timestamp: 1777296337593
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.8-h2b21627_2.conda
+  sha256: df0ee82af2a982e25d6592fd9dab2e1fcc9314708156888a45f1f5af3c6ce324
+  md5: 69ce09a0b01c764627f0f1b0272bad48
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 120596
+  timestamp: 1777296713086
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-15.2.0-h69a1729_8.conda
+  sha256: 10fbca6e0cc0da1018f82f3c92e3841e734e704dbfee5df88ae652a49d8b402f
+  md5: 44a53b93cf0953bde4b0f4e610cef1c3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex * *_gnu
+  constrains:
+  - libgomp 15.2.0 h4751f2c_8
+  - libgcc-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 822224
+  timestamp: 1779212817826
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-15.2.0-hc18542e_8.conda
+  sha256: 71fc8b5195cb0724371da87c77c45c0428ae6686f5735709315eb54e9948f64b
+  md5: d7b72fca6c8e51b78b9a278a48535717
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex * *_gnu
+  constrains:
+  - libgcc-ng ==15.2.0=*_8
+  - libgomp 15.2.0 hf47c802_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 511167
+  timestamp: 1779212371593
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-15.2.0-h166f726_8.conda
+  sha256: 3b4b734309a58b3ded42e01aecfbb91b029ad22d768a4c9f0f4f0006a3172203
+  md5: b3f01816cd1e046648fff257be7b0248
+  depends:
+  - libgcc 15.2.0 h69a1729_8
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28452
+  timestamp: 1779212820023
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgcc-ng-15.2.0-h51576c1_8.conda
+  sha256: fc466a301a5e41ca638920f241b0732c00bf503f466dc0504ea8fb8ecf5bc6e3
+  md5: 09df5fac4dec4376d90942c40dede152
+  depends:
+  - libgcc 15.2.0 hc18542e_8
+  - _libgcc_mutex * main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28472
+  timestamp: 1779212373309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-0.25.1-hf2ab22a_0.conda
+  sha256: c1585ccdee3503c2e055014197f63b99ac47a7493c612beef2162cbdd9f5528c
+  md5: 775a5698ec2a0aa6e2435b86418b563f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 190134
+  timestamp: 1772045245717
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-0.25.1-h8121631_0.conda
+  sha256: cf0bd6eca4badbe25be91962c8d57317eab391c5f013f75098ee5c6d97988100
+  md5: 3c39fd72e5a005e81c78cefe0f4b0464
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 214938
+  timestamp: 1772045240107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-0.25.1-h7b764f5_0.conda
+  sha256: 990d09632f566d8fa499d67fe53c307ca451065997ef2f0028534608fffa26cc
+  md5: ff87319dec2259db334819119e4a3c2c
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: GPL-3.0-or-later
+  size: 177749
+  timestamp: 1772045341415
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgettextpo-devel-0.25.1-hf2ab22a_0.conda
+  sha256: dcf5a9cf369a65a01367967177721b943a2927fa4305c4b4d04d80764d943f8c
+  md5: 5766eead346251db288d5b13c3dffd6f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 hf2ab22a_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36248
+  timestamp: 1772045253856
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgettextpo-devel-0.25.1-h8121631_0.conda
+  sha256: d9884f3f7bd0abd6aba1c96380662d07ecc148e5bccd835e3938cea89eedbba4
+  md5: 60521b8fbf132abc3846a700f33374cf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libgettextpo 0.25.1 h8121631_0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-3.0-or-later
+  size: 36215
+  timestamp: 1772045253063
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgettextpo-devel-0.25.1-h7b764f5_0.conda
+  sha256: 21e809a6b0499e783e55e7cfe36a2df5863c3b7dfed70e73234c38dfc334a235
+  md5: 0b6fe86a04c739e37aa3306bc2ed653e
+  depends:
+  - __osx >=12.1
+  - libgettextpo 0.25.1 h7b764f5_0
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: GPL-3.0-or-later
+  size: 36532
+  timestamp: 1772045351234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.78.0-h79c45ec_0.conda
+  sha256: 541776a694883dce096ada81ae9afd0c740e6f66e056c2e0f36125e3a48ce4ba
+  md5: 91b626db75392fc7254aaad8dc9a9850
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7252351
+  timestamp: 1770755115633
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libgrpc-1.78.0-hec5afc2_0.conda
+  sha256: 65a0abbec427bc3bcf64bb34340be478e1f37b72fc54c0f923ed7c201b4a70ec
+  md5: eb5839753b2b8904f6d7107d6240ef23
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6933116
+  timestamp: 1770754985299
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.78.0-h7694377_0.conda
+  sha256: bee87fb12f38081e6274ac7d8e945d519ea94c9d4e04c8606206b3e98641d23d
+  md5: 39336ad943dcc5f88ad31e32f1c4c66a
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.0.19,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4848994
+  timestamp: 1770754583246
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.78.0-hecd3d80_0.conda
   sha256: df06429097725d99abf7e174d53454341dc4802b0c4dc9d8cfa3d8dcd6f31fb8
   md5: 714d58c2bb7a1b39978b6fe7011d9876
@@ -10557,6 +5638,32 @@ packages:
   license_family: APACHE
   size: 11897881
   timestamp: 1770755767693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.18-h75a1612_0.conda
+  sha256: 8852881ce7522ad4b9eb45ba94cd353f6b381ffd3f9fb5d31426ce2abd8c3ab0
+  md5: 14e4ca2d3797abc3c78ca0ce0e3d9c17
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 789520
+  timestamp: 1771491869505
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libiconv-1.18-h5773563_0.conda
+  sha256: 9be254c07520edfa29369faac79f33e0fade35730e8a2a91485c930ed0e25404
+  md5: 5eeac8fcfd3327525c9aedeb9cf8e7e8
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 778215
+  timestamp: 1771491870922
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.18-h92f5915_0.conda
+  sha256: a27dc69e68b856cdf1170001e570eac0876b5cb160b3b275cc79d8ac5e7bbc0e
+  md5: efcf143adafc878192a4ab5252f4cacb
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-only
+  size: 749113
+  timestamp: 1771491894949
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.18-hc89ec93_0.conda
   sha256: 73e19e873fad84ca239ccfd53a51830a8004a14b388a9d30a8c09ce3b8b386a2
   md5: 53c556b8109eaab09231874106a025f3
@@ -10567,6 +5674,106 @@ packages:
   license: LGPL-2.1-only
   size: 703101
   timestamp: 1771491956799
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libidn2-2.3.8-hf80d704_0.conda
+  sha256: 675beb2f9d9c876b87601b043d7e9e3b87cbec6b2172453932602db74e0099d7
+  md5: 7ab70b332bb2df9ce90a1567126b5d2a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 82352
+  timestamp: 1760364378431
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libidn2-2.3.8-hdd5c969_0.conda
+  sha256: 587aa1813f16530ec81e871d34ad4eaacbe9e4c0a4877003e61ec0dbb6340b81
+  md5: 5bd529c1efa0251f0cebe7f84a504f69
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - gettext >=0.21.0,<1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 119389
+  timestamp: 1760364375350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.conda
+  sha256: bdd1c89fbb3b02907799131cb5a436200d134277cdb9dbebab77ebbd28a68e97
+  md5: 4caba2988c52534c6ba5e88afebba106
+  depends:
+  - __osx >=12.1
+  - gettext >=0.21.0,<1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 114873
+  timestamp: 1760364408172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-0.25.1-h7b764f5_0.conda
+  sha256: 3ac68c21c6ef9200dcb2d66f33d9164197876f0107cac807c9f3fc4ab644cde8
+  md5: 71d922b1c84b98246a9990d29cba6e92
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 84499
+  timestamp: 1772045330319
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libintl-devel-0.25.1-h7b764f5_0.conda
+  sha256: c7a27dcec6a9b8aa4d24345e201dfd9c9b8c857e08bf3b7173431ff8795dbdcb
+  md5: bc68d80a543744b8b36a957ca8a7f024
+  depends:
+  - __osx >=12.1
+  - libiconv >=1.18,<2.0a0
+  - libintl 0.25.1 h7b764f5_0
+  license: LGPL-2.1-or-later
+  size: 39263
+  timestamp: 1772045346385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkrb5-1.22.1-h869c75e_1.conda
+  sha256: 9537c247898fcc6ebc32a7e0454e0b73825e7fd056fc6cdb2d6f3a9333b8bddd
+  md5: 3fd122ff074ed6bed89994053feb1fe3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 804625
+  timestamp: 1775137912599
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libkrb5-1.22.1-h6cab0e1_1.conda
+  sha256: cb01106ff500f91982a885b86002fd82565bef1172c5d2da2e47b89e59596b9a
+  md5: 690464725d117c8ec5194f57b56525b5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 845865
+  timestamp: 1775137916299
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkrb5-1.22.1-hbbdc3aa_1.conda
+  sha256: 8132c7e25e35deaa37898f358c8517d1ba76ab914dd6e440f439fa8d2ff3a796
+  md5: a7963ec6f60d80d694f71d78d026c7a0
+  depends:
+  - __osx >=12.1
+  - lmdb
+  - openssl >=3.5.5,<4.0a0
+  constrains:
+  - krb5 1.22.1
+  license: MIT
+  license_family: MIT
+  size: 666710
+  timestamp: 1775137965346
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libkrb5-1.22.1-h3d06f0e_1.conda
   sha256: b179996d88eb33e2d0adc3418ee08c04dea5b96e49f76502c09af1643f8d9245
   md5: 7cf3e0d3e8de34c05bc06825387cc5d5
@@ -10580,46 +5787,189 @@ packages:
   license_family: MIT
   size: 693609
   timestamp: 1775138282724
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hc213065_1.conda
-  sha256: 64af08eb355d00b312560535c40415125deb59495ffaa567effc611309d69ede
-  md5: 7fae14d333102ededdc1f1e7f2977d4d
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmamba-2.3.2-he97f470_3.conda
+  sha256: 516dd619e0f1ea8b5563c9bbe2ca77bb37b08b06ee2803f6b7a4354766f52c45
+  md5: 717a40340cf56728dedb6ae3d76afe64
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx >=14
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2231146
+  timestamp: 1779881576781
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmamba-2.3.2-h5c8e501_3.conda
+  sha256: f99628f2f7381393808e658ef50a733d1d0197650c7cd788ce89c75a68232b28
+  md5: 46b52c2baac20d3c83becdb333d4fb80
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libsolv >=0.7.30,<0.8.0a0
+  - libstdcxx >=14
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2083126
+  timestamp: 1779881585683
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmamba-2.3.2-h4b9b42c_3.conda
+  sha256: 4bbf9f6b7921815c2a660f02d944c0f07077eda8147afd6103efda6bb3fd18f6
+  md5: ef5038993841784a4d2d26d2fd432b0b
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - cpp-expected >=1.1.0,<1.1.1.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libsolv >=0.7.30,<0.8.0a0
+  - nlohmann_json >=3.11.2,<3.11.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - reproc >=14.2,<15.0a0
+  - reproc-cpp >=14.2,<15.0a0
+  - simdjson >=3.10.1,<3.11.0a0
+  - yaml-cpp >=0.9.0,<0.10.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1468057
+  timestamp: 1779881399341
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libmamba-2.3.2-hf4f7140_3.conda
+  sha256: a3c59714e8af649ef281a051679b28d378f325d896220b163063204dbb6841e0
+  md5: 69166d59baab8da559185e65f546ab37
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - cpp-expected >=1.1.0,<1.1.1.0a0
-  - fmt >=11.2.0,<12.0a0
-  - libarchive >=3.8.2,<3.9.0a0
-  - libcurl >=8.16.0,<9.0a0
+  - fmt >=12.1.0,<13.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libcurl >=8.20.0,<9.0a0
   - libsolv >=0.7.30,<0.8.0a0
   - nlohmann_json >=3.11.2,<3.11.3.0a0
-  - openssl >=3.0.18,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - reproc >=14.2,<15.0a0
   - reproc-cpp >=14.2,<15.0a0
   - simdjson >=3.10.1,<3.11.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  - yaml-cpp >=0.8.0,<0.9.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - yaml-cpp >=0.9.0,<0.10.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 4596223
-  timestamp: 1763112028349
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h364efb6_1.conda
-  sha256: d7f859d0cf60805f7759162ec5fb3faa9fd97f6279e7b596e632e459471c6cec
-  md5: 3d64e598adad837e3aa2fbb2ec352298
+  size: 4616286
+  timestamp: 1779881598384
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmambapy-2.3.2-py313heb26620_3.conda
+  sha256: d63244b197b8c19b88ad8f489853c9b8012e7086ec7867c49c9138b62769ceac
+  md5: f927b2cc31e8c82f17ef4bab5d7c9bdf
   depends:
-  - fmt >=11.2.0,<12.0a0
-  - libmamba 2.3.2 hc213065_1
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=12.1.0,<13.0a0
+  - libgcc >=14
+  - libmamba 2.3.2 he97f470_3
+  - libstdcxx >=14
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 697719
+  timestamp: 1779881653608
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmambapy-2.3.2-py313h8125cf1_3.conda
+  sha256: b177e5d4df46b07196442175e38c7be1bbff0a0a0d70c6936f36b21338721553
+  md5: 62a7292bd6ed424c0b0d05dcf9786b17
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - fmt >=12.1.0,<13.0a0
+  - libgcc >=14
+  - libmamba 2.3.2 h5c8e501_3
+  - libstdcxx >=14
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 597015
+  timestamp: 1779881686575
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmambapy-2.3.2-py313h678a34b_3.conda
+  sha256: 7cd815d87112dcb2035d3f3c98991d13252ad6512215a3befb194717fc3ebd76
+  md5: 639e171bd0fb549293a84769c65cb9fa
+  depends:
+  - __osx >=12.1
+  - fmt >=12.1.0,<13.0a0
+  - libcxx >=19
+  - libmamba 2.3.2 h4b9b42c_3
+  - pybind11-abi 5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 587635
+  timestamp: 1779881457155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libmambapy-2.3.2-py313h0016b16_3.conda
+  sha256: b1aaaf6f95d98aad22841f06d201dfdcf6daac6de68d7066070ee2686e67c8c4
+  md5: 8ccdbfc1bd0fe79f629811cce97d6700
+  depends:
+  - fmt >=12.1.0,<13.0a0
+  - libmamba 2.3.2 hf4f7140_3
   - pybind11-abi 5
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  size: 454648
-  timestamp: 1763112121992
+  size: 460953
+  timestamp: 1779881725601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libmpdec-4.0.0-h5eee18b_0.conda
+  sha256: 61e359466b780d45fc0af671a3959c1877ee68b30b9afb41b8bd112618735cab
+  md5: feb10f42b1a7b523acbf85461be41a3e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88085
+  timestamp: 1726088449399
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libmpdec-4.0.0-h998d150_0.conda
+  sha256: 89e71736f3ab2ca4cca99e79f2e5b1832f21a5a69b1667628f13633e3749fce7
+  md5: 8bd7f4c495a81af4914c899949e52542
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 125873
+  timestamp: 1726088467322
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libmpdec-4.0.0-h80987f9_0.conda
+  sha256: f9b80c20080496cc40ae74500a1944d6a30eadad138fefa8f300bc3a6a4e80b0
+  md5: 7b01d2d5e276a24dd44e7846406656ed
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 70527
+  timestamp: 1726088461517
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libmpdec-4.0.0-h827c3e9_0.conda
   sha256: 3851b0985a481e019440ee2720bdfe1a98fe4db8cd67f8cc16333a0fa40f38df
   md5: a294b317c2e3732cafdba824a893b80c
@@ -10630,6 +5980,100 @@ packages:
   license_family: BSD
   size: 96993
   timestamp: 1726088489806
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.69.0-hc59f8b6_0.conda
+  sha256: ef1003b384126778b7d8b88178cf420b2cf15b55e0d9a55ef07166d7a60d48cb
+  md5: 20413e902c09e4d6ecb5ee6a3d27daf5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 663027
+  timestamp: 1777386823667
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libnghttp2-1.69.0-h2dcec1c_0.conda
+  sha256: 73c5d4b23aef0612d4a473363fec915c892998787b64e58dc29f910e904dd0e4
+  md5: 6f4ab95ca13542c93cd2de03cdc058da
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 677342
+  timestamp: 1777386816636
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.69.0-he427349_0.conda
+  sha256: 661509c2dc7db71bef7dac380aab53739fd13e3843af17931d70b284d8c5692f
+  md5: f448ad808be344b2991d1da2d2f2fe84
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.34.6,<2.0a0
+  - jansson >=2.14,<3.0a0
+  - libcxx >=20
+  - libev >=4.33,<4.34.0a0
+  - libxml2 >=2.14.4,<2.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 563791
+  timestamp: 1777387060041
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-6.33.5-h4435b4a_0.conda
+  sha256: 8b0e109080d826f0a676e6c3261b48580ab9a76cf7fdfa7b579a884db25dcf54
+  md5: 0801fbfd982d1a0de5cc895fed83a19c
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3703875
+  timestamp: 1770634775371
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libprotobuf-6.33.5-h2b0f679_0.conda
+  sha256: 5b3501bbb01c129ce8046693f0f7ded6be9c7e59db60d248bfcb858d8896b6f0
+  md5: aa2d494311b59791b542ceedfc12ff2e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3507714
+  timestamp: 1770634686006
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.5-h55f9a99_0.conda
+  sha256: 6dd05b41bbc78fca07513b9adeff3091e7cc8ef3d89b9a97104b39ffdbee0183
+  md5: d45781f34f4b8e74d5b279e2e5d82c25
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2735206
+  timestamp: 1770634426661
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.5-h65d7223_0.conda
   sha256: dc02d4091ddfcae738ed17ba6ddbdeabfacdfa0b26f8a9332ad612925654630b
   md5: 11b8833fdd04816bf58e8b1fec3512ae
@@ -10644,6 +6088,50 @@ packages:
   license_family: BSD
   size: 7207712
   timestamp: 1770635087009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2025.11.05-h3356fce_1.conda
+  sha256: 57c3216b7bd72f551863b2f0038b10a73432ffd54300a4963638deb9bfd46c10
+  md5: 0767b8ade520f4927ff9d5866d783f6b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210465
+  timestamp: 1770390434417
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libre2-11-2025.11.05-h1b0d54c_1.conda
+  sha256: c7928aee7e68013874b3c891b5ea62a008a6c584e730b73005a2913363d65688
+  md5: 2d6e1172997c845d903d346b97494c07
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203733
+  timestamp: 1770390557525
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hce96306_1.conda
+  sha256: 79c888b9d8e2e2fad78155cbb797e1c70ba07131ebcc9fa42ce241d89f2ec2c1
+  md5: 44b6b0d291189d289f38fa7bba97d117
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=20
+  constrains:
+  - re2 2025-11-05 *_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 164100
+  timestamp: 1770390432249
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-h797e85b_1.conda
   sha256: b3f1b5da9830d15c3505d474343658df271e6ca633499acd268e224257905034
   md5: 531ca8049bd88d4df53d3a58643f31ec
@@ -10659,6 +6147,44 @@ packages:
   license_family: BSD
   size: 272314
   timestamp: 1770390642712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsolv-0.7.30-h6f1ccf3_2.conda
+  sha256: 7a04f79942f6d2ab8004fc61fa663a9fbc020bec723a45db19d56b81e4bedcf5
+  md5: 0d547d53349f3fcf4a20c9a207c08a3b
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 465860
+  timestamp: 1760357067289
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libsolv-0.7.30-h47ed150_2.conda
+  sha256: 1fa267517dcb321545fb486f1ce564cd45b8680659cbff4fa933b74922cb276c
+  md5: 40c52830df19329c37dd2f093eb944de
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 471404
+  timestamp: 1760357069476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsolv-0.7.30-ha443353_2.conda
+  sha256: 1c6d257d1bb7f3101bfe85ad5cd7dfde34f114232adc2184c7af8274d1e35095
+  md5: f39e89f9206a2366089b09a7cd209cf5
+  depends:
+  - __osx >=12.1
+  - libcxx >=17
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383544
+  timestamp: 1760357075048
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libsolv-0.7.30-h23a355e_2.conda
   sha256: b0f6d1ed7cd48d37ae9c1ba34c0fb70baded93a09718c29c6ecf924dd8e0165c
   md5: 0ae4849097816b4452e8fe8a28376a61
@@ -10671,6 +6197,38 @@ packages:
   license_family: BSD
   size: 444021
   timestamp: 1760357137426
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.conda
+  sha256: 57da13c06557d7d6f21a0ac6d1e83a3e990d2217adcc4dc395009eb56ed040a2
+  md5: dd68c24355431c0543339dda1404129d
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 315187
+  timestamp: 1732891131339
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libssh2-1.11.1-hfa2bbb0_0.conda
+  sha256: d4e824be8f9f63f4118733c41cbbcae49631bc74514898242fcccaa62889e677
+  md5: a88e620d4eafd7f199a0502433e5e0c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332414
+  timestamp: 1732891127645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.conda
+  sha256: 379ad3bd0f5024416dd1855cad4391f1891e23f7f07802732bf22ffb5f171486
+  md5: b5aa2854a5872c57538743b4a85a731d
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 298763
+  timestamp: 1732891144732
 - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.conda
   sha256: ff2d46c586844c88b62ef6bb1419f89690a9e4db714ed2cdb3589ffdd0d8ef9e
   md5: d8ae56ee95db60cbd5f8f8ff63ed1f63
@@ -10683,32 +6241,307 @@ packages:
   license_family: BSD
   size: 319541
   timestamp: 1732891385479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.conda
-  sha256: 7f90427c984b96deda664a993dcda120490c955c2298cdffc9860f20f7caf1e0
-  md5: 32feaa8872e9a7c839069a0c2a37df20
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-15.2.0-h39759b7_8.conda
+  sha256: 30b7a96c0f1f527d16ec9ec7f80404f34d4b916332cca0634111ed077d7fc870
+  md5: 157776d72d1eba48854127f461b729cc
   depends:
-  - libiconv >=1.16,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
-  - zlib >=1.2.13,<2.0a0
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 h69a1729_8
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3902423
+  timestamp: 1779212830666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-15.2.0-h9538471_8.conda
+  sha256: 95b8d1cb433ee7351351e613e3e255967d517eb0eeaedec340818aa6aa90c6e4
+  md5: ad52ae62540e04578c90125eebafa228
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc 15.2.0 hc18542e_8
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3830999
+  timestamp: 1779212383079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-15.2.0-hc03a8fd_8.conda
+  sha256: 35c3aff92b054a79655da09d4435faefcd7b23303d225b327065db9d263766ed
+  md5: 1b632358fe0c3badbd77b81ac05a48c2
+  depends:
+  - libstdcxx 15.2.0 h39759b7_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28504
+  timestamp: 1779212854288
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libstdcxx-ng-15.2.0-h719ae8e_8.conda
+  sha256: 56fed649a8357e75320a12f5dc69f8d463ac38f62a808b032d784db913df30b6
+  md5: cece8ba0b16cc5921d56a6b2c808f8ed
+  depends:
+  - libstdcxx 15.2.0 h9538471_8
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 28510
+  timestamp: 1779212405030
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libunistring-1.4.2-h34b0ebb_0.conda
+  sha256: 5d93f88055782e98e7026632aa161bd46ebef47067811e25ba19ee0c4f4bad13
+  md5: e79c628574f0ed3b60bd63e6d78501a1
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 671850
+  timestamp: 1777465777755
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libunistring-1.4.2-h8a6ccf4_0.conda
+  sha256: 61bfcb16676e50beb194b3b8317954b7a6315682cf94266f431f7a6b11a1d376
+  md5: a99663395dab887607b2e5a854389721
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 676495
+  timestamp: 1777465771156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.4.2-hd80fe18_0.conda
+  sha256: 18c9b2617be1ab24291c2c8e6e97f6ac23746902d0ee74f9826c788de751ac3c
+  md5: c457b6d1695d1b5b054632d2d5895517
+  depends:
+  - __osx >=12.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 644497
+  timestamp: 1777466299217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.conda
+  sha256: 2a401aafabac51b7736cfe12d2ab205d29052640ea8183253c9d0a8e7ed0d49a
+  md5: 4a6a2354414c9080327274aa514e5299
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28110
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuuid-1.41.5-h998d150_0.conda
+  sha256: eb8b7877795b5a27d0d4ecfe4e6e103362869362472f301a0c94dad8662e8618
+  md5: 59cd225a7659291aa716c6cdae7e1363
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30035
+  timestamp: 1668082742967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuv-1.52.0-heb5a705_0.conda
+  sha256: a3ffd81bc60a76c78d1e5be3057874feab6a7b89f1e6f274f84cf5315b840598
+  md5: 5c9856df3c68271bf8d0f6eaa1513e3a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 1531227
-  timestamp: 1761769014771
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.conda
-  sha256: 0478d0e08e9737e6680343cd26380d8faf4f038bb59170818868cd2fb69e5481
-  md5: 1e313539489432d5edd44efbec8a4d53
+  size: 901634
+  timestamp: 1772644974924
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libuv-1.52.0-hdc642fd_0.conda
+  sha256: 36fe8711764c8d91bf9861d4642b80c5ec5d22008325763942a66c009f1f4a81
+  md5: 52b484c9618823592d2c26632724dafd
   depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 594684
+  timestamp: 1772644989262
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libuv-1.52.0-h8e34c70_0.conda
+  sha256: d7a69a10437fbe030e3641513046b004164e024f52c4ad3a1afc6bb25a8ca401
+  md5: 5b151376f98c09831d6bd730ca7794c8
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 418963
+  timestamp: 1772645021860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.conda
+  sha256: f9cd1564fc83261ddba7496404f18143d4f8fda52e42c040005c1b1ad3e47f56
+  md5: fdf0d380fa3809a301e2dbc0d5183883
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 440690
+  timestamp: 1746022211479
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxcb-1.17.0-hf66535e_0.conda
+  sha256: 9f4a115a48f07a881abfaa501948db678f63592246af9a6d5ee0609301802bd5
+  md5: 28e00a696fd74b7550b7d1b8698e10af
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 443363
+  timestamp: 1746022227484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.14.6-hf2a51f9_1.conda
+  sha256: 459abeddcd64df95b09e2d9d2d92bbe980ad20ef7294a36928977d94742a93ec
+  md5: dffa9db432bf2a7be752498a5d4fa1ac
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 660718
+  timestamp: 1778673166461
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libxml2-2.14.6-hfdc530d_1.conda
+  sha256: 8a5b4ebdb32935b5be251cb82c2754bd83a9eeecbacd6df11091793be65351a3
+  md5: fffd28c6e7836b329aae76a4da1ddecf
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 655891
+  timestamp: 1778673050392
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.14.6-h1ea6aa3_1.conda
+  sha256: 4cd7a61c92db1c7a436d33416d6e139baee110b322bb49046ee06381e5ac8c1d
+  md5: b9abad7050cac8a791658fa62882650a
+  depends:
+  - __osx >=12.1
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.16,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.8.2,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 557652
+  timestamp: 1778673082116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.14.6-h42c6e62_1.conda
+  sha256: 9e07b51fb07fb6f08a36c23e4dd1cbee30903a256e2562a05d9a9e0576406623
+  md5: 1487ac6819634ff356aae28dda68008b
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 851922
+  timestamp: 1778673294879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzlib-1.3.1-h47b2149_1.conda
+  sha256: 45de7095ec747c8d0e3e47af6f74ff9cbb208473f42b940a284e1998c248b173
+  md5: 7623ef4b77936f7670f6f906c6af4f3a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
   constrains:
   - zlib 1.3.1
   license: Zlib
   license_family: OTHER
-  size: 65950
-  timestamp: 1756476045869
+  size: 60093
+  timestamp: 1776974326015
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/libzlib-1.3.1-h27118de_1.conda
+  sha256: ed2d5f9f5ad9efa6b28163dd79c89f65dacc3cba874921feef961ff06203c809
+  md5: fc57a6ca6d0f766b9d8a96a883afed16
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 59675
+  timestamp: 1776974322337
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-hb4cf58c_1.conda
+  sha256: 39df4501327dc21f6ddfd129db23c9ee6cda4c737c1f1a91e700aa965f8febb6
+  md5: 6cdcab9318862201eb86f27e7efcb7e8
+  depends:
+  - __osx >=12.1
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 44567
+  timestamp: 1776974334576
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h1c6eee0_1.conda
+  sha256: 673d46c51c391e52eddf4fecf3418e727fae4750ce4ecdc98b9de8625a0fc85a
+  md5: 2196721c1cfe5eeb83a9f7f4642b2eab
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 63482
+  timestamp: 1776974452152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lmdb-0.9.31-hb25bd0a_0.conda
+  sha256: 839f0cd7e4a13088dcd9b8ac3213e8992725dd67f8e1a747c54132013b87d4b9
+  md5: 1468bc20414b0fa8eb1b18d3a916039f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480121
+  timestamp: 1754999718088
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lmdb-0.9.31-h998d150_0.conda
+  sha256: c234a53487218459e41273f23d43bd92185e0d35ca667a41abae3ae804c94647
+  md5: ff7911a6103418a2c907d8c0262dd7f2
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414985
+  timestamp: 1754999724928
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lmdb-0.9.31-h79febb2_0.conda
+  sha256: 30f28b8d1eebf4c7bf9600c7fcf4147bdd2b40d0be80326a5994270d6de5f0a0
+  md5: f64afc713eac7e8bf402173915c58ccf
+  depends:
+  - __osx >=11.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205738
+  timestamp: 1754999716617
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/luajit-2.1-h47b2149_0.conda
+  sha256: 54e7711f01d164dc5bd2acf4345b59f38ca48e20b179a4a09de5ab7fc3ee6628
+  md5: 6f3445d61b923a4e22a50b4ede3c1865
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 377746
+  timestamp: 1775637820996
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/luajit-2.1-h27118de_0.conda
+  sha256: cfb6c8794e953d4916360fb5f72c3f32f495ad9c177cbe23733ff1708462e6ae
+  md5: 77eab2a2d275f56e722b1aad11532fd3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 376687
+  timestamp: 1775637816376
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/luajit-2.1-haa24f5a_0.conda
+  sha256: 9193a8452110a692115867a72abf9940989071b6dac14aa9079f078fc4fb0e1c
+  md5: e535d29ea97147f0f6fb78a5a40c389e
+  depends:
+  - __osx >=12.1
+  constrains:
+  - lua <5.1|>=5.2
+  license: MIT
+  license_family: MIT
+  size: 374612
+  timestamp: 1775637687250
 - conda: https://repo.anaconda.com/pkgs/main/win-64/luajit-2.1-h1c6eee0_0.conda
   sha256: 2322b012e84cce27d934eca4c8f7e092c3bcd05c7d8ab8ebafc66a83b6d8473d
   md5: 3217ea6e26ad49643fd3b26a727b63be
@@ -10722,6 +6555,44 @@ packages:
   license_family: MIT
   size: 617767
   timestamp: 1775638149997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lupa-2.6-py313h47b2149_1.conda
+  sha256: b52460d03668dcd7caa7c12d944c98892f085e8510e77cdbc64c36418459a1ec
+  md5: f4ae4fa14f9db66b6fb9f4b72cc55bc4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 150496
+  timestamp: 1775657630843
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lupa-2.6-py313h27118de_1.conda
+  sha256: c8952e2623c4e89a0c3086a3ffdac5749a2912298c4a9b3bcafc239100ea4a52
+  md5: 8a1c323359558fc4a4df9191aa6d00fa
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 143384
+  timestamp: 1775657550865
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lupa-2.6-py313haa24f5a_1.conda
+  sha256: 424cc412f205a886f5da6d45bc08c6098a24428b09c434dc785e9d25e5151941
+  md5: 8b33a63dd414c362bc478d44fa6cad6b
+  depends:
+  - __osx >=12.1
+  - luajit >=2.1,<3.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 122459
+  timestamp: 1775657525476
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lupa-2.6-py313h1c6eee0_1.conda
   sha256: a5456a9662c69cde19382f8d51817dd9582fc05b74490abb69e1301d19c41e07
   md5: 10caec6073639ad0e7f2c01d186952be
@@ -10736,6 +6607,35 @@ packages:
   license_family: MIT
   size: 136199
   timestamp: 1775658064658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.conda
+  sha256: cc19d62a7f2c0af8e1f0e5bf643cf34475a35d5dc82733d679e575daa7b863aa
+  md5: 2ee58861f2b92b868ce761abb831819d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 159495
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/lz4-c-1.9.4-h419075a_1.conda
+  sha256: c19008e27cc137b45fbd1b6ff7d6bc21544cce4bf6b24af4f4fb84b9b776a394
+  md5: 70c4ab9462183ac4af60852d2a79fbf6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 185496
+  timestamp: 1714510593467
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.conda
+  sha256: 34aaf2a9ba8bef897e3684040ecbddbc99be7987ff21fa28c860f33bfac65da5
+  md5: 82202ff2e94bc301fd9c790556506bb7
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160308
+  timestamp: 1714510588159
 - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.conda
   sha256: 0e848b5004a9dc7a06f459cc67c404d7fb0321bf134ec7512815afafe97960b4
   md5: 723e3ccd4ef7c58ddbfeebe69abff662
@@ -10746,26 +6646,119 @@ packages:
   license_family: BSD
   size: 155711
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_1.conda
-  sha256: c293c76f4c1e1b3d61517cd165db9a04c871dbdd9911e7fc32df927fef22d083
-  md5: a099b975d158c47c2c38ae406f4d0659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-4.0.0-py313h06a4308_2.conda
+  sha256: eb345067b96b14e79c4a1edd4acee63c4b175d1818bb9de1c5ca373a6985cd5a
+  md5: d6250f9e480b12792b75ae296c165286
   depends:
   - mdurl >=0.1,<0.2
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   constrains:
-  - mdit-py-plugins >=0.5.0
-  - linkify-it-py >=1,<3
-  - mistune >=3.0,<4.0
-  - commonmark >=0.9,<0.10
   - panflute >=2.3,<2.4
   - mistletoe >=1.0,<2.0
+  - commonmark >=0.9,<0.10
+  - mdit-py-plugins >=0.5.0
   - sphinx-book-theme >=1,<2
-  - markdown >=3.4,<3.9
+  - mistune >=3.0,<4.0
+  - markdown >=3.4,<4
+  - linkify-it-py >=1,<3
   license: MIT
   license_family: MIT
-  size: 268521
-  timestamp: 1767001912508
+  size: 243237
+  timestamp: 1777540569559
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/markdown-it-py-4.0.0-py313hd43f75c_2.conda
+  sha256: f59fa96e5ecb50a3725d890dda7c8a576b3b1bb51cf468d7718033ad29e99c24
+  md5: 52dfa03cd4fc6fcdf6def4692c07af7e
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - linkify-it-py >=1,<3
+  - sphinx-book-theme >=1,<2
+  - panflute >=2.3,<2.4
+  - mistune >=3.0,<4.0
+  - mdit-py-plugins >=0.5.0
+  - mistletoe >=1.0,<2.0
+  - commonmark >=0.9,<0.10
+  - markdown >=3.4,<4
+  license: MIT
+  license_family: MIT
+  size: 242575
+  timestamp: 1777540565819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-4.0.0-py313hca03da5_2.conda
+  sha256: 235bd34b21d4599827b3927ca325d34c1a36fe36a9b91014f3aab6e932206949
+  md5: 185560a1e60a38d87b687b47f672ff67
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - commonmark >=0.9,<0.10
+  - mistune >=3.0,<4.0
+  - mdit-py-plugins >=0.5.0
+  - linkify-it-py >=1,<3
+  - markdown >=3.4,<4
+  - mistletoe >=1.0,<2.0
+  - sphinx-book-theme >=1,<2
+  - panflute >=2.3,<2.4
+  license: MIT
+  license_family: MIT
+  size: 243450
+  timestamp: 1777540586959
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-4.0.0-py313haa95532_2.conda
+  sha256: 84ab8f95af7d8c1c6a3d557f7846f927785a288f40fc43f6065f089738097670
+  md5: ef8d2f56a292e95c6b0bd6179a1c79ed
+  depends:
+  - mdurl >=0.1,<0.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - sphinx-book-theme >=1,<2
+  - mistletoe >=1.0,<2.0
+  - mdit-py-plugins >=0.5.0
+  - linkify-it-py >=1,<3
+  - panflute >=2.3,<2.4
+  - commonmark >=0.9,<0.10
+  - mistune >=3.0,<4.0
+  - markdown >=3.4,<4
+  license: MIT
+  license_family: MIT
+  size: 267752
+  timestamp: 1777540636533
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/marshmallow-3.19.0-py313h06a4308_0.conda
+  sha256: 8509fe80f82fca9edc5b2d5d8b26adf2e06b1efa2f8f1052ee224fc319bea3ae
+  md5: 28351e7fd716ee4b3baef571be119b98
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151241
+  timestamp: 1728403996163
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/marshmallow-3.19.0-py313hd43f75c_0.conda
+  sha256: 708f5a3a55e4d9da40030a857fd39d6040525ffd22ac2d59f0546e3c2b6cc970
+  md5: 1225f726844496e3564e4b2d6c539763
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 151130
+  timestamp: 1728498536715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/marshmallow-3.19.0-py313hca03da5_0.conda
+  sha256: 5c88289d6121bdcaa2f15e224a6ebffe2a79f2a9a7e3502a17e7623b81315f4b
+  md5: 4c3e970508e6cb3ad65579fb6b576143
+  depends:
+  - packaging >=17.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 149478
+  timestamp: 1728598048738
 - conda: https://repo.anaconda.com/pkgs/main/win-64/marshmallow-3.19.0-py313haa95532_0.conda
   sha256: 9c68fb61ad2d99c635e8a3adededd208f4cb13de8593116f0f5fc39bf5ac1057
   md5: aae05fc7685cf4eae8ef741c8203ff8e
@@ -10777,6 +6770,84 @@ packages:
   license_family: MIT
   size: 152235
   timestamp: 1729060636851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-1.26.0-py313h06a4308_0.conda
+  sha256: 9d0d4f67662837bd2ae3866675d792a2b068c9e439755f387494aaef507efaf8
+  md5: 77a8b7d6ae6f60716e05bc5b0e61b385
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - python-dotenv >=1.0.0
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 428184
+  timestamp: 1771960075711
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-1.26.0-py313hd43f75c_0.conda
+  sha256: eb4a26b84d9484a75f49ed4e4596afabb97e0175eedfbb616d79519651ca7596
+  md5: b7268fc357df1edc377e4a02b5c5c115
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - typer >=0.16.0
+  - python-dotenv >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 430285
+  timestamp: 1771960065247
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-1.26.0-py313hca03da5_0.conda
+  sha256: 55f93990fac19dd066121a283c202d81c9498c0cc68b523bbbaf597154a783b5
+  md5: 04ba8f0bfa78cef0456aeff11cfd1308
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - pydantic >=2.11.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.13,<3.14.0a0
+  - python-multipart >=0.0.9
+  - python_abi 3.13.* *_cp313
+  - rich >=13.9.4
+  - sse-starlette >=1.6.1
+  - starlette >=0.27
+  - uvicorn >=0.31.1
+  constrains:
+  - websockets >=15.0.1
+  - python-dotenv >=1.0.0
+  - typer >=0.16.0
+  license: MIT
+  license_family: MIT
+  size: 432541
+  timestamp: 1771960072114
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-1.26.0-py313haa95532_0.conda
   sha256: 6dc3ad40b514baab126201e34b8cbc8ec86a99e6ad5a74d480be7b9bc840a3bb
   md5: 5728b210ab42e67a924dd40f794f6723
@@ -10804,6 +6875,93 @@ packages:
   license_family: MIT
   size: 456382
   timestamp: 1771960175091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mcp-compose-0.1.12-py313h06a4308_0.conda
+  sha256: b6ca5bd3f708610801723deb09a29941cb47061832659de55b414f0496bab3b6
+  md5: e909ab91f515181fff72f312cbe1dcb1
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346906
+  timestamp: 1779919393059
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mcp-compose-0.1.12-py313hd43f75c_0.conda
+  sha256: 830eba7a3d482bf580428ca3df9e79092d6e84525916de57e8a71ba188401ad7
+  md5: 500ea279af0692936f7d51b378eb25ba
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  - opentelemetry-api >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347389
+  timestamp: 1779919403644
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mcp-compose-0.1.12-py313hca03da5_0.conda
+  sha256: 7dcb7ab7f6c3c0fd9301a4c760120e6bacd48762aee3269f304bea64e569ce91
+  md5: 9cd2d7945fcb775737365c00913343e4
+  depends:
+  - cryptography >=41.0.0
+  - fastapi-core >=0.104.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.0
+  - mcp >=1.2.1
+  - prometheus_client
+  - psutil >=5.9.0
+  - pydantic >=2
+  - pyjwt >=2.8.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=1.0.0
+  - python_abi 3.13.* *_cp313
+  - sse-starlette >=1.8.0
+  - toml >=0.10.2
+  - typer
+  - typing-extensions >=4
+  - uvicorn-standard >=0.24.0
+  constrains:
+  - opentelemetry-exporter-otlp-proto-http >=1.20.0
+  - opentelemetry-api >=1.20.0
+  - opentelemetry-sdk >=1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347924
+  timestamp: 1779919417576
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mcp-compose-0.1.12-py313haa95532_0.conda
   sha256: f9f81bf7aaf5324c869ee78b1fbcf0d1ea87df9194253207f54a31064bbabedb
   md5: f5d2f32619b86a3eb68ba296bf576548
@@ -10833,6 +6991,36 @@ packages:
   license_family: BSD
   size: 372921
   timestamp: 1779919449722
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py313h06a4308_0.conda
+  sha256: b4af3847be42fd97001227f10b8e6347aefb45199bcf5f358e870f4c43cbdd9a
+  md5: 39da6986b50a3eb3cbf60c9883f4b92e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26871
+  timestamp: 1758552191170
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/mdurl-0.1.2-py313hd43f75c_0.conda
+  sha256: 06265807625856e9271ef038a6960a4bcf8accca7bc94ec75656a0337b44f993
+  md5: 5ab5b1fc729b44eb2872d740d95c495d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26724
+  timestamp: 1758552208116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py313hca03da5_0.conda
+  sha256: dcfa6b13af360bd6f3388470af3e93a4b6fe2fd47b5d0546daf0f1daed5323bb
+  md5: cc0fbba5b4ee07d4f979149d050c864a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 26834
+  timestamp: 1758552196391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py313haa95532_0.conda
   sha256: c2748474cedb35b4643872288cedf94deae958ff684d17daf222bbb26bac4e79
   md5: 6c5764715afea281b71aa53cdc81c545
@@ -10843,6 +7031,36 @@ packages:
   license_family: MIT
   size: 26954
   timestamp: 1758552317465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/menuinst-2.4.2-py313h06a4308_1.conda
+  sha256: 4a7cbe8e343d05ea964f6b390b4e8e876423080ddc8efee42da96255a8e45dc8
+  md5: 3c19869ee69743cd3e6ed44610f7b845
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257750
+  timestamp: 1765382387320
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/menuinst-2.4.2-py313hd43f75c_1.conda
+  sha256: b5409cf3702b157380400fbfcd648760b401f3673e7360d9c31f570f82126870
+  md5: 0514a2f7425fe0559d98b6593f8c936d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257086
+  timestamp: 1765382393281
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/menuinst-2.4.2-py313hca03da5_1.conda
+  sha256: a0c5e9679295f996f84c36fd654f8a5016a50cee216529421f5413517721316c
+  md5: e5a706e1b73efa80d1ec1f23256e3b86
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 257932
+  timestamp: 1765382400100
 - conda: https://repo.anaconda.com/pkgs/main/win-64/menuinst-2.4.2-py313h885b0b7_1.conda
   sha256: 88a8c0010bd7aab8b0b92e04a411d85881025f3e4eeaa75e4c2dfd3a9ee3b55d
   md5: dfd755d055c9428e5bd5db6edaf24fc1
@@ -10856,16 +7074,81 @@ packages:
   license_family: BSD
   size: 253213
   timestamp: 1765382456721
-- conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-10.8.0-py313haa95532_0.conda
-  sha256: b0a1eee1ac57f7fc418b41ce1be5e591057ec4445e888ba5489f8fcaf184349b
-  md5: 84c4bc844419c60fb8bce4d066acd07a
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/more-itertools-11.0.2-py313h06a4308_0.conda
+  sha256: 772cd3c79506ee5060cb6c75db0a4ccdd0cb2ca2364992d0549f0ffabcabb210
+  md5: 1edd221e035f78818555abc20b080edc
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 169455
-  timestamp: 1761121600827
+  size: 173312
+  timestamp: 1775819413675
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/more-itertools-11.0.2-py313hd43f75c_0.conda
+  sha256: e75b4464d1ba7a1658257980adccee29bbb066c63ca63a7374e32a7874d5565b
+  md5: 1399d3c4c6c2554a5c66960f096ed13d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 174008
+  timestamp: 1775819410873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/more-itertools-11.0.2-py313hca03da5_0.conda
+  sha256: 496025e41f2694702ea58dfd61a922160698b8220766e8e85e74fbd81ec8734a
+  md5: b66a233a8bd8472e809494d0fd8aa4d3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 172229
+  timestamp: 1775819430257
+- conda: https://repo.anaconda.com/pkgs/main/win-64/more-itertools-11.0.2-py313haa95532_0.conda
+  sha256: 01086735ceed2314244ec297539f24f49b1d3a9a3091d250648e85e32f5450a6
+  md5: a9c2f9cee250f2234d101764cc460021
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 172450
+  timestamp: 1775819464842
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py313h6a678d5_0.conda
+  sha256: c9077c988bbab8f4315f9f98657f62d8d0dc87505756d78db808bccb88b32dd5
+  md5: b1fb5c763a2d3e15e633e84bccf52ce4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 123032
+  timestamp: 1750958840666
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/msgpack-python-1.1.1-py313h419075a_0.conda
+  sha256: 7572577e306630dc8dc4f437864b29f96e0996767429de624cf148619f6e3d72
+  md5: 90c7270744a7c8abdf51b5fecf7a9c14
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 120613
+  timestamp: 1750958715349
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py313h313beb8_0.conda
+  sha256: 654f8e502f64eb6f2b196ed85532f0521233fcd2946c4e5c623629357bb458ec
+  md5: 58664c7ab05f2559e22bc3030c90bd2a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 113263
+  timestamp: 1750958887102
 - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py313h5da7b33_0.conda
   sha256: 945bea6ce19a0f2d6ae8ee2ba4ffe2d19c405de54a80fdcc5a576cd93708a067
   md5: d471b10befe27a405de1c7d126f7aeda
@@ -10878,6 +7161,48 @@ packages:
   license_family: Apache
   size: 114961
   timestamp: 1750958855770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py313h06a4308_0.conda
+  sha256: 5d8c7a17076a8dc1766bb75e0dced7d18d6846585e9bcc27a3cee5b62f151573
+  md5: b9ee8adce00b801f3767671675300a6f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154942
+  timestamp: 1728385601732
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nbformat-5.10.4-py313hd43f75c_0.conda
+  sha256: 94a1985a532bf32a2b2892459fe4cb2e32535089746312903753d7836121b1a8
+  md5: 4d635e1fed6b6841ae3db1e0377a7712
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153354
+  timestamp: 1728405954288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py313hca03da5_0.conda
+  sha256: 47720a19543fd6db7571d01a3babda7ddf0f7cf798a33d844fb99b70fce389e6
+  md5: 98737e4835cef677dbf6fa0d9d364968
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.13,<3.14.0a0
+  - python-fastjsonschema >=2.15
+  - python_abi 3.13.* *_cp313
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155808
+  timestamp: 1728586024156
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py313haa95532_0.conda
   sha256: 7602bb66f5702414d75f7ca4293257fad682282b5a1f83de6e127720437a6b5c
   md5: fa4b4c9dabc5f45e04acbc44e1673b11
@@ -10892,6 +7217,55 @@ packages:
   license_family: BSD
   size: 180795
   timestamp: 1739559123487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.5-h7934f7d_0.conda
+  sha256: 5ab33c1e90efbb3507116ae00d1f6740ec74104bb7028dc017f5f76796cee154
+  md5: 0abfc090299da4bb031b84c64309757b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1137647
+  timestamp: 1753947487644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ncurses-6.5-h419075a_0.conda
+  sha256: a15c4e8b1f211f754a41cd4e1710b548cd226114228361cb563342c199d0e9b7
+  md5: 7a1863281d1b73c33d04a3709fda9bda
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1203577
+  timestamp: 1753947513381
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.conda
+  sha256: 1f892801b8436591a24062aa5839b7e2acb25ee588e4882cbd91dfb22e3080c7
+  md5: d8a28b593d36653bec90bd2d78c7538b
+  depends:
+  - __osx >=11.1
+  license: MIT AND X11
+  license_family: MIT
+  size: 906808
+  timestamp: 1753947535285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nlohmann_json-3.11.2-h6a678d5_0.conda
+  sha256: fd26e0dadf88a0de5851d059eddc2079defdda748a74b32a36393dfe25a8a48a
+  md5: 36890f7abd98066b607211b1773e6343
+  license: MIT
+  license_family: MIT
+  size: 127326
+  timestamp: 1680082329609
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/nlohmann_json-3.11.2-h419075a_0.conda
+  sha256: e9e0d1e28e9c65bfe06664c22ede68ce8d400011800af5c83aa1a1b68bbeffae
+  md5: 9e9d478b40d0e254cd3b448f92f47e8c
+  license: MIT
+  license_family: MIT
+  size: 127337
+  timestamp: 1680082426492
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nlohmann_json-3.11.2-h313beb8_0.conda
+  sha256: 3d6e893a665b9688ed924c0232748e905f510831e01582fc6248784fd55fa69b
+  md5: 5cc48a403acb53596382724e41f99a6b
+  license: MIT
+  license_family: MIT
+  size: 128547
+  timestamp: 1680082112201
 - conda: https://repo.anaconda.com/pkgs/main/win-64/nlohmann_json-3.11.2-h6c2663c_0.conda
   sha256: c7981dedae2f3d7734a062f4e07e08a060d462f72c17778df206989a3db42446
   md5: 7533a3f9925b9e46ac0c258be87c2877
@@ -10899,9 +7273,33 @@ packages:
   license_family: MIT
   size: 128841
   timestamp: 1680083671336
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.14.0-py313haa95532_0.conda
-  sha256: 8733722172b598c317765fa957b1f380fc89fc25745e837ff1059c75c8e33fc5
-  md5: 7871b47644f1a81af9f8a4bf98650d14
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openai-2.30.0-py313h06a4308_0.conda
+  sha256: 114e4cceb46e0feaa33113a4fe0c8db5b1879e7c23f91464bbe9cb65bc221cda
+  md5: c73e4d5b5823c880b21b545ac12fbacb
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - websockets >=13,<16
+  - pandas-stubs >=1.1.0.11
+  - pandas >=1.2.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 1116233
+  timestamp: 1777459702066
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openai-2.30.0-py313hd43f75c_0.conda
+  sha256: cd055bc3fe872e2481f9e719bcfd586769a9f4153de8e94ca4c72b8cfc8545f7
+  md5: 88160661ed57dd988dddb7985feb0670
   depends:
   - anyio >=3.5.0,<5
   - distro >=1.7.0,<2
@@ -10915,14 +7313,95 @@ packages:
   - typing-extensions >=4.11,<5
   constrains:
   - sounddevice >=0.5.1
-  - pandas >=1.2.3
   - websockets >=13,<16
   - httpx_aiohttp >=0.1.9
+  - pandas >=1.2.3
   - pandas-stubs >=1.1.0.11
   license: Apache-2.0
   license_family: Apache
-  size: 1081595
-  timestamp: 1767168143409
+  size: 1113065
+  timestamp: 1777459700855
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openai-2.30.0-py313hca03da5_0.conda
+  sha256: 111c4c5bc4bfa8441b6148a3a9b788a882e6925b216f4693f2a269327f68dfbf
+  md5: 04b819788d8761511073a2c2ef231ed6
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - pandas-stubs >=1.1.0.11
+  - httpx_aiohttp >=0.1.9
+  - pandas >=1.2.3
+  - websockets >=13,<16
+  - sounddevice >=0.5.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1123473
+  timestamp: 1777459710818
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openai-2.30.0-py313haa95532_0.conda
+  sha256: cbad1ad7ef96b413e3f64ed5f97242c7b5c6117cc170f271a5d487a8802c3d1e
+  md5: 16123b469db44f12596966f56d316971
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  constrains:
+  - httpx_aiohttp >=0.1.9
+  - sounddevice >=0.5.1
+  - pandas >=1.2.3
+  - websockets >=13,<16
+  - pandas-stubs >=1.1.0.11
+  license: Apache-2.0
+  license_family: Apache
+  size: 1148948
+  timestamp: 1777459774176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openapi-pydantic-0.5.1-py313h06a4308_0.conda
+  sha256: 888b0860bd80a8d21e8cdce284f814f9b1ff132baced1891b8590d018f99ee16
+  md5: d842c01c08579c4398dc5b15a0bd875d
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79899
+  timestamp: 1763721155768
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openapi-pydantic-0.5.1-py313hd43f75c_0.conda
+  sha256: fa57e451d8d5ed37c2e2b144a29234e3771057bf12a3d49e7fd53ebb47734864
+  md5: 583ab7940537e3387afa8c18b28eeb1c
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 79849
+  timestamp: 1763721155450
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openapi-pydantic-0.5.1-py313hca03da5_0.conda
+  sha256: 28957ab11bb5230150f56ed638b55677bd98f6d56a54694d38462d4372a72647
+  md5: b2bded54c66346cf90e89ea7e65d80f6
+  depends:
+  - pydantic >=1.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 80685
+  timestamp: 1763721157221
 - conda: https://repo.anaconda.com/pkgs/main/win-64/openapi-pydantic-0.5.1-py313haa95532_0.conda
   sha256: af0f41dc6f6acd6e46b83ac8c9194e8030ca886534bf9b13ddfa7510b3ae4870
   md5: 4a22cfc41b9cae647b8521b29244e505
@@ -10934,9 +7413,41 @@ packages:
   license_family: MIT
   size: 80996
   timestamp: 1763721195728
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.5-hbb43b14_0.conda
-  sha256: 74838df34c6e4e0d5279a33b7d82ca287b42c45c468e9993668b94fefea1853c
-  md5: 06f0b0505049ec5179fa18c61974bcfb
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.5.6-h1b28b03_0.conda
+  sha256: 2ab27b5fe0a8d348262386d36a17c50bb688dc83a8443fe39ef561ea5fc09a7d
+  md5: 5341b8a62a122529fc2083c6ed4174f6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 5918095
+  timestamp: 1775749314567
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/openssl-3.5.6-h39c9139_0.conda
+  sha256: 1a8c2aa57cbef6576d04a2889da51cef641adbfbea56c66577b90772c0964a98
+  md5: 1fea8b1c8a9858054c8ea4ef0a0f0ce4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 6541356
+  timestamp: 1775749241503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.5.6-ha0b305a_0.conda
+  sha256: fc8e5c30740d42407ab194012329f9f8820832554593821e48fc919d582689a1
+  md5: 58bcf6e120ab49b90438bc8b199dcbc1
+  depends:
+  - __osx >=12.1
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4817235
+  timestamp: 1775749200193
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.5.6-hbb43b14_0.conda
+  sha256: 28f7619d504c79edf0b00035d1001b9a07ba079e60440db55563fe373d82ec73
+  md5: dfd3af7d67edfe056d9f6abb83f472c2
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -10944,8 +7455,44 @@ packages:
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: Apache
-  size: 9306859
-  timestamp: 1772121458614
+  size: 9344164
+  timestamp: 1775751209953
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-api-1.38.0-py313h06a4308_0.conda
+  sha256: 4f921a1defb9dbbdf6ddf5408cba0b4fdd2a1f801dba87718ba086eb17b960b5
+  md5: 8310c25ce1847aee276a9e2617388f46
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101271
+  timestamp: 1763996098531
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-api-1.38.0-py313hd43f75c_0.conda
+  sha256: 775abe2c9d1b738ac1b14a1d97be29fc3798243415c42545662b429346965b47
+  md5: 85b624fe49b39de9fbe86b79144cb7c4
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 100915
+  timestamp: 1763996095398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-api-1.38.0-py313hca03da5_0.conda
+  sha256: e47e6ae1db83116e4a3977e11f92760ad471473991e56ef44c882e76b5793d82
+  md5: 9b5a6adb0e9b7ecc629fd37fd99a4aac
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101534
+  timestamp: 1763996094518
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-api-1.38.0-py313haa95532_0.conda
   sha256: d04d44e41260fcdfc3459bbeae2321294618fd7f947d7bb5e372da2016fc1fb7
   md5: e237a98fa5043fca13e8270162fdcb3b
@@ -10958,6 +7505,39 @@ packages:
   license_family: Apache
   size: 101545
   timestamp: 1763996171123
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313h06a4308_0.conda
+  sha256: c4e391dd39ecff6044c0adc7b773253366819ecaa4f946430e2b953b29655908
+  md5: ea9c98e0799195320c546768f562f351
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37782
+  timestamp: 1764236782492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hd43f75c_0.conda
+  sha256: 4418620b2026351ecc928c0571c1d1bb51e81c777a8ec9b3733dbffa65e670eb
+  md5: fab7d6c7cd4ebefb06eada5bee45916c
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 37829
+  timestamp: 1764236793947
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313hca03da5_0.conda
+  sha256: b78ec594f6a4ee992b658a96d390d62ef3ec4c7ccb23ff127c6c36b7fbea10de
+  md5: dd551f29b6694f41a405d347e5b7641e
+  depends:
+  - opentelemetry-proto 1.38.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 38099
+  timestamp: 1764236649957
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-common-1.38.0-py313haa95532_0.conda
   sha256: b287bd55c69e7f96b52fa7336f296946d636816d60ed286741013bf13b88ae4f
   md5: 1d30146e16512ecb43d947423aabc764
@@ -10969,6 +7549,57 @@ packages:
   license_family: Apache
   size: 37778
   timestamp: 1764236885569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313h06a4308_0.conda
+  sha256: 7bad0fd1ae25158ea631a0efaaa2fb207c21b9c6a9034aa4a8d7fe2e85a5ca5f
+  md5: 4c6786f5a20a0d5705c77a18d97eebec
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43650
+  timestamp: 1764254904983
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hd43f75c_0.conda
+  sha256: 7ce2298076dc66214a1c0a2bd5470c14c67d3a4d8a074c343cc5a41cc5c4083a
+  md5: 211d4704424ad214a215cf0378e685cf
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43410
+  timestamp: 1764254906556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313hca03da5_0.conda
+  sha256: 80ec23c0c2614047271f125513837342e8596fb6dd14e6250a76280bcc23d7f1
+  md5: 9b13a4cb589d5fc73e302f66b526c922
+  depends:
+  - googleapis-common-protos >=1.57,<2
+  - grpcio >=1.66.2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.6.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 43323
+  timestamp: 1764254973641
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-grpc-1.38.0-py313haa95532_0.conda
   sha256: 0e6c7dab76c8fc49939c1e5f6a0e49ed7ff811e02e6b184ec234f9cc6278e18d
   md5: 7784def4d18a62e9c3b0ababce753f2b
@@ -10986,6 +7617,57 @@ packages:
   license_family: Apache
   size: 43263
   timestamp: 1764254987784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313h06a4308_0.conda
+  sha256: 216370ce503733eefaf3b32a34831a2a1362c6205115adc030026a6598d84836
+  md5: de2d09e81412c0288e94586569f8276c
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33381
+  timestamp: 1764254429958
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hd43f75c_0.conda
+  sha256: a44b0b81d8b17bb536d83f36e36543631389f14aa2479857668d5b8eb3dbbf46
+  md5: 928d47e0634131263d53b97b8359431f
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33553
+  timestamp: 1764254406341
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313hca03da5_0.conda
+  sha256: 2ef5f4f527665568dd9fed5043c37beec54ee6d70e173a361a68e4bbe8d12ae6
+  md5: e65ca1299e5e4ca5f515faa509bd23ae
+  depends:
+  - googleapis-common-protos >=1.52,<2
+  - opentelemetry-api >=1.15,<2
+  - opentelemetry-exporter-otlp-proto-common 1.38.0
+  - opentelemetry-proto 1.38.0
+  - opentelemetry-sdk >=1.38.0,<1.39.0.dev
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.7,<3
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 33433
+  timestamp: 1764254395627
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-exporter-otlp-proto-http-1.38.0-py313haa95532_0.conda
   sha256: 601ea19950a0e691b12149bd13d06f898d2a25fe060be1038f195be796359f10
   md5: a02ee8b8d3d1f79ab61b0c0f0dcb6dab
@@ -11003,6 +7685,48 @@ packages:
   license_family: Apache
   size: 33568
   timestamp: 1764254472408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-instrumentation-0.59b0-py313h06a4308_0.conda
+  sha256: c1b1a63010d41fad5813296c8286fa7a7d5dfb390a7e4771aa2f550bd4e460fe
+  md5: a9aa9b02edaa6e129374ae281b4ace66
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58002
+  timestamp: 1764084155711
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-instrumentation-0.59b0-py313hd43f75c_0.conda
+  sha256: 0ad5329cd27439e300a2101e2602fbd4cc3e0d308c86846d33eb1ccdb6fba487
+  md5: aae5f23a1a4a2c152ee68f16d380ff15
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57805
+  timestamp: 1764084154068
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-instrumentation-0.59b0-py313hca03da5_0.conda
+  sha256: a20bf54cb59efc6aab10a0be9eb8845555efe59c3202e7c3f64497bcace4a136
+  md5: 59267a3e2c335ee1d45d703dfaee30f7
+  depends:
+  - opentelemetry-api ~=1.4
+  - opentelemetry-semantic-conventions 0.59b0
+  - packaging >=18.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - wrapt >=1.0.0,<2.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57708
+  timestamp: 1764084154910
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-instrumentation-0.59b0-py313haa95532_0.conda
   sha256: 68e244391c6f93d7d55e941feb790fd4016a402ffda2b8ba684512dd84fe5e53
   md5: 54d8e5a50cb75f7cb10139d86694f4ce
@@ -11017,6 +7741,39 @@ packages:
   license_family: APACHE
   size: 83182
   timestamp: 1764084236614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-proto-1.38.0-py313h06a4308_0.conda
+  sha256: 686ef27b35f51c13a9581a348a1ecd82607b739a54363d02dfb356b4ab17322f
+  md5: e36ceb40f2e628e2b6d4bb62032539a1
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57320
+  timestamp: 1764164412130
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-proto-1.38.0-py313hd43f75c_0.conda
+  sha256: 96fbbef0ecfb3399f7704ae921b987b7d5a42d5a168a68821fd956ce6cd9361a
+  md5: a93dfba7f5563c3430eb842ff88b7cb7
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57059
+  timestamp: 1764164411916
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-proto-1.38.0-py313hca03da5_0.conda
+  sha256: d08ef302f470b46eed77b05cabb61188d28967d84a06401675895014115d4250
+  md5: c2f0aecc8a2ea835b91a7897ab121f5c
+  depends:
+  - protobuf >=5.0,<7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 57335
+  timestamp: 1764164412952
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-proto-1.38.0-py313haa95532_0.conda
   sha256: 4d9af6cfdc6484dd269e39445ff8e1ddbc6e60a4b84b61515b4ebcf07fb5d517
   md5: 642de24674e936a3222d72d484a1ef45
@@ -11028,6 +7785,45 @@ packages:
   license_family: Apache
   size: 57588
   timestamp: 1764164490671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-sdk-1.38.0-py313h06a4308_0.conda
+  sha256: 6159a043c959466238febb04831c5c1eaecbcf555f59be53fd33725ce107db92
+  md5: 2a77251102af2651654e23f12c0e58c6
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 274299
+  timestamp: 1764073186249
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-sdk-1.38.0-py313hd43f75c_0.conda
+  sha256: fc5be1c90f0bdc6a8277ecb53432ecc8bc42c5f55f745f8546d9483cc8962ae6
+  md5: 0ce00548bf7f2bc4d0cca918a84a3989
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275046
+  timestamp: 1764073129503
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-sdk-1.38.0-py313hca03da5_0.conda
+  sha256: fc8704716c509c540a6d2a632dacb7338dcee7cfcca40c6cbb34c719df8e7995
+  md5: c5fda39e599753e09a32115eb8330bac
+  depends:
+  - opentelemetry-api 1.38.0
+  - opentelemetry-semantic-conventions 0.59b0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 275773
+  timestamp: 1764073043306
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-sdk-1.38.0-py313haa95532_0.conda
   sha256: 678a2df75881e5e762497099297bb7d42e1bd2438b3fcd4791337a5ca1eb60dc
   md5: 9692d8b6afeeb44a6c751a3d3c41fdc8
@@ -11041,6 +7837,42 @@ packages:
   license_family: Apache
   size: 275430
   timestamp: 1764073280377
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/opentelemetry-semantic-conventions-0.59b0-py313h06a4308_0.conda
+  sha256: 23ae9ea3eb5feda041a24174ecf9348ec54eb56690b6210ba39a0c82af1f9084
+  md5: e794cf7621bbe67d177b7e279cd6d610
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 179330
+  timestamp: 1764062875253
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/opentelemetry-semantic-conventions-0.59b0-py313hd43f75c_0.conda
+  sha256: ada8ca698ca21c67d6725d3f47a6752163a7059160d59e43411d1083b28b1cd6
+  md5: f14b38ac757bcb80c206d16fb2e55592
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177920
+  timestamp: 1764062882890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/opentelemetry-semantic-conventions-0.59b0-py313hca03da5_0.conda
+  sha256: 4a913889a97d6f5d1b6e37568899688663e888f63b6be791aad80513cb2f8c0f
+  md5: 677be6639bad152b927832a09d639b72
+  depends:
+  - opentelemetry-api 1.38.0.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 180260
+  timestamp: 1764062877653
 - conda: https://repo.anaconda.com/pkgs/main/win-64/opentelemetry-semantic-conventions-0.59b0-py313haa95532_0.conda
   sha256: ccaa74ee5c9369fd9a0c7f43297f672fbb079df1d0930bbb3c51c4158b11ef11
   md5: bb98256d4bf0d8f130f7f1d51b7c5425
@@ -11053,6 +7885,41 @@ packages:
   license_family: Apache
   size: 180937
   timestamp: 1764062960760
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orjson-3.11.7-py313h6e1b9ff_0.conda
+  sha256: 04ec78bc2c79e442e0536742b698b661bfd09918da54af00b722e49afd1b113d
+  md5: 76bffd8af6e6a162a1e7af69b9b800d7
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 337138
+  timestamp: 1771945983540
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/orjson-3.11.7-py313hef68074_0.conda
+  sha256: 56edabec2e0cd4187a8d0564e13e5e063b8c408263c177b186bc3165f8e70ebe
+  md5: 7891ddc6fc7bc7cc362213c18b8eaf6e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 334755
+  timestamp: 1771945967596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orjson-3.11.7-py313h3983f12_0.conda
+  sha256: 79070e3180713ccdb104c8d0321a5650976847315181e66059ef96dc50ec0055
+  md5: 304016a5b391759778800af9f24e1332
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MPL-2.0 AND (Apache-2.0 OR MIT)
+  license_family: OTHER
+  size: 305477
+  timestamp: 1771946048520
 - conda: https://repo.anaconda.com/pkgs/main/win-64/orjson-3.11.7-py313h51239a8_0.conda
   sha256: 481226561000f1eb1e3a067b33713e209d100031c280a6052679f17985b58aee
   md5: f6d731e5099297ec7be0c2302a0ea354
@@ -11066,6 +7933,36 @@ packages:
   license_family: OTHER
   size: 233868
   timestamp: 1771946278261
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-26.0-py313h06a4308_0.conda
+  sha256: 61b1ba92620a61f58dda80ce01252668b4400b29b5751fccbdab73ab30192ecc
+  md5: 0f7d4f61c3851a0d436b96e9cb02c393
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200822
+  timestamp: 1775004135549
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/packaging-26.0-py313hd43f75c_0.conda
+  sha256: 98ab445bd2f6de16a09b09fbef47d5008ba0fde1c7bc4208c92b1498e2daebc0
+  md5: ba91769862d81cb2c29f4918aae1a245
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 198468
+  timestamp: 1775004133206
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-26.0-py313hca03da5_0.conda
+  sha256: 8589b80c03b95c68903efd04bd06cb0fdd0e8a87b16cfc78cd0869926efaaa21
+  md5: 16eee0ba12a1721ab94eb4f87517b5e2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 200339
+  timestamp: 1775004034672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-26.0-py313haa95532_0.conda
   sha256: 377f499629908034474c3ab04a45fcad5ba19158b4e0248a905fe73ffddb8e9f
   md5: 865786bee3991b29c53298346c7f6289
@@ -11076,6 +7973,36 @@ packages:
   license_family: Apache
   size: 201067
   timestamp: 1775004274536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pathable-0.5.0-py313h06a4308_0.conda
+  sha256: e7ae55cfd35826f50d58cb412e7afa9a2261efcfe0d8f3d59812e84f4362164b
+  md5: da78932ffefe7e3f780f75672b3f8b36
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51265
+  timestamp: 1772567686795
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pathable-0.5.0-py313hd43f75c_0.conda
+  sha256: ded674f523390d7edd68072a50b039e4efa2392c3d9d736f3172f4311f198e55
+  md5: 730f7454d70a81d991ac05e09c699166
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51488
+  timestamp: 1772567675008
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pathable-0.5.0-py313hca03da5_0.conda
+  sha256: 960848004bae6134348888cb145fbb6763ef7931c0123b1a95a0e42afe2893e8
+  md5: edb4dc7d24225792e537e7db178ab7a5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 51842
+  timestamp: 1772567682290
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pathable-0.5.0-py313haa95532_0.conda
   sha256: 7f0dd38798a6247880c231a3086130c84e93bc7a17a0344e37f73ad36166f32e
   md5: 7c54e8d8e2c390fbe1ab4bbbd8437def
@@ -11086,6 +8013,41 @@ packages:
   license_family: Apache
   size: 51631
   timestamp: 1772567728989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.46-hf426167_0.conda
+  sha256: c817569288774a61a8081a9e3aa13de5b24f2fd7c971618c7593c4f1764ad0f8
+  md5: 49c2031dcebd085e49c3aff84479e314
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1289658
+  timestamp: 1759825800150
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pcre2-10.46-h1746348_0.conda
+  sha256: 9d025c9cdf32c406b42a1d2461da1247addef78b9b6b81c71f3f18d1d8085e05
+  md5: d2a1b973881c8c0493bf1fd7b62a2918
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 1177858
+  timestamp: 1759825801409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.conda
+  sha256: 502b7b5fa39c8ab2df0213b1541d43bb32f10da44370ad5f1124a010deb86ad2
+  md5: dc957a9fa85669b0f6ce65ea9343fd8f
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 901944
+  timestamp: 1759825795666
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.conda
   sha256: d54ea3169c090404ca6d9d154adf842d61ca7a0bf1e277a10c02e245f186b934
   md5: ce7492b4ef08cfdeb0fc35ab5447ccf4
@@ -11099,6 +8061,47 @@ packages:
   license_family: BSD
   size: 1317213
   timestamp: 1759825896688
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-26.0.1-pyhc872135_1.conda
+  sha256: a3ffa3423f3a1c2a5184fd3e83c4555c9b6d627b0ed2e101b2ab615d585c1f40
+  md5: 694138f71ea48d078f301a9a701bbc62
+  depends:
+  - python >=3.9,<3.14.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1178932
+  timestamp: 1774988902802
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkce-1.0.3-py313h06a4308_0.conda
+  sha256: eaa82556ef0d4f93c075c6e668be0bc84fc76f2401d98304feab16b3a2280f24
+  md5: a1e79da30a6c62c6398e9bb990ee9ed6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9162
+  timestamp: 1728388115083
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pkce-1.0.3-py313hd43f75c_0.conda
+  sha256: b1fb9313725572769a9b65f633abd85489f35935f37417a29de7aed7f4283395
+  md5: ed391ccc6d6caaccedd5250fdeb48807
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9176
+  timestamp: 1728408515784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkce-1.0.3-py313hca03da5_0.conda
+  sha256: 7f72d05283b2b08fd54b37502d60abd66d5592faaaa9393f1bd411f67fbe19ba
+  md5: 5c6344029e52293764fd4f88d6216c07
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 9307
+  timestamp: 1728592695690
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pkce-1.0.3-py313haa95532_0.conda
   sha256: 891ecf91eb86227f847743d2519f9f8c3ff70386d56b0d0507c5dc557392b101
   md5: 1dea692228d870c3278e9797ddc0589a
@@ -11109,6 +8112,36 @@ packages:
   license_family: MIT
   size: 10112
   timestamp: 1729049247460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.9.4-py313h06a4308_0.conda
+  sha256: 91417a676c885bf5bfcbeade3c41314d8843b7aa40d5b293f3588c011b88aed1
+  md5: e1705a98bf3338281b413e1fc8484a12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54729
+  timestamp: 1773652981831
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/platformdirs-4.9.4-py313hd43f75c_0.conda
+  sha256: 856458f97a11a1bc9824c34c0a88ca02c8c670c0728583883d2a83b94b0e6a5e
+  md5: cdff168e8e1d6bbfced0f9ce18a6534a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54735
+  timestamp: 1773652976404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.9.4-py313hca03da5_0.conda
+  sha256: 1f87fc09b22b262cc56578d18695e243c9bd7ad5eb952f33067225ace48f8635
+  md5: f9e7cc4e6d37a4efe63452519464e148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 54951
+  timestamp: 1773653001076
 - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.9.4-py313haa95532_0.conda
   sha256: 7c422f786db266a90afe84e10bc2cd2547118032fd46cbc590ef343de0fd411c
   md5: c73cb48e85b2d4c9f6bee9b364adb4d4
@@ -11119,6 +8152,36 @@ packages:
   license_family: MIT
   size: 54633
   timestamp: 1773653037631
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pluggy-1.6.0-py313h06a4308_0.conda
+  sha256: 55a5e11175cddad88e4e05fcf03c02083ba5ed1f547884ad070e85e66066f563
+  md5: 5c71fdece7639940072a849417bff8da
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47969
+  timestamp: 1776972936162
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pluggy-1.6.0-py313hd43f75c_0.conda
+  sha256: a27491234f720bd1486edb2c146b842f768dae607782df68d2fe985a18358ca6
+  md5: 2a17a7c2c9d580944aec3aeb44f8e14b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47904
+  timestamp: 1776972854196
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pluggy-1.6.0-py313hca03da5_0.conda
+  sha256: 15de93f4306568b51a0000b383c66d275c1f1d95a1b55de4f1625f94072d835a
+  md5: 3550efa655956e28eb7282c3210bb015
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 47964
+  timestamp: 1776972833748
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pluggy-1.6.0-py313haa95532_0.conda
   sha256: d5286244f6ebbceb1cc19c77a342fe6849f646a4a51d2aa8a7fe48af4d75b4c0
   md5: 56ed40dd2a648486a27c2c79f253f2e6
@@ -11129,6 +8192,36 @@ packages:
   license_family: MIT
   size: 48203
   timestamp: 1776973096987
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.24.1-py313h06a4308_0.conda
+  sha256: c568ae60468985d49de2d76af361c7805213fd27c818701544690bd63a772085
+  md5: 7664f08981772ba49fef33294a096a18
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170398
+  timestamp: 1772733409298
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/prometheus_client-0.24.1-py313hd43f75c_0.conda
+  sha256: 998d4481c01d7f506a65482b0355afe949b63e59dd5077588156f76803cec3f0
+  md5: 08a8181515e8bdce86ee017bb1153d69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170028
+  timestamp: 1772733403459
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.24.1-py313hca03da5_0.conda
+  sha256: 79bb9f705e62d8c27201462ce48ee0ef46f01cf937133123d0c7da6e30e52cdf
+  md5: f686d9126128ed3d50046833a1b555a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 170595
+  timestamp: 1772733427973
 - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.24.1-py313haa95532_0.conda
   sha256: a482e9e5c6e30ea4126e3f64fd75590a0d213395adae10e0da11b79fd5a45fb7
   md5: 538e9c192d280b01619787f642e8e5d2
@@ -11139,6 +8232,50 @@ packages:
   license_family: Apache
   size: 171669
   timestamp: 1772733460825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-6.33.5-py313h7354ed3_0.conda
+  sha256: 05d37c95d429b0ab6363072f0ed9125e7f526e14a7371a04792ae01a3a99c89a
+  md5: 4ed25d7e96e43ba1c7bff83aea1a624d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570052
+  timestamp: 1770660764829
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/protobuf-6.33.5-py313h5b11e9f_0.conda
+  sha256: 332b56edc2c69de38132cfc54b14f33fb7389c4b7e88a5514888aa6f946ac5cc
+  md5: c65088b4df85204138e7899b7bb677c5
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579494
+  timestamp: 1770660753322
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-6.33.5-py313h50f4ffc_0.conda
+  sha256: 7e48370a37f6098608fa0fb8391c042526f6aa9c07bc3d68fd954c73e68b9502
+  md5: 70879a51504dda5aff5034450b11a84a
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libprotobuf 6.33.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 461761
+  timestamp: 1770660566466
 - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-6.33.5-py313h854c0a0_0.conda
   sha256: 18213ba9abcbdc83efc0e49693fb96016e883b3a85e58ecca91696898ef6d434
   md5: c981add26704b7d11b6605c103bd02e9
@@ -11154,6 +8291,41 @@ packages:
   license_family: BSD
   size: 490900
   timestamp: 1770660962864
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-7.0.0-py313hee96239_1.conda
+  sha256: fb96bfc34b77bc4f2a631bbc87b0cc7389f7d029a544d4ba7a53baa72d37de98
+  md5: cbc2bbc9f173aea5ef52dbd7d3ffd07d
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550941
+  timestamp: 1761896477134
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/psutil-7.0.0-py313ha28494d_1.conda
+  sha256: 0e5b510c3f984e7d683dc33f19837cc783cdd586db117c49965826334bc921d0
+  md5: 55e55bb476470a157cf4b81f44283436
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 550478
+  timestamp: 1761896485773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py313haa24f5a_1.conda
+  sha256: 4d3a9eb901aad98bb71b01425cb1c93628b70609f7cdbb54a1fdb2d351e70649
+  md5: 6bc6a220a229abae6afa80ccf4c3b06b
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561023
+  timestamp: 1761896362276
 - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py313h02ab6af_1.conda
   sha256: 62d6a63cc8ea42b78731f1336ad68cee6c33401343632c0f5af532167a6f9184
   md5: e1d87eecc309f85ec24e0950615e985e
@@ -11167,41 +8339,211 @@ packages:
   license_family: BSD
   size: 573993
   timestamp: 1761896633111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_0.conda
-  sha256: cc2d35e134b8f401be9544dc98b78b126633c73fbae7f4494e358a8ddf67a300
-  md5: d7ac9b1a569d1c2cd9ee3a4bff6e2e18
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.conda
+  sha256: 119c5ad43fb92b2f14a25c53276072ee77ff6b40c72e6617b523b9de0eb0822a
+  md5: 973a642312d2a28927aaf5b477c67250
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  license_family: MIT
+  size: 5360
+  timestamp: 1505733967605
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pthread-stubs-0.3-hfd63f10_1.conda
+  sha256: 8127d83effe9e77fbcff1dfd1ad61ecb02251615501a9af524a690e573bbc9af
+  md5: bd26b7e13996984230e8ec67f3ebd4c7
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  license_family: MIT
+  size: 7035
+  timestamp: 1615912729649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/py-key-value-aio-0.4.4-py313h06a4308_1.conda
+  sha256: a69af6a08868bc24fc1981a22e1e29c20416f150695a31b4ce78dae833140e57
+  md5: 802842f437b616ba517bbe8ab59ed2dd
   depends:
   - beartype >=0.20.2
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - typing_extensions >=4.15.0
   constrains:
-  - dbus-python >=1.4.0
-  - pymongo >=4.0.0
-  - pathvalidate >=3.3.1
-  - python-duckdb >=1.1.1
-  - asyncpg >=0.30.0
-  - types-hvac >=2.3.0
-  - keyring >=25.6.0
-  - aiomcache >=0.8.0
-  - elasticsearch >=8.0.0
-  - cryptography >=45.0.0
-  - rocksdict >=0.3.24
-  - aioboto3 >=13.3.0
-  - pytz >=2025.2
-  - cachetools >=5.0.0
-  - valkey-glide >=2.1.0
   - types-aiobotocore-s3 >=2.16.0
-  - aiohttp>=3.12
+  - valkey-glide >=2.1.0
+  - pydantic >=2.11.9
   - hvac >=2.3.0
   - diskcache >=5.0.0
-  - types-aiobotocore-dynamodb >=2.16.0
-  - pydantic >=2.11.9
+  - dbus-python >=1.4.0
+  - pytz >=2025.2
+  - python-duckdb >=1.1.1
+  - aiohttp>=3.12
+  - asyncpg >=0.30.0
+  - aiomcache >=0.8.0
+  - pathvalidate >=3.3.1
+  - pymongo >=4.0.0
+  - cachetools >=5.0.0
+  - anyio >=4.4.0
   - redis-py >=4.3.0
+  - cryptography >=45.0.0
+  - types-hvac >=2.3.0
+  - elasticsearch >=8.0.0
+  - aioboto3 >=13.3.0
+  - rocksdict >=0.3.24
+  - types-aiobotocore-dynamodb >=2.16.0
+  - aiofile >=3.9.0
+  - keyring >=25.6.0
   license: Apache-2.0
   license_family: Apache
-  size: 259866
-  timestamp: 1774282584624
+  size: 295896
+  timestamp: 1779978190992
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/py-key-value-aio-0.4.4-py313hd43f75c_1.conda
+  sha256: c3528eaf21b37206af878506da663e604e17be51fb37510459515baa2283c61a
+  md5: 2f3a131bd072f4e2cbee3ad28f540dc2
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - aiofile >=3.9.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - types-aiobotocore-s3 >=2.16.0
+  - cachetools >=5.0.0
+  - aioboto3 >=13.3.0
+  - keyring >=25.6.0
+  - pydantic >=2.11.9
+  - hvac >=2.3.0
+  - types-hvac >=2.3.0
+  - anyio >=4.4.0
+  - pymongo >=4.0.0
+  - valkey-glide >=2.1.0
+  - cryptography >=45.0.0
+  - asyncpg >=0.30.0
+  - pathvalidate >=3.3.1
+  - diskcache >=5.0.0
+  - rocksdict >=0.3.24
+  - dbus-python >=1.4.0
+  - redis-py >=4.3.0
+  - aiomcache >=0.8.0
+  - python-duckdb >=1.1.1
+  - pytz >=2025.2
+  - aiohttp>=3.12
+  - elasticsearch >=8.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 295816
+  timestamp: 1779978081175
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/py-key-value-aio-0.4.4-py313hca03da5_1.conda
+  sha256: ed21b11c3840d2b1dfcd5595672a36ed71a1b10f12839fba86e52308714f734c
+  md5: 3f09888d38880126245060ae0dd6ec38
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - elasticsearch >=8.0.0
+  - aiomcache >=0.8.0
+  - anyio >=4.4.0
+  - cachetools >=5.0.0
+  - types-aiobotocore-s3 >=2.16.0
+  - asyncpg >=0.30.0
+  - valkey-glide >=2.1.0
+  - redis-py >=4.3.0
+  - aioboto3 >=13.3.0
+  - pathvalidate >=3.3.1
+  - python-duckdb >=1.1.1
+  - pydantic >=2.11.9
+  - diskcache >=5.0.0
+  - dbus-python >=1.4.0
+  - rocksdict >=0.3.24
+  - pytz >=2025.2
+  - aiofile >=3.9.0
+  - hvac >=2.3.0
+  - aiohttp>=3.12
+  - keyring >=25.6.0
+  - types-aiobotocore-dynamodb >=2.16.0
+  - pymongo >=4.0.0
+  - cryptography >=45.0.0
+  - types-hvac >=2.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 296892
+  timestamp: 1779978100099
+- conda: https://repo.anaconda.com/pkgs/main/win-64/py-key-value-aio-0.4.4-py313haa95532_1.conda
+  sha256: 48dac7f101db41a5a62015415e122c59826a0924b8827bb99f61e47ea44ee487
+  md5: 0bf986347eb40b585217b8177d1a0baf
+  depends:
+  - beartype >=0.20.2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.15.0
+  constrains:
+  - pydantic >=2.11.9
+  - python-duckdb >=1.1.1
+  - aiomcache >=0.8.0
+  - pathvalidate >=3.3.1
+  - diskcache >=5.0.0
+  - aiohttp>=3.12
+  - types-aiobotocore-dynamodb >=2.16.0
+  - redis-py >=4.3.0
+  - asyncpg >=0.30.0
+  - cryptography >=45.0.0
+  - hvac >=2.3.0
+  - aioboto3 >=13.3.0
+  - aiofile >=3.9.0
+  - cachetools >=5.0.0
+  - dbus-python >=1.4.0
+  - keyring >=25.6.0
+  - pymongo >=4.0.0
+  - valkey-glide >=2.1.0
+  - elasticsearch >=8.0.0
+  - types-aiobotocore-s3 >=2.16.0
+  - pytz >=2025.2
+  - rocksdict >=0.3.24
+  - anyio >=4.4.0
+  - types-hvac >=2.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 297537
+  timestamp: 1779978135168
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.conda
+  sha256: f50092cadf160051b3d2a8e7597d5e13c96487f9383eaaf803063a1bab3c3bd7
+  md5: 7f0df6639fdf60ccd3045ee6faedd32f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14215
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.6-py313h5eee18b_2.conda
+  sha256: e8b63564435784af273ef7a9e99955e3675f0798b294a103d2840f258f051f41
+  md5: 60ea7416e08d78563e31d16c333bd57f
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 93055
+  timestamp: 1736868559715
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycosat-0.6.6-py313h998d150_2.conda
+  sha256: 6d8539b19bb590129d1ff714f1bc551a5d729b690e5d89bb4073d50d264d75a9
+  md5: 574f6176492ab5f26a379307c7377a30
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 92719
+  timestamp: 1736868553560
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycosat-0.6.6-py313h80987f9_2.conda
+  sha256: 64c71fd9fc743693a7e61ecf8fcaf041d6e5c0c8309a92e2f73ac167659a5e76
+  md5: 2ee55b934de679d2f73bd0f3840f1dfd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 90639
+  timestamp: 1736868507679
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycosat-0.6.6-py313h827c3e9_2.conda
   sha256: df4e2759d0dfd24b3e6e00dabfa6583b01c865db0527a0cb4ba21d67ca767b95
   md5: 31fe82cdc830f79c27346b9e66342d2a
@@ -11214,6 +8556,36 @@ packages:
   license_family: MIT
   size: 92654
   timestamp: 1736869076072
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-3.0-py313h06a4308_0.conda
+  sha256: 51454fb76630c6858e090293b2be0936851a1fb1877e1480c7f3b5c090b8b69f
+  md5: 3b8ea90c558c424f123c1fc6069c9fa6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155521
+  timestamp: 1774959763398
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pycparser-3.0-py313hd43f75c_0.conda
+  sha256: 57c7ca7e25924098ada4384f8f5cedcee11c014c86620f6c61c71a0c05b4e641
+  md5: 03fd00dba51a683e8d01f74ec63a1fec
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156035
+  timestamp: 1774959750947
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-3.0-py313hca03da5_0.conda
+  sha256: 3863282d48c05a1b228d17e9e8b65434b693773b001e62109dc8a8280708ce42
+  md5: 63924165d4c0b49b018d6c6c742d5666
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140335
+  timestamp: 1774959697268
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-3.0-py313haa95532_0.conda
   sha256: 48cef9cf6d54f01afab07973fc1b295586120acffb2b9ca592a5bc0deee49dd2
   md5: 9487fca3796d5c8cd0c361909099518d
@@ -11224,12 +8596,60 @@ packages:
   license_family: BSD
   size: 140506
   timestamp: 1774959857744
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.12.5-py313haa95532_0.conda
-  sha256: 923cb9aa819ea8f6b258b391c4ef4abd860ae016b793a2b1aab28ad6b7271e0b
-  md5: 57e5cd75c0aefb820229739e54e986c8
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-2.13.4-py313h06a4308_0.conda
+  sha256: a95fbf7a462cc0d0510a702f13993f2ae026b0373d788cfd475716aac955a124
+  md5: b669824f2ec61c956ab114143eccf3bd
   depends:
   - annotated-types >=0.6.0
-  - pydantic-core 2.41.5
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1128169
+  timestamp: 1778683891285
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-2.13.4-py313hd43f75c_0.conda
+  sha256: 92bc3c7526782aa5bf6491a01db155aa4e29d79e5dc170d359341345d8317f3d
+  md5: ef8d3ac799e68017710c0e673f12d38d
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1126826
+  timestamp: 1778683886054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-2.13.4-py313hca03da5_0.conda
+  sha256: 0fc797970a04dd9485e75ccc37c3bf6b93af0886ebb23d196633fde3a3686395
+  md5: 063dbd636d74525f473fbc88dae48124
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  constrains:
+  - email-validator >=2.0.0
+  license: MIT
+  license_family: MIT
+  size: 1129564
+  timestamp: 1778683904286
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-2.13.4-py313haa95532_0.conda
+  sha256: 85b66c2032f05eaa7203bd00523b030c30a101028c822c712a2886f9fa912a3a
+  md5: 4b854d1dee4ad44d73813be3d8a10fd7
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.46.4
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - typing-inspection >=0.4.2
@@ -11239,22 +8659,120 @@ packages:
   - email-validator >=2.0.0
   license: MIT
   license_family: MIT
-  size: 1110528
-  timestamp: 1773134450949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.41.5-py313h114bc41_1.conda
-  sha256: 926de8c3cf42c9eea67f7fb075331172c3399c10f7fd0d94b4f942b298eb4301
-  md5: 0b2da722db0f7799fd9537438d241594
+  size: 1130443
+  timestamp: 1778683942191
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-core-2.46.4-py313h6e1b9ff_0.conda
+  sha256: 05b763ee21064331e6fbfb20135e801f71fda761556b07c93938cbac6e4b7d6f
+  md5: 1583c5469605cea15689ec0b9ede1bc3
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1885652
+  timestamp: 1778677122534
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-core-2.46.4-py313hef68074_0.conda
+  sha256: 0d91bcec560dccda2733745b3d5df70c57398172e1c5ffcd05317eb354dd4b86
+  md5: f8de87b7f9d4079e54a3b9d95d01db99
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1735370
+  timestamp: 1778677068356
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-core-2.46.4-py313h3983f12_0.conda
+  sha256: ba6b2306d45414884172e8ace37e2ce597a056a51c0667e78564321634709159
+  md5: a6a603da37240ebd3428202bda1eca84
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing-extensions >=4.14.1
+  license: MIT
+  license_family: MIT
+  size: 1679830
+  timestamp: 1778677032197
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-core-2.46.4-py313h51239a8_0.conda
+  sha256: cf77af379766667be472a95840bd05f250c80d672d6bbaa9fc15908d752c0925
+  md5: 15d9c563d8c978085fc5785a51795608
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - typing-extensions >=4.14.1
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  size: 1922906
-  timestamp: 1764010123974
+  size: 1853335
+  timestamp: 1778677510770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pydantic-settings-2.12.0-py313h06a4308_0.conda
+  sha256: cb5a99e9367a101fda496ad62cb52e8931772d8bb8f5853b32650d7644afc229
+  md5: 52b991b3676ad69221ac4efe952ea622
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - google-cloud-secret-manager>=2.23.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  - pyyaml >=6.0.1
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  license: MIT
+  license_family: MIT
+  size: 151041
+  timestamp: 1764165180924
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pydantic-settings-2.12.0-py313hd43f75c_0.conda
+  sha256: 86f1d55ef2d1baae2b6fe4f5996c32207180fee8177af9bd050b8d705c7e7f2e
+  md5: 8bcdca4304da9f754bfb1f5839f796dc
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - azure-identity >=1.16.0
+  - tomli >=2.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - pyyaml >=6.0.1
+  - google-cloud-secret-manager>=2.23.1
+  license: MIT
+  license_family: MIT
+  size: 150714
+  timestamp: 1764165157426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pydantic-settings-2.12.0-py313hca03da5_0.conda
+  sha256: c41dba9cb786921e04c1dcce4427a6310151a44156531d13b8b0b964bffdf834
+  md5: 4bc0da3d9e06af7ce644b3901790c1ee
+  depends:
+  - pydantic >=2.7.0
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.21.0
+  - python_abi 3.13.* *_cp313
+  - typing-inspection >=0.4.0
+  constrains:
+  - boto3>=1.35.0
+  - tomli >=2.0.1
+  - google-cloud-secret-manager>=2.23.1
+  - pyyaml >=6.0.1
+  - azure-keyvault-secrets >=4.8.0
+  - azure-identity >=1.16.0
+  license: MIT
+  license_family: MIT
+  size: 150650
+  timestamp: 1764165172452
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pydantic-settings-2.12.0-py313haa95532_0.conda
   sha256: 41e0f59c3321217f4aa6014c3411daec4264f4ea2483ac4711b90accdc8ae080
   md5: 9be00e22c3dd90cc9dd9e183021866db
@@ -11275,6 +8793,36 @@ packages:
   license_family: MIT
   size: 150711
   timestamp: 1764165274424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.20.0-py313h06a4308_0.conda
+  sha256: 7810c45255be54a77fc8f708d5eace48eebe12267e2e9cedffcdb067c1bc1340
+  md5: ccea3f7c3ca8da985a55fbc042ad8d82
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4943174
+  timestamp: 1775127040649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pygments-2.20.0-py313hd43f75c_0.conda
+  sha256: 3945f2cd00753f3ef45a76ec3c25b5c8a65d6c5c36e5f18b289272f2af5315b7
+  md5: 1e4f8926de2d91ff108ecf1f8d30371f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4941418
+  timestamp: 1775127034860
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.20.0-py313hca03da5_0.conda
+  sha256: aefe5150bc9511f9a6e31975999ab240674991a81a7b0ccc5df44f592283827d
+  md5: 1a096beb854aaa14d863b4da60533f79
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4967892
+  timestamp: 1775127065874
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.20.0-py313haa95532_0.conda
   sha256: 55eb323f6032fe8c04b3336316f03080de2f147a32cc8485a4bf2b3b44cebbb9
   md5: ac3a0314796552bc697699b09c014e71
@@ -11287,6 +8835,42 @@ packages:
   license_family: BSD
   size: 5003268
   timestamp: 1775127093941
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.12.1-py313h06a4308_0.conda
+  sha256: 7cb7783f40374743f4c0c9d49686dfd29745d6a66d8ae26ddc8308f20ef831e8
+  md5: 3cbe7080967f615cd88efd025391b662
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 102773
+  timestamp: 1773773809562
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyjwt-2.12.1-py313hd43f75c_0.conda
+  sha256: 6f44d60503218a48414caa0fd0d40cdb0dcf1aadf000b5415d29bcbd2131ea7d
+  md5: 9f01b187aede17a6e8b192f35472b652
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103005
+  timestamp: 1773773803703
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.12.1-py313hca03da5_0.conda
+  sha256: 8b455cca53f5b8fb51bd25ef8fdaf927bfa0e91dbd48fcbe05e5ed9737708fd5
+  md5: 208f064869aaa98b2340cc60eb64c58b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 103272
+  timestamp: 1773773829773
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.12.1-py313haa95532_0.conda
   sha256: 7aef9d733577597c67e2e122e275063bb1b62289943dde8fc2053e052b4669c4
   md5: ea6817e7fbafb39b117e5d6c30f40a54
@@ -11299,6 +8883,66 @@ packages:
   license_family: MIT
   size: 102610
   timestamp: 1773773869078
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-12.1-py313h73c2a22_0.conda
+  sha256: a452594875ba66d647b65541192f50ab8d45681d8cdc3ab3ec9d237a796839c6
+  md5: c7bc813891134328cf9262beac3465db
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 479484
+  timestamp: 1763629905351
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-12.1-py313h73c2a22_0.conda
+  sha256: 0df17556b26d51e4ac40bfc47965f1f117bc18b8db28dc3fa019e6053588e875
+  md5: fd8423aa2c161f1355d9eb5e53958096
+  depends:
+  - __osx >=12.1
+  - libffi 3.4.*
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 377280
+  timestamp: 1763651408167
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyperclip-1.11.0-py313h06a4308_0.conda
+  sha256: 6752c82dc8d6aa2410c1f5fc594f355661bbd2043ddbcee7120bb54bec9eccd4
+  md5: 41e5a9f1fb430fad7e10a9db74000502
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26218
+  timestamp: 1773985120703
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyperclip-1.11.0-py313hd43f75c_0.conda
+  sha256: 1bbef1f48e7753528341bf23ac4d78d91679959ec0e1f51b7b391c7deeb197e2
+  md5: 90a46389b262fac93bd471f2fc0ea5ff
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - xclip
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25832
+  timestamp: 1773985116510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyperclip-1.11.0-py313hca03da5_0.conda
+  sha256: ce94cf9b7c1c9dc46f158f8ec552d7209ecaa93882c427d63f37e25c4abed58e
+  md5: 505cfc77c635faa08a4a889e1c6c8a10
+  depends:
+  - pyobjc-framework-cocoa
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26139
+  timestamp: 1773985028336
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyperclip-1.11.0-py313haa95532_0.conda
   sha256: fcb763479633b4cc7d05a20cc43670537bf7c4e9c5e473f796860a08104e92c0
   md5: 7aa1773bcce0f593f10a123a140c14db
@@ -11309,6 +8953,36 @@ packages:
   license_family: BSD
   size: 25926
   timestamp: 1773985260113
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py313h06a4308_1.conda
+  sha256: b13f6e99c9e451e2f4aa7216da208ea0c68a9cecafa945d59c9b7c8d554a7005
+  md5: e1ab9ffa1588856f0bdbb204322568c4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35801
+  timestamp: 1761753024312
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pysocks-1.7.1-py313hd43f75c_1.conda
+  sha256: 3aa28f366a3bab840e3c00fb8acd97b3759f74cc0fe16ce5e91b90a57871e55d
+  md5: 43da0d039f7b195466a8be650fa38424
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35803
+  timestamp: 1761753028895
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py313hca03da5_1.conda
+  sha256: 9c857a8b0e6e5b390b17fafb7788844a01ece2f6c5b5aa4d3253f1ab02e94dec
+  md5: 16bf831da5d9b80789ca8c06f958ae2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36057
+  timestamp: 1761753032083
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py313haa95532_1.conda
   sha256: 80a495f4af262ca1119720a007eab7dda13008f48ba1a9e0a0b0003638dc71aa
   md5: fbfa708fb7dba50f62e0363778296f29
@@ -11320,29 +8994,137 @@ packages:
   license_family: BSD
   size: 35859
   timestamp: 1761753068122
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.12-h39c999c_100_cp313.conda
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.13.13-hb7b561f_100_cp313.conda
   build_number: 100
-  sha256: 72ed8ba8d7ddb639d9c49b8ac6580f8e4a07ef9b70ed6e3c9bc9fa759b917195
-  md5: 56ca006b6e825a936082de534f616807
+  sha256: e43d4697c40efbeaddbe332ead42e50847310fe6169792a3f59ee7f667dc26b3
+  md5: f89a334358da4df35098ca9deba1fbd6
   depends:
+  - __glibc >=2.28,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.4,<3.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 33153832
+  timestamp: 1776148532010
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-3.13.13-h0f2f12d_100_cp313.conda
+  build_number: 100
+  sha256: 00215d7abb904516605d67082c7186b60b6e2484f97b2cb419b401066d105d89
+  md5: 207a787e47fa9bf2a1c0c2c8ac812e08
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.35.1
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - libmpdec >=4.0.0,<5.0a0
+  - libuuid >=1.41.5,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 31837743
+  timestamp: 1776148804346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.13.13-ha8cd034_100_cp313.conda
+  build_number: 100
+  sha256: 845ba4ef73057e2b0abeda829750e605b8dff2b9ddac63315fa7e9846a44c40c
+  md5: 5766ed009ee359deae79be0c731f9d48
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.5,<3.0a0
   - libffi >=3.4,<4.0a0
   - libmpdec >=4.0.0,<5.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.0.19,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.5.6,<4.0a0
   - python_abi * *_cp313
-  - sqlite >=3.51.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - xz >=5.8.2,<6.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13578757
+  timestamp: 1776147629054
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.13.13-h39c999c_100_cp313.conda
+  build_number: 100
+  sha256: dd0d092b55af9afdd2b04cb44be3e3ad3679802bef3cd85b5886d8f176cce41c
+  md5: c9bb4829cfe1645f62b5e7a096a963e9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi * *_cp313
+  - sqlite >=3.51.2,<4.0a0
   - tk >=8.6.15,<8.7.0a0
   - tzdata
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
-  - xz >=5.6.4,<6.0a0
+  - xz >=5.8.2,<6.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 16714237
-  timestamp: 1771949289066
+  size: 16758382
+  timestamp: 1776147400245
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py313h06a4308_2.conda
+  sha256: 40e8ae075314cb338cad0de5b1ef35e778298f8759cbd6391e1274c11170537d
+  md5: a844b3df0b11b33f4742841d25146b6c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313830
+  timestamp: 1728385377316
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dateutil-2.9.0post0-py313hd43f75c_2.conda
+  sha256: 0d5279f839e531615cae6b005b988d499c320595a5494e07c4b6c0b0c3d3c694
+  md5: 061428165f4369719796769975341cf7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 315827
+  timestamp: 1728405669914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py313hca03da5_2.conda
+  sha256: ffa7bff5cfa1d97430b7d0ec521b2b236786e07ee76f1108593c41eadf9664bb
+  md5: 2ac600a5ed014f3b8fe2996b213a68e6
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 313686
+  timestamp: 1728585595371
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py313haa95532_2.conda
   sha256: 76a01e3051b5ff8157a5018de495b6f1ca1adaf8854c984a15bb59c7940f1a09
   md5: 43a3d00b9e02e3dea2bdcfec026286ac
@@ -11354,6 +9136,42 @@ packages:
   license_family: BSD
   size: 314702
   timestamp: 1729038434598
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dotenv-1.2.1-py313h06a4308_0.conda
+  sha256: 0b9592d613f10c12d18ef188e3eec0f7ff94ebbdab8ee77f73ddc02d3c77051a
+  md5: 6aa550906f91d13d1371c07e9cb5c5c3
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51623
+  timestamp: 1768559707638
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-dotenv-1.2.1-py313hd43f75c_0.conda
+  sha256: 69a1d0a51f21a0c3980e5efbad4405d95c630d5f017cf731e783b05d9dae9b3c
+  md5: e07c79278a8a508e83e42d176ab595be
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51868
+  timestamp: 1768559706782
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dotenv-1.2.1-py313hca03da5_0.conda
+  sha256: bd7193ebae2aabecbd996e9cc0844e1f112f2cbe144e7d199555d78405f636ee
+  md5: 69ed706ac95df59f56b448091f4c40fa
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - click >=5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51905
+  timestamp: 1768559713789
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dotenv-1.2.1-py313haa95532_0.conda
   sha256: 13d615a42829d3c12dc481c69ab5f1116c3199e288f41254349a06271ce4e9fb
   md5: 072ed01dfef3ee838397aca7daca4909
@@ -11366,6 +9184,36 @@ packages:
   license_family: BSD
   size: 76112
   timestamp: 1768559797418
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py313h06a4308_0.conda
+  sha256: bdf1d5b51557391f395d6fe09fc096a483e16fd4e8d24806979e756468e38812
+  md5: 213fed7b509c30119154cf77a958aa7d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253447
+  timestamp: 1763718602538
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-fastjsonschema-2.21.2-py313hd43f75c_0.conda
+  sha256: da624ac8349c4d3c9785def2d89967def448feb7e4940a001ffda53352766a5e
+  md5: b8dc8f719d9a94474d335a89ff1ab0a9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253530
+  timestamp: 1763718606784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py313hca03da5_0.conda
+  sha256: d3bb009bbbeef58327f24ace232ad6672f9b9f001c415cee2d0d26973384f269
+  md5: 4f88cddab698bd79f5ac2e90d14cbf1a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253652
+  timestamp: 1763718722391
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py313haa95532_0.conda
   sha256: 82a7013143a81abbf1c7657bf8b808bf0dc0a8e3a4b985eda5ad1c57526341e4
   md5: f8d83d25272d9810a1b8f8fc36d6d6b2
@@ -11376,16 +9224,76 @@ packages:
   license_family: BSD
   size: 254671
   timestamp: 1763718769611
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.22-py313haa95532_0.conda
-  sha256: 25a5bf78f4123af6f5e67139d69c90b8a2317a25686ee8439284c0e9eba3065a
-  md5: 7cafce0e85a94c8dd39fc1d34147d291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-multipart-0.0.29-py313h06a4308_0.conda
+  sha256: 38518c171929d43aebd14d5b3a4ae07ca8fc1e3c5b559d93d2c7d1fdfd474ac5
+  md5: f6da44f1a0c19701204d3814cd8f5a00
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
-  size: 62835
-  timestamp: 1770213065957
+  size: 70371
+  timestamp: 1779889654398
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python-multipart-0.0.29-py313hd43f75c_0.conda
+  sha256: c54c6f208047bc8c94bae5cdb295cafdce0072b0fef525735ecedbc50fa462a8
+  md5: 06a1d96bd36a9a13fd00b5855cea64c0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 70879
+  timestamp: 1779889663325
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-multipart-0.0.29-py313hca03da5_0.conda
+  sha256: 290dee7525f088cf979065df63cad60fbf82c0e02c1f1773be0163513529add2
+  md5: eefc93dc9958b1a4450bbe1c66a95b5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 71167
+  timestamp: 1779889676641
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-multipart-0.0.29-py313haa95532_0.conda
+  sha256: f654a8578c15c7d4341952c6b1a3fb623f8b0579e22fda10670c397b1ecb831d
+  md5: d484ad349ee04e4ff3180e0d486899c4
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 70230
+  timestamp: 1779889703227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 2d5e8d21633aa763912fbae5a2f3ffd8c1f3c363b66b0397ad0e25f325460112
+  md5: 5af1bf885def2fa779b0bb002e53651b
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157
+  timestamp: 1764349599777
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: e7035b11d9b02d743d3e802c0d6023a26fefb2c9afc43949a1659198778f8cbe
+  md5: fb2966848729243e63cc897cb90f1eda
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101
+  timestamp: 1764349598421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.13-3_cp313.conda
+  build_number: 3
+  sha256: 0928ef42a325a0aef752e0c268f87b3edd68c155e70dbaa3180da8dfeacccee1
+  md5: 12e362aabff119a51f51ac3c0f3d0a84
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6010
+  timestamp: 1764349560639
 - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.13-3_cp313.conda
   build_number: 3
   sha256: d0a5b4e854c76a4ff354a9ce22725cff8986afff92e3fccca14a02171fccd56e
@@ -11396,6 +9304,36 @@ packages:
   license_family: BSD
   size: 6092
   timestamp: 1764349785264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2026.1.post1-py313h06a4308_0.conda
+  sha256: 4342182e94b23d86b74417a799b300931dfa49129f7e5d9365f32345d9a7f684
+  md5: f700a9cc4e35fd699b4df403f8f14148
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 224571
+  timestamp: 1773043070463
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pytz-2026.1.post1-py313hd43f75c_0.conda
+  sha256: aabb7dbc551fbbc57f29e4b3dae42553d7b0b3df5fafd632d7125ba139456aeb
+  md5: 82cf5e45c6abcf41f54ae3299f0a9f3b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 223054
+  timestamp: 1773043038462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2026.1.post1-py313hca03da5_0.conda
+  sha256: 44d62bb18ba6e206e95d6f75c5d215e610c60960aeef5153db3b76c8eb0ba0de
+  md5: 7faf2150ef3d3493e3554582fec52fcb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 226666
+  timestamp: 1773042949673
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2026.1.post1-py313haa95532_0.conda
   sha256: c56ad8b43d5b1c0839d9bb87ddbb1b969c3591d67df173fa416e38d094c8d81e
   md5: e2698e9bf539b4e68b9b7fde985f7cdc
@@ -11429,6 +9367,44 @@ packages:
   license_family: BSD
   size: 55951
   timestamp: 1768296662106
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.3-py313h591646f_0.conda
+  sha256: 089600b68f1c5fc3c5823528114f763e2789af20f04164ea6c660326513ace67
+  md5: 2384f037ab798b6ce6097c717a8758dc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 253759
+  timestamp: 1763465523432
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/pyyaml-6.0.3-py313hbd8301c_0.conda
+  sha256: 4496ec7513e79769dcdbb4f2db3f3d7968c59240e03e7f29391023820cb70f80
+  md5: a9b067a53f219bf9ed2a4583154facf9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 245388
+  timestamp: 1763465541517
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py313h091b9d3_0.conda
+  sha256: 52d335bd2a19047162856f58afa6a5e10ef612e3b6617bc3d89dd2c968c7f579
+  md5: 5ea183aac23f4bbe41412f200a70d09d
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237854
+  timestamp: 1763465528485
 - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py313hb9a58be_0.conda
   sha256: cdf7b48afb00e8f1c75b8009bf288015f3f894925807350c412d2b40505ff71b
   md5: 99d3b0d7895f14c833020bae2637fbd0
@@ -11443,6 +9419,33 @@ packages:
   license_family: MIT
   size: 232090
   timestamp: 1763465571269
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2025.11.05-h71b5c5c_1.conda
+  sha256: e976cd3fcd8128b6416ed261b33455555e97633d9e7c0b526a252023a23dc48c
+  md5: 631d76b2ec86efd85d6266113f7b20d5
+  depends:
+  - libre2-11 2025.11.05 h3356fce_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26001
+  timestamp: 1770390441796
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/re2-2025.11.05-h4a58e83_1.conda
+  sha256: e024f78c0141941a0ce6b7e30ff10bffd9937a95efbcb9639cf0319cef887d31
+  md5: bb43fdeb5e1bc6595d63be00f22eaf00
+  depends:
+  - libre2-11 2025.11.05 h1b0d54c_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25969
+  timestamp: 1770390562916
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-hff8a8d8_1.conda
+  sha256: a099f0095e595511221b35581ee0a4cc19ee7c1f1f45ebed4cca2f87ea1f2ac6
+  md5: 91b2255e51ad03fbe4460ccb6d3ca14f
+  depends:
+  - libre2-11 2025.11.05 hce96306_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26013
+  timestamp: 1770390441654
 - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hca2749c_1.conda
   sha256: 37ed6c029f2d0ca481bd36dd1a46be9c56d6aefd3af67238aad08a4058078cb1
   md5: 7b2b70a3962203de30cb3f7d4a21e759
@@ -11452,6 +9455,36 @@ packages:
   license_family: BSD
   size: 218680
   timestamp: 1770390656414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readchar-4.2.1-py313h06a4308_0.conda
+  sha256: e1c9e9a33eb6d5a47bdc4ada2379e51419633e237674ca69a0a0676c17b15e0c
+  md5: 33b7455bfa1462c42bbc9a0535070313
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19959
+  timestamp: 1760613452708
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readchar-4.2.1-py313hd43f75c_0.conda
+  sha256: 97032b1b4dcb8436e00a10196d457efc001eb8e9421f3fcec1cfcdeb9c39b710
+  md5: d2228764ccb4ad95813f44effcaaa38a
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 19961
+  timestamp: 1760613342830
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readchar-4.2.1-py313hca03da5_0.conda
+  sha256: 0d5e09acdaf98868658dd89212a4e626ee165b323ab0fb5e643f066d925e5830
+  md5: 65b12cc9b3773ba5fc8a6beb3c3d0938
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 20018
+  timestamp: 1760613321490
 - conda: https://repo.anaconda.com/pkgs/main/win-64/readchar-4.2.1-py313haa95532_0.conda
   sha256: ce9cb1907f5ad2f1da9a073bf941532fcae38754ee519092d675ed2632c15eb0
   md5: 2686c6ca4329a9d6a587103c986e7026
@@ -11462,6 +9495,73 @@ packages:
   license_family: MIT
   size: 20322
   timestamp: 1760613512213
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.3-hc2a1206_0.conda
+  sha256: 0a438fa74f2776bde137017d6c18214b5da65b557f6a59f877fa4e091582f789
+  md5: 8578e006d4ef5cb98a6cda232b3490f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 481826
+  timestamp: 1754485653893
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/readline-8.3-h886d1d0_0.conda
+  sha256: 3cc178114a9108f4d0c81b924a1ce4961733166335b4e09b7e1f88e4cc182ccf
+  md5: f04b3cb7ab28e886ceb012e4e9626e82
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 509455
+  timestamp: 1754485781954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.conda
+  sha256: 22cf28d17df12004caeeaae6ec93a01e3f855eafece0b32a98976eef08968a34
+  md5: fed853901ec41684b9e08b0c7ee4d7f0
+  depends:
+  - __osx >=11.1
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 475276
+  timestamp: 1754485689285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py313h06a4308_0.conda
+  sha256: 8376c334e1fb1b76670880ad259c207aef7e66b28d15b3d0b2635424778795ce
+  md5: ce6e467c7e671a9214bc5d118b8e24a7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82123
+  timestamp: 1762536905383
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/referencing-0.37.0-py313hd43f75c_0.conda
+  sha256: f6e430f0e7deb1e4c4c4ce53f5f11f40733dd3a4c4ad65a38c2149eccd5ca17a
+  md5: f1cd02f5cac4c78dd00805f81f7b66d8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82590
+  timestamp: 1762536906694
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py313hca03da5_0.conda
+  sha256: 7533a707f1ee1e3f8a2f767408e1aad3046d32d83254d6bcd73b92783016fd8d
+  md5: 3fa52decbfabf965e84fd38bfb2e268f
+  depends:
+  - attrs >=22.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 82518
+  timestamp: 1762536906534
 - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py313haa95532_0.conda
   sha256: 175d71ed03e9e70ec164fe1f944955859f1e94b78bd068131737366f52863348
   md5: 45abed89b4fa72b0b16dc01408537551
@@ -11474,27 +9574,147 @@ packages:
   license_family: MIT
   size: 82654
   timestamp: 1762536944331
-- conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.4-hd77b12b_2.conda
-  sha256: 1244464650edae7ee4a7361e2bff996d40f41a984ce824fb96c911151aa0e7df
-  md5: 0145436bf5111660b686d3ad7f1b4235
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-14.2.7-h7bdf020_0.conda
+  sha256: afcc50a102a20a62df24c7fc24633890890af7cf64d9c08ca2286bccf8eec5c7
+  md5: 6457711c539cd20f56d9fa5e6ae5a5f5
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 41178
-  timestamp: 1714681024765
-- conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.4-hd77b12b_2.conda
-  sha256: 977af37a7ae564f8b244b6406fc44db97a17649c7265fffadafba9b927ff77ac
-  md5: 34c1b673ec90d3c79cfb1677505ae5c8
+  size: 33172
+  timestamp: 1779874661488
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-14.2.7-h301ae1c_0.conda
+  sha256: ac4f8229d2aa423275f34dc53516f464d80fe3627412ee7ef2c1f8f00e823b8a
+  md5: 3543296e743c9cb365f2d1dee9cb6e71
   depends:
-  - reproc 14.2.4 hd77b12b_2
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 35033
-  timestamp: 1714681086506
+  size: 35011
+  timestamp: 1779874676017
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-14.2.7-h279499b_0.conda
+  sha256: 15f2f9b90cacb20e84d4ca7870b15ae0226113910f070f12036228a185ee9617
+  md5: c7e057a695cfc78b1d4c785ddec6a37f
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 30651
+  timestamp: 1779874778017
+- conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-14.2.7-h557c29b_0.conda
+  sha256: 0e25fa8814c0154a9e589e68b319b22a39aa2a9d256b3ff8eebc4e0a5be828d7
+  md5: a1848bc3395d29fff4f81de7be74d472
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 43916
+  timestamp: 1779874863790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/reproc-cpp-14.2.7-h7bdf020_0.conda
+  sha256: 9120848526b0a8e31e77203b49a55fbee85cf76ce660271681725520abb0b93f
+  md5: cd9ab66296f9984949c0435f41e72b55
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - reproc 14.2.7 h7bdf020_0
+  license: MIT
+  license_family: MIT
+  size: 24820
+  timestamp: 1779874672388
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/reproc-cpp-14.2.7-h301ae1c_0.conda
+  sha256: 6aabc3074e7c0195de04f8bfafbbd9ba40c34e7598f91837cb835b1da9abe1bf
+  md5: 0798f80fc7bef933ba09c8f4ddba5555
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - reproc 14.2.7 h301ae1c_0
+  license: MIT
+  license_family: MIT
+  size: 24782
+  timestamp: 1779874688284
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/reproc-cpp-14.2.7-h279499b_0.conda
+  sha256: 061c07d08829138f34c19aa3053402e0bf6f925906a7d7578a1635c7e3932dda
+  md5: a80f5d41ad365f36f785e6e322299762
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - reproc 14.2.7 h279499b_0
+  license: MIT
+  license_family: MIT
+  size: 23644
+  timestamp: 1779874801900
+- conda: https://repo.anaconda.com/pkgs/main/win-64/reproc-cpp-14.2.7-h557c29b_0.conda
+  sha256: 47156389bf7f9d04f3c116e6c98c5b9c4311e197fb8be42074ecb16743607187
+  md5: f6ea26bc9084409d0a2a9be480bad52f
+  depends:
+  - reproc 14.2.7 h557c29b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 37142
+  timestamp: 1779874893417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.33.1-py313h06a4308_0.conda
+  sha256: fb7227e6713f831d1558659e3dc71a69e9f53374372972f0e9c0d8ce14220e82
+  md5: 120fcdc3014753b33a63db5930b7a085
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170579
+  timestamp: 1775066095969
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-2.33.1-py313hd43f75c_0.conda
+  sha256: 8e4cdfbe2dbd77b9415effb956d4ab68c8a994b3657438c021be2e81771773b9
+  md5: a7bcec6c82277f3990f35708bd05d660
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 171420
+  timestamp: 1775066082442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.33.1-py313hca03da5_0.conda
+  sha256: 2bc2756ad208ca327f46bbbe424ae887a4df5cc4129c7e1fb91c95fc21059980
+  md5: 056c8adeda5b39d0bd1bcaf1a869cf41
+  depends:
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - urllib3 >=1.26,<3
+  constrains:
+  - chardet >=3.0.2,<8
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 170039
+  timestamp: 1775066216803
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.33.1-py313haa95532_0.conda
   sha256: 2e3287357fab55e326b1d2ed0a4a648647e2ad1ea1851c1da2a98059427558b0
   md5: db2c3d5b826ca6275015bfaaf007188e
@@ -11512,6 +9732,39 @@ packages:
   license_family: Apache
   size: 170995
   timestamp: 1775066185516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py313h06a4308_0.conda
+  sha256: 0a3eb96e3e0c2de1df8880f41e47b1ef34cce72ae53fe3820e339694944105e6
+  md5: 3d3714d0b2268f6cbe59c3d29cfd40e7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88122
+  timestamp: 1728411680534
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/requests-toolbelt-1.0.0-py313hd43f75c_0.conda
+  sha256: a0dc745e608077b2ce3bf9b8564f32fdb834f8be1206b445a9595bd0dad0685a
+  md5: 3f4000830e7a25be1df38114d361b976
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88285
+  timestamp: 1728500408740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py313hca03da5_0.conda
+  sha256: 9d68498b090f71bd57dd69d9139b75391e7da2cba9b2be08786ef82491d679ae
+  md5: 85f9714b8bf50cf6f9c75deb5441bba8
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88498
+  timestamp: 1731721373383
 - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py313haa95532_0.conda
   sha256: 522043089fc1642c8c8798864bdeaad6b7ddcdbfee8a3083fc31bdcc02577166
   md5: b11a903414ef47b3faed42691b1d2c9d
@@ -11523,9 +9776,9 @@ packages:
   license_family: Apache
   size: 89136
   timestamp: 1731731373752
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rich-14.2.0-py313haa95532_0.conda
-  sha256: 54308fc64559dac4eb2f486594c826aaa7ba33d984392c6ee59850491c494a4b
-  md5: 098632335698839505bc680c928fb38f
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-15.0.0-py313h06a4308_0.conda
+  sha256: e6056b611316c3f7a8b4b6f0cd6ed38275f825c3598303e783a07614539158f7
+  md5: 78f44153bae9a28238cf140f78cef7be
   depends:
   - markdown-it-py >=2.2.0
   - pygments >=2.13.0,<3.0.0
@@ -11535,8 +9788,86 @@ packages:
   - ipywidgets >=7.5.1,<9
   license: MIT
   license_family: MIT
-  size: 604180
-  timestamp: 1760375703489
+  size: 626259
+  timestamp: 1778860811865
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-15.0.0-py313hd43f75c_0.conda
+  sha256: 39e74971e59b4d9d2c9a6ad5638108eb9511ca7d137990e308dea7ca77567af5
+  md5: bff53525066be213bbde1a5bb3a1f0c7
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 628546
+  timestamp: 1778860800445
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-14.2.0-py313hca03da5_0.conda
+  sha256: ceb20a4d0571172d728e024274f030472988f4d4ab1965ac462d3fa590fee548
+  md5: ffc0d1741d0d0dbff07518323feb64d8
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 603836
+  timestamp: 1760375502207
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rich-15.0.0-py313haa95532_0.conda
+  sha256: 31cf33152a74005a7b5cd8a8baa8d8dc415197a34e91a144f3d1f67c61b67d7c
+  md5: 844538246a04a0dd3006f70e801aabed
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=7.5.1,<9
+  license: MIT
+  license_family: MIT
+  size: 629366
+  timestamp: 1778860861487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rich-rst-1.3.2-py313h06a4308_0.conda
+  sha256: 9ab35664ea9e41afe5c959070c86854f46eca25982bbf73a9e62a05b9d045d27
+  md5: 42d308b4487e6a58261a971eb689044b
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33936
+  timestamp: 1771961295227
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rich-rst-1.3.2-py313hd43f75c_0.conda
+  sha256: 699d60c5f06a9df8431f7c24ed0d2bb1f09299b32c699ffada923ae58a3aa56b
+  md5: 167fe8ee5af593667148b74a02090717
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33721
+  timestamp: 1771961162662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rich-rst-1.3.2-py313hca03da5_0.conda
+  sha256: a63ed09b318c9368d7a0ec52644a8367ed5b5f117a2b50fc263dac2b3fe37f36
+  md5: b57cd190c76b2fb85cfc3c3d7d4358b9
+  depends:
+  - docutils
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 33777
+  timestamp: 1771961170073
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rich-rst-1.3.2-py313haa95532_0.conda
   sha256: ad249f5c8aae6b75219fad602950c0287295a1b6baf118de85ee83afe1caa9e4
   md5: 0331fdc656de0c90b60866c109b7c686
@@ -11549,6 +9880,41 @@ packages:
   license_family: MIT
   size: 33623
   timestamp: 1771961216902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.28.0-py313h498d7c9_0.conda
+  sha256: 8a11539da653f2eaad8b4518fe504190e70d13158e5ff6231c6792a418cb8736
+  md5: 9630d019be2bb127699a375157124a0e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 346701
+  timestamp: 1762366536075
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/rpds-py-0.28.0-py313hff451be_0.conda
+  sha256: 7a25701e0c870f3d7dabe66635566c7c94bbe62731d920813a1559527669cdb9
+  md5: 7f93cb69d835d6256cc68d0c22843159
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 335795
+  timestamp: 1762366544737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py313h931abed_0.conda
+  sha256: c0c3155d53a74deb3760d6b824779eda02c2b73fe78b7b751b7745e06c7c6e9e
+  md5: 150c83ebdcae2067ae5c34a05c1da4ed
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 311962
+  timestamp: 1762366565780
 - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py313h114bc41_0.conda
   sha256: e9d4ae95e182d385fad599b171f7dbdf125a385566cd551e5ae579aa6699a9f0
   md5: 3253a635462ed5652fb9f5241e201d69
@@ -11562,6 +9928,50 @@ packages:
   license_family: MIT
   size: 219848
   timestamp: 1762366911453
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml-0.18.16-py313h4aee224_0.conda
+  sha256: 83d992869476949a782ae72360b1e3b6a224f9238eae988cfad48a968c8b2d8d
+  md5: dc961556c7bbe4e2aa959e36ab816dcd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271868
+  timestamp: 1762535994695
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml-0.18.16-py313hd7af942_0.conda
+  sha256: d9b2654f8c1f8c7923e4ccb573d55d220cbae0c92716d313c05f41d1a49e653f
+  md5: 28b23d252e0d230044637b0f8f88cca6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271533
+  timestamp: 1762535980215
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml-0.18.16-py313h091b9d3_0.conda
+  sha256: 1040a8e295c8b637eac191aee060ebbde881b75c6a1479ef0971bde031805350
+  md5: b292e4688f8ac6f1c97f1f3e895f5cff
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ruamel.yaml.clib >=0.2.7
+  constrains:
+  - ruamel.yaml.jinja2 >=0.2
+  license: MIT
+  license_family: MIT
+  size: 271430
+  timestamp: 1762535976251
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml-0.18.16-py313hb9a58be_0.conda
   sha256: 4e8a117ed84fdf47dd2ef8ce7c6395af0a1310845917b4087aa98ec045796454
   md5: 97843e1c3c45660d8aa2c6dd6a7d1fc2
@@ -11578,6 +9988,41 @@ packages:
   license_family: MIT
   size: 271852
   timestamp: 1762536109923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.14-py313h4aee224_0.conda
+  sha256: df7d182c5909cf1ae37d0ac9878f22ad91e76fdb87f045c0240d4486a7451789
+  md5: dad8d758af9c2b4369776c601407d9bd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 136835
+  timestamp: 1762530306911
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/ruamel.yaml.clib-0.2.14-py313hd7af942_0.conda
+  sha256: c80d7f66a720a9dd3f035fcc1fcca139b286f159bd7f0677a08a5aa079762524
+  md5: 26960af9de364b5745c254d1a6890c45
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 127958
+  timestamp: 1762530151153
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.14-py313h091b9d3_0.conda
+  sha256: 7686f956aaa99c67ffd4ddcc948fa476397fc6844eeb6142967ddaa7b8114b1d
+  md5: ca9e7978a1057363f0c36d975b764dcb
+  depends:
+  - __osx >=12.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 114492
+  timestamp: 1762530107760
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.14-py313hb9a58be_0.conda
   sha256: 3ca28bf6841518b5004d899bd726b3f0230fd1ebfee34a9c336e6dc0cb41523c
   md5: cac6a4b727d18eb086ea401e817043af
@@ -11591,6 +10036,62 @@ packages:
   license_family: MIT
   size: 108685
   timestamp: 1762530153943
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/secretstorage-3.5.0-py313h3e8c6aa_0.conda
+  sha256: a5dc14f868fcc6b98b5093305e985b1aff2a0ce3fa4edef94932602b23dd8a4b
+  md5: 6ce9737188317c940d461c09c18d0ab3
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31382
+  timestamp: 1775127026347
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/secretstorage-3.5.0-py313hafdef7f_0.conda
+  sha256: f423b3bc7e365996e4fb8b265b7bb6b0790702517185f534adbaf2a55a8c0005
+  md5: 529575cd8e6b7becb44a50d0d35009f0
+  depends:
+  - cryptography >=2.0
+  - dbus >=1.16.2,<2.0a0
+  - jeepney >=0.6
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31316
+  timestamp: 1775127025036
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/semver-3.0.4-py313h06a4308_0.conda
+  sha256: ce726cfd41df7c8a86cbcdedd2ab214ce8ed33a50d74b590260cc53627298336
+  md5: 985226bbcb23ebc859128ca676ad6321
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45387
+  timestamp: 1761903210853
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/semver-3.0.4-py313hd43f75c_0.conda
+  sha256: cd9d1902e6e7675f052439029cfd50fd70a9ec084691702b720e2249953f9b07
+  md5: c9d0d757b916ddfd019821dbbc02a0d9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45447
+  timestamp: 1761903130898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/semver-3.0.4-py313hca03da5_0.conda
+  sha256: 78efad9113b08c223bf96a195fe65996bbdaf3587e87c4b3c6481928070c7529
+  md5: 8b4a9bf142beac7513382b0a84ce51f5
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45786
+  timestamp: 1761903046636
 - conda: https://repo.anaconda.com/pkgs/main/win-64/semver-3.0.4-py313haa95532_0.conda
   sha256: 5158570e5a5891716906743ce9eebe1a0572143dffe808ecba634e5a2c0b3859
   md5: 2dbcf40ddf66f02858c49c67ce0fd953
@@ -11601,6 +10102,36 @@ packages:
   license_family: BSD
   size: 70112
   timestamp: 1761903400398
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-82.0.1-py313h06a4308_0.conda
+  sha256: 3b19305eb5670d0eafa08575636138a86c88b7a1d3a34fc225bd4fb51e0d4dcc
+  md5: 08038e054ee9e8419ea6aa3fd04455ea
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1665385
+  timestamp: 1775048728528
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/setuptools-82.0.1-py313hd43f75c_0.conda
+  sha256: 691001895cc61622efa94d674bdfe7f91dd51bdce52898dbea94d2fb9bbcdd87
+  md5: 10081f3addefc88e8127e68448bf9f6d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1666759
+  timestamp: 1775048722771
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-82.0.1-py313hca03da5_0.conda
+  sha256: 5cf9904f08ee02e6ba687dea9b2dee477d55b5f7486d838ee2faba8d4b1c7dff
+  md5: c396551324d88dfb8c688affa5226c2f
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 1669346
+  timestamp: 1775048820327
 - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-82.0.1-py313haa95532_0.conda
   sha256: 8c047064c40aa8a1c02c2488a7466178b71e87f5fce2ca9b95c96acc60d434b0
   md5: c5e8aa64b4745bdbadc0d37754385ccd
@@ -11611,6 +10142,36 @@ packages:
   license_family: MIT
   size: 1666057
   timestamp: 1775048790435
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shellingham-1.5.4-py313h06a4308_0.conda
+  sha256: 47d5ad98d9f8b7aa0f48cfe606df993fa4e1b1d41ea2896da3a6f1eae0937a89
+  md5: 843241073919fc2c912f6ed85d14681d
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23136
+  timestamp: 1761912223128
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/shellingham-1.5.4-py313hd43f75c_0.conda
+  sha256: 656b3ab4c52768925d82841c3e9827e3a28e55291eaf47484c86fd7be73edec0
+  md5: d32e4a1ec001c6cef1aae68c11480c55
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 23120
+  timestamp: 1761912222490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shellingham-1.5.4-py313hca03da5_0.conda
+  sha256: 43437a90f1db5cd5603620a8af4e37880850dfcd9ab88ae616528ca659449e89
+  md5: 58fe2f1c6896f6e26cea231b74e3888c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: ISC
+  license_family: OTHER
+  size: 22962
+  timestamp: 1761912224859
 - conda: https://repo.anaconda.com/pkgs/main/win-64/shellingham-1.5.4-py313haa95532_0.conda
   sha256: 1f6a915225fb3e8712d8734cae5276eb4527f93f5051f79269c1e1e4d03cd9e5
   md5: 48a11caef15ab91bf7360541a0842d05
@@ -11621,6 +10182,35 @@ packages:
   license_family: OTHER
   size: 23375
   timestamp: 1761912263432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/simdjson-3.10.1-hdb19cb5_0.conda
+  sha256: 452430e6b5df349770e48ef41b2a1ecb8e92ec2b3fc31ddea89478f32ea14c16
+  md5: 7b2a4b5be590071e1b4dce77b413d26a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 264262
+  timestamp: 1734048099531
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/simdjson-3.10.1-hb8fdbf2_0.conda
+  sha256: 0bed4f7057d57ec935f5e9ebd46bdf300ffa236273ac06f5ac173ed640d26b0e
+  md5: 0cefa22396b339a17597faad550d9582
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 226027
+  timestamp: 1734048100065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/simdjson-3.10.1-h48ca7d4_0.conda
+  sha256: 80fdef44c1ea1d8a4ffa768444c116f711058b835c30ddbee929c8a309daf985
+  md5: 443db5b88521ce0e2aaeb77bcf8fb488
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 220407
+  timestamp: 1734048107599
 - conda: https://repo.anaconda.com/pkgs/main/win-64/simdjson-3.10.1-h214f63a_0.conda
   sha256: fc942285ef1ed85c6ae955752e7ebadda95161eefc560c8e034d0d56f33110e1
   md5: e89a4c728f54ef6e0d7845fd1992af58
@@ -11631,6 +10221,36 @@ packages:
   license_family: Apache
   size: 281697
   timestamp: 1734048180938
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py313h06a4308_0.conda
+  sha256: 25c4d3fa5923de3070180fb4c17c0557e172cf323e2a99da868f040f391c1fb7
+  md5: 648ce63d75b826e85fb8801c8b4b4e44
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37483
+  timestamp: 1744271525796
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/six-1.17.0-py313hd43f75c_0.conda
+  sha256: 7bfb98f79c243707ab4ba9c569d96052b16a14185abe9f313e41c67a6fc28510
+  md5: 626970a8b8398716c9b9f9025eafd307
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 37500
+  timestamp: 1744271573927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py313hca03da5_0.conda
+  sha256: c4339bba39bcdbf9301a75b5e772966cbc247356422f66c50ea5c90e5e106edd
+  md5: 4af6f9244bd475289f3410b1c8880ed9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 39474
+  timestamp: 1744271575294
 - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py313haa95532_0.conda
   sha256: fe16c893061086d4882b77d91b95efa937a831ce78bd3eb17cb18c99539b8232
   md5: e7fc4d83bea7ee99038d43c773df475f
@@ -11641,6 +10261,36 @@ packages:
   license_family: MIT
   size: 38706
   timestamp: 1744271651700
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py313h06a4308_0.conda
+  sha256: 7bf4a958a0c21f733d6f218688b4e01b044ffbe11b41505d4092881617c119ab
+  md5: face17589cf2b386d76cc870234dfe6e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17447
+  timestamp: 1764329206740
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sniffio-1.3.1-py313hd43f75c_0.conda
+  sha256: 174cca7b6e743c2c85b3e5b0d3399a29fde9351bff57f28a75e3d2ecc5c27ea7
+  md5: 219c67c8ff19787a64b06c2517d063e9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17506
+  timestamp: 1764329173905
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py313hca03da5_0.conda
+  sha256: 52e26a3e22a62b610e2d3dd43fb5becf4ad9060e3319d5e76211937bce2c0759
+  md5: 6ebd355b1fda9640f8ffc5d07d9ff921
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17410
+  timestamp: 1764329171349
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py313haa95532_0.conda
   sha256: 256d04f9d78737274877cd1fb9d7b15ef9efa940737cba71701ab20f9555322a
   md5: ec4cfcc2fe1e1b4325af67997d46ba36
@@ -11651,6 +10301,47 @@ packages:
   license_family: Other
   size: 17469
   timestamp: 1764329260587
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.51.2-h3e8d24a_0.conda
+  sha256: af5dcb4809daf5ab309df062dbdb5df46575743775da9bf1939dae6f61ca36b4
+  md5: c7b847a43363d2d77724b9ea04881088
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1265119
+  timestamp: 1773313781324
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sqlite-3.51.2-h6a2ceb9_0.conda
+  sha256: d247a646398efd960957cf97af321ee97510dc52495b892fb57805011637de89
+  md5: 55600c8be72a7624ebd63e54ed72cbe0
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1281272
+  timestamp: 1773313781654
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.51.2-h67002bf_0.conda
+  sha256: 3133f8cd69edda2f3c507c5c2270686a6d7aeb0874a3c0a406312b39a13c0269
+  md5: cf083b0b25fff8ddab995ac001076f38
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.3,<9.0a0
+  - zlib >=1.3.1,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1182590
+  timestamp: 1773314600429
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.2-hee5a0db_0.conda
   sha256: d9d5f8b3ba4afcf43baca9386ae69f3b7b0f1d30f35ced10bc52d61fe0d1cd28
   md5: b273f421592da633715a1c28058d0ea9
@@ -11662,6 +10353,42 @@ packages:
   license_family: Other
   size: 938682
   timestamp: 1773313787688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sse-starlette-2.2.1-py313h06a4308_0.conda
+  sha256: 9074c157033b6d6443a3520e459bdef40e1634409eb4d8d9c2beefbffcaeed6f
+  md5: 1fb18f68f15d21748310b2a09ea2f923
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21821
+  timestamp: 1745413175232
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/sse-starlette-2.2.1-py313hd43f75c_0.conda
+  sha256: 1f90b15547d9d7436ef835b336b644a3bbcc15133e2a5af931d4c70a87c46d83
+  md5: 1596a495a1f3def74862ce0efcc8281e
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21754
+  timestamp: 1745413132458
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sse-starlette-2.2.1-py313hca03da5_0.conda
+  sha256: 61cee6962389ff5fc805ab537bb21c207714843bc47302d6ca18acb45f6734c6
+  md5: 685d7b964cfdfd152fb5ddc0951b16d2
+  depends:
+  - anyio >=4.7.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - starlette >=0.41.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23284
+  timestamp: 1745413263670
 - conda: https://repo.anaconda.com/pkgs/main/win-64/sse-starlette-2.2.1-py313haa95532_0.conda
   sha256: 9f666e8156f111864ed9db7cfc4ade7408c9ca70f7f2b83f21bb17028715b6e0
   md5: cdb1d606ebfdb4a999b3936644911c34
@@ -11674,17 +10401,83 @@ packages:
   license_family: BSD
   size: 22693
   timestamp: 1745413221013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.47.3-py313haa95532_0.conda
-  sha256: 47ab748d8923e946c1371b1f0a9512fa93ccedacc387a6a10bbee8c52f85f43f
-  md5: 59708fc1ba21fea3beff24556d600b6d
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/starlette-0.52.1-py313h06a4308_0.conda
+  sha256: 205f2efa8f24e445fdd2efc879eb43fd19885a77d5f72f86ba29ab1e09c5b154
+  md5: d9137689e3d1e45fee0613c791807ca6
   depends:
   - anyio >=3.6.2,<5
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 177278
-  timestamp: 1756910740826
+  size: 179416
+  timestamp: 1773935038245
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/starlette-0.52.1-py313hd43f75c_0.conda
+  sha256: 13d68b3a88d81c4379d44d65d3d269c34a6752dd6869553a934f7a93a696409c
+  md5: 57f468854fad649b203e90595c14129b
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178961
+  timestamp: 1773935043775
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/starlette-0.52.1-py313hca03da5_0.conda
+  sha256: 8c8698c7ef19c251efad29aa3373b9b0254e6fb33a62dc92ef31682e00c6de57
+  md5: 3f457d26bf49537f9afbf846ef1e84f7
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179700
+  timestamp: 1773935049678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/starlette-0.52.1-py313haa95532_0.conda
+  sha256: 747c1e409f3b1b25dbb11d51b477adffe911caef8a680799c6791a1770ca4812
+  md5: d9500a3026c68819025ee4573be8b839
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180098
+  timestamp: 1773935096668
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.15-h54e0aa7_0.conda
+  sha256: a3bcd301ddd0bdb2f52f9bd3274fabe3c33d43ed61e58ee657efeac01b4be157
+  md5: 1fa91e0c4fc9c9435eda3f1a25a676fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3610181
+  timestamp: 1755243907117
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tk-8.6.15-h987d8db_0.conda
+  sha256: 7e200ff8eda9a62b654a30c9edd742a28b023f326d4a18f6f2f4abe951b2c8ec
+  md5: 6a7f42565108e00d27f68f4ae5751c53
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3717438
+  timestamp: 1755243976411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.conda
+  sha256: d2f8bd6a7c62e4a5104134aff22c983b9b50970b9bbf731214504c613ced8042
+  md5: d1329e6c7292f448cdeed21290dd1035
+  depends:
+  - __osx >=11.1
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3448719
+  timestamp: 1755244020166
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.conda
   sha256: 2f7e9d06b513bcabce6d9ae195e45ccf94fd249edfefc591a5430a9f6f92a7fa
   md5: ddff7b6a72958ef802f40a735e505474
@@ -11697,6 +10490,45 @@ packages:
   license_family: BSD
   size: 3700492
   timestamp: 1755244051664
+- conda: https://repo.anaconda.com/pkgs/main/noarch/toml-0.10.2-pyhd3eb1b0_0.conda
+  sha256: c50b132439b0260e4b43649ce30171a4792e186c6f3d657e5936578d4ee3fc56
+  md5: cda05f5f6d8509529d1a2743288d197a
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 20302
+  timestamp: 1616166645426
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.4.0-py313h06a4308_0.conda
+  sha256: 881c460e980d563ae40d9382356f42e4f63bcf8762575abb18170630d3de899c
+  md5: 782987d420694bdc4a207a16db446a56
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82730
+  timestamp: 1768296500871
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomli-2.4.0-py313hd43f75c_0.conda
+  sha256: a274fe0770ea35a7ed5b0c2697b5e9e56c5cecdb3eba316185b5e15d2e863e1e
+  md5: d5ba67844244cfccfa37b1b23ec83b23
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82633
+  timestamp: 1768296495852
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.4.0-py313hca03da5_0.conda
+  sha256: 565876f3bbce59ae9608a9ba4e67a949d65f704d102a2850aa537ece46af9c4e
+  md5: 65d4e75c4c995d35de71b4e16174828c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 82474
+  timestamp: 1768297453889
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.4.0-py313haa95532_0.conda
   sha256: cfd820f3b7c2cb7e7ff53c7110fc11d45220724457831c4b7b44e10f24b4e081
   md5: bf2d1a34135ca0731780c7b012fa5c89
@@ -11707,6 +10539,36 @@ packages:
   license_family: MIT
   size: 82570
   timestamp: 1768296694724
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomlkit-0.13.3-py313h06a4308_0.conda
+  sha256: 158dd73f8c64c1211ef362a68382c1cd1b1a4814b4c84b4859e5fe066304f22e
+  md5: d625085e004f964c54b88a3c6c5e8d7e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189342
+  timestamp: 1762896696002
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tomlkit-0.13.3-py313hd43f75c_0.conda
+  sha256: 4c2f8e0469b67dbb1deec79c9b3d3bff0668044d638beb79c18fb0fbfb13ba9e
+  md5: 8949c7ff2861d1b903cee84c0607eacf
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 188584
+  timestamp: 1762896685732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomlkit-0.13.3-py313hca03da5_0.conda
+  sha256: 5787a058d8aab97129b6201de75e1d3253fe9dbbe991c68b199c7df94962a3b2
+  md5: 9199e3c9a0451d04eff558d461dd1b2c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 189601
+  timestamp: 1762896659686
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tomlkit-0.13.3-py313haa95532_0.conda
   sha256: 5ab0840c91097eb033eb73a06cae0dee6317379b1c15cff4fe9672168488d28b
   md5: c5c83cb181bee0abb42aa29669eecee6
@@ -11717,6 +10579,42 @@ packages:
   license_family: MIT
   size: 189958
   timestamp: 1762896691761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.3-py313h7040dfc_1.conda
+  sha256: 2dae6e5073fc7597727f5fc968f2a7be9fcb5f464d684d6d66d9e8664ab5baf6
+  md5: 17b9f23e939b55ab9cab471b694a79d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 161112
+  timestamp: 1771398721582
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/tqdm-4.67.3-py313had16b7f_1.conda
+  sha256: 6157fd5ae467221b71a6a4fa958ef6c160cfa2f01459bd26864238bd3228d2d6
+  md5: 54a2c4b9c33935687b977159f85bb4cb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160713
+  timestamp: 1771398718073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.3-py313h7eb115d_1.conda
+  sha256: b27733c474fc142c12d0e5c9e9404e500ed8b365a282f491390fca4affbd2cd7
+  md5: af4d88d628ea31190ed1432bba93b9c2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 160792
+  timestamp: 1771398721170
 - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.3-py313h4442805_1.conda
   sha256: d3fe275f6dbc5bd68277660f7cbc07ced89a4fb5198a35ce2c32bc5d02eaa042
   md5: a797878a96f1b422ec8eee84371459f2
@@ -11730,73 +10628,175 @@ packages:
   license_family: MOZILLA
   size: 185961
   timestamp: 1771398813387
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py313haa95532_0.conda
-  sha256: 9617cced1f3dda7b511a1b19fce74ec6126de327febd3cbc096f1393b4253562
-  md5: 0a77cf43cb292b62f1021ec2f59b809c
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.15.0-py313h06a4308_0.conda
+  sha256: 274c0ad0b14fca0b3a3d2d5fff8804d2d99ca660ac338b30224f2824005b1c40
+  md5: 93dd7d3739aa3e9a0b3ce910b5c91d5c
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 214295
-  timestamp: 1729038177233
-- conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.1-py313haa95532_1.conda
-  sha256: e3cdd87c4b0acadd89a849d52e28b2624a3029ff88ba75a77a74bfec6e037135
-  md5: 02621c34f9d5bed45c55831d62a45ae7
+  size: 216754
+  timestamp: 1778743205283
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/traitlets-5.15.0-py313hd43f75c_0.conda
+  sha256: 36d3dcc1fcf349d492bc1fc183f99102f1ad504ea5910e318cbc18e62114d64b
+  md5: 127cf9452aabe77ff4daea094120dcb0
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218385
+  timestamp: 1778743205817
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.15.0-py313hca03da5_0.conda
+  sha256: 3e4e87649ffd0483f6bf8cffe8098106679cd83ca56f3aadd9b18bb183515dbb
+  md5: 17ac336b222db9cf45b6d74890371e12
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217925
+  timestamp: 1778743224108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.15.0-py313haa95532_0.conda
+  sha256: 417774d590210211eb55d4be0103b73d53a390e26363a990b94c212ea11221e3
+  md5: 2baa556e463ae440468ad8353ef83b83
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217412
+  timestamp: 1778743452939
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/truststore-0.10.4-py313h06a4308_0.conda
+  sha256: b69555753dd28bdecf8c6a94f879d8315127f04f4c7a9acd6785f41d5e193edf
+  md5: f8e8226a4e9b6c4c7676c78022f8d003
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 49487
-  timestamp: 1762521065061
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.20.0-py313haa95532_1.conda
-  sha256: bf5f44ef827b63bdfaefef50ae2eca43e9ba0d0dc478a51deec0ef9fee8815b2
-  md5: dfab5f80445eb8659daef0ba9527f95f
+  size: 50225
+  timestamp: 1778600084355
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/truststore-0.10.4-py313hd43f75c_0.conda
+  sha256: 07d7707d700d3ddda46216c4cce3eb8c39b3ab4244ef2600e950a9fdf3352893
+  md5: 9c2d1e8c9740dca79f9281eff9f431fb
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  - typer-slim-standard 0.20.0 py313haa95532_1
-  constrains:
-  - typer-cli 0.20.0.*
-  - typer-slim 0.20.0.*
   license: MIT
   license_family: MIT
-  size: 182475
-  timestamp: 1771513176865
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-0.20.0-py313haa95532_1.conda
-  sha256: dd4e5f1bc66d19d4294dd0730671f7e3a0fe6bdc5c5ab863846edd88b13b06e9
-  md5: 8ec4fad99a2260241e793af8d8ef2369
+  size: 50345
+  timestamp: 1778600086391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/truststore-0.10.4-py313hca03da5_0.conda
+  sha256: 23f924b06f0fcf96757fcce25b5de1c35674da2e9fc8f8157fb7174442b73772
+  md5: c9caedd05a758f1f9df3c49b6225fa37
   depends:
-  - click >=8.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  - typing_extensions >=3.7.4.3
-  constrains:
+  license: MIT
+  license_family: MIT
+  size: 50313
+  timestamp: 1778600098786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/truststore-0.10.4-py313haa95532_0.conda
+  sha256: 6d440c1e88ae74beb26c2f44183cec007ad6b3b4fec076a2f7b23ffa4e698429
+  md5: 48181e0c8f132e1a57fb0d1948a63ffd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 50164
+  timestamp: 1778600148421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typer-0.25.1-py313h06a4308_0.conda
+  sha256: 477ede6c19edc3ec9ac08684e3fc2c3d863cfc1d71042f50ba60f094df177450
+  md5: b524467d0bb8751ea35a55fa87ba71bc
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
   - shellingham >=1.3.0
-  - rich >=10.11.0
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
   license: MIT
   license_family: MIT
-  size: 112460
-  timestamp: 1771513097234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-slim-standard-0.20.0-py313haa95532_1.conda
-  sha256: 05bc257bcdc83b244bbd10915692690463fc8b27e40abb67115df64faaa79fc1
-  md5: 928952e95121b247487ae696bac105fd
+  size: 210715
+  timestamp: 1778701935356
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typer-0.25.1-py313hd43f75c_0.conda
+  sha256: 62ce86e20a16502f21f9d6b19ec878354695c7d2e016f5491d9dca1ea1f9262c
+  md5: c9e278b2ba623fa3634302a105cff672
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 210065
+  timestamp: 1778701931511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typer-0.25.1-py313hca03da5_0.conda
+  sha256: 7c2efb472fd099419f690ff8e5ef42a44c44ad0d06cae1271ad42a75f4fdee65
+  md5: bd9e935bfa0c48ef639e5ccf2cc96dc4
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 210811
+  timestamp: 1778701946808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typer-0.25.1-py313haa95532_0.conda
+  sha256: 4285aa3c362408858342d132a21302e1511a285f2be494ec88a86771e11c6ab3
+  md5: c1b556b36cdd4beda8ff938d08b5987f
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  license: MIT
+  license_family: MIT
+  size: 234563
+  timestamp: 1778701999688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py313h06a4308_0.conda
+  sha256: 8aed1c54e0b3b89551f84dd7815d05e5369632f134661e15fa325f08892e46a7
+  md5: 1c8a1efd0b3a33cee5c2dceae66bbc69
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  - rich
-  - shellingham
-  - typer-slim 0.20.0 py313haa95532_1
-  constrains:
-  - typer 0.20.0.*
-  - typer-cli 0.20.0.*
-  license: MIT
-  license_family: MIT
-  size: 7252
-  timestamp: 1771513106030
+  - typing_extensions 4.15.0 py313h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11238
+  timestamp: 1756280930223
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: 62031a971d86963693de075496ac81eedc99e7a1635a15dfdabe3468cdfbe50d
+  md5: 055d37ff4e41c9b9e33d2bb8919c263b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hd43f75c_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 11203
+  timestamp: 1756280951293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py313hca03da5_0.conda
+  sha256: 7c6b650c981f3b6874c2d3bbda3d336f5fb2694985c306523a0b136ca2f3ed73
+  md5: 22b46f0e6d389d4199ffaa317e9c9a05
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions 4.15.0 py313hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12434
+  timestamp: 1756281597870
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py313haa95532_0.conda
   sha256: 3503a6100d19cd88fcc28c21d6e3517f78e77f4541408266f0d6ffc2010a6ed0
   md5: b9d604ca2915d5b5c2e71c56eddcf39e
@@ -11808,6 +10808,39 @@ packages:
   license_family: PSF
   size: 12368
   timestamp: 1756281409751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-inspection-0.4.2-py313h06a4308_0.conda
+  sha256: 00aa2a9ef266a76e0823cf313c961dccede14699c163261b3422151bcce4c725
+  md5: b5ea08882d6d5cca3e38a27a3575e85c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32310
+  timestamp: 1760614182019
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing-inspection-0.4.2-py313hd43f75c_0.conda
+  sha256: 29ddb0dd120cda4fa324399c1a654c4097d8c9ca0eb26161bc9e1fe9e4983de0
+  md5: ff4e707bcf34fee0e2065cf2487e2103
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32401
+  timestamp: 1760614185275
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-inspection-0.4.2-py313hca03da5_0.conda
+  sha256: ac672d308344cc0852fe43b5099da7eca46ce651afdb79f1cdca256c75488f99
+  md5: 1398c39b86119164f19498b6fbcfdb69
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  size: 32465
+  timestamp: 1760614190333
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-inspection-0.4.2-py313haa95532_0.conda
   sha256: 2d10e45ad212588bd03eded99708a7d2dc50f4353577c890e82a28e6e3593f2a
   md5: e20a2281ead8112e87233f7ced446b0d
@@ -11819,6 +10852,36 @@ packages:
   license_family: MIT
   size: 32527
   timestamp: 1760614225492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py313h06a4308_0.conda
+  sha256: e878aa8e2f1ce2fd0e6d21baeb729023e4a5eeca0e7c8d83b7a244b73bbf3294
+  md5: f3ef53d8c6a2ecffb4fca9c1ddc2bbc9
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 104756
+  timestamp: 1756280924315
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/typing_extensions-4.15.0-py313hd43f75c_0.conda
+  sha256: a51338fb2806bff9dd9b51e044829fbf057de74ca5ca4f33985300e7324c4cec
+  md5: 017a18fc16caf581ce26bac0ad6f9efb
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 101647
+  timestamp: 1756280944673
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py313hca03da5_0.conda
+  sha256: a97465fc1f5093231fd739b63b3ea9282960cc9b79d106893dff7724ffcdacf6
+  md5: 3c37609330dd4baeb0f4842f02cb783e
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: PSF-2.0
+  license_family: PSF
+  size: 106009
+  timestamp: 1756281579411
 - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py313haa95532_0.conda
   sha256: 7ffee67192fba083f61c95f197fc119cb77ef83528d5d18ed2f63a881e46c0b9
   md5: 0e3cbe58bfd973d09298bcbf2de72675
@@ -11829,6 +10892,13 @@ packages:
   license_family: PSF
   size: 103139
   timestamp: 1756281400010
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2026b-he532380_0.conda
+  sha256: 88f1c183adaf24df340d03ef5df510447973b0e80641ab1538e2d66db689c34b
+  md5: 805dd0dbe5ecde428f3c6c1afb6d94e2
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 120718
+  timestamp: 1779900350004
 - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.conda
   sha256: 9dfca4fb23f20e62a48b9c52e2fdf4d0d34bb31eb6a930c2195fcd10651b3cc3
   md5: 15e1b10231d7d236520501fcfb440f31
@@ -11837,6 +10907,36 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 634816
   timestamp: 1752158202557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uncalled-for-0.2.0-py313h06a4308_0.conda
+  sha256: 2d42e7cc0c83fc6152f8c942d9f66c49ea4e49f21d471a665f76e97e56c6a5a8
+  md5: ad4d17d499c69cca7e35518f53419f5c
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24140
+  timestamp: 1774276104417
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uncalled-for-0.2.0-py313hd43f75c_0.conda
+  sha256: 3a46f253864cff829ca94ab2fecdcbd3b6ca02da5ea43d7015cffcd4d46ab256
+  md5: e857fd0d00de0e82669ff9e06d27f6dd
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24215
+  timestamp: 1774276085005
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uncalled-for-0.2.0-py313hca03da5_0.conda
+  sha256: 834ba725d9fbfda00034c04eae2213e577a2fcb917b7a253bdc2d0e8930172ef
+  md5: 7c281290dab4999400a1e12be880c3a2
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 24287
+  timestamp: 1774276373831
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uncalled-for-0.2.0-py313haa95532_0.conda
   sha256: 19b9ca9d334f4dad46930fad8dbd029817e78e1b5b1e4571fa703cdd196ece8b
   md5: 1b5b33b6f59be43d466b89eca9058e3f
@@ -11847,9 +10947,39 @@ packages:
   license_family: MIT
   size: 24294
   timestamp: 1774276137392
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py313haa95532_0.conda
-  sha256: f4d385f2f8c1803164a156f5122bde7d345be80b485827e2046562e1cf307da2
-  md5: 991be321d1493e7325cf42a491eb01d9
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.7.0-py313h06a4308_0.conda
+  sha256: 02cfb9c30d1cf750a42523f273398edd5d8fcb31df0d0da07cf47c94891381c8
+  md5: b5fd092add49ea41b474bc98a75af1da
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 358018
+  timestamp: 1778536210174
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/urllib3-2.7.0-py313hd43f75c_0.conda
+  sha256: 2f429e9acc04a010d2b78629fda1d3c4f31da97de071c876f8a09739a6694e3d
+  md5: 12fbb02050f301302859c818d3f1e396
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 357165
+  timestamp: 1778536199781
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.7.0-py313hca03da5_0.conda
+  sha256: 1663c484954fe3a1c2e6f656ad29dd4a6e31c99635617cc4bc67a583f35c2cac
+  md5: 523fd5bb78899f64e2e04c1b15bd4041
   depends:
   - brotlicffi >=1.2.0
   - pysocks >=1.5.6,<2.0,!=1.5.7
@@ -11860,8 +10990,59 @@ packages:
   - backports.zstd >=1.0.0
   license: MIT
   license_family: MIT
-  size: 358116
-  timestamp: 1767810523479
+  size: 358132
+  timestamp: 1778536217975
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.7.0-py313haa95532_0.conda
+  sha256: f4aa4d5590a45ea91b4b89f2f306c19be0d2ab21c76b4d0995e5938b5328aa37
+  md5: aaabd598ba288a5d67bc60bdf5705c99
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 358522
+  timestamp: 1778536256029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-0.40.0-py313h06a4308_0.conda
+  sha256: f444276b9f9b353c47227ae8ef6418cff0ccd7560b23b3edcf6290005df9cc20
+  md5: 302fdbeea413b0dc179b3ea16886718e
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141937
+  timestamp: 1768226450635
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-0.40.0-py313hd43f75c_0.conda
+  sha256: b6d57df0245c0df353e5f7ca59e3647d5059bb401423c5cf276a30fc626d0145
+  md5: ebabc185d4b18349d7bf0d9f5c3d2901
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140643
+  timestamp: 1768226452652
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-0.40.0-py313hca03da5_0.conda
+  sha256: ebb909b75e5214bfacca7f7121a3449becf208d36d46b899b4270b7358eeb1bb
+  md5: 1b6bf0e4a6bafa3a2df6c2df65f47206
+  depends:
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142181
+  timestamp: 1768226456487
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-0.40.0-py313haa95532_0.conda
   sha256: 79a3d79f156b4e3c2c0403dd306673d0ce0eab9fe826ce222fcd278e25736412
   md5: 892ba822f39d820e448a427969b75326
@@ -11874,6 +11055,57 @@ packages:
   license_family: BSD
   size: 167281
   timestamp: 1768226570499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvicorn-standard-0.40.0-py313h06a4308_0.conda
+  sha256: c4714f77ec6df2606b18fdc2900f0e5305e59b731436b7e95f2cdbe500e6f7e3
+  md5: 2e099756135a2ef67be288cb2d8c3119
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313h06a4308_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39548
+  timestamp: 1768226455792
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvicorn-standard-0.40.0-py313hd43f75c_0.conda
+  sha256: fbbba93cf352e46cccbefedae465c7381d3dfb3ba6a9f0dda6f527e967dad4ec
+  md5: cb02ecced70ccf3114a942f060eb4f66
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hd43f75c_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39602
+  timestamp: 1768226458187
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvicorn-standard-0.40.0-py313hca03da5_0.conda
+  sha256: 436b3d8391a3b1eda354b782c636c53782a89df146d456d3fdeaa8343b0605bb
+  md5: eea1461696459cc24a16b5a689281400
+  depends:
+  - httptools >=0.6.3
+  - python >=3.13,<3.14.0a0
+  - python-dotenv >=0.13
+  - python_abi 3.13.* *_cp313
+  - pyyaml >=5.1
+  - uvicorn 0.40.0 py313hca03da5_0
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  - watchfiles >=0.13
+  - websockets >=10.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39438
+  timestamp: 1768226463310
 - conda: https://repo.anaconda.com/pkgs/main/win-64/uvicorn-standard-0.40.0-py313haa95532_0.conda
   sha256: bf489bb11dd95158312c6b4691d73f1b1a639203cfa9f16e1b0cc5c50b9bb8f8
   md5: 6d196786ef6b84ab5630c064a6163ac1
@@ -11891,35 +11123,117 @@ packages:
   license_family: BSD
   size: 39668
   timestamp: 1768226581896
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_10.conda
-  sha256: d427b27e553a5caa78284a995ff9c3720b0f213a0e650fe9d3b54b4b4a65f241
-  md5: 064c529f6f598fb2225446f76687a170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uvloop-0.22.1-py313h939ff40_1.conda
+  sha256: 734615ac4498aa1bb62aed2bbcc0ec55a1b3ff2c73a071769e4d64421e807e8d
+  md5: c28e5468c6d8844e76d22ac7baea58e4
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 665707
+  timestamp: 1762175545430
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/uvloop-0.22.1-py313hc610eb1_1.conda
+  sha256: f6e2443613a13dcb1bd8aabc3454daf8a4f7de82c0862158b8eb3f5f9d1590dc
+  md5: 27e470f3b095fe3116358db877c2a2ea
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 612267
+  timestamp: 1762175558240
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uvloop-0.22.1-py313h8e34c70_1.conda
+  sha256: bd23f850a94fa6830c8568d1c03ee882000df3a1b366b03332f865856ad3177a
+  md5: 62098dfc2ae82083a56bfd7bc319cf0e
+  depends:
+  - __osx >=12.1
+  - libuv >=1.48.0,<2.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - python >=3.8.1
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 545986
+  timestamp: 1762175544791
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.3-h2df5915_12.conda
+  sha256: 81f68bd3f7e74032547fc3c2b1d7d914b2688cc11f2470625c5c65d49d1474bd
+  md5: 6737bfee92a331a876eadd8a2af7bc09
   depends:
   - vc14_runtime >=14.42.34433
   license: BSD-3-Clause
   license_family: BSD
-  size: 19506
-  timestamp: 1752199946483
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.conda
-  sha256: 747f5d55439e327d3b035c0078be59991ffa5683542fbcecbcc6abcfff50588a
-  md5: 13296ea2847729c01c316b089cb28337
+  size: 16822
+  timestamp: 1779209283775
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_12.conda
+  sha256: 492ba65a50d99120e047469057f5eaddd3043cf17a18761653d1b3ae5d9d6c84
+  md5: 061ea1cc93ee2dd574defcaa4e93c4e5
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.44.35208.* *_10
+  - vs2015_runtime 14.44.35208.* *_12
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  size: 845189
-  timestamp: 1752199754308
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.conda
-  sha256: fa731e65f9c6b7b9559cb93653d067658594f39d2bc5c75cae85ac2385d79d06
-  md5: 58665d8e606897afb52a202669673c40
+  size: 679595
+  timestamp: 1779209267029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_12.conda
+  sha256: 5b484a4b7df0133f60fd9e12dcf1926f868eaa34a2c3ddad8475169a1a99d9fa
+  md5: 74783ea081af58781a57cf9ec9b09008
   depends:
   - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  size: 19526
-  timestamp: 1752199762272
+  size: 16841
+  timestamp: 1779209282759
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/watchfiles-1.1.1-py313h828f358_1.conda
+  sha256: 8ba2673045897d4b473dd974281b5d17db2e3cd42feec3a57dace7ca5a2faae2
+  md5: 9a7b7a4267a510d59d226cd2c271e9cd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 431640
+  timestamp: 1767984676303
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/watchfiles-1.1.1-py313h5331b00_1.conda
+  sha256: 1c63f47cdd8a02e84a0eac4310a93e386ca83c30c066d698a02e0ffa472e5593
+  md5: b60abe6911b141fc8469ee8852c5b1cc
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 421473
+  timestamp: 1767984729070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/watchfiles-1.1.1-py313h931abed_1.conda
+  sha256: 53edfc478b14716b82ac71ee21940a4d0512e6af5a5426cccdc1f67ac32d03fb
+  md5: 3ef9c9cd73f6f7bd7cb9ec85cf3440aa
+  depends:
+  - __osx >=12.1
+  - anyio >=3.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 375190
+  timestamp: 1767984700820
 - conda: https://repo.anaconda.com/pkgs/main/win-64/watchfiles-1.1.1-py313h114bc41_1.conda
   sha256: dc3c74fd7093bffff637f079d3034dc370e15e3a53b2b106e8eb4f963496bfcf
   md5: 18d5cb6b1af206d5279c66db0cb1fefb
@@ -11934,6 +11248,38 @@ packages:
   license_family: MIT
   size: 316002
   timestamp: 1767985067119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websockets-15.0.1-py313h5eee18b_0.conda
+  sha256: 30b177001b71e3ddb69eed8217658c0a9d8240194483418d377e35f59d3b8ea0
+  md5: 946018cc418258ab8d35ed63099a3181
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361630
+  timestamp: 1751974452259
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/websockets-15.0.1-py313h998d150_0.conda
+  sha256: 97a97f5b53defb67fcd5d14f0b84f5c9228086d320cb109357f167f39701228e
+  md5: d6b2c092cb970c634a4b1376a8c212b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368295
+  timestamp: 1751974662854
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websockets-15.0.1-py313h80987f9_0.conda
+  sha256: 54ba860a22cd288c9196080b4431a314e7827f046ab18a458aa64da94c8a8fc9
+  md5: ec80386b367f09af4b44b3824e29acce
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363811
+  timestamp: 1751974819165
 - conda: https://repo.anaconda.com/pkgs/main/win-64/websockets-15.0.1-py313h827c3e9_0.conda
   sha256: 1422f7434ce43647a3336ce4703d6a57905b6ffaf9906a5809fa09cc4fb06bbe
   md5: 05f2ea39368835a4209afca69a5b479c
@@ -11946,6 +11292,39 @@ packages:
   license_family: BSD
   size: 402372
   timestamp: 1751974975676
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.46.3-py313h06a4308_0.conda
+  sha256: 9899eb565f7010fe91efefc9e2b4dc2bc08065430e9e14e3414e7f297948a232
+  md5: 6730c94b00e7d802f421acd3a435af84
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70377
+  timestamp: 1769450261731
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wheel-0.46.3-py313hd43f75c_0.conda
+  sha256: 83f8f2d01220682a28efacae9589d21325dc39be273d6d5d9fd68c6718546393
+  md5: caf0597b40222d6f17f745bd54636cea
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70703
+  timestamp: 1769450262181
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.46.3-py313hca03da5_0.conda
+  sha256: 53344dfbce1a3e0720ea25d92cf9072870362149f2d147941ac8aae1a4239912
+  md5: 0d4dafde912fdee412dadf279d688eb5
+  depends:
+  - packaging >=24.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 70617
+  timestamp: 1769450358672
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.46.3-py313haa95532_0.conda
   sha256: 8206b8d3b204549064bb11d50b812cf283f898444ade26f2bcde765424980575
   md5: 5d0ad25154aadbe531052f5aebb2e9f5
@@ -11966,6 +11345,38 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10272
   timestamp: 1761746316414
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.17.0-py313h5eee18b_0.conda
+  sha256: f3a385b050596fbed9be259f53a41152713b734867a5f38de2cee108aada2034
+  md5: 446fbd19ad7929dd70635f0303c5047b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67121
+  timestamp: 1736540936116
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/wrapt-1.17.0-py313h998d150_0.conda
+  sha256: a853f095b2e6f0777fa569aa073de1aa8be3bc462e7dd6c19138442326c28354
+  md5: 2f59f2d19a1fae28dba2d2f9ea8290a1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 67625
+  timestamp: 1736540966215
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.17.0-py313h80987f9_0.conda
+  sha256: df2aa78b66b2edc73bf71fdaccbd51e715651e197ef00957d8dca52178912773
+  md5: d75550f3641901250eaa43ed71dc40d7
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65365
+  timestamp: 1736541780222
 - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.17.0-py313h827c3e9_0.conda
   sha256: bb5df055aa57eb6b5f9d90cfe6d13c40c6437f4da0bf3611188e8380cceeab3d
   md5: 280ad1ae053ab8dee8a864e78ddf501d
@@ -11978,6 +11389,315 @@ packages:
   license_family: BSD
   size: 70322
   timestamp: 1736543533940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xclip-0.13-h2b58a6a_0.conda
+  sha256: 2953a78b2a6f8988c5ef5536cffccc1e8958ffa98e04365649d39554c214d635
+  md5: 8d5b22b094b6802334d7c8316c4091ce
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23000
+  timestamp: 1771372478643
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xclip-0.13-h4c53172_0.conda
+  sha256: 7fd31bd131ff7bf17f7205165eb3bbb3a29866bae103088ac68b20830d1972aa
+  md5: 750a7b171e663c39f6ecc0771452514a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 23909
+  timestamp: 1771372468468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libice-1.1.2-h9b100fa_0.conda
+  sha256: e83e369e26f364615e54e09559c2e21a5942e5123fa06f99a2f521e22c72350e
+  md5: 7a684ffa744044240b3061ad28531930
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 58122
+  timestamp: 1746171563556
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libice-1.1.2-hf66535e_0.conda
+  sha256: f95499eccf463c8d72a58daeed4e6a0dfab8a2bcfee8b8f4f5770981dd33a656
+  md5: 4f190efcbddae546e15d54f3f0314b96
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 59357
+  timestamp: 1746171572210
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libsm-1.2.6-h9b100fa_0.conda
+  sha256: 6758861c2da82b77bc8b7bc3abe804450a3aa2c7380ab2d78cf22f733f9a523c
+  md5: a1bf3d2a2c2e8d073f6e7524263a2dcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26341
+  timestamp: 1746172168013
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libsm-1.2.6-hf66535e_0.conda
+  sha256: 412c158700bc61564bcbc9e3c8452547bda98d213328191046dcefe115fd26b3
+  md5: 5f236726d0a97a7c6c9ff0aac3ba96a7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 26965
+  timestamp: 1746172174098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.conda
+  sha256: e9e6228687c03d1c1318f6d7434e6c54f1a5e821def15d4926a5ce4c0a01a17e
+  md5: 6298b27afae6f49f03765b2a03df2fcb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 916212
+  timestamp: 1746110020649
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libx11-1.8.12-hf66535e_1.conda
+  sha256: 6dc7b5d8998298e251ab4610f7a1efd9723e1ec78558c749909cda0342194740
+  md5: e87565f2b050d575ee056f472d062383
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 950329
+  timestamp: 1746110056137
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.conda
+  sha256: 68acf87da69a0237d5083798a9cc9b89d2887a84a5323aa740006b53cd5159ef
+  md5: a8005a9f6eb903e113cd5363e8a11459
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 13582
+  timestamp: 1745958707989
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxau-1.0.12-hf66535e_0.conda
+  sha256: 0da54142ef0bd137ad44c8927d6ed12f23f2f10a3797aecbceed8150d07be3c7
+  md5: 96f0df92ef31ad0aaf27b6b373e4f510
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 14118
+  timestamp: 1745958715370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.conda
+  sha256: 459c8497d1c22b020404b481fa12011abeb27d8eefde37dd4ac9f5a443fd5ac7
+  md5: c284a09ddfba81d9c4e740110f09ea06
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19260
+  timestamp: 1745992279492
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxdmcp-1.1.5-hf66535e_0.conda
+  sha256: 54db79084bdfe59f8d9ca7518f8b7441b6d00a6e68a33462ab000fda129fd08d
+  md5: 5bfda69ee113cfc8e38e0214c078ef4e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 19895
+  timestamp: 1745992295156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.conda
+  sha256: 3752508e5432138309facb103965554bf785152e48882dbd881513badd0ed2b8
+  md5: d810521a7b4a177fb3d1152cf84a778d
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 49889
+  timestamp: 1746169291297
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxext-1.3.6-hf66535e_0.conda
+  sha256: 236f4a70a188eba67be9a5b02008b8853db5ac38aac6529874b357caeb69875a
+  md5: 607d46e3586e0c7b93a4495e0fe52db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 50277
+  timestamp: 1746169296094
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxmu-1.2.1-h9b100fa_1.conda
+  sha256: 7628dc6d801b921e4a3dd593511612f84e013328b48311da0062387328a530c4
+  md5: d95e8903fc0067086f153d04b8cbe578
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 95151
+  timestamp: 1746431898579
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxmu-1.2.1-hf66535e_1.conda
+  sha256: b6bd9a5e8fafe433bb619843559adb21200bf4dc2613282d2fef50737b93cc8d
+  md5: f5e59a8d2737934ac40c9bf645a75c52
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 100170
+  timestamp: 1746431911997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxt-1.3.1-h9b100fa_0.conda
+  sha256: c03ca18988dca78468d31f7f3f268baf0c98ac2236aa1262d8ad75d6e1bcdb91
+  md5: 79d7d6794c6adbc537fc98f94e204270
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 409903
+  timestamp: 1746172685149
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-libxt-1.3.1-hf66535e_0.conda
+  sha256: 1eb152302ac0a4f39f3c722aa875e7b61d320e5941d07963851def13e5dfb101
+  md5: c4b133535086cbaaf2403b18dc377e4a
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 417862
+  timestamp: 1746172689660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.conda
+  sha256: aa6d3ab9be5b43d3e8ac0c7e23f2a83c3959f8f30ec758e2fcae91f87a9b23b4
+  md5: 412a0d97a7a51d23326e57226189da92
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-xextproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-renderproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 594175
+  timestamp: 1746046234466
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xorg-xorgproto-2024.1-h998d150_1.conda
+  sha256: 347ac79a59f0c88a743a27b62c41ffe12aaa048c1ae5727646269a655b832f28
+  md5: 46b530510556e0b1830c40b5ac625f0e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-renderproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-xextproto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 595620
+  timestamp: 1746046239552
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.8.2-h448239c_0.conda
+  sha256: 6394c59cbb6ff035f3a5e4d599a32214cb304b362299fd40be39d7ed20bef9d1
+  md5: 3cf8f0b9f45cd775a7ee57ede84f827f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 635646
+  timestamp: 1772548381644
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/xz-5.8.2-hed4fdd2_0.conda
+  sha256: 04d800f866f0deca3a27863708652584f6fd5a04683bb3230aaab8444eab2950
+  md5: 0d2e76f65075404a9c26010882e7a786
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 643308
+  timestamp: 1772548369777
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.8.2-h8bbcb1d_0.conda
+  sha256: 6d98eb8d7f2517e8a870dd44d25519215e2330a88e750ea21b2be9b1b9052fc7
+  md5: bc7f39bd763f6957ec91046f0e67a9f3
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 269216
+  timestamp: 1772548381049
 - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.8.2-h53af0af_0.conda
   sha256: e09005f52c41234213bd52ebd07092d945855b6d631dd709dcf35dbc71a15c63
   md5: 70e604035b6c97b915114912f047fb2a
@@ -11989,6 +11709,28 @@ packages:
   license_family: GPL2
   size: 271653
   timestamp: 1772548477626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda
+  sha256: e22753e19432d606139f7a604757839d265dff93345226ba0732676526870e28
+  md5: 39fdbf4db769e494ffb06d95680c83d8
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 76992
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-0.2.5-hfd63f10_0.conda
+  sha256: 2e8a3db5905010de77f300dce64f1af51376eaa4206da5e5c3898d73c803a577
+  md5: 588d487b103786708d10c1800d048fd4
+  depends:
+  - libgcc-ng >=10.2.0
+  license: MIT
+  size: 77652
+  timestamp: 1619009841594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.conda
+  sha256: d4c5f11b4b9cb372f491caa39fcd28b426aa113cf1232775072ca6385e2fd87c
+  md5: 23a9bda10db68f27fac5c379466c98b7
+  license: MIT
+  size: 73088
+  timestamp: 1629137313522
 - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.conda
   sha256: e197edaa90488491bd6e0eaa51329d2d93242c6acd7d0aa7b0351d4b24412368
   md5: 959a63017c520ef9d345bd82ab344e3e
@@ -11998,16 +11740,79 @@ packages:
   license: MIT
   size: 63112
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.8.0-hd77b12b_1.conda
-  sha256: 0cc485708dd5d8d00b8c9293f4c0a854adfdf8ca48b512afc1ece5764751177b
-  md5: f90bd3c9e348fc821d2699721773225f
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-cpp-0.9.0-he852c71_0.conda
+  sha256: 9881d22ff3a472b6d424ef885baa619b31dd27f2f0a7c3f6dbbace71aa1a5603
+  md5: 7e0c8c5e43d4065f5bb3cb40de4126aa
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 2166174
-  timestamp: 1714514387587
+  size: 234370
+  timestamp: 1779458140041
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/yaml-cpp-0.9.0-hcd08bf0_0.conda
+  sha256: 65852665efa9433cf9add0ea2b46bf409663af4528f17d120410371c6d4731c4
+  md5: 80b96527a03b6186e574059d6af883e2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 222186
+  timestamp: 1779458144514
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-cpp-0.9.0-h9fe17f6_0.conda
+  sha256: d519dc160c79bc40da9ca424a1daed5441d08c58d940516dc387ca25151a3a3a
+  md5: 80f60a3e6c45cddd8e956c50649639a5
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: MIT
+  license_family: MIT
+  size: 131238
+  timestamp: 1779458127666
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-cpp-0.9.0-h9081779_0.conda
+  sha256: b860f44879f826759f3686fea65eefbb86f40ce58ca577eaa2765246f3c49e28
+  md5: e4fd736681f37662a9637b0b9d53fe1b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 154790
+  timestamp: 1779458199902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py313h06a4308_0.conda
+  sha256: 2e748ac14b087c6521a946d5fe6227e93d6f0b7c68fcdb4e7965a8e2f1a8e00b
+  md5: 0c22474f16e65bd9b52fd3b8d60a0372
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32106
+  timestamp: 1763977880529
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zipp-3.23.0-py313hd43f75c_0.conda
+  sha256: 82054f7d23c29bede55d1da674a1997231f7974e8ed9c3ac543a9d8581667994
+  md5: 89dedf7658549815d9e8d5456231932b
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32299
+  timestamp: 1763977879242
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py313hca03da5_0.conda
+  sha256: 502058805ffeb16d372dd378037492076731936614704018d7556b8a7792beb6
+  md5: 1b87c5130b5fd6d1738e28799f8b8236
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 32097
+  timestamp: 1763977879589
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py313haa95532_0.conda
   sha256: e1fabe5d67279888410b53ad3fe26f02d6c82cb3f4124e07b08e7988815cde31
   md5: 58f9bf466a66b75fee3e9522803e26f8
@@ -12018,18 +11823,94 @@ packages:
   license_family: MIT
   size: 32592
   timestamp: 1763978011708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.conda
-  sha256: 116120d38011eea43cbeeb70e00b0eaa3b1c0a3f470df09aadb0d0b66aebbf60
-  md5: 4db9b3fbefe915ffb9eef8c812a98c6a
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.3.1-h47b2149_1.conda
+  sha256: a31e7df4e55a0040e533095c09275a9d58747fb19e5cf9825820af20d4d55c02
+  md5: b987e8069100421df3350e8662d6a96a
   depends:
-  - libzlib 1.3.1 h02ab6af_0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30133
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib 1.3.1 h47b2149_1
   license: Zlib
   license_family: OTHER
-  size: 115567
-  timestamp: 1756476083170
+  size: 91138
+  timestamp: 1776974327859
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zlib-1.3.1-h27118de_1.conda
+  sha256: dcec75ae492e5c0149f4b2d3e8d70d3bf4a892fe0e38f9e8231004e762533a8f
+  md5: 08ed08b247f3fc6c4a5bd14875419365
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=14
+  - libzlib 1.3.1 h27118de_1
+  license: Zlib
+  license_family: OTHER
+  size: 88075
+  timestamp: 1776974324319
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-hb4cf58c_1.conda
+  sha256: 46ea11a239f326ff410d148a882b9c1daf5a26f4811cf8929e06b5ffb7907e27
+  md5: af4b715d560a4a8c11223309f733d433
+  depends:
+  - __osx >=12.1
+  - libzlib 1.3.1 hb4cf58c_1
+  license: Zlib
+  license_family: OTHER
+  size: 76072
+  timestamp: 1776974337144
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h1c6eee0_1.conda
+  sha256: 10596d5e73832102d7c09031ba2cd6e6ce47dd0c71ff94e660bd5759e681ecc2
+  md5: 2cabd7930e833462962979b8bfce6ff3
+  depends:
+  - libzlib 1.3.1 h1c6eee0_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Zlib
+  license_family: OTHER
+  size: 106377
+  timestamp: 1776974467764
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.24.0-py313h3d778a8_0.conda
+  sha256: e3a31827def7e52e8b17481605be98ddc542d651c5267ddfb31780db3d1d78f0
+  md5: 78685aca3b481cf213b92abfbe0b2b21
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 422402
+  timestamp: 1758189113863
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstandard-0.24.0-py313ha8a8473_0.conda
+  sha256: 8d0991b8ee1b489d5fb45cd77902658eba3f129ff09854375eda0863a1e8a85c
+  md5: 8d4a8433cf437f7ecc5aafa9874c2012
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cffi >=1.17
+  - libgcc-ng >=11.2.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 396870
+  timestamp: 1758189118512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.24.0-py313hbc14757_0.conda
+  sha256: 443e7f4075520a4d613ec1d73800bbd40fe9517c263b2e4fb4e9deaa6c596886
+  md5: b282b2aecb718102ee0bb3848514689a
+  depends:
+  - __osx >=12.1
+  - cffi >=1.17
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.7,<1.5.8.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349977
+  timestamp: 1758189118260
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.24.0-py313he335c29_0.conda
   sha256: ecc86fd8a56adb8e6cfc2f6ede240b93350cdbf7382662c6ffb12f526e4dff03
   md5: 2fcbc03acf75dedbb17fec7ef2ba5803
@@ -12046,6 +11927,46 @@ packages:
   license_family: BSD
   size: 337202
   timestamp: 1758189153500
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.7-h11fc155_0.conda
+  sha256: 5d1b1c5041b80b47d2ff06c0ebda0c334f53f521efac824fc79a139cfd9fc4f5
+  md5: 93b0e546434bfb874aeefd6bb6cf40bb
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 622604
+  timestamp: 1758039176606
+- conda: https://repo.anaconda.com/pkgs/main/linux-aarch64/zstd-1.5.7-hc8aa508_0.conda
+  sha256: 5e2ebfa0dc51fd7ccc525bffaebb324e32fa7e367568ce404262dd1ee0b04743
+  md5: abc05ce4daceeb1fa321b365cb847975
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 594707
+  timestamp: 1758039173244
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.conda
+  sha256: 6b3f0cddcf1800a6cf5150d1c3aef7f5088af859939de86416c8e08c1ca499d3
+  md5: f4b8cecc47f8ef5b20b51af6807b2ef1
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 471230
+  timestamp: 1758039171969
 - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.conda
   sha256: c822ed29c20166934ef9c9e29b863bc382b2c3c602ac1f3a62e9af2c0495a74c
   md5: fd829528313216f62505dd7a281230ea

--- a/tool-specs/anaconda-cli/pixi.toml
+++ b/tool-specs/anaconda-cli/pixi.toml
@@ -14,4 +14,4 @@ anaconda-client = "==1.14.1"
 # renovate: datasource=conda depName=main/anaconda-cli-base
 anaconda-cli-base = "==0.8.2"
 # renovate: datasource=conda depName=main/anaconda-mcp
-anaconda-mcp = "==1.1.0"
+anaconda-mcp = "==1.1.1"

--- a/tool-specs/anaconda-cli/pixi.toml
+++ b/tool-specs/anaconda-cli/pixi.toml
@@ -14,4 +14,4 @@ anaconda-client = "==1.14.1"
 # renovate: datasource=conda depName=main/anaconda-cli-base
 anaconda-cli-base = "==0.8.2"
 # renovate: datasource=conda depName=main/anaconda-mcp
-anaconda-mcp = "==1.0.3"
+anaconda-mcp = "==1.1.0"


### PR DESCRIPTION
## Summary

anaconda-mcp 1.1.0 was just released

<!--Link the Jira ticket number below, or delete it if there's none.-->
Jira: CLI-XXXX
