### PR TITLE
feat: Add externally-managed installers table to `ana tool list`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,7 +165,9 @@ pub enum Action {
         pixi: bool,
     },
     FeatureList,
-    DownloadMiniconda,
+    ToolDownload {
+        name: String,
+    },
     TelemetrySubmit,
     TelemetryKill,
     TelemetryStatus,
@@ -211,7 +213,7 @@ impl Action {
                 _ => "feature.disable.unknown",
             },
             Action::FeatureList => "feature.list",
-            Action::DownloadMiniconda => "tool.download.miniconda",
+            Action::ToolDownload { .. } => "tool.download",
             Action::TelemetrySubmit => "telemetry-submit",
             Action::TelemetryKill => "telemetry-kill",
             Action::TelemetryStatus => "telemetry-status",
@@ -481,7 +483,18 @@ impl Action {
                 feature::list::print_feature_list(ctx);
                 Ok(())
             }
-            Action::DownloadMiniconda => installer::run(ctx, None).await,
+            Action::ToolDownload { name } => {
+                // Record what the user actually typed so we can see demand for
+                // installers we don't support yet (e.g. "anaconda").
+                ctx.telemetry.add("installer_name", name.clone());
+                match name.as_str() {
+                    "miniconda" => installer::run(ctx, None).await,
+                    other => Err(miette!(
+                        "only miniconda is currently supported (got '{}')",
+                        other
+                    )),
+                }
+            }
             Action::TelemetrySubmit => {
                 crate::telemetry::submit_pending().map_err(|e| miette!("{}", e))?;
                 Ok(())
@@ -625,16 +638,9 @@ pub fn parse() -> (Action, LogLevel) {
             Some(ToolCommands::Install { name }) => Action::ToolInstall { name },
             Some(ToolCommands::List) => Action::ToolList,
             Some(ToolCommands::Uninstall { name, force }) => Action::ToolUninstall { name, force },
-            Some(ToolCommands::Download { name }) => match name.as_deref() {
+            Some(ToolCommands::Download { name }) => match name {
                 None => Action::ShowSubcommandHelp("tool download".to_string()),
-                Some("miniconda") => Action::DownloadMiniconda,
-                Some(other) => {
-                    eprintln!(
-                        "error: only miniconda is currently supported (got '{}')",
-                        other
-                    );
-                    std::process::exit(1);
-                }
+                Some(name) => Action::ToolDownload { name },
             },
         },
         Some(Commands::Api { command }) => match command {

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -15,6 +15,36 @@ pub struct ToolInfo {
     pub binaries: Vec<PathBuf>,
 }
 
+/// An externally-managed installer. Unlike the rattler-managed tools above,
+/// these are downloaded (and SHA256-verified) into the current directory by
+/// `ana tool download`, then installed by the user — `ana` does not manage the
+/// resulting installation.
+struct Installer {
+    name: &'static str,
+    /// Version offered by the download, or `None` if not yet available. Only
+    /// "latest" is supported today.
+    version: Option<&'static str>,
+    /// Download command, or `None` if not yet available.
+    command: Option<&'static str>,
+    status: &'static str,
+}
+
+/// Externally-managed installers shown in the second table.
+const INSTALLERS: &[Installer] = &[
+    Installer {
+        name: "miniconda",
+        version: Some("latest"),
+        command: Some("ana tool download miniconda"),
+        status: "available",
+    },
+    Installer {
+        name: "anaconda",
+        version: None,
+        command: None,
+        status: "coming soon",
+    },
+];
+
 /// List all available tools with their installation status.
 pub fn list_tools() -> Vec<ToolInfo> {
     specs::all_tools()
@@ -53,5 +83,25 @@ pub fn print_tool_list(_ctx: &mut CommandContext) {
         table.add_row([table::cell(tool.name), status_cell, table::cell(&binaries)]);
     }
 
+    println!("{table}");
+
+    print_installer_list();
+}
+
+/// Print the externally-managed installer table.
+fn print_installer_list() {
+    let mut table = table::new(["Name", "Version", "Download command", "Status"]);
+
+    for installer in INSTALLERS {
+        table.add_row([
+            table::cell(installer.name),
+            table::cell(installer.version.unwrap_or("n/a")),
+            table::cell(installer.command.unwrap_or("n/a")),
+            table::cell(installer.status),
+        ]);
+    }
+
+    println!();
+    println!("Externally Managed Installers");
     println!("{table}");
 }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -135,6 +135,16 @@ class TestToolList:
         assert "pixi" in result.stdout
         assert "anaconda-cli" in result.stdout
 
+    def test_tool_list_shows_externally_managed_installers(
+        self, run_ana: AnaRunner
+    ) -> None:
+        """Test that tool list shows the externally managed installers table."""
+        result = run_ana("tool", "list")
+        assert result.returncode == 0
+        assert "Externally Managed Installers" in result.stdout
+        assert "miniconda" in result.stdout
+        assert "ana tool download miniconda" in result.stdout
+
     def test_tool_list_shows_installed_status(
         self, run_ana: AnaRunner, fake_home: Path
     ) -> None:


### PR DESCRIPTION
## What

`ana tool list` now prints a **second table** for externally-managed installers — things `ana` downloads (and SHA256-verifies) but does *not* manage afterward — keeping them distinct from the rattler-managed tools in the first table.

```
Externally Managed Installers
┌───────────┬─────────┬─────────────────────────────┬─────────────┐
│ Name      │ Version │ Download command            │ Status      │
╞═══════════╪═════════╪═════════════════════════════╪═════════════╡
│ miniconda │ latest  │ ana tool download miniconda │ available   │
├───────────┼─────────┼─────────────────────────────┼─────────────┤
│ anaconda  │ n/a     │ n/a                         │ coming soon │
└───────────┴─────────┴─────────────────────────────┴─────────────┘
```

The `anaconda` row is intentionally a roadmap placeholder (no implementation behind it yet) — it's there to surface demand. See telemetry change below.

## Why a second table

Miniconda is categorically different from `pixi`/`outerbounds`/`anaconda-cli`: those are rattler-managed conda environments installed into `~/.ana/tools` with symlinked binaries. `ana tool download miniconda` instead fetches the `Miniconda3-latest-*` installer into the cwd, verifies it, and leaves installation to the user. Conflating the two in one table would misrepresent what `ana` manages.

## Telemetry: capture demand for unsupported installers

`ana tool download <name>` now records the **name the user typed** as an `installer_name` telemetry attribute. The unsupported-name path was moved out of arg-parsing (which `process::exit`ed before any telemetry context existed) and into the command handler, where it returns an error — so the attempt is recorded on the `cli_command_failure` counter under `command: tool.download`.

This means if a user sees `anaconda` "coming soon" and runs `ana tool download anaconda`, we get a measurable signal — demand attempted, not just demand spoken — to decide whether to build it.

## Test plan

- [x] `cargo test` — 248 passing
- [x] `ana tool list` renders both tables (shown above)
- [x] `ana tool download anaconda` → `only miniconda is currently supported (got 'anaconda')`, exit 1, spools `installer_name: anaconda`
- [x] `ana tool download` (no name) → subcommand help

[CLI-700](https://anaconda.atlassian.net/browse/CLI-700)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLI-700]: https://anaconda.atlassian.net/browse/CLI-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