### PR TITLE
feat: Add ability to download a Miniconda installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ self-replace = "1.5"
 sentry = { version = "0.48", optional = true }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
 serde_json = "1.0"
 serde_yaml = "0.9"
 toml = "1.0"

--- a/docs/design/tool-download.md
+++ b/docs/design/tool-download.md
@@ -1,0 +1,288 @@
+# Implementation Plan: `ana tool download miniconda`
+
+**Status:** Ready to build — Jun 8, 2026. **Repo:** `anaconda/anaconda-cli`
+**Companion docs:** `flowchart-install-miniconda.md`, `design-note-ana-installer-run.md` (superseded).
+
+## What this is
+
+`ana tool download miniconda` fetches the latest official Miniconda installer for the
+current platform/arch, verifies its checksum, writes it to the current directory, and
+prints the exact command to run it. **ana does not run the installer.**
+
+> **Command placement note (PM call):** the command lives under `ana tool download` to
+> sit next to the existing tool-management verbs in the CLI surface. That's a *namespace*
+> decision only — the implementation does **not** live in `src/tools/` (see Code
+> structure). CLI placement and code placement are separate; download shares no machinery
+> with the managed-tool install path.
+
+### Where did this come from?
+
+I got a new laptop from IT. I wanted to get miniconda installed on my machine. I knew we had launched (or were about to launch) `ana`. So I installed it, assuming that I could install miniconda from `ana`. But ana doesn't have that yet. So I had started thinking through whether or not we could make `ana install miniconda` a thing. But that has a number of concerns that are real and need to be figured out from an organizational POV.
+
+ana install miniconda would be great, but it also would override all of the user-facing stuff that miniconda does now:
+
+```
+Installs Miniconda3 py313_26.3.2-2
+-b           run install in batch mode (without manual intervention),
+             it is expected the license terms (if any) are agreed upon
+-f           no error if install prefix already exists
+-h           print this help message and exit
+-p PREFIX    install prefix, defaults to /Users/ericdill/miniconda3, must not contain spaces.
+-s           skip running pre/post-link/install scripts
+-m           disable the creation of menu items / shortcuts
+-u           update an existing installation
+-t           run package tests after installation (may install conda-build)
+-c           run 'conda init' after installation (only applies to batch mode)
+```
+
+
+so, the option space here is bounded by:
+
+1. just choose some sane defaults for the user that runs this
+2. fully expose all these options to ana install miniconda
+
+neither of which is great. if we do (1) then we're masking the miniconda UX and making new installer UX choices implicitly, which i'd only accept if we thought really hard about what we wanted to wrap and why. It also means that we need to walk the legal tightrope within the ana install minicodna path and then we have yet another place here at anaconda where we're trying to maintain an unified legal position.
+
+if we do (2) then we're just replicating the miniconda interface for very little benefit.
+
+so, thinking more about what i actually wanted: a way to install miniconda from the terminal. i just didnt want to open my web browser and navigate to where is the actual shell script i need to download and run. and that is a very easily solvable problem within ana.
+
+ana tool download miniconda is really simple, it sidesteps all of the "should ana be able to run an installer" and the "should ana be able to create a conda env from a lockfile" and all of these things. the only thing that ana needs to do with this workflow is download the installer and then tell me how to run it.
+
+so anyway, the thing that I think would solve my use case would have ana grow a "download an installer for me and tell me where it is and tell me how to run it"
+
+CI SIDEBAR... (TODO in a later PR. calling it out here for some future breadcrumbs)
+this also might be really helpful on ci?? `install ana && ana tool download miniconda --output /tmp/mc.sh && bash /tmp/mc.sh -b -p /tmp/miniconda` is now a thing that would be totally portable?? Don't implement this immediately.
+
+## Surface
+
+```
+ana tool download miniconda
+```
+
+No args. downloads latest for your current platform. I KNOW that we will want to support other downloads at some point. But we can do that later.
+
+downloads to your current directory
+
+## Flow
+
+```mermaid
+flowchart TD
+    start([ana tool download miniconda]) --> plat[detect platform + arch]
+    plat -->|unsupported combo| platErr[/error: no installer for this platform/arch/]
+    plat --> fname[compute canonical filename\nMiniconda3-latest-PLATFORM-ARCH.EXT]
+    fname --> exists{dest already exists?}
+    exists -->|yes| existsErr[/error: file already exists,\nremove it to continue/]
+    exists -->|no| idx[GET /miniconda/.files.json]
+    idx --> parse[look up filename key\n→ expected SHA256 + size]
+    parse -->|key missing| parseErr[/error: filename not in manifest,\nplatform map likely stale/]
+    parse -->|sha256 empty| shaErr[/error: no checksum for this file,\nrefuse unverified download/]
+    parse --> dl[stream-download installer → temp file\nin cwd]
+    dl --> verify{sha256 temp == expected?}
+    verify -->|no| verifyErr[/delete temp, error: checksum mismatch/]
+    verify -->|yes| flush[flush + close file handle]
+    flush --> mv[atomic rename temp → final dest]
+    mv --> done([print dest path + run command])
+```
+
+> ⚠️ **Close the temp file handle before the rename.** On Windows, renaming a file
+> that still has an open handle fails with a sharing violation — and Windows is a
+> shipped target (the `.exe`). `file.flush().await` then `drop(file)` before
+> `rename`. (Caught in code review on the v1 implementation.)
+>
+> ⚠️ **Compare the checksum case-insensitively** (`eq_ignore_ascii_case`). Anaconda's
+> manifest serves lowercase hex today, so this is hardening, not an active bug — but
+> a case-sensitive compare would spuriously fail if that ever changed.
+
+## Platform / arch → filename mapping
+
+| OS detection      | ana arch | filename arch | ext   |
+|-------------------|----------|---------------|-------|
+| macOS, aarch64    | arm64    | `arm64`       | `.sh` |
+| macOS, x86_64     | x86_64   | `x86_64`      | `.sh` |
+| Linux, x86_64     | x86_64   | `x86_64`      | `.sh` |
+| Linux, aarch64    | aarch64  | `aarch64`     | `.sh` |
+| Windows, x86_64   | x86_64   | `x86_64`      | `.exe`|
+
+Filename: `Miniconda3-latest-{MacOSX|Linux|Windows}-{arch}.{sh|exe}`
+Base URL (v1): `https://repo.anaconda.com/miniconda/`
+
+Any OS/arch combo not in the table → clean error (don't guess a URL that 404s).
+
+### What `latest` actually points at (and what we deliberately ship)
+
+There are 13 `Miniconda3-latest-*` aliases in the manifest. Their `mtime` cleanly splits
+"still shipping" from "frozen years ago" — sorted by `mtime`:
+
+| mtime (UTC)          | size     | filename                              | we ship?  |
+|----------------------|----------|---------------------------------------|-----------|
+| 2015-08-24 17:34:00  | 31.3 MB  | `Miniconda3-latest-Linux-armv7l.sh`   | no        |
+| 2015-08-24 17:34:00  | 27.2 MB  | `Miniconda3-latest-MacOSX-x86.sh`     | no        |
+| 2019-01-02 16:05:14  | 65.7 MB  | `Miniconda3-latest-Linux-x86.sh`      | no        |
+| 2022-05-16 19:57:25  | 71.1 MB  | `Miniconda3-latest-Windows-x86.exe`   | no        |
+| 2023-11-16 19:51:52  | 99.5 MB  | `Miniconda3-latest-Linux-ppc64le.sh`  | no        |
+| 2025-02-11 21:04:49  | 150.4 MB | `Miniconda3-latest-Linux-s390x.sh`    | no        |
+| 2025-08-25 20:52:24  | 117.8 MB | `Miniconda3-latest-MacOSX-x86_64.pkg` | no (.pkg) |
+| 2025-08-25 20:52:24  | 118.4 MB | `Miniconda3-latest-MacOSX-x86_64.sh`  | **yes**   |
+| 2026-04-28 17:57:16  | 164.4 MB | `Miniconda3-latest-Linux-aarch64.sh`  | **yes**   |
+| 2026-04-28 17:57:16  | 163.2 MB | `Miniconda3-latest-Linux-x86_64.sh`   | **yes**   |
+| 2026-04-28 17:57:16  | 126.6 MB | `Miniconda3-latest-MacOSX-arm64.pkg`  | no (.pkg) |
+| 2026-04-28 17:57:16  | 127.4 MB | `Miniconda3-latest-MacOSX-arm64.sh`   | **yes**   |
+| 2026-04-28 17:57:16  | 99.2 MB  | `Miniconda3-latest-Windows-x86_64.exe`| **yes**   |
+
+- **The five rows we ship move together.** They share one recent `mtime` (the macOS Intel
+  `.sh` lags one release but is still maintained). Anaconda re-points every live `latest`
+  alias in a single batch per release, so there's no "some platforms lag" race.
+- **`mtime` is a real liveness signal.** The frozen aliases (`Linux-x86`, `MacOSX-x86`,
+  `armv7l`, `ppc64le`, `s390x`, `Windows-x86`) still resolve and would download, but their
+  `latest` pointer hasn't moved in 1–11 years. We intentionally don't map any
+  `detect_target()` output to them. If we ever add an arch and its `latest` mtime is
+  ancient, that's the tell it's effectively dead even though the key exists.
+- **We pick `.sh` over `.pkg` on macOS on purpose.** Both aliases exist per mac arch; the
+  `.pkg` is the GUI installer, the `.sh` is the one the user `bash`-es. Our whole UX is
+  "here's the file, here's the `bash` command," so `.sh` is the only fit.
+
+## Checksum source & verification
+
+`https://repo.anaconda.com/miniconda/.files.json` — one JSON manifest keyed by filename
+(includes the `-latest-` aliases):
+
+```json
+{
+  "Miniconda3-latest-Linux-x86_64.sh": {
+    "md5": "5eb314581f476f57526204386ea87af8",
+    "mtime": 1777399036.7642996,
+    "sha256": "2284bafb7863a23411b19874d216e237964d4b32dd9beb6807fa8b2d84570961",
+    "size": 163179296
+  }
+}
+```
+
+(The `/archive/.files.json` cousin holds the Anaconda Distribution installers, same shape
+— useful for a later distribution-download feature.)
+
+**Strategy:** GET `.files.json`, look up our computed filename key, read `sha256` (and
+`size` for the progress label). Stream-download the installer, compute sha256, compare.
+One small JSON fetch plus the download.
+
+> ⚠️ Don't assume the manifest always has our key or a non-empty `sha256`. Key missing →
+> "filename not in manifest, platform map likely stale." `sha256` empty/missing → fail
+> closed: refuse, don't download unverified. Both are real defensive cases, not theoretical.
+
+## Code structure (anaconda-cli)
+
+This is a *download + verify* command, NOT a `tool install` (no rattler, no lockfile, no
+prefix, no symlinks). It does **not** go through `src/tools/`. New, self-contained:
+
+- **`src/installer/mod.rs`** (new module) — the `download` command.
+  - `detect_target() -> Result<Target>` — `(platform, arch)` → `Target { filename, url }`
+    via `std::env::consts::{OS, ARCH}`. Errors on unsupported combos.
+  - `fetch_manifest() -> Result<HashMap<String, FileEntry>>` — GET `.files.json`,
+    serde-deserialize. `FileEntry { md5, sha256, size, mtime }`. Take a `base_url`
+    parameter (default the public miniconda URL) so the `/archive/` reuse and the
+    follow-on config work drop in without a rewrite.
+  - `expected_for(manifest, filename) -> Result<&FileEntry>` — key lookup; errors on
+    missing key (stale map) or empty `sha256` (refuse unverified).
+  - `download_and_verify(client, url, expected_sha, dest)` — stream to temp in dest's
+    dir, sha256 as we read, flush+close the handle, then compare and atomic-rename on
+    match / delete on mismatch.
+  - `run(ctx, args) -> Result<()>` — orchestrates; prints dest + run-command on success.
+- **CLI wiring** — register a `download <name>` subcommand *under the existing `tool`
+  group* (so the surface is `ana tool download miniconda`; name is `miniconda` only in v1,
+  reject others with "only miniconda supported in v1"). Match the existing clap derive
+  pattern used by `ana tool`. The clap handler dispatches into `src/installer::run()` —
+  CLI placement under `tool` does **not** mean the code lives in `src/tools/`.
+- **Reuse:** get the HTTP client from `ctx` — **`ctx.download_client()`** (no-gzip,
+  binary-optimized, already wraps the standard middleware: retries, user-agent). Thread
+  `ctx: &CommandContext` into `run` and pass the client down to `fetch_manifest` /
+  `download_and_verify`. **Do not build a `reqwest::Client` inline** — CLAUDE.md mandates
+  `ctx` clients ("never construct a new `Client`"). (The `install.rs:101` raw-builder
+  pattern is rattler-specific; don't copy it for an ordinary HTTP command — doing so was
+  flagged in code review.) sha256 via the `sha2` crate (transitively present via rattler;
+  add it as a direct dep — it's not one by default).
+
+### Why a new module, not `src/tools/`
+
+`tools/` is rattler-lockfile installs into `~/.ana/tools/<name>` with bin symlinks. This
+shares none of that machinery — it's an HTTP download to the cwd. Forcing it through
+`tools/` would mean gutting the install path. Keep them separate.
+
+## Success output
+
+macOS / Linux:
+```
+Downloaded Miniconda3-latest-MacOSX-arm64.sh (127.4 MB) to:
+    ./Miniconda3-latest-MacOSX-arm64.sh
+SHA256 verified.
+
+To install, run:
+    bash ./Miniconda3-latest-MacOSX-arm64.sh
+```
+
+Windows:
+```
+Downloaded Miniconda3-latest-Windows-x86_64.exe (99.2 MB) to:
+    .\Miniconda3-latest-Windows-x86_64.exe
+SHA256 verified.
+
+To install, run it from Explorer, or:
+    start "" ".\Miniconda3-latest-Windows-x86_64.exe"
+```
+
+## File already exists at the target
+
+We download to cwd, so on a re-run (or a leftover browser download)
+`Miniconda3-latest-MacOSX-arm64.sh` may already be there. **Insta-fail.** Before
+fetching anything, check the destination; if it exists, error out:
+
+```
+error: ./Miniconda3-latest-MacOSX-arm64.sh already exists. Remove it if you want to continue.
+```
+
+No overwrite, no clobber, no `-f` in v1, no sha-match-skip cleverness. Check it *early* —
+before the manifest fetch and download — so we don't pull 120 MB only to refuse at the
+rename. `-f` to overwrite is the obvious next flag, but it's a follow-on (see below);
+don't build it now.
+
+## Testing
+
+- **Unit:** `detect_target(base_url, os, arch)` for all 5 rows + an unsupported combo.
+  Made pure by taking `(os, arch)` args (the chosen approach — production calls it with
+  `std::env::consts::{OS, ARCH}`). Cleaner than the `temp_env` OS/ARCH mock and avoids a
+  duplicated match block.
+- **Unit:** manifest parser against a captured fixture of real `.files.json` (commit a
+  trimmed snapshot — a handful of keys incl. one `-latest-`). Assert the right SHA for a
+  known filename; assert key-missing and empty-sha256 errors.
+- **Unit:** extract the verify-and-finalize step into a `finalize_verified_download(temp,
+  actual_sha, expected_sha, dest)` helper that takes already-computed bytes/hash, so the
+  mismatch (temp deleted, error, no dest) *and* match (renamed, dest exists) paths are both
+  testable without a network mock. Don't re-implement the compare inline in the test — that
+  asserts on copied code and covers nothing. Include a case-insensitive (uppercase-expected)
+  case here.
+- **Integration (gated/manual):** real download of the smallest installer, full verify +
+  rename. Mark `#[ignore]` so CI doesn't pull 120 MB every run.
+
+## Follow-ons
+
+Deliberately out of v1. `ana tool download miniconda` is useful on its own; these layer
+on without changing its core behavior.
+
+- **`-f` / `--force` to overwrite an existing file.** The obvious next flag — turns the
+  "file already exists" insta-fail into "remove it and re-download." Nice symmetry: the
+  Miniconda installer's own `-f` means "no error if install prefix already exists," so
+  `ana tool download miniconda -f` reading as "no error if the download target already exists"
+  is consistent with the tool we're fetching.
+- **Configurable / login-aware installer host.** Don't hardcode `repo.anaconda.com`
+  forever. ana already treats other remotes as config-driven — `ANA_DOMAIN` (auth),
+  `ANA_PIP_INDEX_URL` (packages) via `src/config.rs`/figment. A later PR resolves the
+  installer base URL in order: explicit `ANA_INSTALLER_BASE_URL` override → logged-in
+  customer's configured installer host → public default. The logged-in rung needs a
+  server field that doesn't exist yet (`whoami`'s `/api/auth/sessions/whoami` payload
+  carries no installer/repo URL today), so it's blocked on the platform team. v1 keeps
+  `fetch_manifest` parameterized by base URL so this drops in cleanly; v1 just always
+  passes the public default. **Air-gapped customers can't reach `repo.anaconda.com` —
+  this is why it eventually matters, but it's not a v1 blocker.**
+- **`--output PATH`.** Choose the download location instead of cwd. Unlocks the CI use
+  case: `ana tool download miniconda --output /tmp/mc.sh && bash /tmp/mc.sh -b -p /tmp/miniconda`.
+- **Other distributions / versions.** Anaconda Distribution via `/archive/.files.json`
+  (no `latest` alias — needs an explicit version), pinned Miniconda versions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1019,7 +1019,7 @@ enum ToolCommands {
 
     /// Download an installer (v1: miniconda only)
     Download {
-        /// Name of the installer to download (only 'miniconda' in v1)
+        /// Installer to download [possible values: miniconda]
         name: Option<String>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -629,7 +629,10 @@ pub fn parse() -> (Action, LogLevel) {
                 None => Action::ShowSubcommandHelp("tool download".to_string()),
                 Some("miniconda") => Action::DownloadMiniconda,
                 Some(other) => {
-                    eprintln!("error: only miniconda supported in v1 (got '{}')", other);
+                    eprintln!(
+                        "error: only miniconda is currently supported (got '{}')",
+                        other
+                    );
                     std::process::exit(1);
                 }
             },
@@ -1017,7 +1020,7 @@ enum ToolCommands {
         force: bool,
     },
 
-    /// Download an installer (v1: miniconda only)
+    /// Download an installer (currently miniconda only)
     Download {
         /// Installer to download [possible values: miniconda]
         name: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ use crate::help;
 use crate::mcp::{self, McpAction, McpCommands};
 #[cfg(unix)]
 use crate::outerbounds::{self, ObAction, ObCommands};
+use crate::installer;
 use crate::tools;
 use crate::update;
 
@@ -164,6 +165,7 @@ pub enum Action {
         pixi: bool,
     },
     FeatureList,
+    DownloadMiniconda,
     TelemetrySubmit,
     TelemetryKill,
     TelemetryStatus,
@@ -209,6 +211,7 @@ impl Action {
                 _ => "feature.disable.unknown",
             },
             Action::FeatureList => "feature.list",
+            Action::DownloadMiniconda => "download.miniconda",
             Action::TelemetrySubmit => "telemetry-submit",
             Action::TelemetryKill => "telemetry-kill",
             Action::TelemetryStatus => "telemetry-status",
@@ -478,6 +481,9 @@ impl Action {
                 feature::list::print_feature_list(ctx);
                 Ok(())
             }
+            Action::DownloadMiniconda => {
+                installer::run(None).await
+            }
             Action::TelemetrySubmit => {
                 crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
                 Ok(())
@@ -671,6 +677,10 @@ pub fn parse() -> (Action, LogLevel) {
                 pixi,
             },
             Some(FeatureCommands::List) => Action::FeatureList,
+        },
+        Some(Commands::Download { command }) => match command {
+            None => Action::ShowSubcommandHelp("download".to_string()),
+            Some(DownloadCommands::Miniconda) => Action::DownloadMiniconda,
         },
         Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
         Some(Commands::TelemetryKill) => Action::TelemetryKill,
@@ -907,6 +917,17 @@ enum Commands {
         command: Option<FeatureCommands>,
     },
 
+    /// Download an installer
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana download <installer>"
+    )]
+    Download {
+        #[command(subcommand)]
+        command: Option<DownloadCommands>,
+    },
+
     /// Submit pending telemetry batches (internal use only)
     #[command(hide = true)]
     TelemetrySubmit,
@@ -1090,6 +1111,12 @@ enum FeatureCommands {
         #[arg(long)]
         pixi: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum DownloadCommands {
+    /// Download the latest Miniconda installer for the current platform
+    Miniconda,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,10 +13,10 @@ use crate::feature;
 use crate::feedback;
 use crate::fetch::api_fetch;
 use crate::help;
+use crate::installer;
 use crate::mcp::{self, McpAction, McpCommands};
 #[cfg(unix)]
 use crate::outerbounds::{self, ObAction, ObCommands};
-use crate::installer;
 use crate::tools;
 use crate::update;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,7 +211,7 @@ impl Action {
                 _ => "feature.disable.unknown",
             },
             Action::FeatureList => "feature.list",
-            Action::DownloadMiniconda => "download.miniconda",
+            Action::DownloadMiniconda => "tool.download.miniconda",
             Action::TelemetrySubmit => "telemetry-submit",
             Action::TelemetryKill => "telemetry-kill",
             Action::TelemetryStatus => "telemetry-status",
@@ -625,6 +625,13 @@ pub fn parse() -> (Action, LogLevel) {
             Some(ToolCommands::Install { name }) => Action::ToolInstall { name },
             Some(ToolCommands::List) => Action::ToolList,
             Some(ToolCommands::Uninstall { name, force }) => Action::ToolUninstall { name, force },
+            Some(ToolCommands::Download { name }) => match name.as_str() {
+                "miniconda" => Action::DownloadMiniconda,
+                other => {
+                    eprintln!("error: only miniconda supported in v1 (got '{}')", other);
+                    std::process::exit(1);
+                }
+            },
         },
         Some(Commands::Api { command }) => match command {
             None => Action::ShowSubcommandHelp("api".to_string()),
@@ -675,10 +682,6 @@ pub fn parse() -> (Action, LogLevel) {
                 pixi,
             },
             Some(FeatureCommands::List) => Action::FeatureList,
-        },
-        Some(Commands::Download { command }) => match command {
-            None => Action::ShowSubcommandHelp("download".to_string()),
-            Some(DownloadCommands::Miniconda) => Action::DownloadMiniconda,
         },
         Some(Commands::TelemetrySubmit) => Action::TelemetrySubmit,
         Some(Commands::TelemetryKill) => Action::TelemetryKill,
@@ -915,17 +918,6 @@ enum Commands {
         command: Option<FeatureCommands>,
     },
 
-    /// Download an installer
-    #[command(
-        subcommand_required = false,
-        arg_required_else_help = false,
-        override_usage = "ana download <installer>"
-    )]
-    Download {
-        #[command(subcommand)]
-        command: Option<DownloadCommands>,
-    },
-
     /// Submit pending telemetry batches (internal use only)
     #[command(hide = true)]
     TelemetrySubmit,
@@ -1023,6 +1015,13 @@ enum ToolCommands {
         #[arg(short = 'y', long = "yes")]
         force: bool,
     },
+
+    /// Download an installer (v1: miniconda only)
+    Download {
+        /// Name of the installer to download (only 'miniconda' in v1)
+        #[arg(required_unless_present = "help", default_value = "")]
+        name: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1109,12 +1108,6 @@ enum FeatureCommands {
         #[arg(long)]
         pixi: bool,
     },
-}
-
-#[derive(Subcommand)]
-enum DownloadCommands {
-    /// Download the latest Miniconda installer for the current platform
-    Miniconda,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -481,9 +481,7 @@ impl Action {
                 feature::list::print_feature_list(ctx);
                 Ok(())
             }
-            Action::DownloadMiniconda => {
-                installer::run(None).await
-            }
+            Action::DownloadMiniconda => installer::run(ctx, None).await,
             Action::TelemetrySubmit => {
                 crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
                 Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -625,9 +625,10 @@ pub fn parse() -> (Action, LogLevel) {
             Some(ToolCommands::Install { name }) => Action::ToolInstall { name },
             Some(ToolCommands::List) => Action::ToolList,
             Some(ToolCommands::Uninstall { name, force }) => Action::ToolUninstall { name, force },
-            Some(ToolCommands::Download { name }) => match name.as_str() {
-                "miniconda" => Action::DownloadMiniconda,
-                other => {
+            Some(ToolCommands::Download { name }) => match name.as_deref() {
+                None => Action::ShowSubcommandHelp("tool download".to_string()),
+                Some("miniconda") => Action::DownloadMiniconda,
+                Some(other) => {
                     eprintln!("error: only miniconda supported in v1 (got '{}')", other);
                     std::process::exit(1);
                 }
@@ -1019,8 +1020,7 @@ enum ToolCommands {
     /// Download an installer (v1: miniconda only)
     Download {
         /// Name of the installer to download (only 'miniconda' in v1)
-        #[arg(required_unless_present = "help", default_value = "")]
-        name: String,
+        name: Option<String>,
     },
 }
 

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -27,6 +27,10 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
             "self",
         ],
     },
+    HelpSection {
+        name: "INSTALLERS",
+        commands: &["download"],
+    },
     // TODO(mattkram): Removed PACKAGES section from help until we can comprehensively
     //                 define the wrappers.
     // HelpSection {

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -27,10 +27,6 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
             "self",
         ],
     },
-    HelpSection {
-        name: "INSTALLERS",
-        commands: &["download"],
-    },
     // TODO(mattkram): Removed PACKAGES section from help until we can comprehensively
     //                 define the wrappers.
     // HelpSection {

--- a/src/help/term.rs
+++ b/src/help/term.rs
@@ -302,6 +302,24 @@ pub fn print_subcommand_help(cmd: &clap::Command, path: &str) {
         let _ = term.write_line("");
     }
 
+    // Arguments section - positional args with help text
+    let positional_args: Vec<_> = cmd
+        .get_arguments()
+        .filter(|a| !is_builtin_arg(a))
+        .filter(|a| !a.is_hide_set())
+        .filter(|a| is_positional(a))
+        .filter(|a| a.get_help().is_some())
+        .collect();
+    if !positional_args.is_empty() {
+        print_section(&term, "ARGUMENTS");
+        for arg in positional_args {
+            let name = format_positional(arg);
+            let desc = arg.get_help().map(|h| h.to_string()).unwrap_or_default();
+            print_command_row(&term, &name, &desc);
+        }
+        let _ = term.write_line("");
+    }
+
     // Options section - always show at least -h, --help
     let option_args: Vec<_> = cmd
         .get_arguments()

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,0 +1,409 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
+use miette::miette;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+
+const MINICONDA_BASE_URL: &str = "https://repo.anaconda.com/miniconda/";
+
+struct Target {
+    filename: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileEntry {
+    sha256: Option<String>,
+    size: Option<u64>,
+    #[allow(dead_code)]
+    md5: Option<String>,
+    #[allow(dead_code)]
+    mtime: Option<f64>,
+}
+
+fn detect_target(base_url: &str) -> miette::Result<Target> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    let (platform, file_arch, ext) = match (os, arch) {
+        ("macos", "aarch64") => ("MacOSX", "arm64", "sh"),
+        ("macos", "x86_64") => ("MacOSX", "x86_64", "sh"),
+        ("linux", "x86_64") => ("Linux", "x86_64", "sh"),
+        ("linux", "aarch64") => ("Linux", "aarch64", "sh"),
+        ("windows", "x86_64") => ("Windows", "x86_64", "exe"),
+        _ => {
+            return Err(miette!(
+                "no Miniconda installer available for {}/{}",
+                os,
+                arch
+            ));
+        }
+    };
+
+    let filename = format!("Miniconda3-latest-{}-{}.{}", platform, file_arch, ext);
+    let url = format!("{}{}", base_url, filename);
+    Ok(Target { filename, url })
+}
+
+async fn fetch_manifest(
+    base_url: &str,
+) -> miette::Result<HashMap<String, FileEntry>> {
+    let manifest_url = format!("{}/.files.json", base_url.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .user_agent(crate::ua::user_agent())
+        .build()
+        .map_err(|e| miette!("failed to create HTTP client: {}", e))?;
+
+    let resp = client
+        .get(&manifest_url)
+        .send()
+        .await
+        .map_err(|e| miette!("failed to fetch manifest: {}", e))?
+        .error_for_status()
+        .map_err(|e| miette!("manifest request failed: {}", e))?;
+
+    let manifest: HashMap<String, FileEntry> = resp
+        .json()
+        .await
+        .map_err(|e| miette!("failed to parse manifest: {}", e))?;
+
+    Ok(manifest)
+}
+
+fn expected_for<'a>(
+    manifest: &'a HashMap<String, FileEntry>,
+    filename: &str,
+) -> miette::Result<&'a FileEntry> {
+    let entry = manifest
+        .get(filename)
+        .ok_or_else(|| miette!("filename '{}' not in manifest — platform map may be stale", filename))?;
+
+    match &entry.sha256 {
+        None => Err(miette!("no SHA256 checksum for '{}' — refusing unverified download", filename)),
+        Some(s) if s.is_empty() => Err(miette!("no SHA256 checksum for '{}' — refusing unverified download", filename)),
+        _ => Ok(entry),
+    }
+}
+
+async fn download_and_verify(
+    url: &str,
+    expected_sha: &str,
+    dest: &PathBuf,
+) -> miette::Result<()> {
+    let client = reqwest::Client::builder()
+        .user_agent(crate::ua::user_agent())
+        .build()
+        .map_err(|e| miette!("failed to create HTTP client: {}", e))?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| miette!("download failed: {}", e))?
+        .error_for_status()
+        .map_err(|e| miette!("download request failed: {}", e))?;
+
+    let total_size = resp.content_length().unwrap_or(0);
+
+    let temp_path = dest.with_extension("tmp");
+
+    let pb = build_progress_bar(total_size);
+
+    let mut file = tokio::fs::File::create(&temp_path)
+        .await
+        .map_err(|e| miette!("failed to create temp file: {}", e))?;
+
+    let mut hasher = Sha256::new();
+    let mut stream = resp.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| miette!("download error: {}", e))?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| miette!("write error: {}", e))?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    pb.finish_and_clear();
+
+    let actual_sha = format!("{:x}", hasher.finalize());
+    if actual_sha != expected_sha {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(miette!(
+            "checksum mismatch for '{}'\n  expected: {}\n  actual:   {}",
+            dest.display(),
+            expected_sha,
+            actual_sha
+        ));
+    }
+
+    tokio::fs::rename(&temp_path, dest)
+        .await
+        .map_err(|e| miette!("failed to move file to destination: {}", e))?;
+
+    Ok(())
+}
+
+fn build_progress_bar(total_size: u64) -> ProgressBar {
+    use crate::ui::styles::UiColor;
+
+    let pb = ProgressBar::new(total_size);
+    let dim = UiColor::Dim.hex();
+    let dim_suffix = UiColor::Dim.apply_to("% |").to_string();
+    let template = format!(
+        "  {{bar:34.{}/{dim}}} {{percent:>2.{dim}}}{dim_suffix} {{elapsed:.{dim}}}",
+        UiColor::Green.hex(),
+    );
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(&template)
+            .unwrap()
+            .progress_chars("━━─"),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}
+
+fn format_size(bytes: u64) -> String {
+    let mb = bytes as f64 / 1_000_000.0;
+    format!("{:.1} MB", mb)
+}
+
+fn run_command(filename: &str) -> String {
+    if filename.ends_with(".exe") {
+        format!(r#"start "" ".\{filename}""#)
+    } else {
+        format!("bash ./{filename}")
+    }
+}
+
+pub async fn run(base_url: Option<&str>) -> miette::Result<()> {
+    let base_url = base_url.unwrap_or(MINICONDA_BASE_URL);
+    let target = detect_target(base_url)?;
+
+    let dest = std::env::current_dir()
+        .map_err(|e| miette!("failed to get current directory: {}", e))?
+        .join(&target.filename);
+
+    if dest.exists() {
+        return Err(miette!(
+            "./{} already exists. Remove it if you want to continue.",
+            target.filename
+        ));
+    }
+
+    let manifest = fetch_manifest(base_url).await?;
+    let entry = expected_for(&manifest, &target.filename)?;
+
+    let expected_sha = entry.sha256.as_deref().unwrap();
+    let size_label = entry.size.map(format_size).unwrap_or_default();
+
+    let size_part = if size_label.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", size_label)
+    };
+    eprintln!("Downloading {}{}", target.filename, size_part);
+
+    download_and_verify(&target.url, expected_sha, &dest).await?;
+
+    let dest_display = if cfg!(windows) {
+        format!(".\\{}", target.filename)
+    } else {
+        format!("./{}", target.filename)
+    };
+
+    println!("Downloaded {}{} to:", target.filename, size_part);
+    println!("    {}", dest_display);
+    println!("SHA256 verified.");
+    println!();
+    println!("To install, run:");
+    println!("    {}", run_command(&target.filename));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_target_supported_combos() {
+        let cases = [
+            ("macos", "aarch64", "Miniconda3-latest-MacOSX-arm64.sh"),
+            ("macos", "x86_64", "Miniconda3-latest-MacOSX-x86_64.sh"),
+            ("linux", "x86_64", "Miniconda3-latest-Linux-x86_64.sh"),
+            ("linux", "aarch64", "Miniconda3-latest-Linux-aarch64.sh"),
+            ("windows", "x86_64", "Miniconda3-latest-Windows-x86_64.exe"),
+        ];
+
+        for (os, arch, expected_filename) in cases {
+            let result = detect_target_with("https://example.com/miniconda/", os, arch);
+            assert!(result.is_ok(), "expected Ok for {}/{}", os, arch);
+            assert_eq!(result.unwrap().filename, expected_filename);
+        }
+    }
+
+    #[test]
+    fn test_detect_target_unsupported_combo() {
+        let result = detect_target_with("https://example.com/", "linux", "mips");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_expected_for_key_missing() {
+        let manifest = HashMap::new();
+        let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not in manifest"));
+    }
+
+    #[test]
+    fn test_expected_for_empty_sha256() {
+        let mut manifest = HashMap::new();
+        manifest.insert(
+            "Miniconda3-latest-Linux-x86_64.sh".to_string(),
+            FileEntry {
+                sha256: Some(String::new()),
+                size: None,
+                md5: None,
+                mtime: None,
+            },
+        );
+        let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("refusing unverified"));
+    }
+
+    #[test]
+    fn test_expected_for_none_sha256() {
+        let mut manifest = HashMap::new();
+        manifest.insert(
+            "Miniconda3-latest-Linux-x86_64.sh".to_string(),
+            FileEntry {
+                sha256: None,
+                size: None,
+                md5: None,
+                mtime: None,
+            },
+        );
+        let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("refusing unverified"));
+    }
+
+    #[test]
+    fn test_expected_for_valid_entry() {
+        let mut manifest = HashMap::new();
+        manifest.insert(
+            "Miniconda3-latest-Linux-x86_64.sh".to_string(),
+            FileEntry {
+                sha256: Some("abc123".to_string()),
+                size: Some(1234),
+                md5: None,
+                mtime: None,
+            },
+        );
+        let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_run_command_sh() {
+        assert_eq!(
+            run_command("Miniconda3-latest-MacOSX-arm64.sh"),
+            "bash ./Miniconda3-latest-MacOSX-arm64.sh"
+        );
+    }
+
+    #[test]
+    fn test_run_command_exe() {
+        assert_eq!(
+            run_command("Miniconda3-latest-Windows-x86_64.exe"),
+            r#"start "" ".\Miniconda3-latest-Windows-x86_64.exe""#
+        );
+    }
+
+    #[test]
+    fn test_format_size() {
+        assert_eq!(format_size(127_400_000), "127.4 MB");
+        assert_eq!(format_size(163_179_296), "163.2 MB");
+    }
+
+    #[test]
+    fn test_manifest_deserialization() {
+        let json = r#"{
+            "Miniconda3-latest-Linux-x86_64.sh": {
+                "md5": "5eb314581f476f57526204386ea87af8",
+                "mtime": 1777399036.7642996,
+                "sha256": "2284bafb7863a23411b19874d216e237964d4b32dd9beb6807fa8b2d84570961",
+                "size": 163179296
+            },
+            "Miniconda3-latest-MacOSX-arm64.sh": {
+                "md5": "deadbeef",
+                "mtime": 1777399036.0,
+                "sha256": "cafebabe1234",
+                "size": 127400000
+            }
+        }"#;
+
+        let manifest: HashMap<String, FileEntry> = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.len(), 2);
+
+        let entry = manifest.get("Miniconda3-latest-Linux-x86_64.sh").unwrap();
+        assert_eq!(
+            entry.sha256.as_deref(),
+            Some("2284bafb7863a23411b19874d216e237964d4b32dd9beb6807fa8b2d84570961")
+        );
+        assert_eq!(entry.size, Some(163179296));
+    }
+
+    #[tokio::test]
+    async fn test_checksum_mismatch_deletes_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("test.sh");
+        let temp = dest.with_extension("tmp");
+
+        // Write a dummy temp file to simulate partial download
+        tokio::fs::write(&temp, b"fake content").await.unwrap();
+
+        // Since we can't easily mock the download, we test the path where temp exists and sha fails
+        // by calling the verify logic inline
+        let actual_sha = format!("{:x}", Sha256::digest(b"fake content"));
+        let expected_sha = "0000000000000000000000000000000000000000000000000000000000000000";
+
+        if actual_sha != expected_sha {
+            let _ = tokio::fs::remove_file(&temp).await;
+        }
+
+        assert!(!temp.exists(), "temp file should be deleted on mismatch");
+        assert!(!dest.exists(), "dest file should not exist");
+    }
+}
+
+#[cfg(test)]
+fn detect_target_with(base_url: &str, os: &str, arch: &str) -> miette::Result<Target> {
+    let (platform, file_arch, ext) = match (os, arch) {
+        ("macos", "aarch64") => ("MacOSX", "arm64", "sh"),
+        ("macos", "x86_64") => ("MacOSX", "x86_64", "sh"),
+        ("linux", "x86_64") => ("Linux", "x86_64", "sh"),
+        ("linux", "aarch64") => ("Linux", "aarch64", "sh"),
+        ("windows", "x86_64") => ("Windows", "x86_64", "exe"),
+        _ => {
+            return Err(miette!(
+                "no Miniconda installer available for {}/{}",
+                os,
+                arch
+            ));
+        }
+    };
+
+    let filename = format!("Miniconda3-latest-{}-{}.{}", platform, file_arch, ext);
+    let url = format!("{}{}", base_url, filename);
+    Ok(Target { filename, url })
+}

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -78,13 +78,22 @@ fn expected_for<'a>(
     manifest: &'a HashMap<String, FileEntry>,
     filename: &str,
 ) -> miette::Result<&'a FileEntry> {
