### PR TITLE
feat: Add experimental fleet feature for conda-ship tool installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 [[package]]
 name = "conda-ship"
 version = "0.4.0"
-source = "git+https://github.com/jezdez/conda-ship?branch=fix%2Fconda-fleet-api#32118e89cedaa2bda100abe0946d97182c3a9649"
+source = "git+https://github.com/jezdez/conda-ship?rev=32118e89cedaa2bda100abe0946d97182c3a9649#32118e89cedaa2bda100abe0946d97182c3a9649"
 dependencies = [
  "astral-reqwest-middleware",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
+ "conda-ship",
  "console",
  "dirs",
  "figment",
@@ -815,6 +816,36 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "conda-ship"
+version = "0.4.0"
+source = "git+https://github.com/jezdez/conda-ship?branch=fix%2Fconda-fleet-api#32118e89cedaa2bda100abe0946d97182c3a9649"
+dependencies = [
+ "astral-reqwest-middleware",
+ "clap",
+ "console",
+ "dirs",
+ "futures",
+ "indicatif",
+ "miette",
+ "rattler",
+ "rattler_cache",
+ "rattler_conda_types",
+ "rattler_lock",
+ "rattler_networking",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.11.0",
+ "tar",
+ "tempfile",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing-subscriber",
+ "zstd",
+]
 
 [[package]]
 name = "configparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,13 +819,14 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conda-ship"
-version = "0.4.0"
-source = "git+https://github.com/jezdez/conda-ship?rev=32118e89cedaa2bda100abe0946d97182c3a9649#32118e89cedaa2bda100abe0946d97182c3a9649"
+version = "0.7.0"
+source = "git+https://github.com/jezdez/conda-ship?tag=0.7.0#b1eac5dfcc9e0403f29f416bc2084d00fca5974f"
 dependencies = [
  "astral-reqwest-middleware",
  "clap",
  "console",
  "dirs",
+ "fs4 0.13.1",
  "futures",
  "indicatif",
  "miette",
@@ -834,6 +835,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_lock",
  "rattler_networking",
+ "rattler_package_streaming",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -842,8 +844,9 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 
@@ -1198,7 +1201,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1294,7 +1297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1432,6 +1435,16 @@ checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1852,7 +1865,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2055,7 +2068,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2215,7 +2228,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2515,7 +2528,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3322,7 +3335,7 @@ dependencies = [
  "digest 0.11.3",
  "dirs",
  "fs-err",
- "fs4",
+ "fs4 1.1.0",
  "futures",
  "hex",
  "itertools 0.15.0",
@@ -3906,7 +3919,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4657,7 +4670,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4667,7 +4680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5524,7 +5537,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ rlimit = "0.11"
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 # Unstable features are hidden and disabled by default.
+# fleet: Use conda-ship's fleet API for tool installation (experimental POC).
 default = []
 diagnostics = ["dep:sentry"]
 unstable = []
+fleet = ["dep:conda-ship"]
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }
@@ -33,6 +35,7 @@ rattler = { version = "0.47", default-features = false, features = ["indicatif"]
 rattler_cache = { version = "0.10", default-features = false }
 rattler_conda_types = { version = "0.48", default-features = false }
 rattler_lock = { version = "0.31", default-features = false }
+conda-ship = { git = "https://github.com/jezdez/conda-ship", branch = "fix/conda-fleet-api", default-features = false, features = ["fleet", "native-tls"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }
 rpassword = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ rattler = { version = "0.47", default-features = false, features = ["indicatif"]
 rattler_cache = { version = "0.10", default-features = false }
 rattler_conda_types = { version = "0.48", default-features = false }
 rattler_lock = { version = "0.31", default-features = false }
-conda-ship = { git = "https://github.com/jezdez/conda-ship", branch = "fix/conda-fleet-api", default-features = false, features = ["fleet", "native-tls"], optional = true }
+# Branch: fix/conda-fleet-api
+conda-ship = { git = "https://github.com/jezdez/conda-ship", rev = "32118e89cedaa2bda100abe0946d97182c3a9649", default-features = false, features = ["fleet", "native-tls"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }
 rpassword = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,7 @@ rattler = { version = "0.47", default-features = false, features = ["indicatif"]
 rattler_cache = { version = "0.10", default-features = false }
 rattler_conda_types = { version = "0.48", default-features = false }
 rattler_lock = { version = "0.31", default-features = false }
-# Branch: fix/conda-fleet-api
-conda-ship = { git = "https://github.com/jezdez/conda-ship", rev = "32118e89cedaa2bda100abe0946d97182c3a9649", default-features = false, features = ["fleet", "native-tls"], optional = true }
+conda-ship = { git = "https://github.com/jezdez/conda-ship", tag = "0.7.0", default-features = false, features = ["fleet", "native-tls"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }
 rpassword = "7"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ build: release  ## Build the release binary (alias for release)
 debug:  ## Build the debug binary
 	pixi run build-debug
 
+fleet:  ## Build the debug binary with fleet feature (experimental)
+	pixi run build-fleet
+
 release:  ## Build the release binary
 	pixi run build-release
 

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:874ba002-2b5e-4884-8e89-86f322576c32",
+  "serialNumber": "urn:uuid:19bf709a-fd96-49f7-a95f-c7550b1698ed",
   "metadata": {
-    "timestamp": "2026-08-02T07:02:28Z",
+    "timestamp": "2026-08-04T20:39:31Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -9731,6 +9731,41 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+      "name": "socket2",
+      "version": "0.5.10",
+      "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/socket2@0.5.10",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/socket2"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/rust-lang/socket2"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-lang/socket2"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
       "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
       "name": "socket2",
@@ -14794,7 +14829,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -15216,7 +15251,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
         "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
@@ -15368,7 +15403,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -15607,7 +15642,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -16759,6 +16794,13 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.5.10",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
@@ -16870,14 +16912,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
@@ -17566,7 +17608,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-08-02T07:02:28Z<br>
+Generated: 2026-08-04T20:39:31Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 457 (59 platform-specific)<br>
+Packages: 458 (59 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -338,6 +338,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.1 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.2 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.5.10 | MIT OR Apache-2.0 |  |  |
 | [socket2](https://crates.io/crates/socket2) | 0.6.5 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
@@ -472,7 +473,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 250 |
+| MIT OR Apache-2.0 | 251 |
 | MIT | 84 |
 | Apache-2.0 OR MIT | 35 |
 | Apache-2.0 | 21 |

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,6 +39,10 @@ description = "Build the Windows shim binary"
 cmd = "python scripts/with_version.py cargo auditable build"
 description = "Build the standalone Rust binary in debug mode"
 
+[tasks.build-fleet]
+cmd = "python scripts/with_version.py cargo auditable build --features fleet"
+description = "Build the debug binary with fleet feature (experimental)"
+
 [tasks.build-release]
 cmd = "python scripts/with_version.py cargo auditable build --release"
 description = "Build the standalone Rust binary in release mode"

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -2,6 +2,7 @@ use crate::context::CommandContext;
 use crate::paths;
 use crate::tools;
 
+#[cfg(not(feature = "fleet"))]
 pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     if paths::tool_prefix("anaconda-cli").exists() {
         eprintln!("anaconda-cli is already installed");
@@ -10,6 +11,22 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
 
     eprintln!("Installing anaconda-cli...");
     tools::install::install_tool(ctx, "anaconda-cli")
+        .await
+        .map_err(|e| format!("{:?}", e))?;
+
+    eprintln!("anaconda-cli installed successfully");
+    Ok(())
+}
+
+#[cfg(feature = "fleet")]
+pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
+    if paths::tool_prefix("anaconda-cli").exists() {
+        eprintln!("anaconda-cli is already installed");
+        return Ok(());
+    }
+
+    eprintln!("Installing anaconda-cli...");
+    tools::fleet::install_tool(ctx, "anaconda-cli")
         .await
         .map_err(|e| format!("{:?}", e))?;
 

--- a/src/anaconda_cli.rs
+++ b/src/anaconda_cli.rs
@@ -2,7 +2,6 @@ use crate::context::CommandContext;
 use crate::paths;
 use crate::tools;
 
-#[cfg(not(feature = "fleet"))]
 pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     if paths::tool_prefix("anaconda-cli").exists() {
         eprintln!("anaconda-cli is already installed");
@@ -10,23 +9,7 @@ pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
     }
 
     eprintln!("Installing anaconda-cli...");
-    tools::install::install_tool(ctx, "anaconda-cli")
-        .await
-        .map_err(|e| format!("{:?}", e))?;
-
-    eprintln!("anaconda-cli installed successfully");
-    Ok(())
-}
-
-#[cfg(feature = "fleet")]
-pub async fn run_bootstrap(ctx: &mut CommandContext) -> Result<(), String> {
-    if paths::tool_prefix("anaconda-cli").exists() {
-        eprintln!("anaconda-cli is already installed");
-        return Ok(());
-    }
-
-    eprintln!("Installing anaconda-cli...");
-    tools::fleet::install_tool(ctx, "anaconda-cli")
+    tools::install_tool(ctx, "anaconda-cli")
         .await
         .map_err(|e| format!("{:?}", e))?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,24 +326,44 @@ impl Action {
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
+            #[cfg(not(feature = "fleet"))]
             Action::ToolInstall { name } => {
                 tools::install::install_tool(ctx, &name).await?;
                 Ok(())
             }
+            #[cfg(feature = "fleet")]
+            Action::ToolInstall { name } => {
+                tools::fleet::install_tool(ctx, &name).await?;
+                Ok(())
+            }
+            #[cfg(not(feature = "fleet"))]
             Action::ToolUninstall { name, force } => {
                 tools::uninstall::uninstall_tool(ctx, &name, force)?;
+                Ok(())
+            }
+            #[cfg(feature = "fleet")]
+            Action::ToolUninstall { name, force } => {
+                tools::fleet::uninstall_tool(ctx, &name, force)?;
                 Ok(())
             }
             Action::ToolList => {
                 tools::list::print_tool_list(ctx);
                 Ok(())
             }
+            #[cfg(not(feature = "fleet"))]
             Action::ToolUpdate => {
                 let updated = tools::install::update_installed_tools(ctx).await?;
                 if updated.is_empty() {
                     eprintln!("All tools are up to date.");
                 }
                 Ok(())
+            }
+            #[cfg(feature = "fleet")]
+            Action::ToolUpdate => {
+                // TODO: Implement update for fleet
+                Err(miette!(
+                    "Tool update is not yet supported with the fleet feature"
+                ))
             }
             Action::Login {
                 api_key,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,44 +326,24 @@ impl Action {
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
-            #[cfg(not(feature = "fleet"))]
             Action::ToolInstall { name } => {
-                tools::install::install_tool(ctx, &name).await?;
+                tools::install_tool(ctx, &name).await?;
                 Ok(())
             }
-            #[cfg(feature = "fleet")]
-            Action::ToolInstall { name } => {
-                tools::fleet::install_tool(ctx, &name).await?;
-                Ok(())
-            }
-            #[cfg(not(feature = "fleet"))]
             Action::ToolUninstall { name, force } => {
-                tools::uninstall::uninstall_tool(ctx, &name, force)?;
-                Ok(())
-            }
-            #[cfg(feature = "fleet")]
-            Action::ToolUninstall { name, force } => {
-                tools::fleet::uninstall_tool(ctx, &name, force)?;
+                tools::uninstall_tool(ctx, &name, force)?;
                 Ok(())
             }
             Action::ToolList => {
                 tools::list::print_tool_list(ctx);
                 Ok(())
             }
-            #[cfg(not(feature = "fleet"))]
             Action::ToolUpdate => {
-                let updated = tools::install::update_installed_tools(ctx).await?;
+                let updated = tools::update_installed_tools(ctx).await?;
                 if updated.is_empty() {
                     eprintln!("All tools are up to date.");
                 }
                 Ok(())
-            }
-            #[cfg(feature = "fleet")]
-            Action::ToolUpdate => {
-                // TODO: Implement update for fleet
-                Err(miette!(
-                    "Tool update is not yet supported with the fleet feature"
-                ))
             }
             Action::Login {
                 api_key,

--- a/src/mcp/run.rs
+++ b/src/mcp/run.rs
@@ -2,9 +2,9 @@ use crate::context::CommandContext;
 use crate::tools;
 
 /// Run the `anaconda mcp` command with the given arguments.
-/// Auto-installs or updates anaconda-cli as needed.
+/// Auto-installs anaconda-cli as needed.
 pub async fn run(ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
-    tools::install::ensure_tool(ctx, "anaconda-cli").await?;
+    tools::ensure_tool(ctx, "anaconda-cli").await?;
 
     let mut mcp_args = vec!["mcp".to_string()];
     mcp_args.extend(args.iter().cloned());

--- a/src/outerbounds/configure.rs
+++ b/src/outerbounds/configure.rs
@@ -208,11 +208,7 @@ fn run_ob_configure(magic_string: &str) -> miette::Result<()> {
 /// Auto-configure Outerbounds using Anaconda SSO.
 pub async fn auto_configure(ctx: &mut CommandContext, ob_domain: &str) -> miette::Result<()> {
     // Ensure outerbounds tool is installed
-    if !crate::paths::bin_path("outerbounds").exists() {
-        status::info("Installing outerbounds tool...");
-        tools::install::install_tool(ctx, "outerbounds").await?;
-        status::blank_line();
-    }
+    tools::ensure_tool(ctx, "outerbounds").await?;
 
     status::info("Configuring Outerbounds via Anaconda SSO");
     status::blank_line();

--- a/src/outerbounds/run.rs
+++ b/src/outerbounds/run.rs
@@ -6,8 +6,7 @@ use super::{InitOptions, ensure_configured, init_project, open_app, view_app};
 
 /// Run the outerbounds CLI wrapper with the given arguments.
 pub async fn run(ctx: &mut CommandContext, args: &[String]) -> miette::Result<()> {
-    // Auto-install or update outerbounds tool as needed
-    tools::install::ensure_tool(ctx, "outerbounds").await?;
+    tools::ensure_tool(ctx, "outerbounds").await?;
 
     // Handle `ob app open <name>`
     if args.len() >= 3 && args[0] == "app" && args[1] == "open" {

--- a/src/tools/fleet.rs
+++ b/src/tools/fleet.rs
@@ -13,6 +13,36 @@ use super::{pixi_config, specs};
 use crate::context::CommandContext;
 use crate::paths;
 
+/// Check if a prefix is an old rattler-based installation (pre-Fleet).
+///
+/// Old installations have:
+/// - A `conda-meta/` directory (bootstrapped conda prefix)
+/// - A `.lockfile-hash` file (ana's old staleness marker)
+/// - No `.{name}.json` Fleet metadata file
+fn is_legacy_rattler_install(prefix: &Path, name: &str) -> bool {
+    let conda_meta = prefix.join("conda-meta");
+    let lockfile_hash = prefix.join(".lockfile-hash");
+    let fleet_metadata = conda_meta.join(format!(".{}.json", name));
+
+    conda_meta.is_dir() && lockfile_hash.exists() && !fleet_metadata.exists()
+}
+
+/// Migrate a legacy rattler-based installation to Fleet.
+///
+/// This removes the old prefix so Fleet can do a fresh install.
+fn migrate_legacy_install(prefix: &Path, name: &str) -> miette::Result<()> {
+    crate::ui::status::info(&format!(
+        "Migrating {} from legacy installation to Fleet...",
+        name
+    ));
+
+    std::fs::remove_dir_all(prefix)
+        .into_diagnostic()
+        .with_context(|| format!("failed to remove legacy installation: {}", prefix.display()))?;
+
+    Ok(())
+}
+
 /// Install a tool using conda-ship's Fleet API.
 pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
     ctx.telemetry.add("tool_name", name.to_string());
@@ -41,6 +71,11 @@ pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Resul
 
     let fleet = Fleet::new(paths::ana_home().join("tools"));
     let prefix = paths::tool_prefix(name);
+
+    // Migrate legacy rattler-based installations
+    if is_legacy_rattler_install(&prefix, name) {
+        migrate_legacy_install(&prefix, name)?;
+    }
 
     eprintln!("Installing {} into {}", name, prefix.display());
 

--- a/src/tools/fleet.rs
+++ b/src/tools/fleet.rs
@@ -1,0 +1,380 @@
+//! Tool installation using conda-ship's Fleet API.
+//!
+//! This module replaces the direct rattler-based installation with conda-ship's
+//! Fleet API, which provides a higher-level abstraction for managing multiple
+//! locked conda prefixes.
+
+use std::path::{Path, PathBuf};
+
+use conda_ship::fleet::{Fleet, InstallOptions, InstalledRuntime, RuntimeSpec};
+use miette::{Context, IntoDiagnostic};
+
+use super::{pixi_config, specs};
+use crate::context::CommandContext;
+use crate::paths;
+
+/// Install a tool using conda-ship's Fleet API.
+pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
+    ctx.telemetry.add("tool_name", name.to_string());
+
+    if let Some(msg) = specs::experimental_message(name) {
+        crate::ui::status::warn(msg);
+        eprintln!();
+    }
+
+    let lock_content =
+        specs::content(name).ok_or_else(|| miette::miette!("unknown tool: {}", name))?;
+
+    let binaries = specs::binaries(name).unwrap_or_default();
+    let binary_names = specs::binary_names(name).unwrap_or_default();
+
+    let delegate = binary_names.first().copied().unwrap_or(name);
+    let requested_specs: Vec<String> = binary_names.iter().map(|s| s.to_string()).collect();
+
+    let spec = RuntimeSpec {
+        id: name.to_string(),
+        version: tool_version_from_lock(&lock_content, name)?,
+        delegate_executable: delegate.to_string(),
+        lock_content,
+        requested_specs,
+    };
+
+    let fleet = Fleet::new(paths::ana_home().join("tools"));
+    let prefix = paths::tool_prefix(name);
+
+    eprintln!("Installing {} into {}", name, prefix.display());
+
+    let installed = fleet
+        .install(spec, InstallOptions::default())
+        .await
+        .with_context(|| format!("failed to install tool: {}", name))?;
+
+    eprintln!(
+        "   Installed {} v{} to {}",
+        installed.id,
+        installed.version,
+        installed.prefix.display()
+    );
+
+    create_bin_symlinks(&installed, &binaries)?;
+
+    if name == "pixi" {
+        pixi_config::configure_default_channels(&paths::bin_path("pixi"))?;
+    }
+
+    Ok(())
+}
+
+/// Uninstall a tool using conda-ship's Fleet API.
+pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
+    ctx.telemetry.add("tool_name", name.to_string());
+
+    if specs::binaries(name).is_none() {
+        return Err(miette::miette!("unknown tool: {}", name));
+    }
+
+    let fleet = Fleet::new(paths::ana_home().join("tools"));
+    let bin_dir = paths::bin_dir();
+
+    let status = fleet.status(name)?;
+    if status.is_none() {
+        eprintln!("{} is not installed", name);
+        return Ok(());
+    }
+
+    let mut to_delete: Vec<String> = Vec::new();
+
+    if let Some(binaries) = specs::binary_names(name) {
+        for binary in binaries {
+            let link_path = paths::bin_path(binary);
+            if link_path.exists() || link_path.is_symlink() {
+                to_delete.push(format!("  {}", link_path.display()));
+            }
+        }
+    }
+
+    let prefix = paths::tool_prefix(name);
+    to_delete.push(format!("  {}", prefix.display()));
+
+    eprintln!("The following will be removed:");
+    for item in &to_delete {
+        eprintln!("{}", item);
+    }
+    eprintln!();
+
+    if !force && !crate::input::prompt_yes_no("Proceed with uninstall?", false) {
+        eprintln!("Aborted.");
+        return Ok(());
+    }
+
+    eprintln!();
+    eprintln!("Uninstalling {}...", name);
+
+    if let Some(binaries) = specs::binary_names(name) {
+        for binary in &binaries {
+            let link_path = paths::bin_path(binary);
+            if link_path.exists() || link_path.is_symlink() {
+                std::fs::remove_file(&link_path)
+                    .into_diagnostic()
+                    .with_context(|| format!("failed to remove: {}", link_path.display()))?;
+                eprintln!("   Removed {}", link_path.display());
+            }
+        }
+
+        #[cfg(windows)]
+        remove_shims_cfg_entries(&binaries)?;
+    }
+
+    fleet
+        .remove(name)
+        .with_context(|| format!("failed to remove tool: {}", name))?;
+
+    eprintln!("   Removed {}", prefix.display());
+
+    cleanup_empty_dir(&bin_dir)?;
+
+    eprintln!("Successfully uninstalled {}", name);
+
+    Ok(())
+}
+
+/// List installed tools using Fleet API.
+pub fn list_installed() -> miette::Result<Vec<InstalledRuntime>> {
+    let fleet = Fleet::new(paths::ana_home().join("tools"));
+    fleet.list()
+}
+
+/// Get status of a specific tool.
+#[allow(dead_code)]
+pub fn tool_status(name: &str) -> miette::Result<Option<InstalledRuntime>> {
+    let fleet = Fleet::new(paths::ana_home().join("tools"));
+    fleet.status(name)
+}
+
+/// Extract version from lockfile for a tool.
+fn tool_version_from_lock(lock_content: &str, tool_name: &str) -> miette::Result<String> {
+    // Parse the lockfile to find the tool's version
+    // Look for a package that matches the tool name
+    for line in lock_content.lines() {
+        let line = line.trim();
+        if line.starts_with("- conda:") && line.contains(&format!("/{tool_name}-")) {
+            // Extract version from URL like: .../pixi-0.70.2-hef7b95b_0.conda
+            if let Some(filename) = line.rsplit('/').next() {
+                let parts: Vec<&str> = filename.split('-').collect();
+                if parts.len() >= 2 {
+                    return Ok(parts[1].to_string());
+                }
+            }
+        }
+    }
+
+    // Fallback to "latest" if we can't extract a version
+    Ok("latest".to_string())
+}
+
+/// Create symlinks (Unix) or shims (Windows) for the tool's binaries in ~/.ana/bin/
+fn create_bin_symlinks(installed: &InstalledRuntime, binaries: &[PathBuf]) -> miette::Result<()> {
+    let bin_dir = paths::bin_dir();
+    std::fs::create_dir_all(&bin_dir)
+        .into_diagnostic()
+        .context("failed to create bin directory")?;
+
+    for binary in binaries {
+        #[cfg(unix)]
+        create_bin_symlink(&bin_dir, &installed.prefix, binary)?;
+        #[cfg(windows)]
+        create_bin_shim(&bin_dir, &installed.prefix, binary)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_bin_symlink(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::Result<()> {
+    let tool_bin = prefix.join(binary);
+    let symlink_path = bin_dir.join(binary.file_name().unwrap());
+
+    if !tool_bin.exists() {
+        eprintln!(
+            "   Warning: binary '{}' not found in {}",
+            binary.display(),
+            prefix.display()
+        );
+        return Ok(());
+    }
+
+    if symlink_path.exists() || symlink_path.is_symlink() {
+        std::fs::remove_file(&symlink_path)
+            .into_diagnostic()
+            .context("failed to remove existing symlink")?;
+    }
+
+    std::os::unix::fs::symlink(&tool_bin, &symlink_path)
+        .into_diagnostic()
+        .with_context(|| format!("failed to create symlink: {}", symlink_path.display()))?;
+
+    eprintln!(
+        "   Linked {} -> {}",
+        symlink_path.display(),
+        tool_bin.display()
+    );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+const SHIM_BINARY: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shim.exe"));
+
+#[cfg(windows)]
+fn create_bin_shim(bin_dir: &Path, prefix: &Path, binary: &Path) -> miette::Result<()> {
+    let tool_bin = prefix.join(binary).with_extension("exe");
+    let shim_name = binary.file_stem().unwrap().to_string_lossy();
+    let shim_path = bin_dir.join(format!("{}.exe", shim_name));
+
+    if !tool_bin.exists() {
+        eprintln!(
+            "   Warning: binary '{}' not found in {}",
+            binary.display(),
+            prefix.display()
+        );
+        return Ok(());
+    }
+
+    std::fs::write(&shim_path, SHIM_BINARY)
+        .into_diagnostic()
+        .with_context(|| format!("failed to write shim: {}", shim_path.display()))?;
+
+    let tool_name = prefix.file_name().unwrap().to_string_lossy();
+    let rel_target = format!("{}\\{}", tool_name, binary.with_extension("exe").display());
+    update_shims_cfg(&shim_name, &rel_target)?;
+
+    eprintln!(
+        "   Created shim {} -> {}",
+        shim_path.display(),
+        tool_bin.display()
+    );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn update_shims_cfg(shim_name: &str, target_path: &str) -> miette::Result<()> {
+    let config_path = paths::ana_home().join("tools").join("shims.cfg");
+
+    let mut entries: Vec<(String, String)> = if config_path.exists() {
+        std::fs::read_to_string(&config_path)
+            .into_diagnostic()
+            .context("failed to read shims.cfg")?
+            .lines()
+            .filter_map(|line| {
+                line.split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let mut found = false;
+    for (name, path) in &mut entries {
+        if name == shim_name {
+            *path = target_path.to_string();
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        entries.push((shim_name.to_string(), target_path.to_string()));
+    }
+
+    let content: String = entries
+        .iter()
+        .map(|(k, v)| format!("{}={}\r\n", k, v))
+        .collect::<Vec<_>>()
+        .join("");
+
+    std::fs::write(&config_path, content)
+        .into_diagnostic()
+        .context("failed to write shims.cfg")?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn remove_shims_cfg_entries(binaries: &[&str]) -> miette::Result<()> {
+    let config_path = paths::ana_home().join("tools").join("shims.cfg");
+
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&config_path)
+        .into_diagnostic()
+        .context("failed to read shims.cfg")?;
+
+    let new_content: String = content
+        .lines()
+        .filter(|line| {
+            if let Some((name, _)) = line.split_once('=') {
+                !binaries.contains(&name)
+            } else {
+                true
+            }
+        })
+        .map(|line| format!("{}\r\n", line))
+        .collect();
+
+    std::fs::write(&config_path, new_content)
+        .into_diagnostic()
+        .context("failed to write shims.cfg")?;
+
+    Ok(())
+}
+
+fn cleanup_empty_dir(path: &Path) -> miette::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let is_empty = path
+        .read_dir()
+        .into_diagnostic()
+        .with_context(|| format!("failed to read directory: {}", path.display()))?
+        .next()
+        .is_none();
+
+    if is_empty {
+        std::fs::remove_dir(path)
+            .into_diagnostic()
+            .with_context(|| format!("failed to remove empty directory: {}", path.display()))?;
+        eprintln!("   Cleaned up empty directory: {}", path.display());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_version_from_lock() {
+        let lock_content = r#"
+version: 6
+environments:
+  default:
+    packages:
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixi-0.70.2-h46fb4a7_0.conda
+"#;
+        let version = tool_version_from_lock(lock_content, "pixi").unwrap();
+        assert_eq!(version, "0.70.2");
+    }
+
+    #[test]
+    fn test_tool_version_from_lock_fallback() {
+        let lock_content = "version: 6\n";
+        let version = tool_version_from_lock(lock_content, "unknown").unwrap();
+        assert_eq!(version, "latest");
+    }
+}

--- a/src/tools/fleet.rs
+++ b/src/tools/fleet.rs
@@ -67,6 +67,9 @@ pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Resul
         delegate_executable: delegate.to_string(),
         lock_content,
         requested_specs,
+        condarc: None,
+        freeze_base: false,
+        installer: None,
     };
 
     let fleet = Fleet::new(paths::ana_home().join("tools"));
@@ -111,7 +114,7 @@ pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miet
     let fleet = Fleet::new(paths::ana_home().join("tools"));
     let bin_dir = paths::bin_dir();
 
-    let status = fleet.status(name)?;
+    let status = fleet.get(name)?;
     if status.is_none() {
         eprintln!("{} is not installed", name);
         return Ok(());
@@ -183,7 +186,7 @@ pub fn list_installed() -> miette::Result<Vec<InstalledRuntime>> {
 #[allow(dead_code)]
 pub fn tool_status(name: &str) -> miette::Result<Option<InstalledRuntime>> {
     let fleet = Fleet::new(paths::ana_home().join("tools"));
-    fleet.status(name)
+    fleet.get(name)
 }
 
 /// Extract version from lockfile for a tool.

--- a/src/tools/list.rs
+++ b/src/tools/list.rs
@@ -12,6 +12,8 @@ use super::specs;
 pub struct ToolInfo {
     pub name: &'static str,
     pub installed: bool,
+    #[cfg(feature = "fleet")]
+    pub version: Option<String>,
     pub binaries: Vec<PathBuf>,
 }
 
@@ -46,6 +48,7 @@ const INSTALLERS: &[Installer] = &[
 ];
 
 /// List all available tools with their installation status.
+#[cfg(not(feature = "fleet"))]
 pub fn list_tools() -> Vec<ToolInfo> {
     specs::all_tools()
         .iter()
@@ -62,7 +65,39 @@ pub fn list_tools() -> Vec<ToolInfo> {
         .collect()
 }
 
+/// List all available tools with their installation status (fleet version).
+#[cfg(feature = "fleet")]
+pub fn list_tools() -> Vec<ToolInfo> {
+    let installed_runtimes = super::fleet::list_installed().unwrap_or_default();
+
+    specs::all_tools()
+        .iter()
+        .map(|name| {
+            let binaries = specs::binaries(name).unwrap_or_default();
+
+            // Check if this tool is installed via fleet
+            let (installed, version) = installed_runtimes
+                .iter()
+                .find(|r| r.id == *name)
+                .map(|r| (true, Some(r.version.clone())))
+                .unwrap_or_else(|| {
+                    // Fallback to checking if prefix exists (for pre-fleet installs)
+                    let prefix = paths::tool_prefix(name);
+                    (prefix.exists(), None)
+                });
+
+            ToolInfo {
+                name,
+                installed,
+                version,
+                binaries,
+            }
+        })
+        .collect()
+}
+
 /// Print the tool list as a formatted table.
+#[cfg(not(feature = "fleet"))]
 pub fn print_tool_list(_ctx: &mut CommandContext) {
     let tools = list_tools();
 
@@ -81,6 +116,39 @@ pub fn print_tool_list(_ctx: &mut CommandContext) {
             .collect::<Vec<_>>()
             .join(", ");
         table.add_row([table::cell(tool.name), status_cell, table::cell(&binaries)]);
+    }
+
+    println!("{table}");
+
+    print_installer_list();
+}
+
+/// Print the tool list as a formatted table (fleet version with version column).
+#[cfg(feature = "fleet")]
+pub fn print_tool_list(_ctx: &mut CommandContext) {
+    let tools = list_tools();
+
+    let mut table = table::new(["Name", "Installed", "Version", "Binaries"]);
+
+    for tool in tools {
+        let status_cell = if tool.installed {
+            table::cell("✓").fg(Color::Green)
+        } else {
+            table::cell("✗").fg(Color::Red)
+        };
+        let version = tool.version.as_deref().unwrap_or("-");
+        let binaries = tool
+            .binaries
+            .iter()
+            .filter_map(|b| b.file_stem().and_then(|s| s.to_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        table.add_row([
+            table::cell(tool.name),
+            status_cell,
+            table::cell(version),
+            table::cell(&binaries),
+        ]);
     }
 
     println!("{table}");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,10 +1,16 @@
+#[cfg(feature = "fleet")]
+pub mod fleet;
+#[cfg(not(feature = "fleet"))]
 pub mod install;
+#[cfg(feature = "fleet")]
+pub use fleet::install_tool;
 pub mod list;
 #[cfg(feature = "unstable")]
 pub mod pip;
 mod pixi_config;
 mod run;
 pub mod specs;
+#[cfg(not(feature = "fleet"))]
 pub mod uninstall;
 #[cfg(feature = "unstable")]
 pub mod utils;
@@ -16,7 +22,18 @@ pub use run::run_tool_binary;
 use crate::context::CommandContext;
 
 /// Ensure a tool is installed, installing it if necessary.
+#[cfg(not(feature = "fleet"))]
 pub async fn ensure_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
     install::ensure_tool(ctx, name).await?;
+    Ok(())
+}
+
+#[cfg(feature = "fleet")]
+pub async fn ensure_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
+    if !crate::paths::tool_prefix(name).exists() {
+        crate::ui::status::info(&format!("Installing {}...", name));
+        fleet::install_tool(ctx, name).await?;
+        crate::ui::status::blank_line();
+    }
     Ok(())
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -12,3 +12,11 @@ pub mod utils;
 pub mod uv;
 
 pub use run::run_tool_binary;
+
+use crate::context::CommandContext;
+
+/// Ensure a tool is installed, installing it if necessary.
+pub async fn ensure_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
+    install::ensure_tool(ctx, name).await?;
+    Ok(())
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "fleet")]
-pub mod fleet;
+mod fleet;
 #[cfg(not(feature = "fleet"))]
-pub mod install;
-#[cfg(feature = "fleet")]
-pub use fleet::install_tool;
+mod install;
 pub mod list;
 #[cfg(feature = "unstable")]
 pub mod pip;
@@ -11,7 +9,7 @@ mod pixi_config;
 mod run;
 pub mod specs;
 #[cfg(not(feature = "fleet"))]
-pub mod uninstall;
+mod uninstall;
 #[cfg(feature = "unstable")]
 pub mod utils;
 #[cfg(feature = "unstable")]
@@ -20,6 +18,50 @@ pub mod uv;
 pub use run::run_tool_binary;
 
 use crate::context::CommandContext;
+
+/// Returns the names of all currently installed tools.
+#[cfg(not(feature = "fleet"))]
+pub fn installed_tools() -> Vec<&'static str> {
+    install::installed_tools()
+}
+
+/// Install a tool by name.
+#[cfg(not(feature = "fleet"))]
+pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
+    install::install_tool(ctx, name).await
+}
+
+#[cfg(feature = "fleet")]
+pub async fn install_tool(ctx: &mut CommandContext, name: &str) -> miette::Result<()> {
+    fleet::install_tool(ctx, name).await
+}
+
+/// Uninstall a tool by name.
+#[cfg(not(feature = "fleet"))]
+pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
+    uninstall::uninstall_tool(ctx, name, force)
+}
+
+#[cfg(feature = "fleet")]
+pub fn uninstall_tool(ctx: &mut CommandContext, name: &str, force: bool) -> miette::Result<()> {
+    fleet::uninstall_tool(ctx, name, force)
+}
+
+/// Update all installed tools.
+///
+/// Returns the names of tools that were updated.
+#[cfg(not(feature = "fleet"))]
+pub async fn update_installed_tools(ctx: &mut CommandContext) -> miette::Result<Vec<String>> {
+    install::update_installed_tools(ctx).await
+}
+
+#[cfg(feature = "fleet")]
+pub async fn update_installed_tools(_ctx: &mut CommandContext) -> miette::Result<Vec<String>> {
+    // TODO: Implement update for fleet
+    Err(miette::miette!(
+        "Tool update is not yet supported with the fleet feature"
+    ))
+}
 
 /// Ensure a tool is installed, installing it if necessary.
 #[cfg(not(feature = "fleet"))]

--- a/src/update.rs
+++ b/src/update.rs
@@ -422,6 +422,7 @@ fn print_update_success(current_version: &str, new_version: &str, elapsed: std::
 ///
 /// After self-replace, the current process still has old lockfiles embedded.
 /// We spawn the new binary to update tools using the new lockfiles.
+#[cfg(not(feature = "fleet"))]
 fn update_installed_tools() {
     use crate::tools::install::installed_tools;
     use crate::ui::status;
@@ -455,6 +456,12 @@ fn update_installed_tools() {
             status::error(&format!("Failed to update tools: {}", e));
         }
     }
+}
+
+#[cfg(feature = "fleet")]
+fn update_installed_tools() {
+    // TODO: Implement tool update for fleet
+    // For now, skip automatic tool updates when using fleet
 }
 
 fn print_up_to_date(current_version: &str) {

--- a/src/update.rs
+++ b/src/update.rs
@@ -424,7 +424,7 @@ fn print_update_success(current_version: &str, new_version: &str, elapsed: std::
 /// We spawn the new binary to update tools using the new lockfiles.
 #[cfg(not(feature = "fleet"))]
 fn update_installed_tools() {
-    use crate::tools::install::installed_tools;
+    use crate::tools::installed_tools;
     use crate::ui::status;
 
     let tools = installed_tools();


### PR DESCRIPTION
## Summary

Adds experimental integration with [conda-ship's Fleet API](https://github.com/jezdez/conda-ship/pull/45) for managing tool installations. When the `fleet` feature is enabled, tool installation uses conda-ship instead of direct rattler calls.

**This is a POC branch** to help identify gaps in the conda-ship Fleet API. Not intended for merge until the upstream PR is finalized.

### What Fleet provides:
- Higher-level abstraction for managing multiple locked conda prefixes
- Shared rattler cache across tools
- Version tracking via Fleet metadata files
- Staleness detection using lock file SHA256 hashes

### Changes:
- Add `conda-ship` as an optional dependency gated behind `fleet` feature
- Add `src/tools/fleet.rs` with Fleet API integration
- Refactor to expose unified public functions from tools module (`install_tool`, `uninstall_tool`, etc.)
- CLI interface has no feature flags - branching logic is encapsulated in `tools/mod.rs`

### Usage:
```bash
# Build with fleet feature
cargo build --features fleet

# Install a tool using Fleet
./target/debug/ana tool install pixi
```

## Test plan
- [x] `cargo build` (default, without fleet) compiles
- [x] `cargo build --features fleet` compiles
- [x] `cargo test` passes
- [x] `cargo clippy` passes (both with and without fleet)
- [ ] Manual test: `ana tool install pixi` with fleet feature
- [ ] Manual test: `ana tool uninstall pixi` with fleet feature
- [ ] Manual test: `ana tool list` shows version info with fleet feature

## Related
- Upstream PR: https://github.com/jezdez/conda-ship/pull/45