### PR TITLE
ci: Add bot code review workflow

### DIFF
--- a/.github/workflows/bot-code-review.yaml
+++ b/.github/workflows/bot-code-review.yaml
@@ -10,7 +10,7 @@ on:
     types: [submitted]
   pull_request:
     types: [opened, reopened]
-
+permissions: {}
 jobs:
   claude-code-review:
     name: Claude Code Review

--- a/.github/workflows/bot-code-review.yaml
+++ b/.github/workflows/bot-code-review.yaml
@@ -15,10 +15,10 @@ jobs:
   claude-code-review:
     name: Claude Code Review
     permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-      actions: read
+      contents: read # To read the repo and PR
+      pull-requests: write # To leave comments on the PR
+      id-token: write # Needed for oidc assume IAM role
+      actions: read # Needed to identify CI failures
     if: |
       (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||

--- a/.github/workflows/bot-code-review.yaml
+++ b/.github/workflows/bot-code-review.yaml
@@ -24,6 +24,6 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-    uses: anaconda/internal-actions/.github/workflows/bot-code-review.yml@1be176d1d4801c4ca716ffaf646726200b60e82f # main
+    uses: anaconda/internal-actions/.github/workflows/bot-code-review.yml@main
     with:
       team: ai-services

--- a/.github/workflows/bot-code-review.yml
+++ b/.github/workflows/bot-code-review.yml
@@ -1,0 +1,29 @@
+# Delegates @claude PR reviews to the org reusable workflow (internal-actions).
+name: '[Bot] Code Review'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  claude-code-review:
+    name: Claude Code Review
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    uses: anaconda/internal-actions/.github/workflows/bot-code-review.yml@1be176d1d4801c4ca716ffaf646726200b60e82f # main
+    with:
+      team: ai-services


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to enable @claude bot PR reviews. This workflow delegates PR reviews to the org's reusable workflow in internal-actions, matching the implementation used in ai-core.

The workflow triggers on:
- New/reopened pull requests
- Issue comments, PR review comments, and PR reviews that mention `@claude`

## Test plan
- [ ] Create a test PR and verify the workflow runs
- [ ] Comment with `@claude` on a PR and verify the bot responds

Jira: [CLI-684](https://anaconda.atlassian.net/browse/CLI-684)

[CLI-684]: https://anaconda.atlassian.net/browse/CLI-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