-    let entry = manifest
-        .get(filename)
-        .ok_or_else(|| miette!("filename '{}' not in manifest — platform map may be stale", filename))?;
+    let entry = manifest.get(filename).ok_or_else(|| {
+        miette!(
+            "filename '{}' not in manifest — platform map may be stale",
+            filename
+        )
+    })?;
 
     match &entry.sha256 {
-        None => Err(miette!("no SHA256 checksum for '{}' — refusing unverified download", filename)),
-        Some(s) if s.is_empty() => Err(miette!("no SHA256 checksum for '{}' — refusing unverified download", filename)),
+        None => Err(miette!(
+            "no SHA256 checksum for '{}' — refusing unverified download",
+            filename
+        )),
+        Some(s) if s.is_empty() => Err(miette!(
+            "no SHA256 checksum for '{}' — refusing unverified download",
+            filename
+        )),
         _ => Ok(entry),
     }
 }
@@ -304,7 +313,12 @@ mod tests {
         );
         let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("refusing unverified"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("refusing unverified")
+        );
     }
 
     #[test]
@@ -321,7 +335,12 @@ mod tests {
         );
         let result = expected_for(&manifest, "Miniconda3-latest-Linux-x86_64.sh");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("refusing unverified"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("refusing unverified")
+        );
     }
 
     #[test]
