### PR TITLE
fix: Add typed arguments to MCP subcommand help

### DIFF
--- a/src/mcp/commands.rs
+++ b/src/mcp/commands.rs
@@ -1,4 +1,53 @@
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
+use std::fmt;
+
+/// Supported AI clients for MCP configuration.
+#[derive(Clone, ValueEnum)]
+pub enum McpClient {
+    #[value(name = "claude-code")]
+    ClaudeCode,
+    #[value(name = "claude-desktop")]
+    ClaudeDesktop,
+    #[value(name = "cursor")]
+    Cursor,
+    #[value(name = "opencode")]
+    Opencode,
+    #[value(name = "vscode")]
+    Vscode,
+    #[value(name = "windsurf")]
+    Windsurf,
+}
+
+impl fmt::Display for McpClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpClient::ClaudeCode => write!(f, "claude-code"),
+            McpClient::ClaudeDesktop => write!(f, "claude-desktop"),
+            McpClient::Cursor => write!(f, "cursor"),
+            McpClient::Opencode => write!(f, "opencode"),
+            McpClient::Vscode => write!(f, "vscode"),
+            McpClient::Windsurf => write!(f, "windsurf"),
+        }
+    }
+}
+
+/// Scope for MCP client configuration.
+#[derive(Clone, ValueEnum)]
+pub enum McpScope {
+    #[value(name = "global")]
+    Global,
+    #[value(name = "project")]
+    Project,
+}
+
+impl fmt::Display for McpScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpScope::Global => write!(f, "global"),
+            McpScope::Project => write!(f, "project"),
+        }
+    }
+}
 
 /// Result of resolving an MCP command.
 pub enum McpAction {
@@ -12,38 +61,127 @@ pub enum McpAction {
 #[derive(Subcommand)]
 pub enum McpCommands {
     /// Start MCP servers from configuration file
-    #[command(trailing_var_arg = true)]
     Serve {
-        #[arg(allow_hyphen_values = true)]
+        /// Path to mcp_compose.toml file
+        #[arg(short = 'c', long = "config")]
+        config: Option<String>,
+
+        /// Host to bind to
+        #[arg(long, default_value = "0.0.0.0")]
+        host: String,
+
+        /// Port to bind to
+        #[arg(long, default_value_t = 8000)]
+        port: u32,
+
+        /// Delay in seconds added before serving
+        #[arg(long, default_value_t = 0)]
+        delay: u32,
+
+        /// Additional arguments passed to the serve command
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
     /// List supported AI clients and their configuration options
-    #[command(trailing_var_arg = true)]
     Clients {
-        #[arg(allow_hyphen_values = true)]
-        args: Vec<String>,
+        /// Project directory to check for project-scoped installs
+        #[arg(long)]
+        project_dir: Option<String>,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Configure AI clients to use Anaconda MCP
-    #[command(trailing_var_arg = true)]
     Setup {
-        #[arg(allow_hyphen_values = true)]
-        args: Vec<String>,
+        /// Client to configure (can be repeated)
+        #[arg(long, value_enum)]
+        client: Vec<McpClient>,
+
+        /// Name for the MCP server entry
+        #[arg(short = 'n', long, default_value = "anaconda-mcp")]
+        name: String,
+
+        /// Install globally or in the current project
+        #[arg(long, value_enum, default_value = "global")]
+        scope: McpScope,
+
+        /// Project directory for --scope project
+        #[arg(long)]
+        project_dir: Option<String>,
+
+        /// Don't create a backup of the existing config file
+        #[arg(long)]
+        no_backup: bool,
+
+        /// Overwrite existing server configuration if present
+        #[arg(short = 'f', long)]
+        force: bool,
+
+        /// Output result as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Remove Anaconda MCP from AI client configurations
-    #[command(trailing_var_arg = true)]
     Remove {
-        #[arg(allow_hyphen_values = true)]
-        args: Vec<String>,
+        /// Client to remove from (can be repeated)
+        #[arg(long, value_enum)]
+        client: Vec<McpClient>,
+
+        /// Name of the MCP server entry to remove
+        #[arg(short = 'n', long, default_value = "anaconda-mcp")]
+        name: String,
+
+        /// Remove from global or project config
+        #[arg(long, value_enum, default_value = "global")]
+        scope: McpScope,
+
+        /// Project directory for --scope project
+        #[arg(long)]
+        project_dir: Option<String>,
+
+        /// Don't create a backup of the existing config file
+        #[arg(long)]
+        no_backup: bool,
+
+        /// Output result as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Manage Terms of Service acceptance
-    #[command(trailing_var_arg = true)]
+    #[command(subcommand_required = false, arg_required_else_help = false)]
     Terms {
-        #[arg(allow_hyphen_values = true)]
-        args: Vec<String>,
+        #[command(subcommand)]
+        command: Option<McpTermsCommands>,
+
+        /// Output in JSON format (when no subcommand is given)
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum McpTermsCommands {
+    /// Check whether the Terms of Service have been accepted
+    Status {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Accept the Terms of Service
+    Accept {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+
+        /// Consent to be contacted for feedback
+        #[arg(long)]
+        consent: bool,
     },
 }
 
@@ -51,30 +189,134 @@ impl McpCommands {
     /// Convert the command into an action.
     pub fn into_action(self) -> McpAction {
         match self {
-            McpCommands::Serve { args } => {
-                let mut cmd_args = vec!["serve".to_string()];
-                cmd_args.extend(args);
-                McpAction::Run(cmd_args)
+            McpCommands::Serve {
+                config,
+                host,
+                port,
+                delay,
+                args: extra_args,
+            } => {
+                let mut args = vec!["serve".to_string()];
+                if let Some(c) = config {
+                    args.push("-c".to_string());
+                    args.push(c);
+                }
+                args.push("--host".to_string());
+                args.push(host);
+                args.push("--port".to_string());
+                args.push(port.to_string());
+                args.push("--delay".to_string());
+                args.push(delay.to_string());
+                args.extend(extra_args);
+                McpAction::Run(args)
             }
-            McpCommands::Clients { args } => {
-                let mut cmd_args = vec!["clients".to_string()];
-                cmd_args.extend(args);
-                McpAction::Run(cmd_args)
+            McpCommands::Clients { project_dir, json } => {
+                let mut args = vec!["clients".to_string()];
+                if let Some(dir) = project_dir {
+                    args.push("--project-dir".to_string());
+                    args.push(dir);
+                }
+                if json {
+                    args.push("--json".to_string());
+                }
+                McpAction::Run(args)
             }
-            McpCommands::Setup { args } => {
-                let mut cmd_args = vec!["setup".to_string()];
-                cmd_args.extend(args);
-                McpAction::Run(cmd_args)
+            McpCommands::Setup {
+                client,
+                name,
+                scope,
+                project_dir,
+                no_backup,
+                force,
+                json,
+            } => {
+                let mut args = vec!["setup".to_string()];
+                for c in client {
+                    args.push("--client".to_string());
+                    args.push(c.to_string());
+                }
+                args.push("--name".to_string());
+                args.push(name);
+                args.push("--scope".to_string());
+                args.push(scope.to_string());
+                if let Some(dir) = project_dir {
+                    args.push("--project-dir".to_string());
+                    args.push(dir);
+                }
+                if no_backup {
+                    args.push("--no-backup".to_string());
+                }
+                if force {
+                    args.push("--force".to_string());
+                }
+                if json {
+                    args.push("--json".to_string());
+                }
+                McpAction::Run(args)
             }
-            McpCommands::Remove { args } => {
-                let mut cmd_args = vec!["remove".to_string()];
-                cmd_args.extend(args);
-                McpAction::Run(cmd_args)
+            McpCommands::Remove {
+                client,
+                name,
+                scope,
+                project_dir,
+                no_backup,
+                json,
+            } => {
+                let mut args = vec!["remove".to_string()];
+                for c in client {
+                    args.push("--client".to_string());
+                    args.push(c.to_string());
+                }
+                args.push("--name".to_string());
+                args.push(name);
+                args.push("--scope".to_string());
+                args.push(scope.to_string());
+                if let Some(dir) = project_dir {
+                    args.push("--project-dir".to_string());
+                    args.push(dir);
+                }
+                if no_backup {
+                    args.push("--no-backup".to_string());
+                }
+                if json {
+                    args.push("--json".to_string());
+                }
+                McpAction::Run(args)
             }
-            McpCommands::Terms { args } => {
-                let mut cmd_args = vec!["terms".to_string()];
-                cmd_args.extend(args);
-                McpAction::Run(cmd_args)
+            McpCommands::Terms { command, json } => match command {
+                None => {
+                    let mut args = vec!["terms".to_string()];
+                    if json {
+                        args.push("--json".to_string());
+                    }
+                    McpAction::Run(args)
+                }
+                Some(terms_cmd) => terms_cmd.into_action(),
+            },
+        }
+    }
+}
+
+impl McpTermsCommands {
+    /// Convert the terms command into an action.
+    pub fn into_action(self) -> McpAction {
+        match self {
+            McpTermsCommands::Status { json } => {
+                let mut args = vec!["terms".to_string(), "status".to_string()];
+                if json {
+                    args.push("--json".to_string());
+                }
+                McpAction::Run(args)
+            }
+            McpTermsCommands::Accept { json, consent } => {
+                let mut args = vec!["terms".to_string(), "accept".to_string()];
+                if json {
+                    args.push("--json".to_string());
+                }
+                if consent {
+                    args.push("--consent".to_string());
+                }
+                McpAction::Run(args)
             }
         }
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -551,3 +551,70 @@ class TestMcpSubcommands:
             f"ana mcp has wrappers for commands that don't exist upstream: {stale_commands}. "
             "Remove them from src/mcp/commands.rs"
         )
+
+    # -------------------------------------------------------------------------
+    # Help option verification tests
+    # These tests ensure all CLI options are properly configured and don't cause
+    # panics. They verify each subcommand's help output includes expected options.
+    # -------------------------------------------------------------------------
+
+    def test_mcp_serve_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp serve --help' shows all expected options."""
+        result = run_ana("mcp", "serve", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--config" in result.stdout, "Missing --config option"
+        assert "--host" in result.stdout, "Missing --host option"
+        assert "--port" in result.stdout, "Missing --port option"
+        assert "--delay" in result.stdout, "Missing --delay option"
+        # Note: --verbose uses trailing_var_arg to avoid conflict with global -v
+
+    def test_mcp_clients_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp clients --help' shows all expected options."""
+        result = run_ana("mcp", "clients", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--project-dir" in result.stdout, "Missing --project-dir option"
+        assert "--json" in result.stdout, "Missing --json option"
+
+    def test_mcp_setup_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp setup --help' shows all expected options."""
+        result = run_ana("mcp", "setup", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--client" in result.stdout, "Missing --client option"
+        assert "--name" in result.stdout, "Missing --name option"
+        assert "--scope" in result.stdout, "Missing --scope option"
+        assert "--project-dir" in result.stdout, "Missing --project-dir option"
+        assert "--no-backup" in result.stdout, "Missing --no-backup option"
+        assert "--force" in result.stdout, "Missing --force option"
+        assert "--json" in result.stdout, "Missing --json option"
+
+    def test_mcp_remove_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp remove --help' shows all expected options."""
+        result = run_ana("mcp", "remove", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--client" in result.stdout, "Missing --client option"
+        assert "--name" in result.stdout, "Missing --name option"
+        assert "--scope" in result.stdout, "Missing --scope option"
+        assert "--project-dir" in result.stdout, "Missing --project-dir option"
+        assert "--no-backup" in result.stdout, "Missing --no-backup option"
+        assert "--json" in result.stdout, "Missing --json option"
+
+    def test_mcp_terms_help_shows_subcommands(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp terms --help' shows subcommands and options."""
+        result = run_ana("mcp", "terms", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "status" in result.stdout.lower(), "Missing 'status' subcommand"
+        assert "accept" in result.stdout.lower(), "Missing 'accept' subcommand"
+        assert "--json" in result.stdout, "Missing --json option"
+
+    def test_mcp_terms_status_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp terms status --help' shows all expected options."""
+        result = run_ana("mcp", "terms", "status", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--json" in result.stdout, "Missing --json option"
+
+    def test_mcp_terms_accept_help_shows_options(self, run_ana: AnaRunner) -> None:
+        """Test that 'ana mcp terms accept --help' shows all expected options."""
+        result = run_ana("mcp", "terms", "accept", "--help")
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "--json" in result.stdout, "Missing --json option"
+        assert "--consent" in result.stdout, "Missing --consent option"


### PR DESCRIPTION
## Summary

Following up on #304, this adds proper option definitions to MCP subcommands so `ana mcp <cmd> --help` shows all available options instead of just `[ARGS]...`.

- Add `McpClient` and `McpScope` enums for validated client/scope choices
- Define typed arguments for `serve`, `clients`, `setup`, `remove` commands
- Convert `terms` to a subcommand group with `status` and `accept` subcommands
- Add 7 integration tests verifying all options appear in help output (prevents clap panics from misconfiguration)

### Before
```
Usage: ana mcp setup [ARGS]...
```

### After
```
Usage: ana mcp setup [OPTIONS]

OPTIONS
  --client             Client to configure (can be repeated)
  -n, --name           Name for the MCP server entry
  --scope              Install globally or in the current project
  --project-dir        Project directory for --scope project
  --no-backup          Don't create a backup of the existing config file
  -f, --force          Overwrite existing server configuration if present
  --json               Output result as JSON
```

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo test` passes (252 tests)
- [x] `pytest tests/test_cli.py::TestMcpSubcommands -v` passes (14 tests)
- [ ] Manual verification of help output for each subcommand