### PR TITLE
feat: Add conda-package feature for distribution as conda package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "anaconda-otel-rs",
  "async-trait",
  "base64",
+ "cfg_aliases",
  "chrono",
  "clap",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -29,7 +29,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "bytestring",
  "derive_more",
@@ -243,6 +243,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -292,7 +293,7 @@ dependencies = [
  "rustc_version_runtime",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
@@ -429,15 +430,15 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.17"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+checksum = "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
 dependencies = [
  "async-compression",
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -556,17 +557,23 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -576,6 +583,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -659,7 +675,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -740,6 +756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +825,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -887,7 +915,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -912,6 +940,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -991,6 +1037,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,9 +1117,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1071,7 +1160,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -1163,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1599,6 +1688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1742,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1951,6 +2058,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,12 +2284,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2281,7 +2413,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2294,7 +2426,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2306,7 +2438,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2388,7 +2520,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2409,7 +2541,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -2420,7 +2552,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2453,7 +2585,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2471,7 +2603,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -2484,7 +2616,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2495,7 +2627,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2507,7 +2639,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2559,7 +2691,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2749,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "path_resolver"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
+checksum = "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
 dependencies = [
  "ahash",
  "fs-err",
@@ -2887,6 +3019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +3062,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,7 +3113,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -3098,22 +3261,25 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.43.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
+checksum = "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
+ "base64",
  "console",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "filetime",
  "fs-err",
  "futures",
+ "hex",
  "humantime",
  "indexmap 2.14.0",
  "indicatif",
  "itertools 0.14.0",
+ "jiff",
  "memchr",
  "memmap2",
  "once_cell",
@@ -3144,19 +3310,20 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.8.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
+checksum = "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
 dependencies = [
  "ahash",
  "anyhow",
  "astral-reqwest-middleware",
  "dashmap",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "fs-err",
  "fs4",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "parking_lot",
  "rattler_conda_types",
@@ -3177,12 +3344,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.4"
+version = "0.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
+checksum = "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
 dependencies = [
  "ahash",
- "chrono",
  "core-foundation",
  "dirs",
  "fancy-regex",
@@ -3192,6 +3358,7 @@ dependencies = [
  "hex",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -3219,12 +3386,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
+checksum = "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.11.3",
  "generic-array",
  "hex",
  "md-5",
@@ -3232,22 +3399,22 @@ dependencies = [
  "serde-untagged",
  "serde_bytes",
  "serde_with",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "rattler_lock"
-version = "0.30.3"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c0fe27729fd9081d25eb1a23d94f49f23ee93a75d59bac0ae3e304bda04aae"
+checksum = "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
 dependencies = [
  "ahash",
- "chrono",
  "file_url",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "jiff",
  "pep440_rs",
  "pep508_rs",
  "rattler_conda_types",
@@ -3268,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
+checksum = "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
 dependencies = [
  "quote",
  "syn",
@@ -3278,14 +3445,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.62"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
+checksum = "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
 dependencies = [
- "chrono",
  "configparser",
  "dirs",
  "fs-err",
+ "hex",
  "indexmap 2.14.0",
  "known-folders",
  "once_cell",
@@ -3296,8 +3463,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
- "shlex",
+ "sha2 0.11.0",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -3309,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
+checksum = "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -3320,8 +3487,10 @@ dependencies = [
  "async-trait",
  "base64",
  "fs-err",
+ "futures",
  "getrandom 0.4.2",
  "http 1.4.1",
+ "http-auth",
  "itertools 0.14.0",
  "reqwest 0.13.4",
  "retry-policies",
@@ -3335,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.2"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
+checksum = "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -3346,13 +3515,15 @@ dependencies = [
  "async-compression",
  "async-spooled-tempfile",
  "bzip2",
- "chrono",
+ "filetime",
  "fs-err",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.4.2",
+ "hex",
  "http 1.4.1",
+ "jiff",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -3374,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
+checksum = "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -3397,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.2"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
+checksum = "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -3409,7 +3580,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_pty",
  "serde_json",
- "shlex",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3418,13 +3589,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.1.1"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
+checksum = "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
 dependencies = [
- "chrono",
- "humantime",
+ "hex",
  "itertools 0.14.0",
+ "jiff",
  "rattler_conda_types",
  "rattler_digest",
  "serde",
@@ -3459,7 +3630,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3722,7 +3893,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3849,7 +4020,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3985,7 +4156,7 @@ version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -4170,7 +4341,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4187,6 +4369,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -4757,7 +4945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5252,7 +5440,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5765,7 +5953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.4",
+ "socket2 0.6.3",
  "time",
  "tracing",
  "url",
@@ -222,7 +222,7 @@ dependencies = [
  "dirs",
  "figment",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.1",
  "indicatif",
  "libc",
  "log",
@@ -242,7 +242,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.11.0",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -276,7 +275,7 @@ dependencies = [
 [[package]]
 name = "anaconda-otel-rs"
 version = "0.1.0"
-source = "git+https://github.com/anaconda/anaconda-otel-rs#716cfc2907c16f5da0438fdb0bf6e146c240a1a1"
+source = "git+https://github.com/anaconda/anaconda-otel-rs#316fa5c05768a6d16da3b215fb50cd44835d7a69"
 dependencies = [
  "chrono",
  "futures-util",
@@ -289,11 +288,10 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "regex",
- "reqwest 0.12.28",
  "rustc_version_runtime",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
@@ -386,7 +384,7 @@ checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.2",
+ "http 1.4.1",
  "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.18",
@@ -430,15 +428,15 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.18"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
+checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
 dependencies = [
  "async-compression",
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
 ]
@@ -557,17 +555,17 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -577,15 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -662,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -697,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -750,12 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,9 +787,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "configparser"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
+checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
 
 [[package]]
 name = "console"
@@ -821,28 +804,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -947,24 +914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1005,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -1088,20 +1038,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "const-oid",
- "crypto-common 0.2.2",
- "ctutils",
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1223,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1543,16 +1482,16 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1650,21 +1589,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-auth"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1674,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1685,7 +1615,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -1715,26 +1645,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -1751,7 +1672,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1786,19 +1707,17 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
- "system-configuration",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -2031,30 +1950,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,12 +2010,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2230,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "mac_address"
@@ -2255,19 +2151,19 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.11.0"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2345,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2658,9 +2554,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.81"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2689,9 +2585,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.117"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2721,7 +2617,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.4.1",
  "opentelemetry",
  "reqwest 0.12.28",
 ]
@@ -2732,7 +2628,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.2",
+ "http 1.4.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -2852,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "path_resolver"
-version = "0.2.11"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
+checksum = "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
 dependencies = [
  "ahash",
  "fs-err",
@@ -2990,15 +2886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3085,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3210,25 +3097,22 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.45.0"
+version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
+checksum = "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
- "base64",
  "console",
- "digest 0.11.3",
+ "digest",
  "dirs",
  "filetime",
  "fs-err",
  "futures",
- "hex",
  "humantime",
  "indexmap 2.14.0",
  "indicatif",
  "itertools 0.14.0",
- "jiff",
  "memchr",
  "memmap2",
  "once_cell",
@@ -3259,20 +3143,19 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
+checksum = "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
 dependencies = [
  "ahash",
  "anyhow",
  "astral-reqwest-middleware",
  "dashmap",
- "digest 0.11.3",
+ "digest",
  "dirs",
  "fs-err",
  "fs4",
  "futures",
- "hex",
  "itertools 0.14.0",
  "parking_lot",
  "rattler_conda_types",
@@ -3293,12 +3176,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.47.2"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
+checksum = "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
 dependencies = [
  "ahash",
- "core-foundation 0.10.1",
+ "chrono",
+ "core-foundation",
  "dirs",
  "fancy-regex",
  "file_url",
@@ -3307,7 +3191,6 @@ dependencies = [
  "hex",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -3335,12 +3218,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
+checksum = "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
 dependencies = [
  "blake2",
- "digest 0.11.3",
+ "digest",
  "generic-array",
  "hex",
  "md-5",
@@ -3348,22 +3231,22 @@ dependencies = [
  "serde-untagged",
  "serde_bytes",
  "serde_with",
- "sha2 0.11.0",
+ "sha2",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.3"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
+checksum = "a0c0fe27729fd9081d25eb1a23d94f49f23ee93a75d59bac0ae3e304bda04aae"
 dependencies = [
  "ahash",
+ "chrono",
  "file_url",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "jiff",
  "pep440_rs",
  "pep508_rs",
  "rattler_conda_types",
@@ -3384,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
+checksum = "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
 dependencies = [
  "quote",
  "syn",
@@ -3394,14 +3277,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.67"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
+checksum = "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
 dependencies = [
+ "chrono",
  "configparser",
  "dirs",
  "fs-err",
- "hex",
  "indexmap 2.14.0",
  "known-folders",
  "once_cell",
@@ -3412,7 +3295,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "shlex",
  "tempfile",
  "thiserror 2.0.18",
@@ -3420,14 +3303,14 @@ dependencies = [
  "unicode-normalization",
  "which",
  "windows 0.61.3",
- "windows-registry 0.5.3",
+ "windows-registry",
 ]
 
 [[package]]
 name = "rattler_networking"
-version = "0.29.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
+checksum = "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -3436,10 +3319,8 @@ dependencies = [
  "async-trait",
  "base64",
  "fs-err",
- "futures",
  "getrandom 0.4.2",
- "http 1.4.2",
- "http-auth",
+ "http 1.4.1",
  "itertools 0.14.0",
  "reqwest 0.13.4",
  "retry-policies",
@@ -3453,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.5"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
+checksum = "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -3464,15 +3345,13 @@ dependencies = [
  "async-compression",
  "async-spooled-tempfile",
  "bzip2",
- "filetime",
+ "chrono",
  "fs-err",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.4.2",
- "hex",
- "http 1.4.2",
- "jiff",
+ "http 1.4.1",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -3494,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
+checksum = "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -3517,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.7"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
+checksum = "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -3538,13 +3417,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.2.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
+checksum = "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
 dependencies = [
- "hex",
+ "chrono",
+ "humantime",
  "itertools 0.14.0",
- "jiff",
  "rattler_conda_types",
  "rattler_digest",
  "serde",
@@ -3627,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3656,9 +3535,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3668,31 +3547,23 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3714,7 +3585,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3753,7 +3624,7 @@ checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.2",
+ "http 1.4.1",
  "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.18",
@@ -3794,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.4"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -3978,7 +3849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4247,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
  "bs58",
@@ -4267,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4298,18 +4169,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -4323,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "2.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -4400,9 +4260,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -4419,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4489,9 +4349,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4531,27 +4391,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows 0.52.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4658,11 +4497,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
@@ -4673,15 +4513,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4724,7 +4564,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4871,7 +4711,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "percent-encoding",
@@ -4920,7 +4760,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -5042,9 +4882,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uname"
@@ -5099,9 +4939,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.3"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5169,7 +5009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.2",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -5213,9 +5053,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5299,9 +5139,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -5317,9 +5157,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5330,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5340,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5350,9 +5190,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5363,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5419,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5443,7 +5283,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "jni",
  "log",
  "ndk-context",
@@ -5455,18 +5295,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
 ]
@@ -5678,17 +5518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,7 +5687,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.2",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5995,9 +5824,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6018,18 +5847,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6059,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ rlimit = "0.11"
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 # Unstable features are hidden and disabled by default.
+# self-update: Enable `ana self update` command. Included by default.
 # conda-package: Build for distribution as a conda package. Disables tool installation
-# (tools are provided as conda dependencies) and resolves binaries from $CONDA_PREFIX/bin/.
-default = []
+# (tools are provided as conda dependencies), disables self-update (managed by conda),
+# and resolves binaries from $CONDA_PREFIX/bin/.
+default = ["self-update"]
 diagnostics = ["dep:sentry"]
 unstable = []
+self-update = []
 conda-package = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,12 @@ rlimit = "0.11"
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 # Unstable features are hidden and disabled by default.
+# conda-package: Build for distribution as a conda package. Disables tool installation
+# (tools are provided as conda dependencies) and resolves binaries from $CONDA_PREFIX/bin/.
 default = []
 diagnostics = ["dep:sentry"]
 unstable = []
+conda-package = []
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,15 @@ rlimit = "0.11"
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 # Unstable features are hidden and disabled by default.
 # self-update: Enable `ana self update` command. Included by default.
-# conda-package: Build for distribution as a conda package. Disables tool installation
-# (tools are provided as conda dependencies), disables self-update (managed by conda),
-# and resolves binaries from $CONDA_PREFIX/bin/.
-default = ["self-update"]
+# tool-install: Enable `ana tool install/uninstall` commands. Included by default.
+# conda-package: Build for distribution as a conda package. Implicitly disables
+# self-update and tool-install (both managed by conda), and resolves binaries
+# from $CONDA_PREFIX/bin/.
+default = ["self-update", "tool-install"]
 diagnostics = ["dep:sentry"]
 unstable = []
 self-update = []
+tool-install = []
 conda-package = []
 
 [dependencies]
@@ -64,3 +66,6 @@ url = "2.5.8"
 temp-env = "0.3"
 tempfile = "3"
 wiremock = "0.6"
+
+[build-dependencies]
+cfg_aliases = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,15 @@ rlimit = "0.11"
 # Unstable features are hidden and disabled by default.
 # self-update: Enable `ana self update` command. Included by default.
 # tool-install: Enable `ana tool install/uninstall` commands. Included by default.
+#   Pulls in rattler for lockfile-based installation.
 # conda-package: Build for distribution as a conda package. Implicitly disables
-# self-update and tool-install (both managed by conda), and resolves binaries
-# from $CONDA_PREFIX/bin/.
+#   self-update and tool-install (both managed by conda), and resolves binaries
+#   from $CONDA_PREFIX/bin/.
 default = ["self-update", "tool-install"]
 diagnostics = ["dep:sentry"]
 unstable = []
 self-update = []
-tool-install = []
+tool-install = ["dep:rattler", "dep:rattler_cache", "dep:rattler_conda_types", "dep:rattler_lock"]
 conda-package = []
 
 [dependencies]
@@ -37,10 +38,10 @@ console = "0.16"
 indicatif = "0.18"
 log = "0.4"
 miette = { version = "7.6", features = ["fancy"] }
-rattler = { version = "0.45", default-features = false, features = ["indicatif"] }
-rattler_cache = { version = "0.10", default-features = false }
-rattler_conda_types = { version = "0.47", default-features = false }
-rattler_lock = { version = "0.31", default-features = false }
+rattler = { version = "0.45", default-features = false, features = ["indicatif"], optional = true }
+rattler_cache = { version = "0.10", default-features = false, optional = true }
+rattler_conda_types = { version = "0.47", default-features = false, optional = true }
+rattler_lock = { version = "0.31", default-features = false, optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }
 rpassword = "7"

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:a94b33bd-a494-4a28-a2f6-57a407794182",
+  "serialNumber": "urn:uuid:126924d3-dda3-446d-9870-4675e920b5c0",
   "metadata": {
-    "timestamp": "2026-05-28T03:51:57Z",
+    "timestamp": "2026-06-25T17:09:52Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -492,16 +492,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
       "author": "Harry [hello@majored.pw]",
       "name": "astral_async_zip",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "description": "An asynchronous ZIP archive reading/writing crate.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+          "content": "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
         }
       ],
       "licenses": [
@@ -509,19 +509,19 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/astral_async_zip@0.0.17",
+      "purl": "pkg:cargo/astral_async_zip@0.0.18",
       "externalReferences": [
         {
           "type": "documentation",
-          "url": "https://docs.rs/async_zip/"
+          "url": "https://docs.rs/astral_async_zip/"
         },
         {
           "type": "website",
-          "url": "https://github.com/Majored/rs-async-zip"
+          "url": "https://github.com/astral-sh/rs-async-zip"
         },
         {
           "type": "vcs",
-          "url": "https://github.com/Majored/rs-async-zip"
+          "url": "https://github.com/astral-sh/rs-async-zip"
         }
       ]
     },
@@ -866,6 +866,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+      "author": "The Rust Project Developers",
+      "name": "bitflags",
+      "version": "1.3.2",
+      "description": "A macro to generate structures which behave like bitflags. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bitflags@1.3.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bitflags"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bitflags/bitflags"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bitflags/bitflags"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
       "author": "The Rust Project Developers",
       "name": "bitflags",
@@ -901,16 +936,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
       "author": "RustCrypto Developers",
       "name": "blake2",
-      "version": "0.10.6",
+      "version": "0.11.0-rc.6",
       "description": "BLAKE2 hash functions",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+          "content": "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
         }
       ],
       "licenses": [
@@ -918,7 +953,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/blake2@0.10.6",
+      "purl": "pkg:cargo/blake2@0.11.0-rc.6",
       "externalReferences": [
         {
           "type": "documentation",
@@ -950,6 +985,37 @@
         }
       ],
       "purl": "pkg:cargo/block-buffer@0.10.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/block-buffer"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
+      "author": "RustCrypto Developers",
+      "name": "block-buffer",
+      "version": "0.12.1",
+      "description": "Buffer types for block processing of data",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/block-buffer@0.12.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1405,6 +1471,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4",
+      "author": "RustCrypto Developers",
+      "name": "cmov",
+      "version": "0.5.4",
+      "description": "Conditional move CPU intrinsics which are guaranteed on major platforms (ARM32/ARM64, x86/x86_64, RISC-V) to execute in constant-time and not be rewritten as branches by the compiler. Provides wrappers for the CMOV family of instructions on x86/x86_64 and CSEL on AArch64, along with a portable \"best-effort\" pure Rust fallback implementation. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/cmov@0.5.4",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/cmov"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
       "name": "colorchoice",
       "version": "1.0.5",
@@ -1595,6 +1692,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
+      "author": "RustCrypto Developers",
+      "name": "const-oid",
+      "version": "0.10.2",
+      "description": "Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/const-oid@0.10.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/const-oid"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/formats/tree/master/const-oid"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/formats"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "author": "RustCrypto Developers",
       "name": "cpufeatures",
@@ -1652,12 +1784,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/RustCrypto/utils"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "linux-x86_64,windows"
         }
       ]
     },
@@ -1842,6 +1968,68 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
+      "author": "RustCrypto Developers",
+      "name": "crypto-common",
+      "version": "0.2.2",
+      "description": "Common traits used by cryptographic algorithms",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crypto-common@0.2.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/crypto-common"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/traits"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2",
+      "author": "RustCrypto Developers",
+      "name": "ctutils",
+      "version": "0.4.2",
+      "description": "Constant-time utility library with selection and equality testing support targeting cryptographic applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/ctutils@0.4.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/RustCrypto/utils/tree/master/ctselect"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/utils"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
       "author": "Ted Driggs <ted.driggs@outlook.com>",
       "name": "darling",
@@ -1962,6 +2150,95 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.0",
+      "author": "The Knurling-rs developers",
+      "name": "defmt-macros",
+      "version": "1.1.0",
+      "description": "defmt macros",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt-macros@1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+      "author": "The Knurling-rs developers",
+      "name": "defmt-parser",
+      "version": "1.0.0",
+      "description": "Parsing library for defmt format strings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt-parser@1.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.0",
+      "author": "The Knurling-rs developers",
+      "name": "defmt",
+      "version": "1.1.0",
+      "description": "A highly efficient logging framework that targets resource-constrained devices, like microcontrollers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt@1.1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://knurling.ferrous-systems.com/"
+        },
+        {
+          "type": "other",
+          "url": "defmt"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "author": "Jacob Pratt <jacob@jhpratt.dev>",
       "name": "deranged",
@@ -2007,6 +2284,37 @@
         }
       ],
       "purl": "pkg:cargo/digest@0.10.7",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/digest"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/traits"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
+      "author": "RustCrypto Developers",
+      "name": "digest",
+      "version": "0.11.3",
+      "description": "Traits for cryptographic hash functions and message authentication codes",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/digest@0.11.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2322,16 +2630,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
       "author": "Raph Levien <raph@google.com>, Robin Stocker <robin@nibor.org>, Keith Hall <keith.hall@available.systems>",
       "name": "fancy-regex",
-      "version": "0.17.0",
-      "description": "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.",
+      "version": "0.18.0",
+      "description": "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around. Aims to be compatible with Oniguruma syntax when the relevant flag is set.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+          "content": "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
         }
       ],
       "licenses": [
@@ -2339,7 +2647,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/fancy-regex@0.17.0",
+      "purl": "pkg:cargo/fancy-regex@0.18.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3530,6 +3838,32 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
+      "name": "http-auth",
+      "version": "0.1.10",
+      "description": "HTTP authentication: parse challenge lists, respond to Basic and Digest challenges. Likely to be extended with server support and additional auth schemes.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/http-auth@0.1.10",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/scottlamb/http-auth"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
       "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http-body-util",
@@ -3681,6 +4015,33 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+      "author": "Pyfisch <pyfisch@posteo.org>",
+      "name": "httpdate",
+      "version": "1.0.3",
+      "description": "HTTP date parsing and formatting",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/httpdate@1.0.3",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/pyfisch/httpdate"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
       "name": "humantime",
       "version": "2.3.0",
@@ -3710,6 +4071,37 @@
         {
           "type": "vcs",
           "url": "https://github.com/chronotope/humantime"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
+      "author": "RustCrypto Developers",
+      "name": "hybrid-array",
+      "version": "0.4.12",
+      "description": "Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/hybrid-array@0.4.12",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/hybrid-array"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/hybrid-array"
         }
       ]
     },
@@ -4499,6 +4891,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "jiff",
+      "version": "0.2.29",
+      "description": "A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/jiff@0.2.29",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jiff"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/jiff"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "jobserver",
@@ -4895,16 +5318,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
       "author": "RustCrypto Developers",
       "name": "md-5",
-      "version": "0.10.6",
+      "version": "0.11.0",
       "description": "MD5 hash function",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+          "content": "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
         }
       ],
       "licenses": [
@@ -4912,7 +5335,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/md-5@0.10.6",
+      "purl": "pkg:cargo/md-5@0.11.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -6044,15 +6467,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
       "name": "path_resolver",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "description": "Provides a trie-based data structure to track and resolve relative path ownership across multiple packages",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
+          "content": "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
         }
       ],
       "licenses": [
@@ -6060,7 +6483,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/path_resolver@0.2.10",
+      "purl": "pkg:cargo/path_resolver@0.2.11",
       "externalReferences": [
         {
           "type": "website",
@@ -6422,6 +6845,60 @@
         {
           "type": "vcs",
           "url": "https://github.com/cryptocorrosion/cryptocorrosion"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0",
+      "author": "CreepySkeleton <creepy-skeleton@yandex.ru>, GnomedDev <david2005thomas@gmail.com>",
+      "name": "proc-macro-error-attr2",
+      "version": "2.0.0",
+      "description": "Attribute macro for the proc-macro-error2 crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/proc-macro-error-attr2@2.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/GnomedDev/proc-macro-error-2"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1",
+      "author": "CreepySkeleton <creepy-skeleton@yandex.ru>, GnomedDev <david2005thomas@gmail.com>",
+      "name": "proc-macro-error2",
+      "version": "2.0.1",
+      "description": "Almost drop-in replacement to panics in proc-macros",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/proc-macro-error2@2.0.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/GnomedDev/proc-macro-error-2"
         }
       ]
     },
@@ -6920,16 +7397,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler",
-      "version": "0.43.2",
+      "version": "0.45.0",
       "description": "Rust library to install conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
+          "content": "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
         }
       ],
       "licenses": [
@@ -6937,7 +7414,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler@0.43.2",
+      "purl": "pkg:cargo/rattler@0.45.0",
       "externalReferences": [
         {
           "type": "website",
@@ -6951,15 +7428,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
       "name": "rattler_cache",
-      "version": "0.8.2",
+      "version": "0.10.0",
       "description": "A crate to manage the caching of data in rattler",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
+          "content": "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
         }
       ],
       "licenses": [
@@ -6967,7 +7444,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_cache@0.8.2",
+      "purl": "pkg:cargo/rattler_cache@0.10.0",
       "externalReferences": [
         {
           "type": "website",
@@ -6981,16 +7458,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_conda_types",
-      "version": "0.46.4",
+      "version": "0.47.2",
       "description": "Rust data types for common types used within the Conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
+          "content": "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
         }
       ],
       "licenses": [
@@ -6998,7 +7475,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_conda_types@0.46.4",
+      "purl": "pkg:cargo/rattler_conda_types@0.47.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7012,16 +7489,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "description": "An simple crate used by rattler crates to compute different hashes from different sources",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
+          "content": "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
         }
       ],
       "licenses": [
@@ -7029,7 +7506,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_digest@1.3.0",
+      "purl": "pkg:cargo/rattler_digest@1.3.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7043,16 +7520,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.30.3",
+      "version": "0.31.3",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a0c0fe27729fd9081d25eb1a23d94f49f23ee93a75d59bac0ae3e304bda04aae"
+          "content": "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
         }
       ],
       "licenses": [
@@ -7060,7 +7537,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.30.3",
+      "purl": "pkg:cargo/rattler_lock@0.31.3",
       "externalReferences": [
         {
           "type": "website",
@@ -7074,16 +7551,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_macros",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "A crate that provideds some procedural macros for the rattler project",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
+          "content": "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
         }
       ],
       "licenses": [
@@ -7091,7 +7568,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_macros@1.1.0",
+      "purl": "pkg:cargo/rattler_macros@1.1.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7105,16 +7582,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_menuinst",
-      "version": "0.2.62",
+      "version": "0.2.67",
       "description": "Install menu entries for a Conda package",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
+          "content": "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
         }
       ],
       "licenses": [
@@ -7122,7 +7599,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_menuinst@0.2.62",
+      "purl": "pkg:cargo/rattler_menuinst@0.2.67",
       "externalReferences": [
         {
           "type": "website",
@@ -7136,16 +7613,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_networking",
-      "version": "0.27.2",
+      "version": "0.29.0",
       "description": "Authenticated requests in the conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
+          "content": "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
         }
       ],
       "licenses": [
@@ -7153,7 +7630,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_networking@0.27.2",
+      "purl": "pkg:cargo/rattler_networking@0.29.0",
       "externalReferences": [
         {
           "type": "website",
@@ -7167,16 +7644,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_package_streaming",
-      "version": "0.26.2",
+      "version": "0.26.5",
       "description": "Extract and stream of Conda package archives",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
+          "content": "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
         }
       ],
       "licenses": [
@@ -7184,7 +7661,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_package_streaming@0.26.2",
+      "purl": "pkg:cargo/rattler_package_streaming@0.26.5",
       "externalReferences": [
         {
           "type": "website",
@@ -7198,15 +7675,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
       "name": "rattler_pty",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "description": "A crate to create pty",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
+          "content": "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
         }
       ],
       "licenses": [
@@ -7214,7 +7691,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_pty@0.2.12",
+      "purl": "pkg:cargo/rattler_pty@0.2.13",
       "externalReferences": [
         {
           "type": "website",
@@ -7259,16 +7736,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_shell",
-      "version": "0.27.2",
+      "version": "0.27.7",
       "description": "A crate to help with activation and deactivation of a conda environment",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
+          "content": "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
         }
       ],
       "licenses": [
@@ -7276,7 +7753,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_shell@0.27.2",
+      "purl": "pkg:cargo/rattler_shell@0.27.7",
       "externalReferences": [
         {
           "type": "website",
@@ -7290,16 +7767,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
+          "content": "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
         }
       ],
       "licenses": [
@@ -7307,7 +7784,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@7.1.1",
+      "purl": "pkg:cargo/rattler_solve@7.2.0",
       "externalReferences": [
         {
           "type": "website",
@@ -8771,6 +9248,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
+      "author": "RustCrypto Developers",
+      "name": "sha2",
+      "version": "0.11.0",
+      "description": "Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/sha2@0.11.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/sha2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/RustCrypto/hashes"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
       "author": "Eliza Weisman <eliza@buoyant.io>",
       "name": "sharded-slab",
@@ -8811,7 +9319,7 @@
       "name": "shlex",
       "version": "1.3.0",
       "description": "Split a string into shell words, like Python's shlex.",
-      "scope": "required",
+      "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
@@ -8824,6 +9332,33 @@
         }
       ],
       "purl": "pkg:cargo/shlex@1.3.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/comex/rust-shlex"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
+      "author": "comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>",
+      "name": "shlex",
+      "version": "2.0.1",
+      "description": "Split a string into shell words, like Python's shlex.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/shlex@2.0.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -13764,10 +14299,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
@@ -13777,6 +14312,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.2+spec-1.1.0",
@@ -13916,13 +14452,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
@@ -13997,19 +14533,29 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
       ]
     },
     {
@@ -14109,6 +14655,10 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
       "dependsOn": []
     },
@@ -14149,6 +14699,10 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -14156,7 +14710,9 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
-      "dependsOn": []
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -14200,6 +14756,18 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
@@ -14236,6 +14804,29 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
@@ -14246,8 +14837,16 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
-        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
-        "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1"
+        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
+        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2"
       ]
     },
     {
@@ -14313,7 +14912,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
@@ -14581,6 +15180,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -14613,8 +15218,18 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
+      "dependsOn": []
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
@@ -14672,6 +15287,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
@@ -14825,6 +15441,14 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
@@ -14896,10 +15520,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
       ]
     },
     {
@@ -15177,7 +15801,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
@@ -15278,6 +15902,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.49"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr2@2.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15393,32 +16033,35 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
+        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -15436,23 +16079,24 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
@@ -15466,26 +16110,26 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
@@ -15505,35 +16149,35 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+        "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
+        "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
@@ -15548,31 +16192,31 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
         "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
-        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -15583,7 +16227,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ambient-id@0.0.11",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
@@ -15592,6 +16236,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
@@ -15605,24 +16251,26 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.2",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_http_range_reader@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
+        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
@@ -15639,7 +16287,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
@@ -15656,17 +16304,17 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
@@ -15674,13 +16322,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
-        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.29",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -16081,6 +16729,14 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
@@ -16088,6 +16744,10 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
       "dependsOn": []
     },
     {
@@ -17128,6 +17788,46 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "id": "RUSTSEC-2026-0173",
+      "description": "[unmaintained] proc-macro-error2 is unmaintained",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0173.html"
+      },
+      "ratings": [
+        {
+          "severity": "info",
+          "method": "other"
+        }
+      ],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error2@2.0.1"
+        }
+      ]
+    },
+    {
+      "id": "RUSTSEC-2026-0186",
+      "description": "[unsound] Unchecked pointer offset in crate `memmap2`",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0186.html"
+      },
+      "ratings": [
+        {
+          "severity": "info",
+          "method": "other"
+        }
+      ],
+      "affects": [
+        {
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10"
+        }
+      ]
     }
   ]
 }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:b59a806e-58e6-4f45-81d0-44c3bd63eb1a",
+  "serialNumber": "urn:uuid:a94b33bd-a494-4a28-a2f6-57a407794182",
   "metadata": {
-    "timestamp": "2026-05-28T02:55:17Z",
+    "timestamp": "2026-05-28T03:51:57Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -1231,12 +1231,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/katharostech/cfg_aliases"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "linux,macos"
         }
       ]
     },