@@ -404,7 +423,10 @@ mod tests {
 
         assert!(result.is_err(), "mismatch should return an error");
         assert!(
-            result.unwrap_err().to_string().contains("checksum mismatch"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("checksum mismatch"),
             "error should mention checksum mismatch"
         );
         assert!(!temp.exists(), "temp file should be deleted on mismatch");

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::Path;
 
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use miette::miette;
+use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
+
+use crate::context::CommandContext;
 
 const MINICONDA_BASE_URL: &str = "https://repo.anaconda.com/miniconda/";
 
@@ -25,10 +28,10 @@ struct FileEntry {
     mtime: Option<f64>,
 }
 
-fn detect_target(base_url: &str) -> miette::Result<Target> {
-    let os = std::env::consts::OS;
-    let arch = std::env::consts::ARCH;
-
+/// Map a `(os, arch)` pair to the canonical Miniconda installer for that platform.
+/// Parameterized on os/arch so it's pure and table-testable; production callers
+/// pass `std::env::consts::{OS, ARCH}`.
+fn detect_target(base_url: &str, os: &str, arch: &str) -> miette::Result<Target> {
     let (platform, file_arch, ext) = match (os, arch) {
         ("macos", "aarch64") => ("MacOSX", "arm64", "sh"),
         ("macos", "x86_64") => ("MacOSX", "x86_64", "sh"),
@@ -50,13 +53,10 @@ fn detect_target(base_url: &str) -> miette::Result<Target> {
 }
 
 async fn fetch_manifest(
+    client: &ClientWithMiddleware,
     base_url: &str,
 ) -> miette::Result<HashMap<String, FileEntry>> {
     let manifest_url = format!("{}/.files.json", base_url.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .user_agent(crate::ua::user_agent())
-        .build()
-        .map_err(|e| miette!("failed to create HTTP client: {}", e))?;
 
     let resp = client
         .get(&manifest_url)
@@ -90,15 +90,11 @@ fn expected_for<'a>(
 }
 
 async fn download_and_verify(
+    client: &ClientWithMiddleware,
     url: &str,
     expected_sha: &str,
-    dest: &PathBuf,
+    dest: &Path,
 ) -> miette::Result<()> {
-    let client = reqwest::Client::builder()
-        .user_agent(crate::ua::user_agent())
-        .build()
-        .map_err(|e| miette!("failed to create HTTP client: {}", e))?;
-
     let resp = client
         .get(url)
         .send()
@@ -131,9 +127,29 @@ async fn download_and_verify(
 
     pb.finish_and_clear();
 
+    // Flush and close the file handle before the rename. On Windows, renaming a
+    // file that still has an open handle fails with a sharing violation — and
+    // this command targets Windows via the `.exe` path.
+    file.flush()
+        .await
+        .map_err(|e| miette!("failed to flush temp file: {}", e))?;
+    drop(file);
+
     let actual_sha = format!("{:x}", hasher.finalize());
-    if actual_sha != expected_sha {
-        let _ = tokio::fs::remove_file(&temp_path).await;
+    finalize_verified_download(&temp_path, &actual_sha, expected_sha, dest).await
+}
+
+/// Given a fully-written temp file and its computed checksum, verify it against
+/// the expected checksum: atomic-rename to `dest` on match, delete the temp file
+/// on mismatch. Comparison is case-insensitive (hex digests may be either case).
+async fn finalize_verified_download(
+    temp_path: &Path,
+    actual_sha: &str,
+    expected_sha: &str,
+    dest: &Path,
+) -> miette::Result<()> {
+    if !actual_sha.eq_ignore_ascii_case(expected_sha) {
+        let _ = tokio::fs::remove_file(temp_path).await;
         return Err(miette!(
             "checksum mismatch for '{}'\n  expected: {}\n  actual:   {}",
             dest.display(),
@@ -142,7 +158,7 @@ async fn download_and_verify(
         ));
     }
 
-    tokio::fs::rename(&temp_path, dest)
+    tokio::fs::rename(temp_path, dest)
         .await
         .map_err(|e| miette!("failed to move file to destination: {}", e))?;
 
@@ -182,9 +198,9 @@ fn run_command(filename: &str) -> String {
     }
 }
 
-pub async fn run(base_url: Option<&str>) -> miette::Result<()> {
+pub async fn run(ctx: &CommandContext, base_url: Option<&str>) -> miette::Result<()> {
     let base_url = base_url.unwrap_or(MINICONDA_BASE_URL);
-    let target = detect_target(base_url)?;
+    let target = detect_target(base_url, std::env::consts::OS, std::env::consts::ARCH)?;
 
     let dest = std::env::current_dir()
         .map_err(|e| miette!("failed to get current directory: {}", e))?
@@ -197,7 +213,9 @@ pub async fn run(base_url: Option<&str>) -> miette::Result<()> {
         ));
     }
 
-    let manifest = fetch_manifest(base_url).await?;
+    let client = ctx.download_client();
+
+    let manifest = fetch_manifest(client, base_url).await?;
     let entry = expected_for(&manifest, &target.filename)?;
 
     let expected_sha = entry.sha256.as_deref().unwrap();
@@ -210,7 +228,7 @@ pub async fn run(base_url: Option<&str>) -> miette::Result<()> {
     };
     eprintln!("Downloading {}{}", target.filename, size_part);
 
-    download_and_verify(&target.url, expected_sha, &dest).await?;
+    download_and_verify(client, &target.url, expected_sha, &dest).await?;
 
     let dest_display = if cfg!(windows) {
         format!(".\\{}", target.filename)
@@ -243,15 +261,24 @@ mod tests {
         ];
 
         for (os, arch, expected_filename) in cases {
-            let result = detect_target_with("https://example.com/miniconda/", os, arch);
+            let result = detect_target("https://example.com/miniconda/", os, arch);
             assert!(result.is_ok(), "expected Ok for {}/{}", os, arch);
             assert_eq!(result.unwrap().filename, expected_filename);
         }
     }
 
     #[test]
+    fn test_detect_target_url() {
+        let target = detect_target("https://example.com/miniconda/", "linux", "x86_64").unwrap();
+        assert_eq!(
+            target.url,
+            "https://example.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+        );
+    }
+
+    #[test]
     fn test_detect_target_unsupported_combo() {
-        let result = detect_target_with("https://example.com/", "linux", "mips");
+        let result = detect_target("https://example.com/", "linux", "mips");
         assert!(result.is_err());
     }
 
@@ -364,46 +391,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_checksum_mismatch_deletes_temp() {
+    async fn test_finalize_deletes_temp_on_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("test.sh");
         let temp = dest.with_extension("tmp");
 
-        // Write a dummy temp file to simulate partial download
         tokio::fs::write(&temp, b"fake content").await.unwrap();
-
-        // Since we can't easily mock the download, we test the path where temp exists and sha fails
-        // by calling the verify logic inline
         let actual_sha = format!("{:x}", Sha256::digest(b"fake content"));
-        let expected_sha = "0000000000000000000000000000000000000000000000000000000000000000";
+        let expected_sha = "0".repeat(64);
 
-        if actual_sha != expected_sha {
-            let _ = tokio::fs::remove_file(&temp).await;
-        }
+        let result = finalize_verified_download(&temp, &actual_sha, &expected_sha, &dest).await;
 
+        assert!(result.is_err(), "mismatch should return an error");
+        assert!(
+            result.unwrap_err().to_string().contains("checksum mismatch"),
+            "error should mention checksum mismatch"
+        );
         assert!(!temp.exists(), "temp file should be deleted on mismatch");
-        assert!(!dest.exists(), "dest file should not exist");
+        assert!(!dest.exists(), "dest file should not exist on mismatch");
     }
-}
 
-#[cfg(test)]
-fn detect_target_with(base_url: &str, os: &str, arch: &str) -> miette::Result<Target> {
-    let (platform, file_arch, ext) = match (os, arch) {
-        ("macos", "aarch64") => ("MacOSX", "arm64", "sh"),
-        ("macos", "x86_64") => ("MacOSX", "x86_64", "sh"),
-        ("linux", "x86_64") => ("Linux", "x86_64", "sh"),
-        ("linux", "aarch64") => ("Linux", "aarch64", "sh"),
-        ("windows", "x86_64") => ("Windows", "x86_64", "exe"),
-        _ => {
-            return Err(miette!(
-                "no Miniconda installer available for {}/{}",
-                os,
-                arch
-            ));
-        }
-    };
+    #[tokio::test]
+    async fn test_finalize_renames_on_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("test.sh");
+        let temp = dest.with_extension("tmp");
 
-    let filename = format!("Miniconda3-latest-{}-{}.{}", platform, file_arch, ext);
-    let url = format!("{}{}", base_url, filename);
-    Ok(Target { filename, url })
+        tokio::fs::write(&temp, b"fake content").await.unwrap();
+        let actual_sha = format!("{:x}", Sha256::digest(b"fake content"));
+
+        // expected provided in UPPERCASE to exercise case-insensitive comparison
+        let expected_sha = actual_sha.to_uppercase();
+
+        let result = finalize_verified_download(&temp, &actual_sha, &expected_sha, &dest).await;
+
+        assert!(result.is_ok(), "matching checksum should succeed");
+        assert!(!temp.exists(), "temp file should be gone after rename");
+        assert!(dest.exists(), "dest file should exist after rename");
+        let contents = tokio::fs::read(&dest).await.unwrap();
+        assert_eq!(contents, b"fake content");
+    }
 }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use futures_util::StreamExt;
-use indicatif::{ProgressBar, ProgressStyle};
 use miette::miette;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
@@ -10,6 +9,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 
 use crate::context::CommandContext;
+use crate::ui::progress::build_progress_bar;
 
 const MINICONDA_BASE_URL: &str = "https://repo.anaconda.com/miniconda/";
 
@@ -172,26 +172,6 @@ async fn finalize_verified_download(
         .map_err(|e| miette!("failed to move file to destination: {}", e))?;
 
     Ok(())
-}
-
-fn build_progress_bar(total_size: u64) -> ProgressBar {
-    use crate::ui::styles::UiColor;
-
-    let pb = ProgressBar::new(total_size);
-    let dim = UiColor::Dim.hex();
-    let dim_suffix = UiColor::Dim.apply_to("% |").to_string();
-    let template = format!(
-        "  {{bar:34.{}/{dim}}} {{percent:>2.{dim}}}{dim_suffix} {{elapsed:.{dim}}}",
-        UiColor::Green.hex(),
-    );
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template(&template)
-            .unwrap()
-            .progress_chars("━━─"),
-    );
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
-    pb
 }
 
 fn format_size(bytes: u64) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod fetch;
 mod help;
 mod http;
 mod input;
+mod installer;
 mod mcp;
 #[cfg(unix)]
 mod outerbounds;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,8 @@
 //! This module provides:
 //! - `styles`: Shared color and style definitions
 //! - `status`: Status output functions (success, error, warn, etc.)
+//! - `progress`: Progress bar utilities
 
+pub mod progress;
 pub mod status;
 pub mod styles;

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -1,0 +1,25 @@
+//! Progress bar utilities for download and transfer operations.
+
+use indicatif::{ProgressBar, ProgressStyle};
+use std::time::Duration;
+
+use super::styles::UiColor;
+
+/// Build a styled progress bar for download operations.
+pub fn build_progress_bar(total_size: u64) -> ProgressBar {
+    let pb = ProgressBar::new(total_size);
+    let dim = UiColor::Dim.hex();
+    let dim_suffix = UiColor::Dim.apply_to("% |").to_string();
+    let template = format!(
+        "  {{bar:34.{}/{dim}}} {{percent:>2.{dim}}}{dim_suffix} {{elapsed:.{dim}}}",
+        UiColor::Green.hex(),
+    );
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(&template)
+            .unwrap()
+            .progress_chars("━━─"),
+    );
+    pb.enable_steady_tick(Duration::from_millis(100));
+    pb
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::context::CommandContext;
 use crate::errors::UpdateError;
+use crate::ui::progress::build_progress_bar;
 
 // GitHub repository for releases (used when ANA_SELF_UPDATE_URL=github)
 const GITHUB_REPO: &str = "anaconda/ana-cli";
@@ -107,20 +107,7 @@ async fn download_and_replace(ctx: &CommandContext, asset: &Asset) -> Result<(),
     eprintln!("  Downloading {} ({:.1} MB)", asset.name, total_mb);
     eprintln!("  {}", UiColor::Dim.apply_to(&asset.url));
 
-    let pb = ProgressBar::new(total_size);
-    let dim = UiColor::Dim.hex();
-    let dim_suffix = UiColor::Dim.apply_to("% |").to_string();
-    let template = format!(
-        "  {{bar:34.{}/{dim}}} {{percent:>2.{dim}}}{dim_suffix} {{elapsed:.{dim}}}",
-        UiColor::Green.hex(),
-    );
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template(&template)
-            .unwrap()
-            .progress_chars("━━─"),
-    );
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = build_progress_bar(total_size);
 
     let temp_dir = std::env::temp_dir();
     let temp_path = temp_dir.join(&asset.name);


### PR DESCRIPTION
`ana download miniconda` — grabs the latest miniconda installer for your platform, checksums it, drops it in your cwd, prints the command to run it. it does not run the installer.

```
$ ana download miniconda
Downloaded Miniconda3-latest-MacOSX-arm64.sh (127.4 MB) to:
    ./Miniconda3-latest-MacOSX-arm64.sh
SHA256 verified.

To install, run:
    bash ./Miniconda3-latest-MacOSX-arm64.sh
```

context: i got a new laptop, wanted miniconda, didn't want to open a browser and go hunt down the right .sh for my arch. that's the whole thing. that's all this solves.

why not `ana install miniconda` that actually runs it? because the moment you run the installer you're in a totally different conversation.
- `-b` is literally license acceptance, so now ana is accepting the TOS on the user's behalf and that's another place we're maintaining a legal position.
- and you're stuck either masking miniconda's own UX behind our defaults or just re-exposing all its flags.

download-only sidesteps all of it. user runs it themselves, accepts the terms interactively, or uses cli flags, same as they would today.

what's actually in here:

- new `src/installer/` module. did NOT route it through `src/tools/` — that's rattler/lockfile/symlink machinery and this shares none of it, it's just "download a file and verify it"
- platform detection → filename for the 5 targets we actually ship (mac arm64/x86_64, linux x86_64/aarch64, win x86_64). anything else is a clean error, not a guessed URL that 404s
- sha256 verify against `repo.anaconda.com/miniconda/.files.json`. fails closed — key missing or empty checksum in the manifest and we refuse, we don't hand you something we couldn't verify
- temp file + atomic rename so a bad download never leaves a half-written file behind
- file already in your cwd → insta-fail ("remove it if you want to continue"), checked *before* the download so we don't pull 120mb just to bail at the end

stuff i left out on purpose — these are follow-ons, not oversights:

- `-f`/`--force` to overwrite instead of failing. obvious next flag. and miniconda's own installer uses `-f` for "no error if prefix exists" so it lines up nicely
- `--output PATH` to land it somewhere other than cwd. this is the one that makes it useful in CI: `ana download miniconda --output /tmp/mc.sh && bash /tmp/mc.sh -b -p /tmp/miniconda`
- not hardcoding `repo.anaconda.com` forever. we already config-drive our other remotes (`ANA_DOMAIN`, `ANA_PIP_INDEX_URL`) and the installer host should resolve the same way eventually. env override, then logged-in customer's host, then public default. it's not immediately clear to me how the custom installer stuff that our proserv team manages works. we should probably have some thinking about how to better support simpler bootstrapping with custom installers. but that's out of scope for this. also matters for air-gapped customers who can't reach `repo.anaconda.com` at all? does PSM mirror the installers too? if so we could look at supporting that use case too.
- other distributions / pinned versions. anaconda distribution lives at `/archive/.files.json`, no `latest` alias so that one needs an explicit version
