### PR TITLE
fix(ci): Skip cargo cache on release builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
         shell: bash
 
       - name: Cache Cargo registry and build
+        if: ${{ github.event_name != 'workflow_call' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -39,6 +39,7 @@ jobs:
             ci
           scopes: |
             foobar # First scope is not working, dummy value
+            ci
             deps
           requireScope: false
           # Ensure subject is not empty And starts with an uppercase letter

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,7 +12,7 @@ IS_WINDOWS = sys.platform == "win32"
 PIXI_BIN = "pixi.exe" if IS_WINDOWS else "pixi"
 
 
-class TestToolInstallHelp:
+class TestToolHelp:
     """Tests for tool command help."""
 
     def test_tool_help(self, run_ana: AnaRunner) -> None:
@@ -31,6 +31,17 @@ class TestToolInstallHelp:
         result = run_ana("tool", "install", "--help")
         assert result.returncode == 0
         assert "Install a tool" in result.stdout
+
+    def test_tool_download_subcommand_exists(self, run_ana: AnaRunner) -> None:
+        """Verify the download subcommand is present in the binary."""
+        result = run_ana("tool", "--help")
+        assert result.returncode == 0
+        assert "download" in result.stdout.lower()
+
+    def test_tool_download_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("tool", "download", "--help")
+        assert result.returncode == 0
+        assert "miniconda" in result.stdout.lower()
 
 
 class TestToolInstallPixi:


### PR DESCRIPTION
## Summary
Disables cargo caching for release builds (triggered via `workflow_call` from release.yaml). This ensures releases always compile from source, avoiding stale cached artifacts.

This caused v0.2.0 to ship without the `ana tool download miniconda` feature despite the code being present at the tagged commit - cargo restored a cached `target/` directory from an earlier build and didn't detect the source changes.

## Test plan
- [ ] Merge this PR
- [ ] Create v0.2.1 release
- [ ] Verify `ana tool download --help` shows the download subcommand