@@ -13756,6 +13750,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#anaconda-anon-usage@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:c7d481c1-3416-484b-bc1e-dd3a96b75193",
+  "serialNumber": "urn:uuid:b59a806e-58e6-4f45-81d0-44c3bd63eb1a",
   "metadata": {
-    "timestamp": "2026-06-22T19:21:31Z",
+    "timestamp": "2026-05-28T02:55:17Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -43,7 +43,7 @@
       "name": "anaconda-otel-rs",
       "version": "0.1.0",
       "scope": "required",
-      "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40716cfc2907c16f5da0438fdb0bf6e146c240a1a1"
+      "purl": "pkg:cargo/anaconda-otel-rs@0.1.0?vcs_url=git%2Bhttps://github.com/anaconda/anaconda-otel-rs%40316fa5c05768a6d16da3b215fb50cd44835d7a69"
     },
     {
       "type": "library",
@@ -492,16 +492,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
       "author": "Harry [hello@majored.pw]",
       "name": "astral_async_zip",
-      "version": "0.0.18",
+      "version": "0.0.17",
       "description": "An asynchronous ZIP archive reading/writing crate.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
+          "content": "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
         }
       ],
       "licenses": [
@@ -509,19 +509,19 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/astral_async_zip@0.0.18",
+      "purl": "pkg:cargo/astral_async_zip@0.0.17",
       "externalReferences": [
         {
           "type": "documentation",
-          "url": "https://docs.rs/astral_async_zip/"
+          "url": "https://docs.rs/async_zip/"
         },
         {
           "type": "website",
-          "url": "https://github.com/astral-sh/rs-async-zip"
+          "url": "https://github.com/Majored/rs-async-zip"
         },
         {
           "type": "vcs",
-          "url": "https://github.com/astral-sh/rs-async-zip"
+          "url": "https://github.com/Majored/rs-async-zip"
         }
       ]
     },
@@ -866,16 +866,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
       "author": "The Rust Project Developers",
       "name": "bitflags",
-      "version": "2.13.0",
+      "version": "2.11.1",
       "description": "A macro to generate structures which behave like bitflags. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+          "content": "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
         }
       ],
       "licenses": [
@@ -883,7 +883,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/bitflags@2.13.0",
+      "purl": "pkg:cargo/bitflags@2.11.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -901,16 +901,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
       "author": "RustCrypto Developers",
       "name": "blake2",
-      "version": "0.11.0-rc.6",
+      "version": "0.10.6",
       "description": "BLAKE2 hash functions",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+          "content": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
         }
       ],
       "licenses": [
@@ -918,7 +918,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/blake2@0.11.0-rc.6",
+      "purl": "pkg:cargo/blake2@0.10.6",
       "externalReferences": [
         {
           "type": "documentation",
@@ -950,37 +950,6 @@
         }
       ],
       "purl": "pkg:cargo/block-buffer@0.10.4",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/block-buffer"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/utils"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
-      "author": "RustCrypto Developers",
-      "name": "block-buffer",
-      "version": "0.12.1",
-      "description": "Buffer types for block processing of data",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/block-buffer@0.12.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1170,16 +1139,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.2.64",
+      "version": "1.2.62",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+          "content": "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
         }
       ],
       "licenses": [
@@ -1187,7 +1156,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.2.64",
+      "purl": "pkg:cargo/cc@1.2.62",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1304,15 +1273,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
       "name": "chrono",
-      "version": "0.4.45",
+      "version": "0.4.44",
       "description": "Date and time library for Rust",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+          "content": "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
         }
       ],
       "licenses": [
@@ -1320,7 +1289,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/chrono@0.4.45",
+      "purl": "pkg:cargo/chrono@0.4.44",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1442,37 +1411,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4",
-      "author": "RustCrypto Developers",
-      "name": "cmov",
-      "version": "0.5.4",
-      "description": "Conditional move CPU intrinsics which are guaranteed on major platforms (ARM32/ARM64, x86/x86_64, RISC-V) to execute in constant-time and not be rewritten as branches by the compiler. Provides wrappers for the CMOV family of instructions on x86/x86_64 and CSEL on AArch64, along with a portable \"best-effort\" pure Rust fallback implementation. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/cmov@0.5.4",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/cmov"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/utils"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#colorchoice@1.0.5",
       "name": "colorchoice",
       "version": "1.0.5",
@@ -1588,16 +1526,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.2.0",
-      "author": "QEDK <hi@qedk.xyz>",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
+      "author": "QEDK <qedk.en@gmail.com>",
       "name": "configparser",
-      "version": "3.2.0",
+      "version": "3.1.0",
       "description": "A simple configuration parsing utility with no dependencies that allows you to parse INI and ini-style syntax. You can use this to write Rust programs which can be customized by end users easily.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
+          "content": "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
         }
       ],
       "licenses": [
@@ -1605,7 +1543,7 @@
           "expression": "MIT OR LGPL-3.0-or-later"
         }
       ],
-      "purl": "pkg:cargo/configparser@3.2.0",
+      "purl": "pkg:cargo/configparser@3.1.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1658,41 +1596,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/console-rs/console"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
-      "author": "RustCrypto Developers",
-      "name": "const-oid",
-      "version": "0.10.2",
-      "description": "Const-friendly implementation of the ISO/IEC Object Identifier (OID) standard as defined in ITU X.660, with support for BER/DER encoding/decoding as well as heapless no_std (i.e. embedded) support ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/const-oid@0.10.2",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/const-oid"
-        },
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/formats/tree/master/const-oid"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/formats"
         }
       ]
     },
@@ -1755,6 +1658,12 @@
         {
           "type": "vcs",
           "url": "https://github.com/RustCrypto/utils"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux-x86_64,windows"
         }
       ]
     },
@@ -1939,68 +1848,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
-      "author": "RustCrypto Developers",
-      "name": "crypto-common",
-      "version": "0.2.2",
-      "description": "Common traits used by cryptographic algorithms",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/crypto-common@0.2.2",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/crypto-common"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/traits"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2",
-      "author": "RustCrypto Developers",
-      "name": "ctutils",
-      "version": "0.4.2",
-      "description": "Constant-time utility library with selection and equality testing support targeting cryptographic applications. Supports `const fn` where appropriate. Built on the `cmov` crate which provides architecture-specific predication intrinsics. Heavily inspired by the `subtle` crate. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/ctutils@0.4.2",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/RustCrypto/utils/tree/master/ctselect"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/utils"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
       "author": "Ted Driggs <ted.driggs@outlook.com>",
       "name": "darling",
@@ -2166,37 +2013,6 @@
         }
       ],
       "purl": "pkg:cargo/digest@0.10.7",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/digest"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/traits"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
-      "author": "RustCrypto Developers",
-      "name": "digest",
-      "version": "0.11.3",
-      "description": "Traits for cryptographic hash functions and message authentication codes",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/digest@0.11.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2391,41 +2207,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-      "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
-      "name": "encoding_rs",
-      "version": "0.8.35",
-      "description": "A Gecko-oriented implementation of the Encoding Standard",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
-        }
-      ],
-      "purl": "pkg:cargo/encoding_rs@0.8.35",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/encoding_rs/"
-        },
-        {
-          "type": "website",
-          "url": "https://docs.rs/encoding_rs/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/hsivonen/encoding_rs"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "author": "Anton Lazarev <https://antonok.com>",
       "name": "enum_dispatch",
@@ -2547,16 +2328,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
       "author": "Raph Levien <raph@google.com>, Robin Stocker <robin@nibor.org>, Keith Hall <keith.hall@available.systems>",
       "name": "fancy-regex",
-      "version": "0.18.0",
-      "description": "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around. Aims to be compatible with Oniguruma syntax when the relevant flag is set.",
+      "version": "0.17.0",
+      "description": "An implementation of regexes, supporting a relatively rich set of features, including backreferences and look-around.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+          "content": "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
         }
       ],
       "licenses": [
@@ -2564,7 +2345,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/fancy-regex@0.18.0",
+      "purl": "pkg:cargo/fancy-regex@0.17.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3507,16 +3288,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
       "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "h2",
-      "version": "0.4.15",
+      "version": "0.4.14",
       "description": "An HTTP/2 client and server",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+          "content": "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
         }
       ],
       "licenses": [
@@ -3524,7 +3305,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/h2@0.4.15",
+      "purl": "pkg:cargo/h2@0.4.14",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3755,32 +3536,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
-      "name": "http-auth",
-      "version": "0.1.10",
-      "description": "HTTP authentication: parse challenge lists, respond to Basic and Digest challenges. Likely to be extended with server support and additional auth schemes.",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/http-auth@0.1.10",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/scottlamb/http-auth"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
       "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http-body-util",
@@ -3870,16 +3625,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
       "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http",
-      "version": "1.4.2",
+      "version": "1.4.1",
       "description": "A set of types for representing HTTP requests and responses. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+          "content": "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
         }
       ],
       "licenses": [
@@ -3887,7 +3642,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/http@1.4.2",
+      "purl": "pkg:cargo/http@1.4.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3932,33 +3687,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
-      "author": "Pyfisch <pyfisch@posteo.org>",
-      "name": "httpdate",
-      "version": "1.0.3",
-      "description": "HTTP date parsing and formatting",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/httpdate@1.0.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/pyfisch/httpdate"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
       "name": "humantime",
       "version": "2.3.0",
@@ -3988,37 +3716,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/chronotope/humantime"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
-      "author": "RustCrypto Developers",
-      "name": "hybrid-array",
-      "version": "0.4.12",
-      "description": "Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/hybrid-array@0.4.12",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/hybrid-array"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/hybrid-array"
         }
       ]
     },
@@ -4128,16 +3825,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
       "author": "Sean McArthur <sean@seanmonstar.com>",
       "name": "hyper",
-      "version": "1.10.1",
+      "version": "1.10.0",
       "description": "A protective and efficient HTTP library for all.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+          "content": "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
         }
       ],
       "licenses": [
@@ -4145,7 +3842,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/hyper@1.10.1",
+      "purl": "pkg:cargo/hyper@1.10.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4808,37 +4505,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-      "author": "Andrew Gallant <jamslam@gmail.com>",
-      "name": "jiff",
-      "version": "0.2.28",
-      "description": "A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "Unlicense OR MIT"
-        }
-      ],
-      "purl": "pkg:cargo/jiff@0.2.28",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/jiff"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/BurntSushi/jiff"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "jobserver",
@@ -5142,16 +4808,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
       "author": "The Rust Project Developers",
       "name": "log",
-      "version": "0.4.33",
+      "version": "0.4.30",
       "description": "A lightweight logging facade for Rust ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+          "content": "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
         }
       ],
       "licenses": [
@@ -5159,7 +4825,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/log@0.4.33",
+      "purl": "pkg:cargo/log@0.4.30",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5235,16 +4901,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
       "author": "RustCrypto Developers",
       "name": "md-5",
-      "version": "0.11.0",
+      "version": "0.10.6",
       "description": "MD5 hash function",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+          "content": "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
         }
       ],
       "licenses": [
@@ -5252,7 +4918,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/md-5@0.11.0",
+      "purl": "pkg:cargo/md-5@0.10.6",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5266,16 +4932,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
       "author": "Andrew Gallant <jamslam@gmail.com>, bluss",
       "name": "memchr",
-      "version": "2.8.2",
+      "version": "2.8.1",
       "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+          "content": "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
         }
       ],
       "licenses": [
@@ -5283,7 +4949,7 @@
           "expression": "Unlicense OR MIT"
         }
       ],
-      "purl": "pkg:cargo/memchr@2.8.2",
+      "purl": "pkg:cargo/memchr@2.8.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5520,16 +5186,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "author": "Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>",
       "name": "mio",
-      "version": "1.2.1",
+      "version": "1.2.0",
       "description": "Lightweight non-blocking I/O.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+          "content": "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
         }
       ],
       "licenses": [
@@ -5537,7 +5203,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/mio@1.2.1",
+      "purl": "pkg:cargo/mio@1.2.0",
       "externalReferences": [
         {
           "type": "website",
@@ -5952,16 +5618,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.116",
       "author": "Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>",
       "name": "openssl-sys",
-      "version": "0.9.117",
+      "version": "0.9.116",
       "description": "FFI bindings to OpenSSL",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+          "content": "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
         }
       ],
       "licenses": [
@@ -5969,7 +5635,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/openssl-sys@0.9.117",
+      "purl": "pkg:cargo/openssl-sys@0.9.116",
       "externalReferences": [
         {
           "type": "other",
@@ -5989,16 +5655,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.81",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.80",
       "author": "Steven Fackler <sfackler@gmail.com>",
       "name": "openssl",
-      "version": "0.10.81",
+      "version": "0.10.80",
       "description": "OpenSSL bindings",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+          "content": "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
         }
       ],
       "licenses": [
@@ -6006,7 +5672,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/openssl@0.10.81",
+      "purl": "pkg:cargo/openssl@0.10.80",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6384,15 +6050,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
       "name": "path_resolver",
-      "version": "0.2.11",
+      "version": "0.2.10",
       "description": "Provides a trie-based data structure to track and resolve relative path ownership across multiple packages",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
+          "content": "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
         }
       ],
       "licenses": [
@@ -6400,7 +6066,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/path_resolver@0.2.11",
+      "purl": "pkg:cargo/path_resolver@0.2.10",
       "externalReferences": [
         {
           "type": "website",
@@ -6868,16 +6534,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3",
       "author": "Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>",
       "name": "prost-derive",
-      "version": "0.14.4",
+      "version": "0.14.3",
       "description": "Generate encoding and decoding implementations for Prost annotated types.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+          "content": "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
         }
       ],
       "licenses": [
@@ -6885,7 +6551,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/prost-derive@0.14.4",
+      "purl": "pkg:cargo/prost-derive@0.14.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6895,16 +6561,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
       "author": "Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>",
       "name": "prost",
-      "version": "0.14.4",
+      "version": "0.14.3",
       "description": "A Protocol Buffers implementation for the Rust Language.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+          "content": "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
         }
       ],
       "licenses": [
@@ -6912,7 +6578,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/prost@0.14.4",
+      "purl": "pkg:cargo/prost@0.14.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -7260,16 +6926,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler",
-      "version": "0.45.0",
+      "version": "0.43.2",
       "description": "Rust library to install conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
+          "content": "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
         }
       ],
       "licenses": [
@@ -7277,7 +6943,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler@0.45.0",
+      "purl": "pkg:cargo/rattler@0.43.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7291,15 +6957,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
       "name": "rattler_cache",
-      "version": "0.10.0",
+      "version": "0.8.2",
       "description": "A crate to manage the caching of data in rattler",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
+          "content": "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
         }
       ],
       "licenses": [
@@ -7307,7 +6973,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_cache@0.10.0",
+      "purl": "pkg:cargo/rattler_cache@0.8.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7321,16 +6987,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_conda_types",
-      "version": "0.47.2",
+      "version": "0.46.4",
       "description": "Rust data types for common types used within the Conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
+          "content": "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
         }
       ],
       "licenses": [
@@ -7338,7 +7004,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_conda_types@0.47.2",
+      "purl": "pkg:cargo/rattler_conda_types@0.46.4",
       "externalReferences": [
         {
           "type": "website",
@@ -7352,16 +7018,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
-      "version": "1.3.1",
+      "version": "1.3.0",
       "description": "An simple crate used by rattler crates to compute different hashes from different sources",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
+          "content": "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
         }
       ],
       "licenses": [
@@ -7369,7 +7035,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_digest@1.3.1",
+      "purl": "pkg:cargo/rattler_digest@1.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -7383,16 +7049,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.31.3",
+      "version": "0.30.3",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
+          "content": "a0c0fe27729fd9081d25eb1a23d94f49f23ee93a75d59bac0ae3e304bda04aae"
         }
       ],
       "licenses": [
@@ -7400,7 +7066,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.31.3",
+      "purl": "pkg:cargo/rattler_lock@0.30.3",
       "externalReferences": [
         {
           "type": "website",
@@ -7414,16 +7080,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_macros",
-      "version": "1.1.1",
+      "version": "1.1.0",
       "description": "A crate that provideds some procedural macros for the rattler project",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
+          "content": "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
         }
       ],
       "licenses": [
@@ -7431,7 +7097,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_macros@1.1.1",
+      "purl": "pkg:cargo/rattler_macros@1.1.0",
       "externalReferences": [
         {
           "type": "website",
@@ -7445,16 +7111,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_menuinst",
-      "version": "0.2.67",
+      "version": "0.2.62",
       "description": "Install menu entries for a Conda package",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
+          "content": "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
         }
       ],
       "licenses": [
@@ -7462,7 +7128,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_menuinst@0.2.67",
+      "purl": "pkg:cargo/rattler_menuinst@0.2.62",
       "externalReferences": [
         {
           "type": "website",
@@ -7476,16 +7142,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_networking",
-      "version": "0.29.0",
+      "version": "0.27.2",
       "description": "Authenticated requests in the conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
+          "content": "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
         }
       ],
       "licenses": [
@@ -7493,7 +7159,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_networking@0.29.0",
+      "purl": "pkg:cargo/rattler_networking@0.27.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7507,16 +7173,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_package_streaming",
-      "version": "0.26.5",
+      "version": "0.26.2",
       "description": "Extract and stream of Conda package archives",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
+          "content": "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
         }
       ],
       "licenses": [
@@ -7524,7 +7190,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_package_streaming@0.26.5",
+      "purl": "pkg:cargo/rattler_package_streaming@0.26.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7538,15 +7204,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
       "name": "rattler_pty",
-      "version": "0.2.13",
+      "version": "0.2.12",
       "description": "A crate to create pty",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
+          "content": "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
         }
       ],
       "licenses": [
@@ -7554,7 +7220,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_pty@0.2.13",
+      "purl": "pkg:cargo/rattler_pty@0.2.12",
       "externalReferences": [
         {
           "type": "website",
@@ -7599,16 +7265,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_shell",
-      "version": "0.27.7",
+      "version": "0.27.2",
       "description": "A crate to help with activation and deactivation of a conda environment",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
+          "content": "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
         }
       ],
       "licenses": [
@@ -7616,7 +7282,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_shell@0.27.7",
+      "purl": "pkg:cargo/rattler_shell@0.27.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7630,16 +7296,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "7.2.0",
+      "version": "7.1.1",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
+          "content": "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
         }
       ],
       "licenses": [
@@ -7647,7 +7313,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@7.2.0",
+      "purl": "pkg:cargo/rattler_solve@7.1.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7857,16 +7523,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex-syntax",
-      "version": "0.8.11",
+      "version": "0.8.10",
       "description": "A regular expression parser.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+          "content": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
         }
       ],
       "licenses": [
@@ -7874,7 +7540,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/regex-syntax@0.8.11",
+      "purl": "pkg:cargo/regex-syntax@0.8.10",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7892,16 +7558,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex",
-      "version": "1.12.4",
+      "version": "1.12.3",
       "description": "An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+          "content": "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
         }
       ],
       "licenses": [
@@ -7909,7 +7575,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/regex@1.12.4",
+      "purl": "pkg:cargo/regex@1.12.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8110,16 +7776,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.3",
       "author": "Conrad Kleinespel <conradk@conradk.com>",
       "name": "rpassword",
-      "version": "7.5.4",
-      "description": "Read passwords in console applications (unix, windows, macos, wasm).",
+      "version": "7.5.3",
+      "description": "Read passwords in console applications.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+          "content": "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
         }
       ],
       "licenses": [
@@ -8127,7 +7793,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rpassword@7.5.4",
+      "purl": "pkg:cargo/rpassword@7.5.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8987,16 +8653,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
       "author": "Jonas Bushart, Marcin Ka\u017amierczak",
       "name": "serde_with",
-      "version": "3.21.0",
+      "version": "3.20.0",
       "description": "Custom de/serialization functions for Rust's serde",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+          "content": "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
         }
       ],
       "licenses": [
@@ -9004,7 +8670,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with@3.21.0",
+      "purl": "pkg:cargo/serde_with@3.20.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9018,16 +8684,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
       "author": "Jonas Bushart",
       "name": "serde_with_macros",
-      "version": "3.21.0",
+      "version": "3.20.0",
       "description": "proc-macro library for serde_with",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+          "content": "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
         }
       ],
       "licenses": [
@@ -9035,7 +8701,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_with_macros@3.21.0",
+      "purl": "pkg:cargo/serde_with_macros@3.20.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9111,37 +8777,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-      "author": "RustCrypto Developers",
-      "name": "sha2",
-      "version": "0.11.0",
-      "description": "Pure Rust implementation of the SHA-2 hash function family including SHA-224, SHA-256, SHA-384, and SHA-512. ",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/sha2@0.11.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/sha2"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/RustCrypto/hashes"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
       "author": "Eliza Weisman <eliza@buoyant.io>",
       "name": "sharded-slab",
@@ -9177,16 +8812,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
       "author": "comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>",
       "name": "shlex",
-      "version": "2.0.1",
+      "version": "1.3.0",
       "description": "Split a string into shell words, like Python's shlex.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+          "content": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
         }
       ],
       "licenses": [
@@ -9194,7 +8829,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/shlex@2.0.1",
+      "purl": "pkg:cargo/shlex@1.3.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -9428,16 +9063,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
       "author": "The Servo Project Developers",
       "name": "smallvec",
-      "version": "1.15.2",
+      "version": "1.15.1",
       "description": "'Small vector' optimization: store up to a small number of items on the stack",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+          "content": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
         }
       ],
       "licenses": [
@@ -9445,7 +9080,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/smallvec@1.15.2",
+      "purl": "pkg:cargo/smallvec@1.15.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9459,16 +9094,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
       "name": "socket2",
-      "version": "0.6.4",
+      "version": "0.6.3",
       "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+          "content": "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
         }
       ],
       "licenses": [
@@ -9476,7 +9111,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/socket2@0.6.4",
+      "purl": "pkg:cargo/socket2@0.6.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9758,16 +9393,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "syn",
-      "version": "2.0.118",
+      "version": "2.0.117",
       "description": "Parser for Rust source code",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+          "content": "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
         }
       ],
       "licenses": [
@@ -9775,7 +9410,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/syn@2.0.118",
+      "purl": "pkg:cargo/syn@2.0.117",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10161,16 +9796,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
       "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
       "name": "time-core",
-      "version": "0.1.9",
+      "version": "0.1.8",
       "description": "This crate is an implementation detail and should not be relied upon directly.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+          "content": "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
         }
       ],
       "licenses": [
@@ -10178,7 +9813,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/time-core@0.1.9",
+      "purl": "pkg:cargo/time-core@0.1.8",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10188,16 +9823,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27",
       "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
       "name": "time-macros",
-      "version": "0.2.29",
+      "version": "0.2.27",
       "description": "    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+          "content": "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
         }
       ],
       "licenses": [
@@ -10205,7 +9840,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/time-macros@0.2.29",
+      "purl": "pkg:cargo/time-macros@0.2.27",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10215,16 +9850,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
       "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
       "name": "time",
-      "version": "0.3.49",
+      "version": "0.3.47",
       "description": "Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+          "content": "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
         }
       ],
       "licenses": [
@@ -10232,7 +9867,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/time@0.3.49",
+      "purl": "pkg:cargo/time@0.3.47",
       "externalReferences": [
         {
           "type": "website",
@@ -11178,15 +10813,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0",
+      "author": "Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>",
       "name": "typenum",
-      "version": "1.20.1",
+      "version": "1.20.0",
       "description": "Typenum is a Rust library for type-level numbers evaluated at     compile time. It currently supports bits, unsigned integers, and signed     integers. It also provides a type-level array of type-level numbers, but its     implementation is incomplete.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+          "content": "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
         }
       ],
       "licenses": [
@@ -11194,7 +10830,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/typenum@1.20.1",
+      "purl": "pkg:cargo/typenum@1.20.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -11393,16 +11029,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
       "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
       "name": "unicode-segmentation",
-      "version": "1.13.3",
+      "version": "1.13.2",
       "description": "This crate provides Grapheme Cluster, Word and Sentence boundaries according to Unicode Standard Annex #29 rules. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+          "content": "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
         }
       ],
       "licenses": [
@@ -11410,7 +11046,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/unicode-segmentation@1.13.3",
+      "purl": "pkg:cargo/unicode-segmentation@1.13.2",
       "externalReferences": [
         {
           "type": "website",
@@ -11730,16 +11366,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1",
       "author": "Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>",
       "name": "uuid",
-      "version": "1.23.3",
+      "version": "1.23.1",
       "description": "A library to generate and parse UUIDs.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+          "content": "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
         }
       ],
       "licenses": [
@@ -11747,7 +11383,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/uuid@1.23.3",
+      "purl": "pkg:cargo/uuid@1.23.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -11991,16 +11627,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
       "author": "Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>",
       "name": "which",
-      "version": "8.0.4",
+      "version": "8.0.2",
       "description": "A Rust equivalent of Unix command \"which\". Locate installed executable in cross platforms.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+          "content": "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
         }
       ],
       "licenses": [
@@ -12008,7 +11644,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/which@8.0.4",
+      "purl": "pkg:cargo/which@8.0.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12223,16 +11859,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
       "author": "Manish Goregaokar <manishsmail@gmail.com>",
       "name": "yoke",
-      "version": "0.8.3",
+      "version": "0.8.2",
       "description": "Abstraction allowing borrowed data to be carried along with the backing data it borrows from",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+          "content": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
         }
       ],
       "licenses": [
@@ -12240,7 +11876,7 @@
           "expression": "Unicode-3.0"
         }
       ],
-      "purl": "pkg:cargo/yoke@0.8.3",
+      "purl": "pkg:cargo/yoke@0.8.2",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12250,16 +11886,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.49",
       "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
       "name": "zerocopy",
-      "version": "0.8.52",
+      "version": "0.8.49",
       "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+          "content": "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
         }
       ],
       "licenses": [
@@ -12267,7 +11903,7 @@
           "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/zerocopy@0.8.52",
+      "purl": "pkg:cargo/zerocopy@0.8.49",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12331,16 +11967,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
       "author": "The RustCrypto Project Developers",
       "name": "zeroize",
-      "version": "1.9.0",
+      "version": "1.8.2",
       "description": "Securely clear secrets from memory with a simple trait built on stable Rust primitives which guarantee memory is zeroed using an operation will not be 'optimized away' by the compiler. Uses a portable pure Rust implementation that works everywhere, even WASM! ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+          "content": "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
         }
       ],
       "licenses": [
@@ -12348,11 +11984,11 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/zeroize@1.9.0",
+      "purl": "pkg:cargo/zeroize@1.8.2",
       "externalReferences": [
         {
-          "type": "documentation",
-          "url": "https://docs.rs/zeroize"
+          "type": "website",
+          "url": "https://github.com/RustCrypto/utils/tree/master/zeroize"
         },
         {
           "type": "vcs",
@@ -12724,43 +12360,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
-      "author": "The Servo Project Developers",
-      "name": "core-foundation",
-      "version": "0.9.4",
-      "description": "Bindings to Core Foundation for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/core-foundation@0.9.4",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/servo/core-foundation-rs"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/servo/core-foundation-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "macos"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
       "author": "Ed Barnard <eabarnard@gmail.com>",
       "name": "plist",
@@ -12901,72 +12500,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/kornelski/rust-security-framework"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "macos"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0",
-      "author": "Mullvad VPN",
-      "name": "system-configuration-sys",
-      "version": "0.6.0",
-      "description": "Low level bindings to SystemConfiguration framework for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/system-configuration-sys@0.6.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/mullvad/system-configuration-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "macos"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
-      "author": "Mullvad VPN",
-      "name": "system-configuration",
-      "version": "0.7.0",
-      "description": "Bindings to SystemConfiguration framework for macOS",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/system-configuration@0.7.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/mullvad/system-configuration-rs"
         }
       ],
       "properties": [
@@ -13720,38 +13253,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
-      "name": "windows-registry",
-      "version": "0.6.1",
-      "description": "Windows registry",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-registry@0.6.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
       "author": "Microsoft",
       "name": "windows-result",
@@ -14224,7 +13725,7 @@
     {
       "ref": "git+https://github.com/anaconda/anaconda-otel-rs#0.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
@@ -14234,8 +13735,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
-        "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#rustc_version_runtime@0.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
@@ -14256,33 +13756,32 @@
         "registry+https://github.com/rust-lang/crates.io-index#anaconda-anon-usage@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#figment@0.10.19",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.2+spec-1.1.0",
@@ -14310,13 +13809,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
-        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52"
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.49"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -14345,7 +13844,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3"
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
       ]
     },
     {
@@ -14385,7 +13884,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -14422,13 +13921,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
@@ -14459,7 +13958,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -14503,25 +14002,19 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
       ]
     },
     {
@@ -14558,12 +14051,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1"
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0"
       ]
     },
     {
@@ -14583,7 +14076,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
@@ -14613,15 +14106,11 @@
         "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4",
       "dependsOn": []
     },
     {
@@ -14632,7 +14121,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.3",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2"
       ]
     },
@@ -14642,7 +14131,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.32",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
         "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3"
       ]
@@ -14652,7 +14141,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
       "dependsOn": []
     },
     {
@@ -14665,10 +14154,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -14676,9 +14161,7 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
-      ]
+      "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -14706,7 +14189,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
@@ -14718,19 +14201,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
-        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cmov@0.5.4"
+        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0"
       ]
     },
     {
@@ -14747,7 +14218,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
         "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -14755,7 +14226,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -14772,6 +14243,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
       ]
     },
@@ -14779,16 +14251,8 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
-        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
-        "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.10.2",
-        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#ctutils@0.4.2"
+        "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.7",
+        "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1"
       ]
     },
     {
@@ -14810,7 +14274,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -14828,18 +14292,12 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -14860,11 +14318,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
       ]
     },
     {
@@ -14993,7 +14451,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15013,7 +14471,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12"
       ]
@@ -15034,7 +14492,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1",
+        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
       ]
     },
@@ -15069,14 +14527,14 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
@@ -15128,18 +14586,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
       ]
     },
@@ -15147,7 +14599,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2"
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1"
       ]
     },
     {
@@ -15155,7 +14607,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
@@ -15166,25 +14618,15 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.40",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
@@ -15197,7 +14639,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
@@ -15212,35 +14654,32 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
-        "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1"
       ]
@@ -15257,7 +14696,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
         "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
         "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
         "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.8",
         "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
       ]
@@ -15279,7 +14718,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#icu_properties@2.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
       ]
     },
@@ -15308,7 +14747,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
         "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
         "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.8",
         "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
         "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
@@ -15322,7 +14761,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4"
       ]
     },
@@ -15391,13 +14830,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
@@ -15409,8 +14841,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15418,7 +14850,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4"
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3"
       ]
     },
     {
@@ -15452,7 +14884,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
       "dependsOn": []
     },
     {
@@ -15469,14 +14901,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
       "dependsOn": []
     },
     {
@@ -15496,7 +14928,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15534,7 +14966,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
@@ -15544,10 +14976,10 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.81",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.116",
+        "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.80",
         "registry+https://github.com/rust-lang/crates.io-index#schannel@0.1.29",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
@@ -15557,7 +14989,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
@@ -15567,7 +14999,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
@@ -15582,7 +15014,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -15610,7 +15042,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -15622,7 +15054,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15630,23 +15062,23 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.116",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.81",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.80",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117"
+        "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.116"
       ]
     },
     {
@@ -15654,7 +15086,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28"
       ]
@@ -15662,12 +15094,12 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-otlp@0.31.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-proto@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -15678,7 +15110,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
         "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.6",
         "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.6"
       ]
@@ -15686,7 +15118,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-stdout@0.31.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0"
       ]
@@ -15745,12 +15177,12 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
@@ -15775,7 +15207,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15796,10 +15228,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
@@ -15816,7 +15248,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -15850,7 +15282,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52"
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.49"
       ]
     },
     {
@@ -15858,7 +15290,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
         "registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1"
       ]
@@ -15874,32 +15306,32 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
         "registry+https://github.com/rust-lang/crates.io-index#rusty-fork@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#unarray@0.1.4"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.4"
+        "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.3"
       ]
     },
     {
@@ -15918,7 +15350,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -15966,70 +15398,66 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.43.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.10",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
         "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3"
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.8.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
@@ -16043,36 +15471,36 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -16082,40 +15510,40 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
+        "registry+https://github.com/rust-lang/crates.io-index#blake2@0.10.6",
+        "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
         "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#md-5@0.10.6",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.30.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -16125,42 +15553,42 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.62",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#configparser@3.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#configparser@3.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
-        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ambient-id@0.0.11",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
@@ -16169,9 +15597,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
@@ -16184,26 +15610,24 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.2",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_http_range_reader@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.17",
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.27.2",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
@@ -16220,7 +15644,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
@@ -16237,17 +15661,17 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
@@ -16255,13 +15679,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
+        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.46.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -16287,7 +15711,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16309,21 +15733,21 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
+        "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.10"
       ]
     },
     {
@@ -16331,7 +15755,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
@@ -16343,28 +15767,20 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
         "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
-        "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
-        "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
@@ -16379,15 +15795,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
+        "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.14",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
@@ -16415,7 +15831,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
@@ -16429,7 +15845,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#rtoolbox@0.0.5",
@@ -16467,7 +15883,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
@@ -16476,7 +15892,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
       ]
     },
     {
@@ -16494,7 +15910,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13",
         "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
-        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
       ]
     },
     {
@@ -16535,7 +15951,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#secrecy@0.10.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
+        "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2"
       ]
     },
     {
@@ -16589,7 +16005,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16597,7 +16013,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
       ]
@@ -16607,7 +16023,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16626,11 +16042,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.20.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
+        "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
@@ -16638,17 +16054,17 @@
         "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.20.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16670,21 +16086,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#shlex@1.3.0",
       "dependsOn": []
     },
     {
@@ -16731,13 +16139,13 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
@@ -16763,7 +16171,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16785,7 +16193,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
@@ -16803,7 +16211,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16855,7 +16263,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16863,7 +16271,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16885,25 +16293,26 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9"
+        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
+        "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29"
+        "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.8",
+        "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.27"
       ]
     },
     {
@@ -16928,7 +16337,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -16970,11 +16379,11 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -17039,7 +16448,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.6",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
+        "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.3",
         "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.6"
       ]
     },
@@ -17051,7 +16460,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
@@ -17065,13 +16474,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#http@1.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
@@ -17106,7 +16515,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -17118,7 +16527,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36"
       ]
@@ -17127,7 +16536,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
@@ -17142,7 +16551,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
         "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
@@ -17170,7 +16579,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.0",
       "dependsOn": []
     },
     {
@@ -17202,7 +16611,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.2",
       "dependsOn": []
     },
     {
@@ -17252,7 +16661,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
@@ -17274,7 +16683,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2"
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1"
       ]
     },
     {
@@ -17297,12 +16706,12 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#webbrowser@1.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
       ]
@@ -17314,7 +16723,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -17340,12 +16749,12 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
         "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
@@ -17353,7 +16762,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.49",
       "dependsOn": []
     },
     {
@@ -17361,7 +16770,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117",
         "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
       ]
     },
@@ -17372,14 +16781,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.8.2",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
-        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
         "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.8"
       ]
     },
@@ -17388,13 +16797,13 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.2",
         "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.8",
         "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3"
       ]
@@ -17405,8 +16814,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3"
       ]
@@ -17424,7 +16833,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.3",
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.30",
         "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
       ]
     },
@@ -17437,7 +16846,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.62",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },
@@ -17459,26 +16868,19 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49"
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.47"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.1"
       ]
     },
     {
@@ -17491,26 +16893,11 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
-        "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0"
       ]
     },
     {
@@ -17616,7 +17003,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -17624,7 +17011,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.117"
       ]
     },
     {
@@ -17655,14 +17042,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
       ]
     },
     {
@@ -17754,27 +17133,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
-    }
-  ],
-  "vulnerabilities": [
-    {
-      "id": "RUSTSEC-2026-0186",
-      "description": "[unsound] Unchecked pointer offset in crate `memmap2`",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0186.html"
-      },
-      "ratings": [
-        {
-          "severity": "info",
-          "method": "other"
-        }
-      ],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10"
-        }
-      ]
     }
   ]
 }

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-06-22T19:21:31Z<br>
+Generated: 2026-05-28T02:55:17Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 458 (70 platform-specific)<br>
+Packages: 442 (67 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
-<br>**[Security advisories](#security-advisories): 1 (1 INFO) across 1 package**
+<br>**Security advisories: 0 found at this time**
 
 ## Packages
 
@@ -27,7 +27,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [astral-reqwest-middleware](https://crates.io/crates/astral-reqwest-middleware) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.2 | MIT OR Apache-2.0 |  |  |
 | [astral\_async\_http\_range\_reader](https://crates.io/crates/astral_async_http_range_reader) | 0.11.0 | MIT |  |  |
-| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.18 | MIT |  |  |
+| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |  |
 | [async-compression](https://crates.io/crates/async-compression) | 0.4.42 | MIT OR Apache-2.0 |  |  |
 | [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |  |
 | [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |  |
@@ -39,38 +39,34 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
-| [bitflags](https://crates.io/crates/bitflags) | 2.13.0 | MIT OR Apache-2.0 |  |  |
-| [blake2](https://crates.io/crates/blake2) | 0.11.0-rc.6 | MIT OR Apache-2.0 |  |  |
+| [bitflags](https://crates.io/crates/bitflags) | 2.11.1 | MIT OR Apache-2.0 |  |  |
+| [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
-| [block-buffer](https://crates.io/crates/block-buffer) | 0.12.1 | MIT OR Apache-2.0 |  |  |
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
 | [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.3 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.2.64 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.2.62 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
 | [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
-| [chrono](https://crates.io/crates/chrono) | 0.4.45 | MIT OR Apache-2.0 |  |  |
+| [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
 | [clap](https://crates.io/crates/clap) | 4.6.1 | MIT OR Apache-2.0 |  |  |
 | [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |  |
 | [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.1 | MIT OR Apache-2.0 |  |  |
 | [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |  |
-| [cmov](https://crates.io/crates/cmov) | 0.5.4 | Apache-2.0 OR MIT |  |  |
 | [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |  |
 | [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |  |
 | [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.38 | MIT OR Apache-2.0 |  |  |
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.32 | MIT OR Apache-2.0 |  |  |
-| [configparser](https://crates.io/crates/configparser) | 3.2.0 | MIT OR LGPL-3.0-or-later | linux |  |
+| [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
-| [const-oid](https://crates.io/crates/const-oid) | 0.10.2 | Apache-2.0 OR MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
-| [core-foundation](https://crates.io/crates/core-foundation) | 0.9.4 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
-| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 | linux-x86_64, windows |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |  |
@@ -78,15 +74,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |  |
 | [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT | windows |  |
 | [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |  |
-| [crypto-common](https://crates.io/crates/crypto-common) | 0.2.2 | MIT OR Apache-2.0 |  |  |
-| [ctutils](https://crates.io/crates/ctutils) | 0.4.2 | Apache-2.0 OR MIT |  |  |
 | [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |  |
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.2.1 | MIT |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
-| [digest](https://crates.io/crates/digest) | 0.11.3 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [displaydoc](https://crates.io/crates/displaydoc) | 0.2.6 | MIT OR Apache-2.0 |  |  |
@@ -94,12 +87,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
 | [either](https://crates.io/crates/either) | 1.16.0 | MIT OR Apache-2.0 |  |  |
 | [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
-| [encoding\_rs](https://crates.io/crates/encoding_rs) | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause |  |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
 | [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
-| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.18.0 | MIT |  |  |
+| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
 | [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
 | [figment](https://crates.io/crates/figment) | 0.10.19 | MIT OR Apache-2.0 |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.3.1 | BSD-3-Clause |  |  |
@@ -130,7 +122,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [getrandom](https://crates.io/crates/getrandom) | 0.4.2 | MIT OR Apache-2.0 |  |  |
 | [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 | linux, macos |  |
 | [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |  |
-| [h2](https://crates.io/crates/h2) | 0.4.15 | MIT |  |  |
+| [h2](https://crates.io/crates/h2) | 0.4.14 | MIT |  |  |
 | [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.14.5 | MIT OR Apache-2.0 |  |  |
@@ -139,16 +131,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [heck](https://crates.io/crates/heck) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
-| [http](https://crates.io/crates/http) | 1.4.2 | MIT OR Apache-2.0 |  |  |
-| [http-auth](https://crates.io/crates/http-auth) | 0.1.10 | MIT OR Apache-2.0 |  |  |
+| [http](https://crates.io/crates/http) | 1.4.1 | MIT OR Apache-2.0 |  |  |
 | [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
 | [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
 | [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
-| [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
-| [hybrid-array](https://crates.io/crates/hybrid-array) | 0.4.12 | MIT OR Apache-2.0 |  |  |
-| [hyper](https://crates.io/crates/hyper) | 1.10.1 | MIT |  |  |
+| [hyper](https://crates.io/crates/hyper) | 1.10.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.9 | Apache-2.0 OR ISC OR MIT |  |  |
 | [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |  |
@@ -173,7 +162,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
-| [jiff](https://crates.io/crates/jiff) | 0.2.28 | Unlicense OR MIT |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
@@ -185,19 +173,19 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
 | [lock\_api](https://crates.io/crates/lock_api) | 0.4.14 | MIT OR Apache-2.0 |  |  |
-| [log](https://crates.io/crates/log) | 0.4.33 | MIT OR Apache-2.0 |  |  |
+| [log](https://crates.io/crates/log) | 0.4.30 | MIT OR Apache-2.0 |  |  |
 | [mac\_address](https://crates.io/crates/mac_address) | 1.1.8 | MIT OR Apache-2.0 |  |  |
 | [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |  |
-| [md-5](https://crates.io/crates/md-5) | 0.11.0 | MIT OR Apache-2.0 |  |  |
-| [memchr](https://crates.io/crates/memchr) | 2.8.2 | Unlicense OR MIT |  |  |
-| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  | 1 |
+| [md-5](https://crates.io/crates/md-5) | 0.10.6 | MIT OR Apache-2.0 |  |  |
+| [memchr](https://crates.io/crates/memchr) | 2.8.1 | Unlicense OR MIT |  |  |
+| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  |  |
 | [memoffset](https://crates.io/crates/memoffset) | 0.9.1 | MIT | linux, macos |  |
 | [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |  |
 | [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |  |
 | [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |  |
 | [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |  |
 | [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |  |
-| [mio](https://crates.io/crates/mio) | 1.2.1 | MIT |  |  |
+| [mio](https://crates.io/crates/mio) | 1.2.0 | MIT |  |  |
 | [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |  |
 | [nix](https://crates.io/crates/nix) | 0.29.0 | MIT | linux, macos |  |
 | [nix](https://crates.io/crates/nix) | 0.30.1 | MIT | linux, macos |  |
@@ -211,10 +199,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [object](https://crates.io/crates/object) | 0.37.3 | Apache-2.0 OR MIT | linux, macos |  |
 | [once\_cell](https://crates.io/crates/once_cell) | 1.21.4 | MIT OR Apache-2.0 |  |  |
 | [once\_cell\_polyfill](https://crates.io/crates/once_cell_polyfill) | 1.70.2 | MIT OR Apache-2.0 | windows |  |
-| [openssl](https://crates.io/crates/openssl) | 0.10.81 | Apache-2.0 | linux |  |
+| [openssl](https://crates.io/crates/openssl) | 0.10.80 | Apache-2.0 | linux |  |
 | [openssl-macros](https://crates.io/crates/openssl-macros) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
 | [openssl-probe](https://crates.io/crates/openssl-probe) | 0.2.1 | MIT OR Apache-2.0 | linux |  |
-| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.117 | MIT | linux |  |
+| [openssl-sys](https://crates.io/crates/openssl-sys) | 0.9.116 | MIT | linux |  |
 | [opentelemetry](https://crates.io/crates/opentelemetry) | 0.31.0 | Apache-2.0 |  |  |
 | [opentelemetry-http](https://crates.io/crates/opentelemetry-http) | 0.31.0 | Apache-2.0 |  |  |
 | [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) | 0.31.1 | Apache-2.0 |  |  |
@@ -227,7 +215,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
-| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.11 | BSD-3-Clause |  |  |
+| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.10 | BSD-3-Clause |  |  |
 | [pear](https://crates.io/crates/pear) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pear\_codegen](https://crates.io/crates/pear_codegen) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
@@ -245,8 +233,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |  |
 | [proc-macro2-diagnostics](https://crates.io/crates/proc-macro2-diagnostics) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |  |
-| [prost](https://crates.io/crates/prost) | 0.14.4 | Apache-2.0 |  |  |
-| [prost-derive](https://crates.io/crates/prost-derive) | 0.14.4 | Apache-2.0 |  |  |
+| [prost](https://crates.io/crates/prost) | 0.14.3 | Apache-2.0 |  |  |
+| [prost-derive](https://crates.io/crates/prost-derive) | 0.14.3 | Apache-2.0 |  |  |
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux |  |
@@ -258,34 +246,34 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
-| [rattler](https://crates.io/crates/rattler) | 0.45.0 | BSD-3-Clause |  |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.0 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.47.2 | BSD-3-Clause |  |  |
-| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.1 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.3 | BSD-3-Clause |  |  |
-| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.1 | BSD-3-Clause |  |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.67 | BSD-3-Clause |  |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.29.0 | BSD-3-Clause |  |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.5 | BSD-3-Clause |  |  |
-| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.13 | BSD-3-Clause |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.43.2 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.8.2 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.46.4 | BSD-3-Clause |  |  |
+| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.0 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.30.3 | BSD-3-Clause |  |  |
+| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.0 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.62 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.27.2 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.2 | BSD-3-Clause |  |  |
+| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.12 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.1 | BSD-3-Clause |  |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.7 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.0 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.2 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.1.1 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |
 | [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |  |
 | [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
-| [regex](https://crates.io/crates/regex) | 1.12.4 | MIT OR Apache-2.0 |  |  |
+| [regex](https://crates.io/crates/regex) | 1.12.3 | MIT OR Apache-2.0 |  |  |
 | [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
-| [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.11 | MIT OR Apache-2.0 |  |  |
+| [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.10 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.13.4 | MIT OR Apache-2.0 |  |  |
 | [reqwest-middleware](https://crates.io/crates/reqwest-middleware) | 0.5.2 | MIT OR Apache-2.0 |  |  |
 | [retry-policies](https://crates.io/crates/retry-policies) | 0.5.2 | MIT OR Apache-2.0 |  |  |
 | [ring](https://crates.io/crates/ring) | 0.17.14 | Apache-2.0 AND ISC |  |  |
 | [rlimit](https://crates.io/crates/rlimit) | 0.11.0 | MIT | linux, macos |  |
-| [rpassword](https://crates.io/crates/rpassword) | 7.5.4 | Apache-2.0 |  |  |
+| [rpassword](https://crates.io/crates/rpassword) | 7.5.3 | Apache-2.0 |  |  |
 | [rtoolbox](https://crates.io/crates/rtoolbox) | 0.0.5 | Apache-2.0 |  |  |
 | [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |  |
 | [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.2 | Apache-2.0 OR MIT |  |  |
@@ -316,13 +304,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
 | [serde\_spanned](https://crates.io/crates/serde_spanned) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
-| [serde\_with](https://crates.io/crates/serde_with) | 3.21.0 | MIT OR Apache-2.0 |  |  |
-| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.21.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with](https://crates.io/crates/serde_with) | 3.20.0 | MIT OR Apache-2.0 |  |  |
+| [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.20.0 | MIT OR Apache-2.0 |  |  |
 | [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |  |
 | [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |  |
-| [sha2](https://crates.io/crates/sha2) | 0.11.0 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
-| [shlex](https://crates.io/crates/shlex) | 2.0.1 | MIT OR Apache-2.0 |  |  |
+| [shlex](https://crates.io/crates/shlex) | 1.3.0 | MIT OR Apache-2.0 |  |  |
 | [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
 | [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |  |
@@ -330,8 +317,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |  |
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
-| [smallvec](https://crates.io/crates/smallvec) | 1.15.2 | MIT OR Apache-2.0 |  |  |
-| [socket2](https://crates.io/crates/socket2) | 0.6.4 | MIT OR Apache-2.0 |  |  |
+| [smallvec](https://crates.io/crates/smallvec) | 1.15.1 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.6.3 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
 | [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |  |
@@ -340,12 +327,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [supports-color](https://crates.io/crates/supports-color) | 3.0.2 | Apache-2.0 |  |  |
 | [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |  |
 | [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |  |
-| [syn](https://crates.io/crates/syn) | 2.0.118 | MIT OR Apache-2.0 |  |  |
+| [syn](https://crates.io/crates/syn) | 2.0.117 | MIT OR Apache-2.0 |  |  |
 | [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |  |
 | [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |  |
 | [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |  |
-| [system-configuration](https://crates.io/crates/system-configuration) | 0.7.0 | MIT OR Apache-2.0 | macos |  |
-| [system-configuration-sys](https://crates.io/crates/system-configuration-sys) | 0.6.0 | MIT OR Apache-2.0 | macos |  |
 | [tar](https://crates.io/crates/tar) | 0.4.46 | MIT OR Apache-2.0 |  |  |
 | [tempfile](https://crates.io/crates/tempfile) | 3.27.0 | MIT OR Apache-2.0 |  |  |
 | [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |  |
@@ -355,9 +340,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [thiserror-impl](https://crates.io/crates/thiserror-impl) | 1.0.69 | MIT OR Apache-2.0 |  |  |
 | [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.18 | MIT OR Apache-2.0 |  |  |
 | [thread\_local](https://crates.io/crates/thread_local) | 1.1.9 | MIT OR Apache-2.0 |  |  |
-| [time](https://crates.io/crates/time) | 0.3.49 | MIT OR Apache-2.0 |  |  |
-| [time-core](https://crates.io/crates/time-core) | 0.1.9 | MIT OR Apache-2.0 |  |  |
-| [time-macros](https://crates.io/crates/time-macros) | 0.2.29 | MIT OR Apache-2.0 |  |  |
+| [time](https://crates.io/crates/time) | 0.3.47 | MIT OR Apache-2.0 |  |  |
+| [time-core](https://crates.io/crates/time-core) | 0.1.8 | MIT OR Apache-2.0 |  |  |
+| [time-macros](https://crates.io/crates/time-macros) | 0.2.27 | MIT OR Apache-2.0 |  |  |
 | [tinystr](https://crates.io/crates/tinystr) | 0.8.3 | Unicode-3.0 |  |  |
 | [tinyvec](https://crates.io/crates/tinyvec) | 1.11.0 | Zlib OR Apache-2.0 OR MIT |  |  |
 | [tinyvec\_macros](https://crates.io/crates/tinyvec_macros) | 0.1.1 | MIT OR Apache-2.0 OR Zlib |  |  |
@@ -389,14 +374,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [try-lock](https://crates.io/crates/try-lock) | 0.2.5 | MIT |  |  |
 | [typed-path](https://crates.io/crates/typed-path) | 0.12.3 | MIT OR Apache-2.0 |  |  |
 | [typeid](https://crates.io/crates/typeid) | 1.0.3 | MIT OR Apache-2.0 |  |  |
-| [typenum](https://crates.io/crates/typenum) | 1.20.1 | MIT OR Apache-2.0 |  |  |
+| [typenum](https://crates.io/crates/typenum) | 1.20.0 | MIT OR Apache-2.0 |  |  |
 | [unarray](https://crates.io/crates/unarray) | 0.1.4 | MIT OR Apache-2.0 |  |  |
 | [uncased](https://crates.io/crates/uncased) | 0.9.10 | MIT OR Apache-2.0 |  |  |
 | [unicase](https://crates.io/crates/unicase) | 2.9.0 | MIT OR Apache-2.0 |  |  |
 | [unicode-ident](https://crates.io/crates/unicode-ident) | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |  |  |
 | [unicode-linebreak](https://crates.io/crates/unicode-linebreak) | 0.1.5 | Apache-2.0 |  |  |
 | [unicode-normalization](https://crates.io/crates/unicode-normalization) | 0.1.25 | MIT OR Apache-2.0 |  |  |
-| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.3 | MIT OR Apache-2.0 |  |  |
+| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | 1.13.2 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.1.14 | MIT OR Apache-2.0 |  |  |
 | [unicode-width](https://crates.io/crates/unicode-width) | 0.2.2 | MIT OR Apache-2.0 |  |  |
 | [unit-prefix](https://crates.io/crates/unit-prefix) | 0.5.2 | MIT |  |  |
@@ -407,7 +392,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
-| [uuid](https://crates.io/crates/uuid) | 1.23.3 | Apache-2.0 OR MIT |  |  |
+| [uuid](https://crates.io/crates/uuid) | 1.23.1 | Apache-2.0 OR MIT |  |  |
 | [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |  |
 | [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 | linux |  |
 | [version-ranges](https://crates.io/crates/version-ranges) | 0.1.3 | MPL-2.0 |  |  |
@@ -415,7 +400,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.1 | MIT OR Apache-2.0 |  |  |
-| [which](https://crates.io/crates/which) | 8.0.4 | MIT |  |  |
+| [which](https://crates.io/crates/which) | 8.0.2 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 | windows |  |
@@ -434,7 +419,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 | windows |  |
-| [windows-registry](https://crates.io/crates/windows-registry) | 0.6.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 | windows |  |
 | [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 | windows |  |
@@ -452,12 +436,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 | linux, macos |  |
 | [xxhash-rust](https://crates.io/crates/xxhash-rust) | 0.8.15 | BSL-1.0 |  |  |
 | [yansi](https://crates.io/crates/yansi) | 1.0.1 | MIT OR Apache-2.0 |  |  |
-| [yoke](https://crates.io/crates/yoke) | 0.8.3 | Unicode-3.0 |  |  |
+| [yoke](https://crates.io/crates/yoke) | 0.8.2 | Unicode-3.0 |  |  |
 | [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |  |
-| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |  |  |
+| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.49 | BSD-2-Clause OR Apache-2.0 OR MIT |  |  |
 | [zerofrom](https://crates.io/crates/zerofrom) | 0.1.8 | Unicode-3.0 |  |  |
 | [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |  |
-| [zeroize](https://crates.io/crates/zeroize) | 1.9.0 | Apache-2.0 OR MIT |  |  |
+| [zeroize](https://crates.io/crates/zeroize) | 1.8.2 | Apache-2.0 OR MIT |  |  |
 | [zerotrie](https://crates.io/crates/zerotrie) | 0.2.4 | Unicode-3.0 |  |  |
 | [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |  |
 | [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |  |
@@ -469,30 +453,23 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
 
-## Security Advisories
-
-| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
-| --- | --- | --- | :---: | :---: | --- |
-| memmap2 | 0.9.10 | [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) |  |  | INFO |
-
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 252 |
+| MIT OR Apache-2.0 | 241 |
 | MIT | 84 |
-| Apache-2.0 OR MIT | 36 |
+| Apache-2.0 OR MIT | 33 |
 | Apache-2.0 | 20 |
 | BSD-3-Clause | 18 |
 | Unicode-3.0 | 18 |
 | ISC | 3 |
-| Unlicense OR MIT | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
+| Unlicense OR MIT | 2 |
 | Zlib | 2 |
-| (Apache-2.0 OR MIT) AND BSD-3-Clause | 1 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |
 | Apache-2.0  OR  MIT | 1 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-28T02:55:17Z<br>
+Generated: 2026-05-28T03:51:57Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 442 (67 platform-specific)<br>
+Packages: 442 (66 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -50,7 +50,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
 | [cc](https://crates.io/crates/cc) | 1.2.62 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT |  |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.44 | MIT OR Apache-2.0 |  |  |
 | [clap](https://crates.io/crates/clap) | 4.6.1 | MIT OR Apache-2.0 |  |  |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-28T03:51:57Z<br>
+Generated: 2026-06-25T17:09:52Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 442 (66 platform-specific)<br>
+Packages: 460 (65 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
-<br>**Security advisories: 0 found at this time**
+<br>**[Security advisories](#security-advisories): 2 (2 INFO) across 2 packages**
 
 ## Packages
 
@@ -27,7 +27,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [astral-reqwest-middleware](https://crates.io/crates/astral-reqwest-middleware) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.2 | MIT OR Apache-2.0 |  |  |
 | [astral\_async\_http\_range\_reader](https://crates.io/crates/astral_async_http_range_reader) | 0.11.0 | MIT |  |  |
-| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.17 | MIT |  |  |
+| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.18 | MIT |  |  |
 | [async-compression](https://crates.io/crates/async-compression) | 0.4.42 | MIT OR Apache-2.0 |  |  |
 | [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |  |
 | [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |  |
@@ -39,9 +39,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
+| [bitflags](https://crates.io/crates/bitflags) | 1.3.2 | MIT OR Apache-2.0 |  |  |
 | [bitflags](https://crates.io/crates/bitflags) | 2.11.1 | MIT OR Apache-2.0 |  |  |
-| [blake2](https://crates.io/crates/blake2) | 0.10.6 | MIT OR Apache-2.0 |  |  |
+| [blake2](https://crates.io/crates/blake2) | 0.11.0-rc.6 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
+| [block-buffer](https://crates.io/crates/block-buffer) | 0.12.1 | MIT OR Apache-2.0 |  |  |
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
 | [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.3 | MIT OR Apache-2.0 |  |  |
@@ -57,16 +59,18 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |  |
 | [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.1 | MIT OR Apache-2.0 |  |  |
 | [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |  |
+| [cmov](https://crates.io/crates/cmov) | 0.5.4 | Apache-2.0 OR MIT |  |  |
 | [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |  |
 | [comfy-table](https://crates.io/crates/comfy-table) | 7.2.2 | MIT |  |  |
 | [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.38 | MIT OR Apache-2.0 |  |  |
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.32 | MIT OR Apache-2.0 |  |  |
 | [configparser](https://crates.io/crates/configparser) | 3.1.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
+| [const-oid](https://crates.io/crates/const-oid) | 0.10.2 | Apache-2.0 OR MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
-| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 | linux-x86_64, windows |  |
+| [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  |  |
@@ -74,12 +78,18 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |  |
 | [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT | windows |  |
 | [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |  |
+| [crypto-common](https://crates.io/crates/crypto-common) | 0.2.2 | MIT OR Apache-2.0 |  |  |
+| [ctutils](https://crates.io/crates/ctutils) | 0.4.2 | Apache-2.0 OR MIT |  |  |
 | [darling](https://crates.io/crates/darling) | 0.23.0 | MIT |  |  |
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.2.1 | MIT |  |  |
+| [defmt](https://crates.io/crates/defmt) | 1.1.0 | MIT OR Apache-2.0 |  |  |
+| [defmt-macros](https://crates.io/crates/defmt-macros) | 1.1.0 | MIT OR Apache-2.0 |  |  |
+| [defmt-parser](https://crates.io/crates/defmt-parser) | 1.0.0 | MIT OR Apache-2.0 |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
+| [digest](https://crates.io/crates/digest) | 0.11.3 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
 | [displaydoc](https://crates.io/crates/displaydoc) | 0.2.6 | MIT OR Apache-2.0 |  |  |
@@ -91,7 +101,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [equivalent](https://crates.io/crates/equivalent) | 1.0.2 | Apache-2.0 OR MIT |  |  |
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
 | [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
-| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.17.0 | MIT |  |  |
+| [fancy-regex](https://crates.io/crates/fancy-regex) | 0.18.0 | MIT |  |  |
 | [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
 | [figment](https://crates.io/crates/figment) | 0.10.19 | MIT OR Apache-2.0 |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.3.1 | BSD-3-Clause |  |  |
@@ -132,11 +142,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [hex](https://crates.io/crates/hex) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
 | [http](https://crates.io/crates/http) | 1.4.1 | MIT OR Apache-2.0 |  |  |
+| [http-auth](https://crates.io/crates/http-auth) | 0.1.10 | MIT OR Apache-2.0 |  |  |
 | [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
 | [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
 | [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
+| [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
 | [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
+| [hybrid-array](https://crates.io/crates/hybrid-array) | 0.4.12 | MIT OR Apache-2.0 |  |  |
 | [hyper](https://crates.io/crates/hyper) | 1.10.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.9 | Apache-2.0 OR ISC OR MIT |  |  |
 | [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |  |
@@ -162,6 +175,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
+| [jiff](https://crates.io/crates/jiff) | 0.2.29 | Unlicense OR MIT |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
@@ -176,9 +190,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [log](https://crates.io/crates/log) | 0.4.30 | MIT OR Apache-2.0 |  |  |
 | [mac\_address](https://crates.io/crates/mac_address) | 1.1.8 | MIT OR Apache-2.0 |  |  |
 | [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |  |
-| [md-5](https://crates.io/crates/md-5) | 0.10.6 | MIT OR Apache-2.0 |  |  |
+| [md-5](https://crates.io/crates/md-5) | 0.11.0 | MIT OR Apache-2.0 |  |  |
 | [memchr](https://crates.io/crates/memchr) | 2.8.1 | Unlicense OR MIT |  |  |
-| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  |  |
+| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  | 1 |
 | [memoffset](https://crates.io/crates/memoffset) | 0.9.1 | MIT | linux, macos |  |
 | [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |  |
 | [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |  |
@@ -215,7 +229,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
-| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.10 | BSD-3-Clause |  |  |
+| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.11 | BSD-3-Clause |  |  |
 | [pear](https://crates.io/crates/pear) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pear\_codegen](https://crates.io/crates/pear_codegen) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
@@ -230,6 +244,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |  |
 | [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |  |
 | [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |  |
+| [proc-macro-error-attr2](https://crates.io/crates/proc-macro-error-attr2) | 2.0.0 | MIT OR Apache-2.0 |  |  |
+| [proc-macro-error2](https://crates.io/crates/proc-macro-error2) | 2.0.1 | MIT OR Apache-2.0 |  | 1 |
 | [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |  |
 | [proc-macro2-diagnostics](https://crates.io/crates/proc-macro2-diagnostics) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |  |
@@ -246,19 +262,19 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
-| [rattler](https://crates.io/crates/rattler) | 0.43.2 | BSD-3-Clause |  |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.8.2 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.46.4 | BSD-3-Clause |  |  |
-| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.0 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.30.3 | BSD-3-Clause |  |  |
-| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.0 | BSD-3-Clause |  |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.62 | BSD-3-Clause |  |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.27.2 | BSD-3-Clause |  |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.2 | BSD-3-Clause |  |  |
-| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.12 | BSD-3-Clause |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.45.0 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.0 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.47.2 | BSD-3-Clause |  |  |
+| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.1 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.3 | BSD-3-Clause |  |  |
+| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.1 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.67 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.29.0 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.5 | BSD-3-Clause |  |  |
+| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.13 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.1 | BSD-3-Clause |  |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.2 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.1.1 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.7 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.0 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |
@@ -308,8 +324,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [serde\_with\_macros](https://crates.io/crates/serde_with_macros) | 3.20.0 | MIT OR Apache-2.0 |  |  |
 | [serde\_yaml](https://crates.io/crates/serde_yaml) | 0.9.34+deprecated | MIT OR Apache-2.0 |  |  |
 | [sha2](https://crates.io/crates/sha2) | 0.10.9 | MIT OR Apache-2.0 |  |  |
+| [sha2](https://crates.io/crates/sha2) | 0.11.0 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
 | [shlex](https://crates.io/crates/shlex) | 1.3.0 | MIT OR Apache-2.0 |  |  |
+| [shlex](https://crates.io/crates/shlex) | 2.0.1 | MIT OR Apache-2.0 |  |  |
 | [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
 | [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |  |
@@ -453,22 +471,29 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
 
+## Security Advisories
+
+| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
+| --- | --- | --- | :---: | :---: | --- |
+| memmap2 | 0.9.10 | [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) |  |  | INFO |
+| proc-macro-error2 | 2.0.1 | [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173.html) |  |  | INFO |
+
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 241 |
+| MIT OR Apache-2.0 | 255 |
 | MIT | 84 |
-| Apache-2.0 OR MIT | 33 |
+| Apache-2.0 OR MIT | 36 |
 | Apache-2.0 | 20 |
 | BSD-3-Clause | 18 |
 | Unicode-3.0 | 18 |
 | ISC | 3 |
+| Unlicense OR MIT | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |
 | MPL-2.0 | 2 |
-| Unlicense OR MIT | 2 |
 | Zlib | 2 |
 | (MIT OR Apache-2.0) AND Unicode-3.0 | 1 |
 | 0BSD OR MIT OR Apache-2.0 | 1 |

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,12 @@
 fn main() {
+    // Set up cfg aliases for feature combinations
+    cfg_aliases::cfg_aliases! {
+        // self_update: enabled by default, disabled by conda-package
+        self_update: { all(feature = "self-update", not(feature = "conda-package")) },
+        // tool_install: enabled by default, disabled by conda-package
+        tool_install: { all(feature = "tool-install", not(feature = "conda-package")) },
+    }
+
     // Re-run build.rs if these env vars change
     println!("cargo:rerun-if-env-changed=PKG_VERSION");
     println!("cargo:rerun-if-env-changed=SENTRY_DSN");

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -7,29 +7,10 @@ source:
 
 build:
   number: 0
-  script:
-    - if: unix
-      then:
-        - mkdir -p .cargo
-        - echo '[net]' > .cargo/config.toml
-        - echo 'git-fetch-with-cli = true' >> .cargo/config.toml
-        - git config --global url."https://x-access-token:${{ env.get("GITHUB_TOKEN", default="") }}@github.com/".insteadOf "https://github.com/"
-        - cargo build --release --features conda-package
-        - mkdir -p $PREFIX/bin
-        - cp target/release/ana $PREFIX/bin/
-    - if: win
-      then:
-        - if not exist .cargo mkdir .cargo
-        - echo [net] > .cargo\config.toml
-        - echo git-fetch-with-cli = true >> .cargo\config.toml
-        - cargo build --release --features conda-package
-        - if not exist %PREFIX%\Library\bin mkdir %PREFIX%\Library\bin
-        - copy target\release\ana.exe %PREFIX%\Library\bin\ana.exe
+  # The binary is pre-built by CI before rattler-build runs.
+  # build.sh/build.bat use $RECIPE_DIR to find the pre-built binary at target/release/.
 
 requirements:
-  build:
-    - rust
-    - git
   run:
     - anaconda-client
 

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -14,7 +14,7 @@ build:
         - echo '[net]' > .cargo/config.toml
         - echo 'git-fetch-with-cli = true' >> .cargo/config.toml
         - git config --global url."https://x-access-token:${{ env.get("GITHUB_TOKEN", default="") }}@github.com/".insteadOf "https://github.com/"
-        - cargo build --release --features conda-package
+        - cargo build --release --no-default-features --features conda-package
         - mkdir -p $PREFIX/bin
         - cp target/release/ana $PREFIX/bin/
     - if: win
@@ -22,7 +22,7 @@ build:
         - if not exist .cargo mkdir .cargo
         - echo [net] > .cargo\config.toml
         - echo git-fetch-with-cli = true >> .cargo\config.toml
-        - cargo build --release --features conda-package
+        - cargo build --release --no-default-features --features conda-package
         - if not exist %PREFIX%\Library\bin mkdir %PREFIX%\Library\bin
         - copy target\release\ana.exe %PREFIX%\Library\bin\ana.exe
 

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -7,6 +7,32 @@ source:
 
 build:
   number: 0
+  script:
+    - if: unix
+      then:
+        - mkdir -p .cargo
+        - echo '[net]' > .cargo/config.toml
+        - echo 'git-fetch-with-cli = true' >> .cargo/config.toml
+        - git config --global url."https://x-access-token:${{ env.get("GITHUB_TOKEN", default="") }}@github.com/".insteadOf "https://github.com/"
+        - cargo build --release --features conda-package
+        - mkdir -p $PREFIX/bin
+        - cp target/release/ana $PREFIX/bin/
+    - if: win
+      then:
+        - if not exist .cargo mkdir .cargo
+        - echo [net] > .cargo\config.toml
+        - echo git-fetch-with-cli = true >> .cargo\config.toml
+        - cargo build --release --features conda-package
+        - if not exist %PREFIX%\Library\bin mkdir %PREFIX%\Library\bin
+        - copy target\release\ana.exe %PREFIX%\Library\bin\ana.exe
+
+requirements:
+  build:
+    - rust
+    - git
+  run:
+    - anaconda-client
+    - anaconda-mcp
 
 about:
   homepage: https://github.com/anaconda/ana-cli

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -14,7 +14,7 @@ build:
         - echo '[net]' > .cargo/config.toml
         - echo 'git-fetch-with-cli = true' >> .cargo/config.toml
         - git config --global url."https://x-access-token:${{ env.get("GITHUB_TOKEN", default="") }}@github.com/".insteadOf "https://github.com/"
-        - cargo build --release --no-default-features --features conda-package
+        - cargo build --release --features conda-package
         - mkdir -p $PREFIX/bin
         - cp target/release/ana $PREFIX/bin/
     - if: win
@@ -22,7 +22,7 @@ build:
         - if not exist .cargo mkdir .cargo
         - echo [net] > .cargo\config.toml
         - echo git-fetch-with-cli = true >> .cargo\config.toml
-        - cargo build --release --no-default-features --features conda-package
+        - cargo build --release --features conda-package
         - if not exist %PREFIX%\Library\bin mkdir %PREFIX%\Library\bin
         - copy target\release\ana.exe %PREFIX%\Library\bin\ana.exe
 

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -32,7 +32,6 @@ requirements:
     - git
   run:
     - anaconda-client
-    - anaconda-mcp
 
 about:
   homepage: https://github.com/anaconda/ana-cli

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ana-cli
+  name: anaconda-cli
   version: ${{ env.get("PKG_VERSION") | default("0.0.0") }}
 
 source:

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,8 +27,13 @@ cmd = "pre-commit run --verbose --show-diff-on-failure --color=always --all-file
 description = "Run pre-commit hooks on all files"
 
 
+[tasks.build-conda-binary]
+cmd = "python scripts/with_version.py cargo build --release --no-default-features --features conda-package"
+description = "Build the Rust binary with conda-package features for conda packaging"
+
 [tasks.build-conda]
 cmd = "python scripts/with_version.py rattler-build build --recipe conda.recipe"
+depends-on = ["build-conda-binary"]
 description = "Build the conda package"
 
 [tasks.build-shim]

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -2,22 +2,22 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::context::CommandContext;
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::paths;
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::tools;
 
 /// Bootstrap anaconda-cli installation.
 ///
 /// When built with `conda-package` feature, this is a no-op since anaconda-cli
 /// is provided as a conda dependency.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 pub async fn run_bootstrap(_ctx: &mut CommandContext) -> Result<(), String> {
     eprintln!("anaconda-cli is provided by conda. No bootstrap needed.");
     Ok(())
 }
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     if paths::tool_prefix("anaconda-cli").exists() {
         eprintln!("anaconda-cli is already installed");
@@ -34,7 +34,7 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
 }
 
 /// Resolve the path to the anaconda binary.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 fn resolve_anaconda_bin() -> Result<PathBuf, String> {
     let conda_prefix = std::env::var("CONDA_PREFIX")
         .map_err(|_| "CONDA_PREFIX not set. Are you in an active conda environment?".to_string())?;
@@ -58,7 +58,7 @@ fn resolve_anaconda_bin() -> Result<PathBuf, String> {
     Ok(anaconda_bin)
 }
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 fn resolve_anaconda_bin() -> Result<PathBuf, String> {
     let anaconda_bin = paths::bin_path("anaconda");
 

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -1,7 +1,23 @@
+use std::path::PathBuf;
+use std::process::Command;
+
 use crate::context::CommandContext;
+#[cfg(not(feature = "conda-package"))]
 use crate::paths;
+#[cfg(not(feature = "conda-package"))]
 use crate::tools;
 
+/// Bootstrap anaconda-cli installation.
+///
+/// When built with `conda-package` feature, this is a no-op since anaconda-cli
+/// is provided as a conda dependency.
+#[cfg(feature = "conda-package")]
+pub async fn run_bootstrap(_ctx: &mut CommandContext) -> Result<(), String> {
+    eprintln!("anaconda-cli is provided by conda. No bootstrap needed.");
+    Ok(())
+}
+
+#[cfg(not(feature = "conda-package"))]
 pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     if paths::tool_prefix("anaconda-cli").exists() {
         eprintln!("anaconda-cli is already installed");
@@ -17,12 +33,70 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     Ok(())
 }
 
+/// Resolve the path to the anaconda binary.
+#[cfg(feature = "conda-package")]
+fn resolve_anaconda_bin() -> Result<PathBuf, String> {
+    let conda_prefix = std::env::var("CONDA_PREFIX")
+        .map_err(|_| "CONDA_PREFIX not set. Are you in an active conda environment?".to_string())?;
+
+    let bin_subdir = if cfg!(windows) { "Scripts" } else { "bin" };
+    let binary = if cfg!(windows) {
+        "anaconda.exe"
+    } else {
+        "anaconda"
+    };
+
+    let anaconda_bin = PathBuf::from(&conda_prefix).join(bin_subdir).join(binary);
+
+    if !anaconda_bin.exists() {
+        return Err(format!(
+            "anaconda not found at {}. Is the conda environment configured correctly?",
+            anaconda_bin.display()
+        ));
+    }
+
+    Ok(anaconda_bin)
+}
+
+#[cfg(not(feature = "conda-package"))]
+fn resolve_anaconda_bin() -> Result<PathBuf, String> {
+    let anaconda_bin = paths::bin_path("anaconda");
+
+    if !anaconda_bin.exists() {
+        return Err(format!(
+            "anaconda not found at {}. Run `ana bootstrap` first.",
+            anaconda_bin.display()
+        ));
+    }
+
+    Ok(anaconda_bin)
+}
+
 pub fn run_subcommand(
     _ctx: &mut CommandContext,
     subcommand: &str,
     args: &[String],
 ) -> Result<(), String> {
-    let mut full_args = vec![subcommand.to_string()];
-    full_args.extend(args.iter().cloned());
-    tools::run_tool_binary("anaconda-cli", "anaconda", &full_args).map_err(|e| format!("{:?}", e))
+    let anaconda_bin = resolve_anaconda_bin()?;
+    run_anaconda_command(&anaconda_bin, subcommand, args)
+}
+
+fn run_anaconda_command(
+    anaconda_bin: &std::path::Path,
+    subcommand: &str,
+    args: &[String],
+) -> Result<(), String> {
+    let status = Command::new(anaconda_bin)
+        .arg(subcommand)
+        .args(args)
+        .status()
+        .map_err(|e| format!("Failed to run anaconda: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        let msg = format!("anaconda exited with code {}", status.code().unwrap_or(1));
+        tracing::error!("{}", msg);
+        Err(msg)
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,12 +17,12 @@ use crate::installer;
 use crate::mcp::{self, McpAction, McpCommands};
 #[cfg(unix)]
 use crate::outerbounds::{self, ObAction, ObCommands};
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::tools;
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 use crate::tools::list as tools_list;
 use crate::ui::status;
-#[cfg(feature = "self-update")]
+#[cfg(self_update)]
 use crate::update;
 use crate::utils::capitalize_first;
 
@@ -99,7 +99,7 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
 }
 
 /// Action to be performed, returned by parse()
-#[cfg_attr(feature = "conda-package", allow(dead_code))]
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub enum Action {
     ShowHelp,
     ShowSubcommandHelp(String),
@@ -292,30 +292,30 @@ impl Action {
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
-            #[cfg(feature = "conda-package")]
+            #[cfg(not(tool_install))]
             Action::ToolInstall { name: _ } => {
                 Err(crate::errors::ToolManagementUnavailableError.into())
             }
-            #[cfg(not(feature = "conda-package"))]
+            #[cfg(tool_install)]
             Action::ToolInstall { name } => {
                 tools::install::install_tool(ctx, &name).await?;
                 Ok(())
             }
-            #[cfg(feature = "conda-package")]
+            #[cfg(not(tool_install))]
             Action::ToolUninstall { name: _, force: _ } => {
                 Err(crate::errors::ToolManagementUnavailableError.into())
             }
-            #[cfg(not(feature = "conda-package"))]
+            #[cfg(tool_install)]
             Action::ToolUninstall { name, force } => {
                 tools::uninstall::uninstall_tool(ctx, &name, force)?;
                 Ok(())
             }
-            #[cfg(feature = "conda-package")]
+            #[cfg(not(tool_install))]
             Action::ToolList => {
-                tools_list::print_tool_list(ctx);
+                crate::tools::list::print_tool_list(ctx);
                 Ok(())
             }
-            #[cfg(not(feature = "conda-package"))]
+            #[cfg(tool_install)]
             Action::ToolList => {
                 tools::list::print_tool_list(ctx);
                 Ok(())
@@ -336,27 +336,31 @@ impl Action {
             Action::Logout => Ok(auth::logout(ctx).into_diagnostic()?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx).into_diagnostic()?),
             Action::Whoami { json } => Ok(auth::whoami(ctx, json).await.into_diagnostic()?),
-            #[cfg(not(feature = "self-update"))]
+            #[cfg(not(self_update))]
             Action::Update {
                 version: _,
                 force: _,
             } => Err(crate::errors::SelfUpdateUnavailableError.into()),
+<<<<<<< HEAD
             #[cfg(feature = "self-update")]
 >>>>>>> 9a00df3f (feat: Add self-update feature flag to disable ana self update)
+=======
+            #[cfg(self_update)]
+>>>>>>> a4b7fa51 (refac: Use cfg-aliases for cleaner feature flag handling)
             Action::Update { version, force } => {
                 update::run_update(ctx, VERSION, version, force).await;
                 Ok(())
             }
-            #[cfg(not(feature = "self-update"))]
+            #[cfg(not(self_update))]
             Action::CheckForUpdate => Err(crate::errors::SelfUpdateUnavailableError.into()),
-            #[cfg(feature = "self-update")]
+            #[cfg(self_update)]
             Action::CheckForUpdate => {
                 update::check_for_update(ctx, VERSION).await;
                 Ok(())
             }
-            #[cfg(not(feature = "self-update"))]
+            #[cfg(not(self_update))]
             Action::ShowAvailableVersions => Err(crate::errors::SelfUpdateUnavailableError.into()),
-            #[cfg(feature = "self-update")]
+            #[cfg(self_update)]
             Action::ShowAvailableVersions => {
                 update::show_available_versions(ctx, VERSION).await;
                 Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ use crate::tools;
 #[cfg(feature = "conda-package")]
 use crate::tools::list as tools_list;
 use crate::ui::status;
+#[cfg(feature = "self-update")]
 use crate::update;
 use crate::utils::capitalize_first;
 
@@ -323,18 +324,39 @@ impl Action {
                 api_key,
                 prompt_api_key,
                 force,
+<<<<<<< HEAD
             } => Ok(auth::login(ctx, api_key, prompt_api_key, force).await?),
             Action::Logout => Ok(auth::logout(ctx)?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
             Action::Whoami { json } => Ok(auth::whoami(ctx, json).await?),
+=======
+            } => Ok(auth::login(ctx, api_key, prompt_api_key, force)
+                .await
+                .into_diagnostic()?),
+            Action::Logout => Ok(auth::logout(ctx).into_diagnostic()?),
+            Action::ShowApiKey => Ok(auth::show_api_key(ctx).into_diagnostic()?),
+            Action::Whoami { json } => Ok(auth::whoami(ctx, json).await.into_diagnostic()?),
+            #[cfg(not(feature = "self-update"))]
+            Action::Update {
+                version: _,
+                force: _,
+            } => Err(crate::errors::SelfUpdateUnavailableError.into()),
+            #[cfg(feature = "self-update")]
+>>>>>>> 9a00df3f (feat: Add self-update feature flag to disable ana self update)
             Action::Update { version, force } => {
                 update::run_update(ctx, VERSION, version, force).await;
                 Ok(())
             }
+            #[cfg(not(feature = "self-update"))]
+            Action::CheckForUpdate => Err(crate::errors::SelfUpdateUnavailableError.into()),
+            #[cfg(feature = "self-update")]
             Action::CheckForUpdate => {
                 update::check_for_update(ctx, VERSION).await;
                 Ok(())
             }
+            #[cfg(not(feature = "self-update"))]
+            Action::ShowAvailableVersions => Err(crate::errors::SelfUpdateUnavailableError.into()),
+            #[cfg(feature = "self-update")]
             Action::ShowAvailableVersions => {
                 update::show_available_versions(ctx, VERSION).await;
                 Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,10 @@ use crate::installer;
 use crate::mcp::{self, McpAction, McpCommands};
 #[cfg(unix)]
 use crate::outerbounds::{self, ObAction, ObCommands};
+#[cfg(not(feature = "conda-package"))]
 use crate::tools;
+#[cfg(feature = "conda-package")]
+use crate::tools::list as tools_list;
 use crate::ui::status;
 use crate::update;
 use crate::utils::capitalize_first;
@@ -95,6 +98,7 @@ fn build_tracing_filter(level: LogLevel) -> tracing_subscriber::EnvFilter {
 }
 
 /// Action to be performed, returned by parse()
+#[cfg_attr(feature = "conda-package", allow(dead_code))]
 pub enum Action {
     ShowHelp,
     ShowSubcommandHelp(String),
@@ -287,14 +291,30 @@ impl Action {
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
+            #[cfg(feature = "conda-package")]
+            Action::ToolInstall { name: _ } => {
+                Err(crate::errors::ToolManagementUnavailableError.into())
+            }
+            #[cfg(not(feature = "conda-package"))]
             Action::ToolInstall { name } => {
                 tools::install::install_tool(ctx, &name).await?;
                 Ok(())
             }
+            #[cfg(feature = "conda-package")]
+            Action::ToolUninstall { name: _, force: _ } => {
+                Err(crate::errors::ToolManagementUnavailableError.into())
+            }
+            #[cfg(not(feature = "conda-package"))]
             Action::ToolUninstall { name, force } => {
                 tools::uninstall::uninstall_tool(ctx, &name, force)?;
                 Ok(())
             }
+            #[cfg(feature = "conda-package")]
+            Action::ToolList => {
+                tools_list::print_tool_list(ctx);
+                Ok(())
+            }
+            #[cfg(not(feature = "conda-package"))]
             Action::ToolList => {
                 tools::list::print_tool_list(ctx);
                 Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -312,7 +312,7 @@ impl Action {
             }
             #[cfg(not(tool_install))]
             Action::ToolList => {
-                crate::tools::list::print_tool_list(ctx);
+                tools_list::print_tool_list(ctx);
                 Ok(())
             }
             #[cfg(tool_install)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ use crate::fetch::api_fetch;
 use crate::help;
 use crate::installer;
 use crate::mcp::{self, McpAction, McpCommands};
-#[cfg(unix)]
+#[cfg(all(unix, tool_install))]
 use crate::outerbounds::{self, ObAction, ObCommands};
 #[cfg(tool_install)]
 use crate::tools;
@@ -125,11 +125,11 @@ pub enum Action {
     OrgProxy {
         args: Vec<String>,
     },
-    #[cfg(unix)]
+    #[cfg(all(unix, tool_install))]
     ObProxy {
         args: Vec<String>,
     },
-    #[cfg(unix)]
+    #[cfg(all(unix, tool_install))]
     ObAutoConfigure {
         instance: String,
     },
@@ -196,9 +196,9 @@ impl Action {
             Action::ShowAvailableVersions => "self.update.list",
             Action::Bootstrap => "bootstrap",
             Action::OrgProxy { .. } => "org",
-            #[cfg(unix)]
+            #[cfg(all(unix, tool_install))]
             Action::ObProxy { .. } => "ob",
-            #[cfg(unix)]
+            #[cfg(all(unix, tool_install))]
             Action::ObAutoConfigure { .. } => "ob.configure.auto",
             Action::McpRun { .. } => "mcp",
             Action::UserAgent { .. } => "user-agent",
@@ -286,9 +286,9 @@ impl Action {
                 anaconda_cli::run_subcommand(ctx, "org", &args).map_err(|e| miette!("{}", e))?
             ),
             Action::McpRun { args } => mcp::run(ctx, &args).await,
-            #[cfg(unix)]
+            #[cfg(all(unix, tool_install))]
             Action::ObProxy { args } => outerbounds::run(ctx, &args).await,
-            #[cfg(unix)]
+            #[cfg(all(unix, tool_install))]
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
@@ -324,29 +324,16 @@ impl Action {
                 api_key,
                 prompt_api_key,
                 force,
-<<<<<<< HEAD
             } => Ok(auth::login(ctx, api_key, prompt_api_key, force).await?),
             Action::Logout => Ok(auth::logout(ctx)?),
             Action::ShowApiKey => Ok(auth::show_api_key(ctx)?),
             Action::Whoami { json } => Ok(auth::whoami(ctx, json).await?),
-=======
-            } => Ok(auth::login(ctx, api_key, prompt_api_key, force)
-                .await
-                .into_diagnostic()?),
-            Action::Logout => Ok(auth::logout(ctx).into_diagnostic()?),
-            Action::ShowApiKey => Ok(auth::show_api_key(ctx).into_diagnostic()?),
-            Action::Whoami { json } => Ok(auth::whoami(ctx, json).await.into_diagnostic()?),
             #[cfg(not(self_update))]
             Action::Update {
                 version: _,
                 force: _,
             } => Err(crate::errors::SelfUpdateUnavailableError.into()),
-<<<<<<< HEAD
-            #[cfg(feature = "self-update")]
->>>>>>> 9a00df3f (feat: Add self-update feature flag to disable ana self update)
-=======
             #[cfg(self_update)]
->>>>>>> a4b7fa51 (refac: Use cfg-aliases for cleaner feature flag handling)
             Action::Update { version, force } => {
                 update::run_update(ctx, VERSION, version, force).await;
                 Ok(())
@@ -654,7 +641,7 @@ pub fn parse() -> (Action, LogLevel) {
                 McpAction::Run(args) => Action::McpRun { args },
             },
         },
-        #[cfg(unix)]
+        #[cfg(all(unix, tool_install))]
         Some(Commands::Ob { command }) => {
             if !feature::is_feature_enabled("outerbounds") {
                 use crate::ui::status::{blank_line, highlight, tip, warn};
@@ -822,9 +809,9 @@ fn print_clap_error(e: &clap::Error) {
 /// Get subcommand names and descriptions from clap for help introspection.
 /// Filters out experimental commands when their features are not enabled.
 fn get_subcommand_descriptions() -> HashMap<String, String> {
-    #[cfg(unix)]
+    #[cfg(all(unix, tool_install))]
     let show_ob = feature::is_feature_enabled("outerbounds");
-    #[cfg(not(unix))]
+    #[cfg(not(all(unix, tool_install)))]
     let show_ob = false;
 
     Cli::command()
@@ -958,7 +945,7 @@ enum Commands {
     },
 
     /// Outerbounds platform CLI (experimental)
-    #[cfg(unix)]
+    #[cfg(all(unix, tool_install))]
     #[command(
         subcommand_required = false,
         arg_required_else_help = false,

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,8 +96,10 @@ pub struct CommandContext {
     /// HTTP client for API requests (lazy initialized).
     client: OnceLock<Client>,
     /// GitHub API client (lazy initialized).
+    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
     github_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Download client (lazy initialized).
+    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
     download_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Unauthenticated client (lazy initialized).
     unauthenticated_client: OnceLock<Client>,
@@ -141,6 +143,7 @@ impl CommandContext {
 
     /// Get or create a GitHub API client.
     /// Uses GITHUB_TOKEN for authentication if available (higher rate limits).
+    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
     pub fn github_client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         self.github_client.get_or_init(|| {
             let builder = reqwest::Client::builder();
@@ -153,6 +156,7 @@ impl CommandContext {
     }
 
     /// Get or create a download client optimized for binary downloads (no gzip).
+    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
     pub fn download_client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         self.download_client.get_or_init(|| {
             http::build_client(reqwest::Client::builder().no_gzip())

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,10 +96,10 @@ pub struct CommandContext {
     /// HTTP client for API requests (lazy initialized).
     client: OnceLock<Client>,
     /// GitHub API client (lazy initialized).
-    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+    #[cfg_attr(not(self_update), allow(dead_code))]
     github_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Download client (lazy initialized).
-    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+    #[cfg_attr(not(self_update), allow(dead_code))]
     download_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Unauthenticated client (lazy initialized).
     unauthenticated_client: OnceLock<Client>,
@@ -143,7 +143,7 @@ impl CommandContext {
 
     /// Get or create a GitHub API client.
     /// Uses GITHUB_TOKEN for authentication if available (higher rate limits).
-    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+    #[cfg_attr(not(self_update), allow(dead_code))]
     pub fn github_client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         self.github_client.get_or_init(|| {
             let builder = reqwest::Client::builder();
@@ -156,7 +156,7 @@ impl CommandContext {
     }
 
     /// Get or create a download client optimized for binary downloads (no gzip).
-    #[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+    #[cfg_attr(not(self_update), allow(dead_code))]
     pub fn download_client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         self.download_client.get_or_init(|| {
             http::build_client(reqwest::Client::builder().no_gzip())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -194,6 +194,16 @@ pub struct ToolManagementUnavailableError;
 )]
 pub struct AnacondaMcpNotInstalledError;
 
+/// Error when self-update is unavailable.
+#[cfg(not(feature = "self-update"))]
+#[derive(Error, Debug, Diagnostic)]
+#[error("Self-update is not available in this build.")]
+#[diagnostic(
+    code(ana::self_update::unavailable),
+    help("If installed via conda, update with:\n\n    conda update ana-cli")
+)]
+pub struct SelfUpdateUnavailableError;
+
 /// Authentication errors (re-exported from auth module for convenience).
 pub use crate::auth::errors::AuthError;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -169,6 +169,21 @@ pub enum ToolError {
 )]
 pub struct OuterboundsNotConfiguredError;
 
+/// Error when tool management is unavailable (conda-package build).
+#[cfg(feature = "conda-package")]
+#[derive(Error, Debug, Diagnostic)]
+#[error("Tool management is not available in the conda package.")]
+#[diagnostic(
+    code(ana::tool::conda_package),
+    help(
+        "When installed as a conda package, tools are managed by conda.\n\
+         To use `ana tool install/uninstall`, install ana standalone:\n\
+         \n\
+         curl -fsSL https://anaconda.sh | bash"
+    )
+)]
+pub struct ToolManagementUnavailableError;
+
 /// Authentication errors (re-exported from auth module for convenience).
 pub use crate::auth::errors::AuthError;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -184,6 +184,16 @@ pub struct OuterboundsNotConfiguredError;
 )]
 pub struct ToolManagementUnavailableError;
 
+/// Error when anaconda-mcp is not installed (conda-package build).
+#[cfg(feature = "conda-package")]
+#[derive(Error, Debug, Diagnostic)]
+#[error("The mcp subcommand requires anaconda-mcp to be installed.")]
+#[diagnostic(
+    code(ana::mcp::not_installed),
+    help("Install it with:\n\n    conda install anaconda-mcp")
+)]
+pub struct AnacondaMcpNotInstalledError;
+
 /// Authentication errors (re-exported from auth module for convenience).
 pub use crate::auth::errors::AuthError;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -170,7 +170,7 @@ pub enum ToolError {
 pub struct OuterboundsNotConfiguredError;
 
 /// Error when tool management is unavailable (conda-package build).
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 #[derive(Error, Debug, Diagnostic)]
 #[error("Tool management is not available in the conda package.")]
 #[diagnostic(
@@ -195,7 +195,7 @@ pub struct ToolManagementUnavailableError;
 pub struct AnacondaMcpNotInstalledError;
 
 /// Error when self-update is unavailable.
-#[cfg(not(feature = "self-update"))]
+#[cfg(not(self_update))]
 #[derive(Error, Debug, Diagnostic)]
 #[error("Self-update is not available in this build.")]
 #[diagnostic(

--- a/src/feature/experimental.rs
+++ b/src/feature/experimental.rs
@@ -74,6 +74,7 @@ fn save_config(config: &AnaConfig) -> miette::Result<()> {
 }
 
 /// Check if an experimental feature is enabled.
+#[cfg_attr(not(all(unix, tool_install)), allow(dead_code))]
 pub fn is_feature_enabled(name: &str) -> bool {
     let config = load_config();
     config

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -6,7 +6,9 @@ mod main_x;
 #[cfg(feature = "unstable")]
 mod wheels;
 
-pub use experimental::{disable_feature, enable_feature, is_feature_enabled, is_valid_feature};
+#[cfg(all(unix, tool_install))]
+pub use experimental::is_feature_enabled;
+pub use experimental::{disable_feature, enable_feature, is_valid_feature};
 pub use main_x::{
     disable_main_x_conda, disable_main_x_pixi, enable_main_x_conda, enable_main_x_pixi,
 };

--- a/src/http.rs
+++ b/src/http.rs
@@ -165,7 +165,7 @@ impl Client {
 }
 
 /// Create a `HeaderMap` with a sensitive `Authorization: Bearer` header.
-#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+#[cfg_attr(not(self_update), allow(dead_code))]
 pub fn bearer_header(token: &str) -> reqwest::header::HeaderMap {
     let mut headers = reqwest::header::HeaderMap::new();
     let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap();
@@ -176,7 +176,7 @@ pub fn bearer_header(token: &str) -> reqwest::header::HeaderMap {
 
 /// Get Cloudflare Zero Trust headers if environment variables are set.
 /// Returns None if either CF_ACCESS_CLIENT_ID or CF_ACCESS_CLIENT_SECRET is missing.
-#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+#[cfg_attr(not(self_update), allow(dead_code))]
 pub fn cloudflare_headers() -> Option<reqwest::header::HeaderMap> {
     let client_id = env::var("CF_ACCESS_CLIENT_ID").ok()?;
     let client_secret = env::var("CF_ACCESS_CLIENT_SECRET").ok()?;
@@ -202,7 +202,7 @@ pub fn cloudflare_headers() -> Option<reqwest::header::HeaderMap> {
 /// Build an HTTP client with user-agent and logging middleware (no base URL).
 /// If CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET environment variables are set,
 /// Cloudflare Zero Trust headers are automatically included.
-#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
+#[cfg_attr(not(self_update), allow(dead_code))]
 pub fn build_client(
     builder: reqwest::ClientBuilder,
 ) -> std::result::Result<reqwest_middleware::ClientWithMiddleware, reqwest::Error> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -165,6 +165,7 @@ impl Client {
 }
 
 /// Create a `HeaderMap` with a sensitive `Authorization: Bearer` header.
+#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
 pub fn bearer_header(token: &str) -> reqwest::header::HeaderMap {
     let mut headers = reqwest::header::HeaderMap::new();
     let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap();
@@ -175,6 +176,7 @@ pub fn bearer_header(token: &str) -> reqwest::header::HeaderMap {
 
 /// Get Cloudflare Zero Trust headers if environment variables are set.
 /// Returns None if either CF_ACCESS_CLIENT_ID or CF_ACCESS_CLIENT_SECRET is missing.
+#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
 pub fn cloudflare_headers() -> Option<reqwest::header::HeaderMap> {
     let client_id = env::var("CF_ACCESS_CLIENT_ID").ok()?;
     let client_secret = env::var("CF_ACCESS_CLIENT_SECRET").ok()?;
@@ -200,6 +202,7 @@ pub fn cloudflare_headers() -> Option<reqwest::header::HeaderMap> {
 /// Build an HTTP client with user-agent and logging middleware (no base URL).
 /// If CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET environment variables are set,
 /// Cloudflare Zero Trust headers are automatically included.
+#[cfg_attr(not(feature = "self-update"), allow(dead_code))]
 pub fn build_client(
     builder: reqwest::ClientBuilder,
 ) -> std::result::Result<reqwest_middleware::ClientWithMiddleware, reqwest::Error> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -118,6 +118,7 @@ fn parse_yes_no(input: &str, default: bool) -> bool {
 ///
 /// Displays `message` followed by `: ` and waits for input.
 /// Returns the trimmed input string, or an error if reading fails.
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn prompt_input(message: &str) -> Result<String, String> {
     use std::io::Write;
     print!("{}: ", message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod http;
 mod input;
 mod installer;
 mod mcp;
-#[cfg(unix)]
+#[cfg(all(unix, tool_install))]
 mod outerbounds;
 mod paths;
 mod qr;
@@ -37,9 +37,12 @@ fn prepare_runtime() {
         unsafe {
             libc::signal(libc::SIGPIPE, libc::SIG_DFL);
         }
+    }
 
-        // Raise RLIMIT_NOFILE for rattler installations. On macOS, respects
-        // kern.maxfilesperproc (the real hard ceiling).
+    // Raise RLIMIT_NOFILE for rattler installations. On macOS, respects
+    // kern.maxfilesperproc (the real hard ceiling).
+    #[cfg(all(unix, tool_install))]
+    {
         match rlimit::increase_nofile_limit(2048) {
             Ok(n) => tracing::debug!(limit = n, "RLIMIT_NOFILE raised"),
             Err(e) => tracing::warn!(error = %e, "Failed to raise RLIMIT_NOFILE"),

--- a/src/mcp/run.rs
+++ b/src/mcp/run.rs
@@ -1,15 +1,15 @@
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 use std::path::PathBuf;
 
 use crate::context::CommandContext;
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::paths;
 use crate::tools;
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::ui::status;
 
 /// Check if anaconda-mcp is installed by looking for its conda-meta entry.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 fn is_anaconda_mcp_installed() -> bool {
     let Some(conda_prefix) = std::env::var("CONDA_PREFIX").ok() else {
         return false;
@@ -38,7 +38,7 @@ fn is_anaconda_mcp_installed() -> bool {
 /// When built without `conda-package` feature, auto-installs anaconda-cli if not present.
 /// When built with `conda-package` feature, anaconda-cli is expected to be provided by conda,
 /// and anaconda-mcp must be installed for the mcp subcommand to work.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 pub async fn run(_ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
     if !is_anaconda_mcp_installed() {
         return Err(crate::errors::AnacondaMcpNotInstalledError.into());
@@ -49,7 +49,7 @@ pub async fn run(_ctx: &mut CommandContext, args: &[String]) -> miette::Result<(
     tools::run_tool_binary("anaconda-cli", "anaconda", &mcp_args)
 }
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 pub async fn run(ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
     if !paths::tool_prefix("anaconda-cli").exists() {
         status::info("Installing anaconda-cli...");

--- a/src/mcp/run.rs
+++ b/src/mcp/run.rs
@@ -1,10 +1,22 @@
 use crate::context::CommandContext;
+#[cfg(not(feature = "conda-package"))]
 use crate::paths;
 use crate::tools;
+#[cfg(not(feature = "conda-package"))]
 use crate::ui::status;
 
 /// Run the `anaconda mcp` command with the given arguments.
-/// Auto-installs anaconda-cli if not present.
+///
+/// When built without `conda-package` feature, auto-installs anaconda-cli if not present.
+/// When built with `conda-package` feature, anaconda-cli is expected to be provided by conda.
+#[cfg(feature = "conda-package")]
+pub async fn run(_ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
+    let mut mcp_args = vec!["mcp".to_string()];
+    mcp_args.extend(args.iter().cloned());
+    tools::run_tool_binary("anaconda-cli", "anaconda", &mcp_args)
+}
+
+#[cfg(not(feature = "conda-package"))]
 pub async fn run(ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
     if !paths::tool_prefix("anaconda-cli").exists() {
         status::info("Installing anaconda-cli...");

--- a/src/mcp/run.rs
+++ b/src/mcp/run.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "conda-package")]
+use std::path::PathBuf;
+
 use crate::context::CommandContext;
 #[cfg(not(feature = "conda-package"))]
 use crate::paths;
@@ -5,12 +8,42 @@ use crate::tools;
 #[cfg(not(feature = "conda-package"))]
 use crate::ui::status;
 
+/// Check if anaconda-mcp is installed by looking for its conda-meta entry.
+#[cfg(feature = "conda-package")]
+fn is_anaconda_mcp_installed() -> bool {
+    let Some(conda_prefix) = std::env::var("CONDA_PREFIX").ok() else {
+        return false;
+    };
+
+    let conda_meta = PathBuf::from(&conda_prefix).join("conda-meta");
+    if !conda_meta.is_dir() {
+        return false;
+    }
+
+    // Look for anaconda-mcp-*.json in conda-meta
+    std::fs::read_dir(&conda_meta)
+        .map(|entries| {
+            entries.filter_map(|e| e.ok()).any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("anaconda-mcp-")
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Run the `anaconda mcp` command with the given arguments.
 ///
 /// When built without `conda-package` feature, auto-installs anaconda-cli if not present.
-/// When built with `conda-package` feature, anaconda-cli is expected to be provided by conda.
+/// When built with `conda-package` feature, anaconda-cli is expected to be provided by conda,
+/// and anaconda-mcp must be installed for the mcp subcommand to work.
 #[cfg(feature = "conda-package")]
 pub async fn run(_ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
+    if !is_anaconda_mcp_installed() {
+        return Err(crate::errors::AnacondaMcpNotInstalledError.into());
+    }
+
     let mut mcp_args = vec!["mcp".to_string()];
     mcp_args.extend(args.iter().cloned());
     tools::run_tool_binary("anaconda-cli", "anaconda", &mcp_args)

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -33,6 +33,7 @@ fn tools_dir() -> PathBuf {
 }
 
 /// Returns the bin directory for shims (~/.ana/bin).
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn bin_dir() -> PathBuf {
     ana_home().join("bin")
 }
@@ -52,6 +53,7 @@ pub fn binary_name(name: &str) -> String {
 }
 
 /// Returns the path to a binary in the bin directory, adding .exe on Windows.
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn bin_path(name: &str) -> PathBuf {
     bin_dir().join(binary_name(name))
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,10 +1,13 @@
+#[cfg(tool_install)]
 pub mod install;
 pub mod list;
 #[cfg(feature = "unstable")]
 pub mod pip;
+#[cfg(tool_install)]
 mod pixi_config;
 mod run;
 pub mod specs;
+#[cfg(tool_install)]
 pub mod uninstall;
 #[cfg(feature = "unstable")]
 pub mod utils;

--- a/src/tools/run.rs
+++ b/src/tools/run.rs
@@ -3,14 +3,14 @@ use std::process::Command;
 
 use miette::miette;
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 use crate::paths;
 
 /// Resolve the path to a tool binary.
 ///
 /// When built with `conda-package` feature, looks in `$CONDA_PREFIX/bin/`.
 /// Otherwise, looks in the tool's installation directory under `~/.ana/tools/`.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 fn resolve_tool_binary(binary_name: &str) -> miette::Result<PathBuf> {
     let conda_prefix = std::env::var("CONDA_PREFIX")
         .map_err(|_| miette!("CONDA_PREFIX not set. Are you in an active conda environment?"))?;
@@ -35,7 +35,7 @@ fn resolve_tool_binary(binary_name: &str) -> miette::Result<PathBuf> {
     Ok(tool_bin)
 }
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 fn resolve_tool_binary_with_tool_name(
     tool_name: &str,
     binary_name: &str,
@@ -60,13 +60,13 @@ fn resolve_tool_binary_with_tool_name(
 ///
 /// When built with `conda-package` feature, the `tool_name` parameter is ignored
 /// and the binary is resolved from `$CONDA_PREFIX/bin/`.
-#[cfg(feature = "conda-package")]
+#[cfg(not(tool_install))]
 pub fn run_tool_binary(_tool_name: &str, binary_name: &str, args: &[String]) -> miette::Result<()> {
     let tool_bin = resolve_tool_binary(binary_name)?;
     run_binary(&tool_bin, binary_name, args)
 }
 
-#[cfg(not(feature = "conda-package"))]
+#[cfg(tool_install)]
 pub fn run_tool_binary(tool_name: &str, binary_name: &str, args: &[String]) -> miette::Result<()> {
     let tool_bin = resolve_tool_binary_with_tool_name(tool_name, binary_name)?;
     run_binary(&tool_bin, binary_name, args)

--- a/src/tools/run.rs
+++ b/src/tools/run.rs
@@ -1,27 +1,79 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 use miette::miette;
 
+#[cfg(not(feature = "conda-package"))]
 use crate::paths;
 
-/// Run a binary from within a tool's installation directory.
-pub fn run_tool_binary(tool_name: &str, binary_name: &str, args: &[String]) -> miette::Result<()> {
+/// Resolve the path to a tool binary.
+///
+/// When built with `conda-package` feature, looks in `$CONDA_PREFIX/bin/`.
+/// Otherwise, looks in the tool's installation directory under `~/.ana/tools/`.
+#[cfg(feature = "conda-package")]
+fn resolve_tool_binary(binary_name: &str) -> miette::Result<PathBuf> {
+    let conda_prefix = std::env::var("CONDA_PREFIX")
+        .map_err(|_| miette!("CONDA_PREFIX not set. Are you in an active conda environment?"))?;
+
+    let bin_subdir = if cfg!(windows) { "Scripts" } else { "bin" };
+    let binary = if cfg!(windows) {
+        format!("{}.exe", binary_name)
+    } else {
+        binary_name.to_string()
+    };
+
+    let tool_bin = PathBuf::from(&conda_prefix).join(bin_subdir).join(&binary);
+
+    if !tool_bin.exists() {
+        return Err(miette!(
+            "{} not found at {}. Is the conda environment configured correctly?",
+            binary_name,
+            tool_bin.display()
+        ));
+    }
+
+    Ok(tool_bin)
+}
+
+#[cfg(not(feature = "conda-package"))]
+fn resolve_tool_binary_with_tool_name(
+    tool_name: &str,
+    binary_name: &str,
+) -> miette::Result<PathBuf> {
     let bin_subdir = if cfg!(windows) { "Scripts" } else { "bin" };
     let binary = paths::binary_name(binary_name);
     let tool_bin = paths::tool_prefix(tool_name).join(bin_subdir).join(&binary);
 
     if !tool_bin.exists() {
-        let msg = format!(
+        return Err(miette!(
             "{} not found at {}. Run `ana tool install {}` first.",
             binary_name,
             tool_bin.display(),
             tool_name
-        );
-        tracing::error!("{}", msg);
-        return Err(miette!(msg));
+        ));
     }
 
-    let status = Command::new(&tool_bin)
+    Ok(tool_bin)
+}
+
+/// Run a binary from within a tool's installation directory.
+///
+/// When built with `conda-package` feature, the `tool_name` parameter is ignored
+/// and the binary is resolved from `$CONDA_PREFIX/bin/`.
+#[cfg(feature = "conda-package")]
+pub fn run_tool_binary(_tool_name: &str, binary_name: &str, args: &[String]) -> miette::Result<()> {
+    let tool_bin = resolve_tool_binary(binary_name)?;
+    run_binary(&tool_bin, binary_name, args)
+}
+
+#[cfg(not(feature = "conda-package"))]
+pub fn run_tool_binary(tool_name: &str, binary_name: &str, args: &[String]) -> miette::Result<()> {
+    let tool_bin = resolve_tool_binary_with_tool_name(tool_name, binary_name)?;
+    run_binary(&tool_bin, binary_name, args)
+}
+
+fn run_binary(tool_bin: &PathBuf, binary_name: &str, args: &[String]) -> miette::Result<()> {
+    let status = Command::new(tool_bin)
         .args(args)
         .status()
         .map_err(|e| miette!("Failed to run {}: {}", binary_name, e))?;

--- a/src/tools/specs.rs
+++ b/src/tools/specs.rs
@@ -59,7 +59,7 @@ pub fn binaries(name: &str) -> Option<Vec<PathBuf>> {
 }
 
 /// Returns the binary names to link for a tool.
-#[cfg_attr(feature = "conda-package", allow(dead_code))]
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn binary_names(name: &str) -> Option<Vec<&'static str>> {
     find_tool(name).map(|t| {
         t.binaries

--- a/src/tools/specs.rs
+++ b/src/tools/specs.rs
@@ -59,6 +59,7 @@ pub fn binaries(name: &str) -> Option<Vec<PathBuf>> {
 }
 
 /// Returns the binary names to link for a tool.
+#[cfg_attr(feature = "conda-package", allow(dead_code))]
 pub fn binary_names(name: &str) -> Option<Vec<&'static str>> {
     find_tool(name).map(|t| {
         t.binaries

--- a/src/tools/specs.rs
+++ b/src/tools/specs.rs
@@ -3,11 +3,13 @@
 use std::path::PathBuf;
 
 /// Tool configuration.
+#[cfg_attr(not(tool_install), allow(dead_code))]
 struct Tool {
     name: &'static str,
+    #[cfg_attr(not(tool_install), allow(dead_code))]
     lockfile: &'static str,
     binaries: &'static [&'static [&'static str]],
-    /// If set, the tool is experimental and this message will be shown as a warning.
+    #[cfg_attr(not(tool_install), allow(dead_code))]
     experimental: Option<&'static str>,
 }
 
@@ -44,6 +46,7 @@ fn find_tool(name: &str) -> Option<&'static Tool> {
 ///
 /// If `ANA_LOCKFILES_DIR` is set, reads from that directory.
 /// Otherwise, returns the embedded lockfile compiled into the binary.
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn content(name: &str) -> Option<String> {
     if let Ok(dir) = std::env::var("ANA_LOCKFILES_DIR") {
         let path = PathBuf::from(dir).join(name).join("pixi.lock");
@@ -75,6 +78,7 @@ pub fn all_tools() -> Vec<&'static str> {
 }
 
 /// Returns the experimental warning message for a tool, if any.
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn experimental_message(name: &str) -> Option<&'static str> {
     find_tool(name).and_then(|t| t.experimental)
 }

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -11,7 +11,7 @@ use crate::paths;
 ///
 /// Removes the tool's environment and any symlinks in the bin directory.
 /// Cleans up empty directories afterward.
-#[cfg_attr(feature = "conda-package", allow(dead_code))]
+#[cfg_attr(not(tool_install), allow(dead_code))]
 pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
     ctx.telemetry.add("tool_name", name.to_string());
 
@@ -94,7 +94,7 @@ pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miet
 }
 
 /// Remove a directory if it's empty.
-#[cfg_attr(feature = "conda-package", allow(dead_code))]
+#[cfg_attr(not(tool_install), allow(dead_code))]
 fn cleanup_empty_dir(path: &std::path::Path) -> miette::Result<()> {
     if !path.exists() {
         return Ok(());

--- a/src/tools/uninstall.rs
+++ b/src/tools/uninstall.rs
@@ -11,6 +11,7 @@ use crate::paths;
 ///
 /// Removes the tool's environment and any symlinks in the bin directory.
 /// Cleans up empty directories afterward.
+#[cfg_attr(feature = "conda-package", allow(dead_code))]
 pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
     ctx.telemetry.add("tool_name", name.to_string());
 
@@ -93,6 +94,7 @@ pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miet
 }
 
 /// Remove a directory if it's empty.
+#[cfg_attr(feature = "conda-package", allow(dead_code))]
 fn cleanup_empty_dir(path: &std::path::Path) -> miette::Result<()> {
     if !path.exists() {
         return Ok(());

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,3 +1,10 @@
+//! Self-update functionality for ana.
+//!
+//! This module is compiled out when built without the `self-update` feature
+//! (e.g., when installed via conda where updates are managed externally).
+
+#![cfg_attr(not(feature = "self-update"), allow(dead_code, unused_imports))]
+
 use std::collections::HashMap;
 
 use serde::Deserialize;

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,7 +3,7 @@
 //! This module is compiled out when built without the `self-update` feature
 //! (e.g., when installed via conda where updates are managed externally).
 
-#![cfg_attr(not(feature = "self-update"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(self_update), allow(dead_code, unused_imports))]
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary
Adds feature flags and build infrastructure to support distributing `ana` as a conda package:

- **`conda-package` feature**: When enabled, disables self-managed functionality (self-update, tool install/uninstall) since these are managed by conda
- **`self-update` feature**: Makes `ana self update` optional (included by default, disabled for conda builds)
- **`tool-install` feature**: Makes `ana tool install/uninstall` optional with rattler as an optional dependency (included by default, disabled for conda builds)
- **cfg-aliases**: Uses `cfg_aliases` crate for cleaner feature flag handling in the codebase
- **anaconda-mcp check**: Checks for `anaconda-mcp` availability before running MCP subcommand rather than hard-depending on it
- **Recipe updates**: Updated conda recipe to use the new feature flags

When built with `--no-default-features --features conda-package`:
- `ana self update` returns an error explaining it's not available
- `ana tool install/uninstall` returns an error explaining tools are managed by conda
- `ana tool list` still works (shows available tools)
- `ana bootstrap` is a no-op (anaconda-cli provided by conda)
- Binary resolution uses `$CONDA_PREFIX/bin/` instead of internal tool paths

## Test plan
- [ ] `cargo build` - default features work
- [ ] `cargo build --no-default-features --features conda-package` - conda package build works
- [ ] `cargo test` - all tests pass
- [ ] `cargo clippy` - no warnings