### PR TITLE
feat: Add background update notification system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -21,20 +21,20 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.12.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
- "foldhash 0.1.5",
+ "foldhash",
  "futures-core",
  "http 0.2.12",
  "httparse",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.13.0"
+version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -129,7 +129,7 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "encoding_rs",
- "foldhash 0.1.5",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -144,7 +144,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "time",
  "tracing",
  "url",
@@ -204,7 +204,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ dependencies = [
  "owo-colors",
  "rattler",
  "rattler_cache",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_lock",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -246,7 +246,7 @@ dependencies = [
  "sha2 0.11.0",
  "temp-env",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "toml 1.1.3+spec-1.1.0",
  "toml_edit",
@@ -266,7 +266,7 @@ dependencies = [
  "base64",
  "cargo-lock",
  "dirs",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "libc",
  "mac_address",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert-json-diff"
@@ -391,21 +391,21 @@ dependencies = [
  "http 1.4.2",
  "reqwest 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tower-service",
 ]
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -423,7 +423,7 @@ dependencies = [
  "itertools 0.14.0",
  "memmap2",
  "reqwest 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -440,7 +440,7 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
 ]
@@ -476,13 +476,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -559,9 +559,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
@@ -622,15 +628,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -664,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -682,15 +688,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -713,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -723,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -735,14 +741,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -812,9 +818,9 @@ checksum = "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -892,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -902,18 +908,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -921,7 +927,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -986,7 +992,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -997,7 +1003,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1043,10 +1049,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.0"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -1080,7 +1117,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1124,7 +1161,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1133,7 +1170,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1145,7 +1182,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1193,7 +1230,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1220,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1236,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "figment"
@@ -1261,7 +1298,7 @@ checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "typed-path",
  "url",
 ]
@@ -1322,12 +1359,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1358,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1380,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1395,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1405,15 +1436,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1422,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1441,32 +1472,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1517,17 +1548,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1586,22 +1615,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1671,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -1681,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1694,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "http-content-range"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1"
+checksum = "0298eab7a8b2346aa6e6b3502dfddf643735e45864cbe4ce9c73606cecb8b53f"
 
 [[package]]
 name = "httparse"
@@ -1712,24 +1732,24 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1795,12 +1815,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -1815,7 +1835,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1910,12 +1930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.1.9"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "indexmap"
@@ -1973,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2004,7 +2018,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2045,10 +2059,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2057,14 +2073,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.28"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2079,7 +2105,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -2094,7 +2120,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2113,24 +2139,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2143,7 +2169,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2172,7 +2198,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2182,12 +2208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,15 +2215,15 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2278,15 +2298,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2327,7 +2347,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2358,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2397,7 +2417,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2410,7 +2430,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2422,7 +2442,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2461,7 +2481,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2504,7 +2524,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2525,7 +2545,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2536,7 +2556,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2569,7 +2589,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2587,7 +2607,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2600,7 +2620,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2611,7 +2631,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2623,7 +2643,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2675,7 +2695,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2691,7 +2711,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2722,7 +2742,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2752,7 +2772,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.12.28",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2791,8 +2811,8 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -2902,7 +2922,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2972,7 +2992,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2989,22 +3009,22 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3040,20 +3060,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3066,7 +3076,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3079,9 +3089,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3107,10 +3117,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3122,7 +3132,7 @@ dependencies = [
  "hex",
  "percent-encoding",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3142,18 +3152,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3172,9 +3182,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3182,12 +3192,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3252,7 +3262,7 @@ dependencies = [
  "parking_lot",
  "path_resolver",
  "rattler_cache",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_digest",
  "rattler_menuinst",
  "rattler_networking",
@@ -3267,7 +3277,7 @@ dependencies = [
  "simple_spawn_blocking",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -3292,7 +3302,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "parking_lot",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -3302,7 +3312,7 @@ dependencies = [
  "serde_json",
  "simple_spawn_blocking",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -3344,7 +3354,49 @@ dependencies = [
  "smallvec",
  "strum",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
+ "tracing",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "rattler_conda_types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017a8ae50486c176ed5dcd2b2118883e1eb89abcacb6fdb434b6f5cb5aa2fdf7"
+dependencies = [
+ "ahash",
+ "core-foundation 0.10.1",
+ "dirs",
+ "fancy-regex",
+ "file_url",
+ "fs-err",
+ "glob",
+ "hex",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "jiff",
+ "lazy-regex",
+ "memmap2",
+ "nom",
+ "nom-language",
+ "purl",
+ "rattler_digest",
+ "rattler_macros",
+ "rattler_redaction",
+ "regex",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "serde_yaml",
+ "simd-json",
+ "smallvec",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.19",
  "tracing",
  "typed-path",
  "url",
@@ -3372,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.3"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
+checksum = "0fc13501d19e0994f1d460569a89b595d3a7808d9c7948ec44f29b3cb202bc9b"
 dependencies = [
  "ahash",
  "file_url",
@@ -3383,7 +3435,7 @@ dependencies = [
  "jiff",
  "pep440_rs",
  "pep508_rs",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.0",
  "rattler_digest",
  "rattler_solve",
  "serde",
@@ -3392,7 +3444,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "serde_yaml",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "typed-path",
  "url",
@@ -3406,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3424,7 +3476,7 @@ dependencies = [
  "once_cell",
  "plist",
  "quick-xml 0.37.5",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_shell",
  "regex",
  "serde",
@@ -3432,12 +3484,12 @@ dependencies = [
  "sha2 0.11.0",
  "shlex",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "unicode-normalization",
  "which",
  "windows 0.61.3",
- "windows-registry",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -3454,7 +3506,7 @@ dependencies = [
  "base64",
  "fs-err",
  "futures",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "http 1.4.2",
  "http-auth",
  "itertools 0.14.0",
@@ -3463,7 +3515,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -3486,12 +3538,12 @@ dependencies = [
  "futures",
  "futures-util",
  "getrandom 0.2.17",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hex",
  "http 1.4.2",
  "jiff",
  "num_cpus",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
@@ -3500,7 +3552,7 @@ dependencies = [
  "simple_spawn_blocking",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3543,30 +3595,30 @@ dependencies = [
  "fs-err",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "rattler_conda_types",
+ "rattler_conda_types 0.47.2",
  "rattler_pty",
  "serde_json",
  "shlex",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
+checksum = "fb5972bed20c404d943da0ed351bbd97cd91b01086620bc68563e9dfe173c198"
 dependencies = [
  "hex",
  "itertools 0.14.0",
  "jiff",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.0",
  "rattler_digest",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -3596,7 +3648,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3607,34 +3659,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3644,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3656,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3773,7 +3825,7 @@ dependencies = [
  "http 1.4.2",
  "reqwest 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tower-service",
 ]
 
@@ -3783,7 +3835,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -3832,15 +3884,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3867,18 +3919,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3889,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -3909,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3994,7 +4046,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4097,7 +4149,7 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -4130,7 +4182,7 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58d26379236c4ef97eaf081bca3c7bf0ef6f06b3aa881eca2ee8e8dbc923e5b8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -4145,10 +4197,10 @@ checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -4156,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4198,29 +4250,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -4232,13 +4284,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -4291,7 +4343,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4366,15 +4418,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd-json"
-version = "0.17.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
 dependencies = [
  "halfbrown",
  "ref-cast",
@@ -4386,9 +4438,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4402,9 +4454,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_spawn_blocking"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+checksum = "83a7b2679ee03cca581f57e5a4fecac405aa6b5d5174abe65b4b41fa181d8438"
 dependencies = [
  "tokio",
 ]
@@ -4436,9 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4474,7 +4526,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4516,9 +4568,20 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4542,7 +4605,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4566,7 +4629,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4608,10 +4671,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4621,7 +4684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4645,11 +4708,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4660,34 +4723,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "js-sys",
@@ -4706,9 +4769,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4726,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4741,9 +4804,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4751,20 +4814,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4801,14 +4864,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4840,7 +4904,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4871,7 +4935,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4880,7 +4944,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4943,7 +5007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4991,7 +5055,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5240,13 +5304,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -5259,9 +5323,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -5330,23 +5394,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5357,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5367,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5377,46 +5432,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -5433,22 +5466,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5482,18 +5503,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -5520,7 +5541,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5647,7 +5668,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5658,7 +5679,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5702,6 +5723,17 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5857,9 +5889,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5889,97 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5999,9 +5943,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"
@@ -6028,28 +5972,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6069,7 +6013,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6109,7 +6053,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6129,15 +6073,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "owo-colors",
  "rattler",
  "rattler_cache",
- "rattler_conda_types 0.47.2",
+ "rattler_conda_types",
  "rattler_lock",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.18"
+version = "0.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
+checksum = "bd939d79959c3f49a648a1d7857d63cc62548725a6b060b8dbf0ea5c92470b63"
 dependencies = [
  "async-compression",
  "crc32fast",
@@ -482,7 +482,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -518,7 +518,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -714,14 +714,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -741,14 +741,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1292,11 +1292,11 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
+checksum = "5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "percent-encoding",
  "thiserror 2.0.19",
  "typed-path",
@@ -1399,14 +1399,14 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "fs-err",
  "rustix",
  "tokio",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1568,9 +1568,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1656,7 +1656,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1820,7 +1820,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1958,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
+checksum = "134d2c4324d61664107020b79019cf6a6aec153f0b79bc9619ee9e794a5fb021"
 
 [[package]]
 name = "indexmap"
@@ -2052,6 +2052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,7 +2116,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2215,9 +2224,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -2422,18 +2431,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -2884,19 +2881,19 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "path_resolver"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
+checksum = "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
 dependencies = [
  "ahash",
  "fs-err",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "proptest",
  "tempfile",
  "tracing",
@@ -3015,7 +3012,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap 2.14.0",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3143,15 +3140,6 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -3237,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.45.0"
+version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
+checksum = "417e0f429d4c0f849d8e862c6d522efb35c6cb48cb6fb9e34a9a26fb6b70850f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -3254,7 +3242,7 @@ dependencies = [
  "humantime",
  "indexmap 2.14.0",
  "indicatif",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "memchr",
  "memmap2",
@@ -3262,7 +3250,7 @@ dependencies = [
  "parking_lot",
  "path_resolver",
  "rattler_cache",
- "rattler_conda_types 0.47.2",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_menuinst",
  "rattler_networking",
@@ -3286,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
+checksum = "1e608aa1824f88fbdf0839ed2e5d5a762692cad6aa864a725b44844d79e28c8e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3300,9 +3288,9 @@ dependencies = [
  "fs4",
  "futures",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "parking_lot",
- "rattler_conda_types 0.47.2",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -3320,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.47.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
+checksum = "f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -3333,49 +3321,7 @@ dependencies = [
  "glob",
  "hex",
  "indexmap 2.14.0",
- "itertools 0.14.0",
- "jiff",
- "lazy-regex",
- "memmap2",
- "nom",
- "nom-language",
- "purl",
- "rattler_digest",
- "rattler_macros",
- "rattler_redaction",
- "regex",
- "serde",
- "serde-untagged",
- "serde_json",
- "serde_repr",
- "serde_with",
- "serde_yaml",
- "simd-json",
- "smallvec",
- "strum",
- "tempfile",
- "thiserror 2.0.19",
- "tracing",
- "typed-path",
- "url",
-]
-
-[[package]]
-name = "rattler_conda_types"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017a8ae50486c176ed5dcd2b2118883e1eb89abcacb6fdb434b6f5cb5aa2fdf7"
-dependencies = [
- "ahash",
- "core-foundation 0.10.1",
- "dirs",
- "fancy-regex",
- "file_url",
- "fs-err",
- "glob",
- "hex",
- "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "lazy-regex",
  "memmap2",
@@ -3404,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
+checksum = "56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3"
 dependencies = [
  "blake2",
  "digest 0.11.3",
@@ -3424,18 +3370,18 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc13501d19e0994f1d460569a89b595d3a7808d9c7948ec44f29b3cb202bc9b"
+checksum = "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
 dependencies = [
  "ahash",
  "file_url",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "pep440_rs",
  "pep508_rs",
- "rattler_conda_types 0.48.0",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_solve",
  "serde",
@@ -3453,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
+checksum = "bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -3463,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.67"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
+checksum = "b99d32612f64644cbcaf39caf83fb89409477b579985735930996fe1f71b0cf2"
 dependencies = [
  "configparser",
  "dirs",
@@ -3475,8 +3421,8 @@ dependencies = [
  "known-folders",
  "once_cell",
  "plist",
- "quick-xml 0.37.5",
- "rattler_conda_types 0.47.2",
+ "quick-xml",
+ "rattler_conda_types",
  "rattler_shell",
  "regex",
  "serde",
@@ -3488,15 +3434,15 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "which",
- "windows 0.61.3",
- "windows-registry 0.5.3",
+ "windows 0.62.2",
+ "windows-registry",
 ]
 
 [[package]]
 name = "rattler_networking"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
+checksum = "a79426b2af3db171d23fba74bfa9abf832367af610bbee76f979d47f9a094f2a"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -3509,7 +3455,7 @@ dependencies = [
  "getrandom 0.4.3",
  "http 1.4.2",
  "http-auth",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "reqwest 0.13.4",
  "retry-policies",
  "serde",
@@ -3522,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.5"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
+checksum = "4db3af7641d6c40af2f8f2be0a494ad4d04c3825dc5ed1e7957d3c019637b5b2"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -3543,7 +3489,7 @@ dependencies = [
  "http 1.4.2",
  "jiff",
  "num_cpus",
- "rattler_conda_types 0.47.2",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
@@ -3563,21 +3509,21 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
+checksum = "ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix 0.31.3",
  "signal-hook",
  "tokio",
 ]
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b"
+checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest 0.13.4",
@@ -3586,16 +3532,16 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.7"
+version = "0.27.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
+checksum = "40e36d0927ce8ee7cc7648be7060f8d1bbda9ac0afeb24e280af644d21d6ba28"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fs-err",
  "indexmap 2.14.0",
- "itertools 0.14.0",
- "rattler_conda_types 0.47.2",
+ "itertools 0.15.0",
+ "rattler_conda_types",
  "rattler_pty",
  "serde_json",
  "shlex",
@@ -3607,14 +3553,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5972bed20c404d943da0ed351bbd97cd91b01086620bc68563e9dfe173c198"
+checksum = "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
 dependencies = [
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
- "rattler_conda_types 0.48.0",
+ "rattler_conda_types",
  "rattler_digest",
  "serde",
  "tempfile",
@@ -3679,7 +3625,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4265,7 +4211,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4290,7 +4236,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4398,9 +4344,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4579,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4734,7 +4680,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4852,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5562,36 +5508,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
+ "windows-collections",
  "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -5614,39 +5538,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5656,8 +5556,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5684,25 +5584,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -5711,18 +5595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -5731,18 +5604,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5751,16 +5615,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5769,7 +5624,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5796,7 +5651,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5817,20 +5672,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ unstable = []
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }
 async-trait = "0.1"
 base64 = "0.22"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 futures-util = "0.3"
 dirs = "6"
 figment = { version = "0.10", features = ["env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ console = "0.16"
 indicatif = "0.18"
 log = "0.4"
 miette = { version = "7.6", features = ["fancy"] }
-rattler = { version = "0.45", default-features = false, features = ["indicatif"] }
+rattler = { version = "0.47", default-features = false, features = ["indicatif"] }
 rattler_cache = { version = "0.10", default-features = false }
-rattler_conda_types = { version = "0.47", default-features = false }
+rattler_conda_types = { version = "0.48", default-features = false }
 rattler_lock = { version = "0.31", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:bb8fc7e6-7527-449e-b22e-901d23b75cdc",
+  "serialNumber": "urn:uuid:0672b760-30e4-4448-b8cf-9c34449c78a3",
   "metadata": {
-    "timestamp": "2026-07-15T15:42:38Z",
+    "timestamp": "2026-07-21T14:29:34Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -394,16 +394,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "anyhow",
-      "version": "1.0.102",
+      "version": "1.0.104",
       "description": "Flexible concrete Error type built on std::error::Error",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+          "content": "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
         }
       ],
       "licenses": [
@@ -411,7 +411,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/anyhow@1.0.102",
+      "purl": "pkg:cargo/anyhow@1.0.104",
       "externalReferences": [
         {
           "type": "documentation",
@@ -452,16 +452,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.4",
       "author": "Alex Crichton <alex@alexcrichton.com>, dignifiedquire <me@dignifiequire.com>, Artem Vorotnikov <artem@vorotnikov.me>, Aiden McClelland <me@drbonez.dev>",
       "name": "astral-tokio-tar",
-      "version": "0.6.2",
+      "version": "0.6.4",
       "description": "A Rust implementation of an async TAR file reader and writer. This library does not currently handle compression, but it is abstract over all I/O readers and writers. Additionally, great lengths are taken to ensure that the entire contents are never required to be entirely resident in memory all at once. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+          "content": "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
         }
       ],
       "licenses": [
@@ -469,7 +469,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/astral-tokio-tar@0.6.2",
+      "purl": "pkg:cargo/astral-tokio-tar@0.6.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -637,16 +637,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "async-trait",
-      "version": "0.1.89",
+      "version": "0.1.91",
       "description": "Type erasure for async trait methods",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+          "content": "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
         }
       ],
       "licenses": [
@@ -654,7 +654,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/async-trait@0.1.89",
+      "purl": "pkg:cargo/async-trait@0.1.91",
       "externalReferences": [
         {
           "type": "documentation",
@@ -888,16 +888,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
       "author": "The Rust Project Developers",
       "name": "bitflags",
-      "version": "2.13.0",
+      "version": "1.3.2",
       "description": "A macro to generate structures which behave like bitflags. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+          "content": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
         }
       ],
       "licenses": [
@@ -905,7 +905,42 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/bitflags@2.13.0",
+      "purl": "pkg:cargo/bitflags@1.3.2",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/bitflags"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bitflags/bitflags"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/bitflags/bitflags"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
+      "author": "The Rust Project Developers",
+      "name": "bitflags",
+      "version": "2.13.1",
+      "description": "A macro to generate structures which behave like bitflags. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/bitflags@2.13.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1100,16 +1135,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
       "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "bytes",
-      "version": "1.11.1",
+      "version": "1.12.1",
       "description": "Types and traits for working with bytes",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+          "content": "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
         }
       ],
       "licenses": [
@@ -1117,7 +1152,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/bytes@1.11.1",
+      "purl": "pkg:cargo/bytes@1.12.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1192,16 +1227,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.2.64",
+      "version": "1.3.0",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+          "content": "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
         }
       ],
       "licenses": [
@@ -1209,7 +1244,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.2.64",
+      "purl": "pkg:cargo/cc@1.3.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1254,16 +1289,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
       "author": "Zicklag <zicklag@katharostech.com>",
       "name": "cfg_aliases",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "description": "A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+          "content": "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
         }
       ],
       "licenses": [
@@ -1271,7 +1306,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/cfg_aliases@0.2.1",
+      "purl": "pkg:cargo/cfg_aliases@0.2.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1295,16 +1330,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.1",
       "author": "RustCrypto Developers",
       "name": "chacha20",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "description": "The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2). Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+          "content": "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
         }
       ],
       "licenses": [
@@ -1312,7 +1347,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/chacha20@0.10.0",
+      "purl": "pkg:cargo/chacha20@0.10.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1360,15 +1395,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
       "name": "clap",
-      "version": "4.6.1",
+      "version": "4.6.3",
       "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+          "content": "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
         }
       ],
       "licenses": [
@@ -1376,7 +1411,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/clap@4.6.1",
+      "purl": "pkg:cargo/clap@4.6.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1386,15 +1421,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.2",
       "name": "clap_builder",
-      "version": "4.6.0",
+      "version": "4.6.2",
       "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+          "content": "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
         }
       ],
       "licenses": [
@@ -1402,7 +1437,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/clap_builder@4.6.0",
+      "purl": "pkg:cargo/clap_builder@4.6.2",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1412,15 +1447,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3",
       "name": "clap_derive",
-      "version": "4.6.1",
+      "version": "4.6.3",
       "description": "Parse command line argument by defining a struct, derive crate.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+          "content": "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
         }
       ],
       "licenses": [
@@ -1428,7 +1463,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/clap_derive@4.6.1",
+      "purl": "pkg:cargo/clap_derive@4.6.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1651,15 +1686,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
       "name": "console",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "description": "A terminal and console abstraction for Rust",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+          "content": "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
         }
       ],
       "licenses": [
@@ -1667,7 +1702,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/console@0.16.3",
+      "purl": "pkg:cargo/console@0.16.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1809,15 +1844,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
       "name": "crossbeam-deque",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "description": "Concurrent work-stealing deque",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+          "content": "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
         }
       ],
       "licenses": [
@@ -1825,7 +1860,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/crossbeam-deque@0.8.6",
+      "purl": "pkg:cargo/crossbeam-deque@0.8.7",
       "externalReferences": [
         {
           "type": "website",
@@ -1839,15 +1874,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20",
       "name": "crossbeam-epoch",
-      "version": "0.9.18",
+      "version": "0.9.20",
       "description": "Epoch-based garbage collection",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+          "content": "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
         }
       ],
       "licenses": [
@@ -1855,7 +1890,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/crossbeam-epoch@0.9.18",
+      "purl": "pkg:cargo/crossbeam-epoch@0.9.20",
       "externalReferences": [
         {
           "type": "website",
@@ -1869,15 +1904,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22",
       "name": "crossbeam-utils",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "description": "Utilities for concurrent programming",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+          "content": "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
         }
       ],
       "licenses": [
@@ -1885,7 +1920,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/crossbeam-utils@0.8.21",
+      "purl": "pkg:cargo/crossbeam-utils@0.8.22",
       "externalReferences": [
         {
           "type": "website",
@@ -2138,6 +2173,95 @@
         {
           "type": "vcs",
           "url": "https://github.com/xacrimon/dashmap"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.1",
+      "author": "The Knurling-rs developers",
+      "name": "defmt-macros",
+      "version": "1.1.1",
+      "description": "defmt macros",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt-macros@1.1.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+      "author": "The Knurling-rs developers",
+      "name": "defmt-parser",
+      "version": "1.0.0",
+      "description": "Parsing library for defmt format strings",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt-parser@1.0.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.1",
+      "author": "The Knurling-rs developers",
+      "name": "defmt",
+      "version": "1.1.1",
+      "description": "A highly efficient logging framework that targets resource-constrained devices, like microcontrollers",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/defmt@1.1.1",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://knurling.ferrous-systems.com/"
+        },
+        {
+          "type": "other",
+          "url": "defmt"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/knurling-rs/defmt"
         }
       ]
     },
@@ -2600,16 +2724,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.5.0",
       "author": "Stjepan Glavina <stjepang@gmail.com>",
       "name": "fastrand",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "description": "A simple and fast random number generator",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+          "content": "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
         }
       ],
       "licenses": [
@@ -2617,7 +2741,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/fastrand@2.4.1",
+      "purl": "pkg:cargo/fastrand@2.5.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -2967,16 +3091,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
       "author": "Andrew Hickman <andrew.hickman1@sky.com>",
       "name": "fs-err",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "A drop-in replacement for std::fs with more helpful error messages.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+          "content": "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
         }
       ],
       "licenses": [
@@ -2984,7 +3108,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/fs-err@3.3.0",
+      "purl": "pkg:cargo/fs-err@3.3.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3029,15 +3153,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
       "name": "futures-channel",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "Channels for asynchronous communication using futures-rs. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+          "content": "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
         }
       ],
       "licenses": [
@@ -3045,7 +3169,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-channel@0.3.32",
+      "purl": "pkg:cargo/futures-channel@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3059,15 +3183,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
       "name": "futures-core",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "The core traits and types in for the `futures` library. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+          "content": "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
         }
       ],
       "licenses": [
@@ -3075,7 +3199,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-core@0.3.32",
+      "purl": "pkg:cargo/futures-core@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3089,15 +3213,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.33",
       "name": "futures-executor",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "Executors for asynchronous tasks based on the futures-rs library. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+          "content": "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
         }
       ],
       "licenses": [
@@ -3105,7 +3229,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-executor@0.3.32",
+      "purl": "pkg:cargo/futures-executor@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3119,15 +3243,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
       "name": "futures-io",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+          "content": "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
         }
       ],
       "licenses": [
@@ -3135,7 +3259,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-io@0.3.32",
+      "purl": "pkg:cargo/futures-io@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3184,15 +3308,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.33",
       "name": "futures-macro",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "The futures-rs procedural macro implementations. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+          "content": "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
         }
       ],
       "licenses": [
@@ -3200,7 +3324,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-macro@0.3.32",
+      "purl": "pkg:cargo/futures-macro@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3214,15 +3338,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
       "name": "futures-sink",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "The asynchronous `Sink` trait for the futures-rs library. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+          "content": "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
         }
       ],
       "licenses": [
@@ -3230,7 +3354,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-sink@0.3.32",
+      "purl": "pkg:cargo/futures-sink@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3244,15 +3368,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.33",
       "name": "futures-task",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "Tools for working with tasks. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+          "content": "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
         }
       ],
       "licenses": [
@@ -3260,7 +3384,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-task@0.3.32",
+      "purl": "pkg:cargo/futures-task@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3274,15 +3398,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
       "name": "futures-util",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "Common utilities and extension traits for the futures-rs library. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+          "content": "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
         }
       ],
       "licenses": [
@@ -3290,7 +3414,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures-util@0.3.32",
+      "purl": "pkg:cargo/futures-util@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3304,15 +3428,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
       "name": "futures",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "description": "An implementation of futures and streams featuring zero allocations, composability, and iterator-like interfaces. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+          "content": "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
         }
       ],
       "licenses": [
@@ -3320,7 +3444,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/futures@0.3.32",
+      "purl": "pkg:cargo/futures@0.3.33",
       "externalReferences": [
         {
           "type": "website",
@@ -3427,16 +3551,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
       "author": "The Rand Project Developers",
       "name": "getrandom",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "description": "A small cross-platform library for retrieving random data from system source",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+          "content": "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
         }
       ],
       "licenses": [
@@ -3444,7 +3568,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/getrandom@0.4.2",
+      "purl": "pkg:cargo/getrandom@0.4.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3803,16 +3927,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
       "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http-body-util",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "description": "Combinators and adapters for HTTP request or response bodies. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+          "content": "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
         }
       ],
       "licenses": [
@@ -3820,7 +3944,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/http-body-util@0.1.3",
+      "purl": "pkg:cargo/http-body-util@0.1.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3834,16 +3958,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
       "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
       "name": "http-body",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "description": "Trait representing an asynchronous, streaming, HTTP request or response body. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+          "content": "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
         }
       ],
       "licenses": [
@@ -3851,7 +3975,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/http-body@1.0.1",
+      "purl": "pkg:cargo/http-body@1.1.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3865,16 +3989,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.5",
       "author": "Yuri Astrakhan <YuriAstrakhan@gmail.com>",
       "name": "http-content-range",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "description": "HTTP Content Range response header parser",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1"
+          "content": "0298eab7a8b2346aa6e6b3502dfddf643735e45864cbe4ce9c73606cecb8b53f"
         }
       ],
       "licenses": [
@@ -3882,7 +4006,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/http-content-range@0.2.4",
+      "purl": "pkg:cargo/http-content-range@0.2.5",
       "externalReferences": [
         {
           "type": "vcs",
@@ -3981,15 +4105,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.4.0",
       "name": "humantime",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "description": "A parser and formatter for std::time::{Duration, SystemTime}",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+          "content": "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
         }
       ],
       "licenses": [
@@ -3997,7 +4121,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/humantime@2.3.0",
+      "purl": "pkg:cargo/humantime@2.4.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4015,16 +4139,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.13",
       "author": "RustCrypto Developers",
       "name": "hybrid-array",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "description": "Hybrid typenum-based and const generic array types designed to provide the flexibility of typenum-based expressions while also allowing interoperability and a transition path to const generics ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+          "content": "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
         }
       ],
       "licenses": [
@@ -4032,7 +4156,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/hybrid-array@0.4.12",
+      "purl": "pkg:cargo/hybrid-array@0.4.13",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4150,16 +4274,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
       "author": "Sean McArthur <sean@seanmonstar.com>",
       "name": "hyper",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "description": "A protective and efficient HTTP library for all.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+          "content": "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
         }
       ],
       "licenses": [
@@ -4167,7 +4291,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/hyper@1.10.1",
+      "purl": "pkg:cargo/hyper@1.11.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4588,15 +4712,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
       "name": "indicatif",
-      "version": "0.18.4",
+      "version": "0.18.6",
       "description": "A progress bar and cli reporting library for Rust",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+          "content": "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
         }
       ],
       "licenses": [
@@ -4604,7 +4728,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/indicatif@0.18.4",
+      "purl": "pkg:cargo/indicatif@0.18.6",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4861,16 +4985,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff-core@0.1.0",
       "author": "Andrew Gallant <jamslam@gmail.com>",
-      "name": "jiff",
-      "version": "0.2.28",
-      "description": "A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. ",
+      "name": "jiff-core",
+      "version": "0.1.0",
+      "description": "Low level datetime primitives for the Jiff library.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+          "content": "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
         }
       ],
       "licenses": [
@@ -4878,7 +5002,42 @@
           "expression": "Unlicense OR MIT"
         }
       ],
-      "purl": "pkg:cargo/jiff@0.2.28",
+      "purl": "pkg:cargo/jiff-core@0.1.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/jiff-core"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-core"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/BurntSushi/jiff"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+      "author": "Andrew Gallant <jamslam@gmail.com>",
+      "name": "jiff",
+      "version": "0.2.34",
+      "description": "A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. ",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Unlicense OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/jiff@0.2.34",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4892,16 +5051,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "jobserver",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "description": "An implementation of the GNU Make jobserver for Rust. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+          "content": "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
         }
       ],
       "licenses": [
@@ -4909,7 +5068,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/jobserver@0.1.34",
+      "purl": "pkg:cargo/jobserver@0.1.35",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5042,16 +5201,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-      "author": "The Rust Project Developers",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
       "name": "libc",
-      "version": "0.2.186",
+      "version": "0.2.188",
       "description": "Raw FFI bindings to platform libraries like libc.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+          "content": "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
         }
       ],
       "licenses": [
@@ -5059,7 +5217,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/libc@0.2.186",
+      "purl": "pkg:cargo/libc@0.2.188",
       "externalReferences": [
         {
           "type": "vcs",
@@ -5319,16 +5477,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
       "author": "Andrew Gallant <jamslam@gmail.com>, bluss",
       "name": "memchr",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for 1, 2 or 3 byte search and single substring search. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+          "content": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
         }
       ],
       "licenses": [
@@ -5336,7 +5494,7 @@
           "expression": "Unlicense OR MIT"
         }
       ],
-      "purl": "pkg:cargo/memchr@2.8.2",
+      "purl": "pkg:cargo/memchr@2.8.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5354,16 +5512,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
       "author": "Dan Burkert <dan@danburkert.com>, Yevhenii Reizner <razrfalcon@gmail.com>, The Contributors",
       "name": "memmap2",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "description": "Cross-platform Rust API for memory-mapped file IO",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+          "content": "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
         }
       ],
       "licenses": [
@@ -5371,7 +5529,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/memmap2@0.9.10",
+      "purl": "pkg:cargo/memmap2@0.9.11",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5573,16 +5731,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
       "author": "Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>",
       "name": "mio",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "description": "Lightweight non-blocking I/O.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+          "content": "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
         }
       ],
       "licenses": [
@@ -5590,7 +5748,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/mio@1.2.1",
+      "purl": "pkg:cargo/mio@1.2.2",
       "externalReferences": [
         {
           "type": "website",
@@ -6709,15 +6867,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.14.0",
       "name": "portable-atomic",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "description": "Portable atomic types including support for 128-bit atomics, atomic float, etc. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+          "content": "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
         }
       ],
       "licenses": [
@@ -6725,7 +6883,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/portable-atomic@1.13.1",
+      "purl": "pkg:cargo/portable-atomic@1.14.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6855,16 +7013,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
       "author": "David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>",
       "name": "proc-macro2",
-      "version": "1.0.106",
+      "version": "1.0.107",
       "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+          "content": "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
         }
       ],
       "licenses": [
@@ -6872,7 +7030,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/proc-macro2@1.0.106",
+      "purl": "pkg:cargo/proc-macro2@1.0.107",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7072,16 +7230,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "quote",
-      "version": "1.0.45",
+      "version": "1.0.47",
       "description": "Quasi-quoting macro quote!(...)",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+          "content": "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
         }
       ],
       "licenses": [
@@ -7089,7 +7247,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/quote@1.0.45",
+      "purl": "pkg:cargo/quote@1.0.47",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7103,16 +7261,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.2",
       "author": "The Rand Project Developers, The Rust Project Developers",
       "name": "rand",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "description": "Random number generators and other randomness functionality. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+          "content": "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
         }
       ],
       "licenses": [
@@ -7120,7 +7278,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rand@0.10.1",
+      "purl": "pkg:cargo/rand@0.10.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7138,16 +7296,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.5",
       "author": "The Rand Project Developers, The Rust Project Developers",
       "name": "rand",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "description": "Random number generators and other randomness functionality. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+          "content": "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
         }
       ],
       "licenses": [
@@ -7155,7 +7313,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rand@0.9.4",
+      "purl": "pkg:cargo/rand@0.9.5",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7405,6 +7563,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_conda_types",
+      "version": "0.48.0",
+      "description": "Rust data types for common types used within the Conda ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "017a8ae50486c176ed5dcd2b2118883e1eb89abcacb6fdb434b6f5cb5aa2fdf7"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_conda_types@0.48.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
@@ -7436,16 +7625,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4ec8b22e87f14a9ca2e55061f71b1d51d2dfb4aa1766babb95f06f6218d6733a"
+          "content": "0fc13501d19e0994f1d460569a89b595d3a7808d9c7948ec44f29b3cb202bc9b"
         }
       ],
       "licenses": [
@@ -7453,7 +7642,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.31.3",
+      "purl": "pkg:cargo/rattler_lock@0.31.4",
       "externalReferences": [
         {
           "type": "website",
@@ -7683,16 +7872,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0a9bbdbf299cc4f9b363bd54a4e315be7e96c7645f0a75df5853405d0189ead6"
+          "content": "fb5972bed20c404d943da0ed351bbd97cd91b01086620bc68563e9dfe173c198"
         }
       ],
       "licenses": [
@@ -7700,7 +7889,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@7.2.0",
+      "purl": "pkg:cargo/rattler_solve@7.2.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7778,16 +7967,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.26",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "ref-cast-impl",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "description": "Derive implementation for ref_cast::RefCast.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+          "content": "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
         }
       ],
       "licenses": [
@@ -7795,7 +7984,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/ref-cast-impl@1.0.25",
+      "purl": "pkg:cargo/ref-cast-impl@1.0.26",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7809,16 +7998,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "ref-cast",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "description": "Safely cast &T to &U where the struct U contains a single field of type T.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+          "content": "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
         }
       ],
       "licenses": [
@@ -7826,7 +8015,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/ref-cast@1.0.25",
+      "purl": "pkg:cargo/ref-cast@1.0.26",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7840,16 +8029,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.30",
       "author": "Jiahao XU <Jiahao_XU@outlook.com>",
       "name": "reflink-copy",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "description": "copy-on-write mechanism on supported file systems",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+          "content": "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
         }
       ],
       "licenses": [
@@ -7857,7 +8046,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/reflink-copy@0.1.29",
+      "purl": "pkg:cargo/reflink-copy@0.1.30",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7875,16 +8064,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex-automata",
-      "version": "0.4.14",
+      "version": "0.4.16",
       "description": "Automata construction and matching using regular expressions.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+          "content": "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
         }
       ],
       "licenses": [
@@ -7892,7 +8081,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/regex-automata@0.4.14",
+      "purl": "pkg:cargo/regex-automata@0.4.16",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7945,16 +8134,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
       "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
       "name": "regex",
-      "version": "1.12.4",
+      "version": "1.13.1",
       "description": "An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+          "content": "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
         }
       ],
       "licenses": [
@@ -7962,7 +8151,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/regex@1.12.4",
+      "purl": "pkg:cargo/regex@1.13.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8225,16 +8414,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.28",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "rustc-demangle",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "description": "Rust compiler symbol demangling. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+          "content": "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
         }
       ],
       "licenses": [
@@ -8242,7 +8431,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rustc-demangle@0.1.27",
+      "purl": "pkg:cargo/rustc-demangle@0.1.28",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8260,16 +8449,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.3",
       "author": "The Rust Project Developers",
       "name": "rustc-hash",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "description": "A speedy, non-cryptographic hashing algorithm used by rustc",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+          "content": "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
         }
       ],
       "licenses": [
@@ -8277,7 +8466,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/rustc-hash@2.1.2",
+      "purl": "pkg:cargo/rustc-hash@2.1.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -8385,15 +8574,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
       "name": "rustls-pki-types",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "description": "Shared types for the rustls PKI ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+          "content": "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
         }
       ],
       "licenses": [
@@ -8401,7 +8590,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rustls-pki-types@1.14.1",
+      "purl": "pkg:cargo/rustls-pki-types@1.15.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8445,15 +8634,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.40",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.42",
       "name": "rustls",
-      "version": "0.23.40",
+      "version": "0.23.42",
       "description": "Rustls is a modern TLS library written in Rust.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+          "content": "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
         }
       ],
       "licenses": [
@@ -8461,7 +8650,7 @@
           "expression": "Apache-2.0 OR ISC OR MIT"
         }
       ],
-      "purl": "pkg:cargo/rustls@0.23.40",
+      "purl": "pkg:cargo/rustls@0.23.42",
       "externalReferences": [
         {
           "type": "website",
@@ -8785,16 +8974,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
       "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
       "name": "serde",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "description": "A generic serialization/deserialization framework",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+          "content": "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
         }
       ],
       "licenses": [
@@ -8802,7 +8991,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde@1.0.228",
+      "purl": "pkg:cargo/serde@1.0.229",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8851,16 +9040,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
       "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
       "name": "serde_core",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "description": "Serde traits only, with no support for derive -- use the `serde` crate instead",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+          "content": "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
         }
       ],
       "licenses": [
@@ -8868,7 +9057,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_core@1.0.228",
+      "purl": "pkg:cargo/serde_core@1.0.229",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8886,16 +9075,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.229",
       "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
       "name": "serde_derive",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+          "content": "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
         }
       ],
       "licenses": [
@@ -8903,7 +9092,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_derive@1.0.228",
+      "purl": "pkg:cargo/serde_derive@1.0.229",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8921,16 +9110,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
       "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
       "name": "serde_json",
-      "version": "1.0.150",
+      "version": "1.0.151",
       "description": "A JSON serialization file format",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+          "content": "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
         }
       ],
       "licenses": [
@@ -8938,7 +9127,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_json@1.0.150",
+      "purl": "pkg:cargo/serde_json@1.0.151",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8952,16 +9141,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "serde_repr",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "description": "Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+          "content": "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
         }
       ],
       "licenses": [
@@ -8969,7 +9158,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/serde_repr@0.1.20",
+      "purl": "pkg:cargo/serde_repr@0.1.21",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9331,16 +9520,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.10",
       "author": "Marvin Countryman <me@maar.vin>",
       "name": "simd-adler32",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "description": "A SIMD-accelerated Adler-32 hash algorithm implementation.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+          "content": "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
         }
       ],
       "licenses": [
@@ -9348,7 +9537,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/simd-adler32@0.3.9",
+      "purl": "pkg:cargo/simd-adler32@0.3.10",
       "externalReferences": [
         {
           "type": "vcs",
@@ -9358,16 +9547,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
       "author": "Heinz N. Gies <heinz@licenser.net>, Sunny Gleason",
       "name": "simd-json",
-      "version": "0.17.0",
+      "version": "0.17.3",
       "description": "High performance JSON parser based on a port of simdjson",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+          "content": "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
         }
       ],
       "licenses": [
@@ -9375,7 +9564,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/simd-json@0.17.0",
+      "purl": "pkg:cargo/simd-json@0.17.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9424,15 +9613,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
       "name": "simple_spawn_blocking",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "A simple crate to make spawning blocking tasks more ergonomic",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+          "content": "83a7b2679ee03cca581f57e5a4fecac405aa6b5d5174abe65b4b41fa181d8438"
         }
       ],
       "licenses": [
@@ -9440,7 +9629,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/simple_spawn_blocking@1.1.0",
+      "purl": "pkg:cargo/simple_spawn_blocking@1.1.1",
       "externalReferences": [
         {
           "type": "website",
@@ -9512,16 +9701,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
       "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
       "name": "socket2",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "description": "Utilities for handling networking sockets with a maximal amount of configuration possible intended. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+          "content": "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
         }
       ],
       "licenses": [
@@ -9529,7 +9718,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/socket2@0.6.4",
+      "purl": "pkg:cargo/socket2@0.6.5",
       "externalReferences": [
         {
           "type": "documentation",
@@ -9842,16 +10031,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "syn",
-      "version": "2.0.118",
+      "version": "2.0.119",
       "description": "Parser for Rust source code",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+          "content": "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
         }
       ],
       "licenses": [
@@ -9859,7 +10048,38 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/syn@2.0.118",
+      "purl": "pkg:cargo/syn@2.0.119",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/syn"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/dtolnay/syn"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2",
+      "author": "David Tolnay <dtolnay@gmail.com>",
+      "name": "syn",
+      "version": "3.0.2",
+      "description": "Parser for Rust source code",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/syn@3.0.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10125,16 +10345,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.19",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "thiserror-impl",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "description": "Implementation detail of the `thiserror` crate",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+          "content": "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
         }
       ],
       "licenses": [
@@ -10142,7 +10362,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/thiserror-impl@2.0.18",
+      "purl": "pkg:cargo/thiserror-impl@2.0.19",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10183,16 +10403,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "thiserror",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "description": "derive(Error)",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+          "content": "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
         }
       ],
       "licenses": [
@@ -10200,7 +10420,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/thiserror@2.0.18",
+      "purl": "pkg:cargo/thiserror@2.0.19",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10214,16 +10434,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.10",
       "author": "Amanieu d'Antras <amanieu@gmail.com>",
       "name": "thread_local",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "description": "Per-object thread-local storage",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+          "content": "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
         }
       ],
       "licenses": [
@@ -10231,7 +10451,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/thread_local@1.1.9",
+      "purl": "pkg:cargo/thread_local@1.1.10",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10272,16 +10492,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.32",
       "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
       "name": "time-macros",
-      "version": "0.2.29",
+      "version": "0.2.32",
       "description": "    Procedural macros for the time crate.     This crate is an implementation detail and should not be relied upon directly. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+          "content": "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
         }
       ],
       "licenses": [
@@ -10289,7 +10509,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/time-macros@0.2.29",
+      "purl": "pkg:cargo/time-macros@0.2.32",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10299,16 +10519,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.54",
       "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
       "name": "time",
-      "version": "0.3.49",
+      "version": "0.3.54",
       "description": "Date and time library. Fully interoperable with the standard library. Mostly compatible with #![no_std].",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+          "content": "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
         }
       ],
       "licenses": [
@@ -10316,7 +10536,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/time@0.3.49",
+      "purl": "pkg:cargo/time@0.3.54",
       "externalReferences": [
         {
           "type": "website",
@@ -10357,16 +10577,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.12.0",
       "author": "Lokathor <zefria@gmail.com>",
       "name": "tinyvec",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "description": "`tinyvec` provides 100% safe vec-like data structures.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+          "content": "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
         }
       ],
       "licenses": [
@@ -10374,7 +10594,7 @@
           "expression": "Zlib OR Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/tinyvec@1.11.0",
+      "purl": "pkg:cargo/tinyvec@1.12.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10411,16 +10631,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.1",
       "author": "Tokio Contributors <team@tokio.rs>",
       "name": "tokio-macros",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "description": "Tokio's proc macros. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+          "content": "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
         }
       ],
       "licenses": [
@@ -10428,7 +10648,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tokio-macros@2.7.0",
+      "purl": "pkg:cargo/tokio-macros@2.7.1",
       "externalReferences": [
         {
           "type": "website",
@@ -10542,16 +10762,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
       "author": "Tokio Contributors <team@tokio.rs>",
       "name": "tokio-util",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "description": "Additional utilities for working with Tokio. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+          "content": "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
         }
       ],
       "licenses": [
@@ -10559,7 +10779,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tokio-util@0.7.18",
+      "purl": "pkg:cargo/tokio-util@0.7.19",
       "externalReferences": [
         {
           "type": "website",
@@ -10573,16 +10793,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
       "author": "Tokio Contributors <team@tokio.rs>",
       "name": "tokio",
-      "version": "1.52.3",
+      "version": "1.53.1",
       "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+          "content": "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
         }
       ],
       "licenses": [
@@ -10590,7 +10810,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tokio@1.52.3",
+      "purl": "pkg:cargo/tokio@1.53.1",
       "externalReferences": [
         {
           "type": "website",
@@ -11814,16 +12034,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.24.0",
       "author": "Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>",
       "name": "uuid",
-      "version": "1.23.3",
+      "version": "1.24.0",
       "description": "A library to generate and parse UUIDs.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+          "content": "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
         }
       ],
       "licenses": [
@@ -11831,7 +12051,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/uuid@1.23.3",
+      "purl": "pkg:cargo/uuid@1.24.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -11849,16 +12069,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.2",
       "author": "Heinz N. Gies <heinz@licenser.net>",
       "name": "value-trait",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "description": "Traits to deal with JSONesque values",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+          "content": "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
         }
       ],
       "licenses": [
@@ -11866,7 +12086,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/value-trait@0.12.1",
+      "purl": "pkg:cargo/value-trait@0.12.2",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12075,16 +12295,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.5",
       "author": "Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>",
       "name": "which",
-      "version": "8.0.4",
+      "version": "8.0.5",
       "description": "A Rust equivalent of Unix command \"which\". Locate installed executable in cross platforms.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+          "content": "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
         }
       ],
       "licenses": [
@@ -12092,7 +12312,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/which@8.0.4",
+      "purl": "pkg:cargo/which@8.0.5",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12132,15 +12352,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4",
       "name": "winnow",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "A byte-oriented, zero-copy, parser combinators library",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+          "content": "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
         }
       ],
       "licenses": [
@@ -12148,7 +12368,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/winnow@1.0.3",
+      "purl": "pkg:cargo/winnow@1.0.4",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12222,16 +12442,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.18",
       "author": "Douman <douman@gmx.se>",
       "name": "xxhash-rust",
-      "version": "0.8.15",
+      "version": "0.8.18",
       "description": "Implementation of xxhash",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+          "content": "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
         }
       ],
       "licenses": [
@@ -12239,7 +12459,7 @@
           "expression": "BSL-1.0"
         }
       ],
-      "purl": "pkg:cargo/xxhash-rust@0.8.15",
+      "purl": "pkg:cargo/xxhash-rust@0.8.18",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12334,16 +12554,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.55",
       "author": "Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>",
       "name": "zerocopy",
-      "version": "0.8.52",
+      "version": "0.8.55",
       "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+          "content": "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
         }
       ],
       "licenses": [
@@ -12351,7 +12571,7 @@
           "expression": "BSD-2-Clause OR Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/zerocopy@0.8.52",
+      "purl": "pkg:cargo/zerocopy@0.8.55",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12558,15 +12778,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.6",
       "name": "zlib-rs",
-      "version": "0.6.3",
+      "version": "0.6.6",
       "description": "A memory-safe zlib implementation written in rust",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+          "content": "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
         }
       ],
       "licenses": [
@@ -12574,7 +12794,7 @@
           "expression": "Zlib"
         }
       ],
-      "purl": "pkg:cargo/zlib-rs@0.6.3",
+      "purl": "pkg:cargo/zlib-rs@0.6.6",
       "externalReferences": [
         {
           "type": "website",
@@ -12588,16 +12808,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.23",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "zmij",
-      "version": "1.0.21",
-      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
+      "version": "1.0.23",
+      "description": "A double-to-string conversion algorithm based on Schubfach and xjb",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+          "content": "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
         }
       ],
       "licenses": [
@@ -12605,7 +12825,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/zmij@1.0.21",
+      "purl": "pkg:cargo/zmij@1.0.23",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12845,16 +13065,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.10.0",
       "author": "Ed Barnard <eabarnard@gmail.com>",
       "name": "plist",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "description": "A rusty plist parser. Supports Serde serialization.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+          "content": "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
         }
       ],
       "licenses": [
@@ -12862,7 +13082,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/plist@1.9.0",
+      "purl": "pkg:cargo/plist@1.10.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -12882,15 +13102,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
       "name": "quick-xml",
-      "version": "0.39.4",
+      "version": "0.41.0",
       "description": "High performance xml reader and writer",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+          "content": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
         }
       ],
       "licenses": [
@@ -12898,7 +13118,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/quick-xml@0.39.4",
+      "purl": "pkg:cargo/quick-xml@0.41.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -13804,6 +14024,38 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
+      "name": "windows-registry",
+      "version": "0.6.1",
+      "description": "Windows registry",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/windows-registry@0.6.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/microsoft/windows-rs"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "windows"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
       "author": "Microsoft",
       "name": "windows-result",
@@ -14278,18 +14530,18 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anaconda-anon-usage@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#anaconda-otel-rs@0.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
-        "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#figment@0.10.19",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
@@ -14297,21 +14549,21 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
         "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.12+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_edit@0.25.13+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
@@ -14335,13 +14587,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
-        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52"
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.55"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
@@ -14354,9 +14606,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#secrecy@0.10.3",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19"
       ]
     },
     {
@@ -14365,19 +14617,19 @@
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3"
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.24.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anaconda-otel-rs@0.1.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -14386,15 +14638,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
         "registry+https://github.com/rust-lang/crates.io-index#rustc_version_runtime@0.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.9",
         "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.30.13",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-opentelemetry@0.32.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -14430,31 +14682,31 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
     },
@@ -14462,15 +14714,15 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_http_range_reader@0.11.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.5",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -14481,9 +14733,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
@@ -14491,9 +14743,9 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#compression-codecs@0.4.38",
         "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
@@ -14504,15 +14756,15 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
       ]
     },
     {
@@ -14534,10 +14786,10 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.28",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
@@ -14556,7 +14808,11 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
       "dependsOn": []
     },
     {
@@ -14574,7 +14830,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.12.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
+        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.13"
       ]
     },
     {
@@ -14584,7 +14840,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#bs58@0.5.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.12.0"
       ]
     },
     {
@@ -14592,7 +14848,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
       "dependsOn": []
     },
     {
@@ -14605,17 +14861,17 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1"
       ]
     },
@@ -14624,11 +14880,11 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
@@ -14640,19 +14896,19 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.1"
+        "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.2",
+        "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anstream@1.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#anstyle@1.0.14",
@@ -14661,12 +14917,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -14695,7 +14951,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#compression-core@0.4.32",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#zstd-safe@7.2.4",
         "registry+https://github.com/rust-lang/crates.io-index#zstd@0.13.3"
       ]
@@ -14709,10 +14965,10 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -14724,13 +14980,13 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -14740,26 +14996,26 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
@@ -14777,7 +15033,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.2.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12"
+        "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.13"
       ]
     },
     {
@@ -14797,25 +15053,25 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
         "registry+https://github.com/rust-lang/crates.io-index#strsim@0.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.23.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.23.0",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5",
         "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.14",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -14823,9 +15079,31 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt-parser@1.0.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#defmt-macros@1.1.1"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
@@ -14847,9 +15125,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -14861,9 +15139,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -14890,9 +15168,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -14902,33 +15180,33 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.5.0",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#figment@0.10.19",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#pear@0.2.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#uncased@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
       ]
@@ -14938,7 +15216,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
@@ -14947,7 +15225,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -14959,7 +15237,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
-        "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3"
+        "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.6"
       ]
     },
     {
@@ -14993,100 +15271,100 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32"
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.33",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32"
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#parking@2.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.33",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.33",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-macro@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32"
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-task@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
       ]
@@ -15095,21 +15373,21 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
@@ -15125,15 +15403,15 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -15141,7 +15419,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.16.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229"
       ]
     },
     {
@@ -15176,41 +15454,41 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#http-content-range@0.2.5",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18"
       ]
     },
@@ -15223,11 +15501,11 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#humantime@2.4.0",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.12",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hybrid-array@0.4.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#typenum@1.20.1"
       ]
@@ -15237,23 +15515,23 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.40",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.42",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
@@ -15261,40 +15539,40 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
         "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#httparse@1.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#httpdate@1.0.3",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1"
       ]
     },
@@ -15391,7 +15669,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229"
       ]
     },
     {
@@ -15399,14 +15677,14 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
-        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
+        "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#unit-prefix@0.5.2"
       ]
@@ -15422,8 +15700,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15451,26 +15729,34 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff-core@0.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.34",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff-core@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -15478,7 +15764,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex-proc_macros@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4"
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1"
       ]
     },
     {
@@ -15490,7 +15776,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
       "dependsOn": []
     },
     {
@@ -15525,7 +15811,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14"
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16"
       ]
     },
     {
@@ -15536,13 +15822,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -15554,9 +15840,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#miette-derive@7.6.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -15590,20 +15876,20 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1",
-        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.10"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
@@ -15617,20 +15903,20 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.29.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -15642,13 +15928,13 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15664,13 +15950,13 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
@@ -15680,9 +15966,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -15692,8 +15978,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
       ]
@@ -15701,10 +15987,10 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.81",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117"
       ]
@@ -15712,8 +15998,8 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry-http@0.31.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28"
@@ -15729,7 +16015,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -15754,25 +16040,25 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#opentelemetry_sdk@0.31.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-executor@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.5",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
@@ -15807,7 +16093,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
@@ -15816,7 +16102,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
@@ -15836,16 +16122,16 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pear_codegen@0.2.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#unscanny@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#version-ranges@0.1.3"
@@ -15859,9 +16145,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.69",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
@@ -15877,9 +16163,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#pin-project-internal@1.1.13",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -15897,7 +16183,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.13.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.14.0",
       "dependsOn": []
     },
     {
@@ -15913,21 +16199,21 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52"
+        "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.55"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2-diagnostics@0.10.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5",
         "registry+https://github.com/rust-lang/crates.io-index#yansi@1.0.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
       ]
@@ -15937,9 +16223,9 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.8.0",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.5",
         "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_xorshift@0.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11",
@@ -15951,17 +16237,17 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#prost-derive@0.14.4"
       ]
     },
@@ -15970,8 +16256,8 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19"
       ]
     },
     {
@@ -15981,25 +16267,25 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#chacha20@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.9.5"
@@ -16031,23 +16317,23 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.3",
+        "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#humantime@2.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.4",
+        "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
@@ -16059,33 +16345,33 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
-        "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.30",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3"
+        "registry+https://github.com/rust-lang/crates.io-index#uuid@1.24.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
@@ -16096,11 +16382,11 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
@@ -16113,32 +16399,71 @@
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
-        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
         "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
+        "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
@@ -16153,45 +16478,45 @@
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#md-5@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
-        "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15"
+        "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.18"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -16199,25 +16524,25 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index#plist@1.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
-        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+        "registry+https://github.com/rust-lang/crates.io-index#which@8.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3"
       ]
@@ -16226,22 +16551,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ambient-id@0.0.11",
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#async-once-cell@0.5.4",
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
@@ -16250,32 +16575,32 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
-        "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.2",
+        "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.4",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_http_range_reader@0.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
-        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.46",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#zip@8.6.0",
@@ -16285,10 +16610,10 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
@@ -16302,40 +16627,40 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.28",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.6",
-        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21"
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
       ]
     },
     {
@@ -16346,33 +16671,33 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.26",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.25"
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.26"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.29",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.30",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
       ]
     },
@@ -16381,23 +16706,23 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16",
         "registry+https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.11"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
@@ -16405,30 +16730,30 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.12.28",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-channel@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#mime@0.3.17",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
@@ -16439,30 +16764,30 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#h2@0.4.15",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-rustls@0.27.9",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-tls@0.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
-        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#mime_guess@2.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
@@ -16472,29 +16797,29 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#rtoolbox@0.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -16502,16 +16827,16 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rtoolbox@0.0.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.27",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.28",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.3",
       "dependsOn": []
     },
     {
@@ -16530,14 +16855,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
       ]
@@ -16546,15 +16871,15 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.40",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.42",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.14.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13",
         "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
@@ -16577,18 +16902,18 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
-        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150"
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
-        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150"
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151"
       ]
     },
     {
@@ -16604,7 +16929,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#self-replace@1.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0"
       ]
@@ -16612,14 +16937,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#erased-serde@0.4.10",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#typeid@1.0.3"
       ]
     },
@@ -16627,56 +16952,56 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ordered-float@2.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.229"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_bytes@0.11.19",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.229",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.23"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
@@ -16685,7 +17010,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229"
       ]
     },
     {
@@ -16699,19 +17024,19 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49"
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.54"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#darling@0.23.0",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -16720,7 +17045,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.23",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#unsafe-libyaml@0.2.11"
       ]
     },
@@ -16754,29 +17079,29 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.10",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
-        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.25",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.150",
+        "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#simdutf8@0.1.5",
-        "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1"
+        "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.2"
       ]
     },
     {
@@ -16784,9 +17109,9 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
@@ -16796,13 +17121,13 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -16824,9 +17149,9 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#strum_macros@0.28.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -16855,25 +17180,33 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.24"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32"
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -16881,7 +17214,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
@@ -16892,25 +17225,25 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.46",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.4.1",
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
+        "registry+https://github.com/rust-lang/crates.io-index#fastrand@2.5.0",
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#terminal_size@0.4.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -16923,17 +17256,17 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.19",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
       ]
     },
     {
@@ -16943,13 +17276,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.18"
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.19"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.10",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4"
       ]
@@ -16959,21 +17292,21 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.32",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.54",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
         "registry+https://github.com/rust-lang/crates.io-index#num-conv@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.29"
+        "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.32"
       ]
     },
     {
@@ -16984,7 +17317,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.12.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
       ]
@@ -16994,58 +17327,59 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-native-tls@0.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.40",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.42",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
-        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
-        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.0",
+        "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-macros@2.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -17053,7 +17387,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
@@ -17065,24 +17399,24 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.1.1+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.2+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3"
+        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.1.1+spec-1.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
@@ -17092,13 +17426,13 @@
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.1.1+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.2+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3"
+        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3"
+        "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
       ]
     },
     {
@@ -17108,7 +17442,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic-prost@0.14.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
         "registry+https://github.com/rust-lang/crates.io-index#prost@0.14.4",
         "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.6"
       ]
@@ -17116,11 +17450,11 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tonic@0.14.6",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
+        "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
@@ -17135,16 +17469,16 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
-        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body-util@0.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#http-body@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
@@ -17162,11 +17496,11 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
-        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
+        "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
@@ -17174,9 +17508,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.31",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -17210,10 +17544,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#matchers@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.14",
+        "registry+https://github.com/rust-lang/crates.io-index#regex-automata@0.4.16",
         "registry+https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
-        "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#thread_local@1.1.10",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.36",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -17268,7 +17602,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.11.0"
+        "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.12.0"
       ]
     },
     {
@@ -17305,8 +17639,8 @@
         "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#idna@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.228"
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.229"
       ]
     },
     {
@@ -17322,14 +17656,14 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.23.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#uuid@1.24.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1"
+        "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#value-trait@0.12.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#float-cmp@0.10.0",
         "registry+https://github.com/rust-lang/crates.io-index#halfbrown@0.4.0",
@@ -17354,7 +17688,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -17372,9 +17706,9 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
@@ -17382,9 +17716,9 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
@@ -17398,7 +17732,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.15",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#xxhash-rust@0.8.18",
       "dependsOn": []
     },
     {
@@ -17408,9 +17742,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119",
         "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
       ]
     },
@@ -17423,15 +17757,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.52",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zerocopy@0.8.55",
       "dependsOn": []
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119",
         "registry+https://github.com/rust-lang/crates.io-index#synstructure@0.13.2"
       ]
     },
@@ -17456,9 +17790,9 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -17475,18 +17809,18 @@
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49",
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.54",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
         "registry+https://github.com/rust-lang/crates.io-index#zopfli@0.8.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zlib-rs@0.6.6",
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.21",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#zmij@1.0.23",
       "dependsOn": []
     },
     {
@@ -17495,7 +17829,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.20.3",
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
-        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.9"
+        "registry+https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.10"
       ]
     },
     {
@@ -17507,7 +17841,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.2.64",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },
@@ -17525,46 +17859,46 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.9.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#plist@1.10.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
-        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.49"
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#time@0.3.54"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.2"
+        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework@3.7.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
       ]
     },
@@ -17572,13 +17906,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration@0.7.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.0",
+        "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
         "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0"
       ]
@@ -17604,7 +17938,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -17684,17 +18018,17 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.106",
-        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.118"
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
@@ -17725,6 +18059,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
       ]
     },
     {
@@ -17820,34 +18162,6 @@
   ],
   "vulnerabilities": [
     {
-      "id": "RUSTSEC-2026-0204",
-      "description": "Affected versions of `fmt::Display` dereference the underlying pointer. This causes a invalid pointer dereference e.g., when a pointer created with `Atomic::null` or `Shared::null`. `fmt::Debug` impls and pre-0.9 `fmt::Display` impls, which do not dereference pointers, are not affected by this issue.",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0204.html"
-      },
-      "ratings": [],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.18"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0194",
-      "description": "`BytesStart::attributes()` returns an `Attributes` iterator which, by default\n(`with_checks(true)`), rejects a start tag that repeats an attribute name. For\neach attribute yielded, the iterator compared the new name against every name\nseen so far in the same tag using a linear scan, so a start tag with `N`\ndistinct attribute names cost `O(N\u00b2)` byte comparisons. There was no bound on\n`N` other than the size of the buffered start tag.\n\n## Impact\n\nAny code that parses untrusted XML and iterates a start tag's attributes with\nthe default duplicate check enabled can be made to spend CPU time quadratic in\nthe number of attributes on a single tag. Because the check is pure computation\nwith no `.await`/I/O, an I/O-based timeout on the consumer (for example a read\nor request timeout) cannot interrupt it while it runs.\n\nMeasured cost of a single start tag, release build:\n\n| Attributes on one tag | Time |\n|---|---|\n| 80,000  | ~6 s   |\n| 800,000 | ~10 min |\n\nThe cost grows with the square of the attribute count, so a start tag of a few\ntens of megabytes can stall a parsing thread for hours. No memory is exhausted\nand the parser does not crash; the effect is CPU exhaustion on the thread doing\nthe parsing: a single crafted start tag can pin a CPU core for minutes to hours,\ndenying service to that worker. A deployment that places a wall-clock bound on\nparsing, or confines it to a non-critical thread, may consider the availability\nimpact lower.\n\n## Affected code paths\n\n* `BytesStart::attributes()` / `Attributes` iterated with checks enabled (the\n  default), and `BytesStart::try_get_attribute`.\n* `NsReader`, which resolves namespaces by iterating a tag's attributes and so\n  reaches the same check internally.\n\nConsumers that iterate attributes with `.attributes().with_checks(false)` and do\nnot use `NsReader` are not affected.\n\nThis was reported as reachable by a remote, unauthenticated attacker in a\nreal-world RPKI relying party (NLnet Labs Routinator) via a crafted RRDP\n`snapshot.xml`.\n\n## Remediation\n\nUpgrade to `quick-xml >= 0.41.0`, where the duplicate check keeps the linear\nscan for start tags with a small number of attributes and switches to an `O(1)`\nhash pre-filter above a threshold, making the whole tag `O(N)`. The reported\n`AttrError::Duplicated` positions are unchanged.\n\nIf upgrading is not possible and duplicate-name detection is not required,\ndisable it with `.attributes().with_checks(false)` (this does not help\n`NsReader` consumers, which have no equivalent opt-out before 0.41.0).",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0194.html"
-      },
-      "ratings": [],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5"
-        }
-      ]
-    },
-    {
       "id": "RUSTSEC-2026-0195",
       "description": "`NsReader` resolves namespaces by calling `NamespaceResolver::push` for every\n`Start`/`Empty` event *before* the event is returned to the caller. `push`\niterated all `xmlns` / `xmlns:*` attributes on the start tag and, for each one,\nappended the prefix bytes to an internal buffer and pushed a `NamespaceBinding`\n(32 bytes on 64-bit) to an internal `Vec`, with no upper bound on the number of\ndeclarations.\n\n## Impact\n\nA start tag with `N` namespace declarations drove roughly `3\u00d7` the tag's byte\nsize in `NamespaceResolver` heap, allocated *inside* `quick-xml` before the\n`NsReader` consumer ever received the event and could inspect or reject it. A\nconsumer that bounds its *input* size therefore still cannot bound this\nallocation: an `M`-byte start tag yields on the order of `3 \u00d7 M` bytes of\nresolver heap the caller never sees.\n\nOn untrusted XML this lets a remote, unauthenticated attacker force large heap\nallocations with a single start tag. With several `NsReader`s running\nconcurrently on independent inputs (a common server pattern), the allocations\nstack and can exhaust process memory, causing the operating system to kill the\nprocess (OOM). This was confirmed against a real-world RPKI relying party (NLnet\nLabs Routinator), where concurrent RRDP validation workers parsing a crafted\n`snapshot.xml` exceeded the memory limit and the process was OOM-killed.\n\n## Affected code paths\n\nConsumers using `NsReader` (which always calls `NamespaceResolver::push` before\nyielding `Start`/`Empty`), or calling `NamespaceResolver::push` directly. A plain\n`Reader` that does not perform namespace resolution is not affected.\n\n## Remediation\n\nUpgrade to `quick-xml >= 0.41.0`. `NamespaceResolver::push` now rejects a start\ntag that declares more than `DEFAULT_MAX_DECLARATIONS_PER_ELEMENT` (256)\nnamespace bindings, returning the new `NamespaceError::TooManyDeclarations`\ninstead of allocating without limit. The limit is configurable via\n`NamespaceResolver::set_max_declarations_per_element` (use `usize::MAX` to\nrestore the previous unbounded behavior), and `NsReader::resolver_mut()` is\nprovided to reach it.\n\nThere is no clean workaround for `NsReader` consumers before 0.41.0, as the\nallocation happens inside the reader with no configuration knob to cap it.",
       "source": {
@@ -17871,59 +18185,7 @@
       "ratings": [],
       "affects": [
         {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0195",
-      "description": "`NsReader` resolves namespaces by calling `NamespaceResolver::push` for every\n`Start`/`Empty` event *before* the event is returned to the caller. `push`\niterated all `xmlns` / `xmlns:*` attributes on the start tag and, for each one,\nappended the prefix bytes to an internal buffer and pushed a `NamespaceBinding`\n(32 bytes on 64-bit) to an internal `Vec`, with no upper bound on the number of\ndeclarations.\n\n## Impact\n\nA start tag with `N` namespace declarations drove roughly `3\u00d7` the tag's byte\nsize in `NamespaceResolver` heap, allocated *inside* `quick-xml` before the\n`NsReader` consumer ever received the event and could inspect or reject it. A\nconsumer that bounds its *input* size therefore still cannot bound this\nallocation: an `M`-byte start tag yields on the order of `3 \u00d7 M` bytes of\nresolver heap the caller never sees.\n\nOn untrusted XML this lets a remote, unauthenticated attacker force large heap\nallocations with a single start tag. With several `NsReader`s running\nconcurrently on independent inputs (a common server pattern), the allocations\nstack and can exhaust process memory, causing the operating system to kill the\nprocess (OOM). This was confirmed against a real-world RPKI relying party (NLnet\nLabs Routinator), where concurrent RRDP validation workers parsing a crafted\n`snapshot.xml` exceeded the memory limit and the process was OOM-killed.\n\n## Affected code paths\n\nConsumers using `NsReader` (which always calls `NamespaceResolver::push` before\nyielding `Start`/`Empty`), or calling `NamespaceResolver::push` directly. A plain\n`Reader` that does not perform namespace resolution is not affected.\n\n## Remediation\n\nUpgrade to `quick-xml >= 0.41.0`. `NamespaceResolver::push` now rejects a start\ntag that declares more than `DEFAULT_MAX_DECLARATIONS_PER_ELEMENT` (256)\nnamespace bindings, returning the new `NamespaceError::TooManyDeclarations`\ninstead of allocating without limit. The limit is configurable via\n`NamespaceResolver::set_max_declarations_per_element` (use `usize::MAX` to\nrestore the previous unbounded behavior), and `NsReader::resolver_mut()` is\nprovided to reach it.\n\nThere is no clean workaround for `NsReader` consumers before 0.41.0, as the\nallocation happens inside the reader with no configuration knob to cap it.",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0195.html"
-      },
-      "ratings": [],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.39.4"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0190",
-      "description": "[unsound] Unsoundness in `Error::downcast_mut()`",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0190.html"
-      },
-      "ratings": [
-        {
-          "severity": "info",
-          "method": "other"
-        }
-      ],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0186",
-      "description": "[unsound] Unchecked pointer offset in crate `memmap2`",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0186.html"
-      },
-      "ratings": [
-        {
-          "severity": "info",
-          "method": "other"
-        }
-      ],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.10"
+          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5"
         }
       ]
     }

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:0672b760-30e4-4448-b8cf-9c34449c78a3",
+  "serialNumber": "urn:uuid:e967743c-1415-4a59-a387-e22a964d9006",
   "metadata": {
-    "timestamp": "2026-07-21T14:29:34Z",
+    "timestamp": "2026-07-22T13:42:08Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -514,16 +514,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.20",
       "author": "Harry [hello@majored.pw]",
       "name": "astral_async_zip",
-      "version": "0.0.18",
+      "version": "0.0.20",
       "description": "An asynchronous ZIP archive reading/writing crate.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
+          "content": "bd939d79959c3f49a648a1d7857d63cc62548725a6b060b8dbf0ea5c92470b63"
         }
       ],
       "licenses": [
@@ -531,7 +531,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/astral_async_zip@0.0.18",
+      "purl": "pkg:cargo/astral_async_zip@0.0.20",
       "externalReferences": [
         {
           "type": "documentation",
@@ -1395,15 +1395,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.4",
       "name": "clap",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+          "content": "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
         }
       ],
       "licenses": [
@@ -1411,7 +1411,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/clap@4.6.3",
+      "purl": "pkg:cargo/clap@4.6.4",
       "externalReferences": [
         {
           "type": "vcs",
@@ -1447,15 +1447,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.4",
       "name": "clap_derive",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "description": "Parse command line argument by defining a struct, derive crate.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+          "content": "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
         }
       ],
       "licenses": [
@@ -1463,7 +1463,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/clap_derive@4.6.3",
+      "purl": "pkg:cargo/clap_derive@4.6.4",
       "externalReferences": [
         {
           "type": "vcs",
@@ -2782,16 +2782,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "file_url",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Helper functions to work with file:// urls",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
+          "content": "5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8"
         }
       ],
       "licenses": [
@@ -2799,7 +2799,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/file_url@0.3.1",
+      "purl": "pkg:cargo/file_url@0.3.2",
       "externalReferences": [
         {
           "type": "vcs",
@@ -3122,16 +3122,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@1.1.0",
       "author": "Dan Burkert <dan@danburkert.com>, Al Liu <scygliu1@gmail.com>",
       "name": "fs4",
-      "version": "0.13.1",
+      "version": "1.1.0",
       "description": "No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+          "content": "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
         }
       ],
       "licenses": [
@@ -3139,7 +3139,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/fs4@0.13.1",
+      "purl": "pkg:cargo/fs4@1.1.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -3147,7 +3147,7 @@
         },
         {
           "type": "vcs",
-          "url": "https://github.com/al8n/fs4-rs"
+          "url": "https://github.com/al8n/fs4"
         }
       ]
     },
@@ -3618,16 +3618,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.4",
       "author": "The Rust Project Developers",
       "name": "glob",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "description": "Support for matching file paths against Unix shell style patterns. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+          "content": "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
         }
       ],
       "licenses": [
@@ -3635,7 +3635,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/glob@0.3.3",
+      "purl": "pkg:cargo/glob@0.3.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -4954,6 +4954,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
+      "author": "bluss",
+      "name": "itertools",
+      "version": "0.15.0",
+      "description": "Extra iterator adaptors, iterator methods, free functions, and macros.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/itertools@0.15.0",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/itertools/"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/rust-itertools/itertools"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "itoa",
@@ -5201,15 +5232,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
       "name": "libc",
-      "version": "0.2.188",
+      "version": "0.2.189",
       "description": "Raw FFI bindings to platform libraries like libc.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+          "content": "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
         }
       ],
       "licenses": [
@@ -5217,7 +5248,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/libc@0.2.188",
+      "purl": "pkg:cargo/libc@0.2.189",
       "externalReferences": [
         {
           "type": "vcs",
@@ -5826,16 +5857,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
-      "author": "The nix-rust Project Developers",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.31.3",
       "name": "nix",
-      "version": "0.30.1",
+      "version": "0.31.3",
       "description": "Rust friendly bindings to *nix APIs",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+          "content": "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
         }
       ],
       "licenses": [
@@ -5843,7 +5873,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/nix@0.30.1",
+      "purl": "pkg:cargo/nix@0.31.3",
       "externalReferences": [
         {
           "type": "vcs",
@@ -6595,15 +6625,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.12",
       "name": "path_resolver",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "description": "Provides a trie-based data structure to track and resolve relative path ownership across multiple packages",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "83a6d8be98ef9723e752c20eef948d3195d4e1314bc3cc033a8ff26b4e31d660"
+          "content": "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
         }
       ],
       "licenses": [
@@ -6611,7 +6641,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/path_resolver@0.2.11",
+      "purl": "pkg:cargo/path_resolver@0.2.12",
       "externalReferences": [
         {
           "type": "website",
@@ -7194,15 +7224,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
       "name": "quick-xml",
-      "version": "0.37.5",
+      "version": "0.41.0",
       "description": "High performance xml reader and writer",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+          "content": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
         }
       ],
       "licenses": [
@@ -7210,7 +7240,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/quick-xml@0.37.5",
+      "purl": "pkg:cargo/quick-xml@0.41.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7224,7 +7254,7 @@
       "properties": [
         {
           "name": "cdx:ana:platforms",
-          "value": "linux"
+          "value": "linux,macos"
         }
       ]
     },
@@ -7471,16 +7501,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.47.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler",
-      "version": "0.45.0",
+      "version": "0.47.1",
       "description": "Rust library to install conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "6c752d2553c0dc75d6fe041006ac6026b1f9e16c9cd071327a6bb850ce9ea661"
+          "content": "417e0f429d4c0f849d8e862c6d522efb35c6cb48cb6fb9e34a9a26fb6b70850f"
         }
       ],
       "licenses": [
@@ -7488,7 +7518,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler@0.45.0",
+      "purl": "pkg:cargo/rattler@0.47.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7502,15 +7532,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
       "name": "rattler_cache",
-      "version": "0.10.0",
+      "version": "0.10.3",
       "description": "A crate to manage the caching of data in rattler",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1057d4a19f6ec09383cd00150a29119aace8e17019891c5a47eda9f1838a5955"
+          "content": "1e608aa1824f88fbdf0839ed2e5d5a762692cad6aa864a725b44844d79e28c8e"
         }
       ],
       "licenses": [
@@ -7518,7 +7548,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_cache@0.10.0",
+      "purl": "pkg:cargo/rattler_cache@0.10.3",
       "externalReferences": [
         {
           "type": "website",
@@ -7532,16 +7562,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_conda_types",
-      "version": "0.47.2",
+      "version": "0.48.1",
       "description": "Rust data types for common types used within the Conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "385575f3cfb4b9ce40c13d90b37964c80d8b527b62514118e4783ae0717b3ebd"
+          "content": "f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad"
         }
       ],
       "licenses": [
@@ -7549,7 +7579,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_conda_types@0.47.2",
+      "purl": "pkg:cargo/rattler_conda_types@0.48.1",
       "externalReferences": [
         {
           "type": "website",
@@ -7563,47 +7593,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
-      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
-      "name": "rattler_conda_types",
-      "version": "0.48.0",
-      "description": "Rust data types for common types used within the Conda ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "017a8ae50486c176ed5dcd2b2118883e1eb89abcacb6fdb434b6f5cb5aa2fdf7"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "BSD-3-Clause"
-        }
-      ],
-      "purl": "pkg:cargo/rattler_conda_types@0.48.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/conda/rattler"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/conda/rattler"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "An simple crate used by rattler crates to compute different hashes from different sources",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2e4af3c4e8b0cf496e66a5f2e7244364409a20cd4338ad9b331bd7247de32b69"
+          "content": "56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3"
         }
       ],
       "licenses": [
@@ -7611,7 +7610,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_digest@1.3.1",
+      "purl": "pkg:cargo/rattler_digest@1.3.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7625,16 +7624,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.31.4",
+      "version": "0.31.5",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0fc13501d19e0994f1d460569a89b595d3a7808d9c7948ec44f29b3cb202bc9b"
+          "content": "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
         }
       ],
       "licenses": [
@@ -7642,7 +7641,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.31.4",
+      "purl": "pkg:cargo/rattler_lock@0.31.5",
       "externalReferences": [
         {
           "type": "website",
@@ -7656,16 +7655,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.2",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_macros",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "description": "A crate that provideds some procedural macros for the rattler project",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ac3d93067b745b200dd741e872f4160de24d1b972ee63db65e8a2cf6a447f1ff"
+          "content": "bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2"
         }
       ],
       "licenses": [
@@ -7673,7 +7672,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_macros@1.1.1",
+      "purl": "pkg:cargo/rattler_macros@1.1.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7687,16 +7686,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.70",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_menuinst",
-      "version": "0.2.67",
+      "version": "0.2.70",
       "description": "Install menu entries for a Conda package",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "0929ebccbf2e674fe03e4c338da00fccaf36248812675527b7181fb2b6220b5d"
+          "content": "b99d32612f64644cbcaf39caf83fb89409477b579985735930996fe1f71b0cf2"
         }
       ],
       "licenses": [
@@ -7704,7 +7703,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_menuinst@0.2.67",
+      "purl": "pkg:cargo/rattler_menuinst@0.2.70",
       "externalReferences": [
         {
           "type": "website",
@@ -7718,16 +7717,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.30.2",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_networking",
-      "version": "0.29.0",
+      "version": "0.30.2",
       "description": "Authenticated requests in the conda ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e7ab3403a06270c88d721acd0b6c1eca2d3583644620912174af8c0283f75821"
+          "content": "a79426b2af3db171d23fba74bfa9abf832367af610bbee76f979d47f9a094f2a"
         }
       ],
       "licenses": [
@@ -7735,7 +7734,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_networking@0.29.0",
+      "purl": "pkg:cargo/rattler_networking@0.30.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7749,16 +7748,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.8",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_package_streaming",
-      "version": "0.26.5",
+      "version": "0.26.8",
       "description": "Extract and stream of Conda package archives",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "97dae388123a82dac3b091ebe56d26ea4990cca85e92a6e86152378a89422034"
+          "content": "4db3af7641d6c40af2f8f2be0a494ad4d04c3825dc5ed1e7957d3c019637b5b2"
         }
       ],
       "licenses": [
@@ -7766,7 +7765,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_package_streaming@0.26.5",
+      "purl": "pkg:cargo/rattler_package_streaming@0.26.8",
       "externalReferences": [
         {
           "type": "website",
@@ -7780,15 +7779,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.15",
       "name": "rattler_pty",
-      "version": "0.2.13",
+      "version": "0.2.15",
       "description": "A crate to create pty",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ff93008508cca251d4db3c70bcf6c35a7752b4b25999616d5fc37c665a94b93a"
+          "content": "ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328"
         }
       ],
       "licenses": [
@@ -7796,7 +7795,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_pty@0.2.13",
+      "purl": "pkg:cargo/rattler_pty@0.2.15",
       "externalReferences": [
         {
           "type": "website",
@@ -7810,16 +7809,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_redaction",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "description": "Redact sensitive information from URLs (ie. conda tokens)",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b"
+          "content": "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
         }
       ],
       "licenses": [
@@ -7827,7 +7826,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_redaction@0.2.1",
+      "purl": "pkg:cargo/rattler_redaction@0.2.2",
       "externalReferences": [
         {
           "type": "website",
@@ -7841,16 +7840,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.10",
       "author": "Wolf Vollprecht <w.vollprecht@gmail.com>",
       "name": "rattler_shell",
-      "version": "0.27.7",
+      "version": "0.27.10",
       "description": "A crate to help with activation and deactivation of a conda environment",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8905552b6405344ca5470d601d24488ad814f8bf79ae7687ea6137c0047d9192"
+          "content": "40e36d0927ce8ee7cc7648be7060f8d1bbda9ac0afeb24e280af644d21d6ba28"
         }
       ],
       "licenses": [
@@ -7858,7 +7857,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_shell@0.27.7",
+      "purl": "pkg:cargo/rattler_shell@0.27.10",
       "externalReferences": [
         {
           "type": "website",
@@ -7872,16 +7871,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "fb5972bed20c404d943da0ed351bbd97cd91b01086620bc68563e9dfe173c198"
+          "content": "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
         }
       ],
       "licenses": [
@@ -7889,7 +7888,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@7.2.1",
+      "purl": "pkg:cargo/rattler_solve@7.2.2",
       "externalReferences": [
         {
           "type": "website",
@@ -9483,24 +9482,24 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.4.4",
       "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>",
       "name": "signal-hook",
-      "version": "0.3.18",
+      "version": "0.4.4",
       "description": "Unix signal handling",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+          "content": "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
         }
       ],
       "licenses": [
         {
-          "expression": "Apache-2.0 OR MIT"
+          "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/signal-hook@0.3.18",
+      "purl": "pkg:cargo/signal-hook@0.4.4",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10062,16 +10061,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3",
       "author": "David Tolnay <dtolnay@gmail.com>",
       "name": "syn",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "description": "Parser for Rust source code",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+          "content": "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
         }
       ],
       "licenses": [
@@ -10079,7 +10078,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/syn@3.0.2",
+      "purl": "pkg:cargo/syn@3.0.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -10731,16 +10730,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
       "author": "Tokio Contributors <team@tokio.rs>",
       "name": "tokio-stream",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "description": "Utilities to work with `Stream` and `tokio`. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+          "content": "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
         }
       ],
       "licenses": [
@@ -10748,7 +10747,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tokio-stream@0.1.18",
+      "purl": "pkg:cargo/tokio-stream@0.1.19",
       "externalReferences": [
         {
           "type": "website",
@@ -13102,42 +13101,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
-      "name": "quick-xml",
-      "version": "0.41.0",
-      "description": "High performance xml reader and writer",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/quick-xml@0.41.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://docs.rs/quick-xml"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/tafia/quick-xml"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "macos"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
       "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
       "name": "security-framework-sys",
@@ -13572,38 +13535,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
-      "name": "windows-collections",
-      "version": "0.2.0",
-      "description": "Windows collection types",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-collections@0.2.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
       "name": "windows-collections",
       "version": "0.3.2",
@@ -13669,39 +13600,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-      "author": "Microsoft",
-      "name": "windows-core",
-      "version": "0.61.2",
-      "description": "Core type support for COM and Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-core@0.61.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
       "name": "windows-core",
       "version": "0.62.2",
@@ -13719,38 +13617,6 @@
         }
       ],
       "purl": "pkg:cargo/windows-core@0.62.2",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
-      "name": "windows-future",
-      "version": "0.2.1",
-      "description": "Windows async types",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-future@0.2.1",
       "externalReferences": [
         {
           "type": "vcs",
@@ -13862,39 +13728,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-      "author": "Microsoft",
-      "name": "windows-link",
-      "version": "0.1.3",
-      "description": "Linking for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-link@0.1.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
       "name": "windows-link",
       "version": "0.2.1",
@@ -13912,38 +13745,6 @@
         }
       ],
       "purl": "pkg:cargo/windows-link@0.2.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
-      "name": "windows-numerics",
-      "version": "0.2.0",
-      "description": "Windows numeric types",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-numerics@0.2.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -13991,39 +13792,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
-      "author": "Microsoft",
-      "name": "windows-registry",
-      "version": "0.5.3",
-      "description": "Windows registry",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-registry@0.5.3",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
       "name": "windows-registry",
       "version": "0.6.1",
@@ -14056,39 +13824,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-      "author": "Microsoft",
-      "name": "windows-result",
-      "version": "0.3.4",
-      "description": "Windows error handling",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-result@0.3.4",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
       "name": "windows-result",
       "version": "0.4.1",
@@ -14106,39 +13841,6 @@
         }
       ],
       "purl": "pkg:cargo/windows-result@0.4.1",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
-      "author": "Microsoft",
-      "name": "windows-strings",
-      "version": "0.4.2",
-      "description": "Windows string types",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-strings@0.4.2",
       "externalReferences": [
         {
           "type": "vcs",
@@ -14317,39 +14019,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
-      "author": "Microsoft",
-      "name": "windows-threading",
-      "version": "0.1.0",
-      "description": "Windows threading",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows-threading@0.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
       "name": "windows-threading",
       "version": "0.2.1",
@@ -14400,43 +14069,6 @@
         }
       ],
       "purl": "pkg:cargo/windows@0.52.0",
-      "externalReferences": [
-        {
-          "type": "documentation",
-          "url": "https://microsoft.github.io/windows-docs-rs/"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/microsoft/windows-rs"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:ana:platforms",
-          "value": "windows"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
-      "author": "Microsoft",
-      "name": "windows",
-      "version": "0.61.3",
-      "description": "Rust for Windows",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/windows@0.61.3",
       "externalReferences": [
         {
           "type": "documentation",
@@ -14533,7 +14165,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.91",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.45",
-        "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
+        "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.4",
         "registry+https://github.com/rust-lang/crates.io-index#comfy-table@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
@@ -14541,15 +14173,15 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#miette@7.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#opentelemetry@0.31.0",
         "registry+https://github.com/rust-lang/crates.io-index#owo-colors@4.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler@0.47.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
@@ -14618,7 +14250,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#mac_address@1.1.8",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
@@ -14701,11 +14333,11 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#portable-atomic@1.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@2.1.3",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
@@ -14720,14 +14352,14 @@
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.20",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0",
@@ -14764,7 +14396,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -14786,7 +14418,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#addr2line@0.25.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#object@0.37.3",
         "registry+https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.28",
@@ -14871,7 +14503,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1"
       ]
     },
@@ -14901,10 +14533,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap@4.6.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.6.2",
-        "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3"
+        "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.4"
       ]
     },
     {
@@ -14917,12 +14549,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@4.6.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#heck@0.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -14968,7 +14600,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#encode_unicode@1.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -14980,13 +14612,13 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15125,7 +14757,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#option-ext@0.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -15187,7 +14819,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15212,9 +14844,9 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
@@ -15225,7 +14857,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15278,12 +14910,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#fs4@1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
@@ -15373,21 +15005,21 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.3.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.10.1"
       ]
     },
@@ -15396,7 +15028,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.4",
       "dependsOn": []
     },
     {
@@ -15454,7 +15086,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#hostname@0.4.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
@@ -15546,7 +15178,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#ipnet@2.12.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
@@ -15700,7 +15332,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.17",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -15720,6 +15352,12 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0"
       ]
@@ -15747,7 +15385,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15776,7 +15414,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
       "dependsOn": []
     },
     {
@@ -15828,7 +15466,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15882,14 +15520,14 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
@@ -15906,17 +15544,17 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.9.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#nix@0.31.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15950,7 +15588,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -15979,7 +15617,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
       ]
@@ -15990,7 +15628,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117"
       ]
@@ -16057,7 +15695,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.9.5",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
@@ -16093,18 +15731,18 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.12",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.12",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#proptest@1.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -16265,7 +15903,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
       ]
@@ -16315,7 +15953,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.45.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler@0.47.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
@@ -16330,20 +15968,20 @@
         "registry+https://github.com/rust-lang/crates.io-index#humantime@2.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.11",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#path_resolver@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.70",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.30.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.8",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.10",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.30",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
@@ -16361,7 +15999,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
@@ -16370,16 +16008,16 @@
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#fs4@0.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#fs4@1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.30.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.8",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
@@ -16392,27 +16030,27 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
-        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
+        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.4",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
@@ -16431,46 +16069,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
-        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.3",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
-        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
-        "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
-        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
-        "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
         "registry+https://github.com/rust-lang/crates.io-index#digest@0.11.3",
@@ -16487,18 +16086,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.4",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
@@ -16513,14 +16112,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
         "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.67",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_menuinst@0.2.70",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#configparser@3.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
@@ -16530,9 +16129,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#known-folders@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#plist@1.10.0",
-        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+        "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.10",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
@@ -16543,12 +16142,12 @@
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.25",
         "registry+https://github.com/rust-lang/crates.io-index#which@8.0.5",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3"
+        "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.6.1",
+        "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.30.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ambient-id@0.0.11",
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
@@ -16560,7 +16159,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http-auth@0.1.10",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#retry-policies@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
@@ -16572,12 +16171,12 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.5",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_package_streaming@0.26.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#astral-tokio-tar@0.6.4",
         "registry+https://github.com/rust-lang/crates.io-index#astral_async_http_range_reader@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.18",
+        "registry+https://github.com/rust-lang/crates.io-index#astral_async_zip@0.0.20",
         "registry+https://github.com/rust-lang/crates.io-index#async-compression@0.4.42",
         "registry+https://github.com/rust-lang/crates.io-index#async-spooled-tempfile@0.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#bzip2@0.6.1",
@@ -16589,10 +16188,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.29.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_networking@0.30.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#simple_spawn_blocking@1.1.1",
@@ -16608,16 +16207,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.15",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
-        "registry+https://github.com/rust-lang/crates.io-index#nix@0.30.1",
-        "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
+        "registry+https://github.com/rust-lang/crates.io-index#nix@0.31.3",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.4.4",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#astral-reqwest-middleware@0.5.1",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
@@ -16625,15 +16224,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_shell@0.27.10",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.104",
         "registry+https://github.com/rust-lang/crates.io-index#enum_dispatch@0.3.13",
         "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.47.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.13",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_pty@0.2.15",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#shlex@2.0.1",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
@@ -16643,13 +16242,13 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.0",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
@@ -16675,7 +16274,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -16688,7 +16287,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#reflink-copy@0.1.30",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows@0.62.2"
       ]
@@ -16806,20 +16405,20 @@
         "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rpassword@7.5.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#rtoolbox@0.0.5",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
@@ -16827,7 +16426,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rtoolbox@0.0.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0"
       ]
     },
@@ -16857,7 +16456,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.12.1"
       ]
     },
@@ -16977,7 +16576,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -16995,7 +16594,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -17079,13 +16678,13 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.4.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8"
       ]
     },
@@ -17127,7 +16726,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -17188,7 +16787,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
@@ -17214,7 +16813,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
@@ -17225,7 +16824,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tar@0.4.46",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.29",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#xattr@1.6.1"
       ]
     },
@@ -17266,7 +16865,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.2"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -17349,7 +16948,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
@@ -17364,7 +16963,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#futures-io@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.33",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1"
       ]
@@ -17373,7 +16972,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.12.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
@@ -17459,7 +17058,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.13",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.19",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
@@ -17688,7 +17287,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -17708,7 +17307,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#which@8.0.5",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -17859,14 +17458,14 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -17880,16 +17479,10 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.41.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -17898,7 +17491,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188",
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#security-framework-sys@2.17.0"
       ]
     },
@@ -17906,7 +17499,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.6.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7",
-        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.188"
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
       ]
     },
     {
@@ -17962,12 +17555,6 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.3.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2"
@@ -17980,16 +17567,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-interface@0.59.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-implement@0.60.2",
@@ -17997,14 +17574,6 @@
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
         "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.5.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0"
       ]
     },
     {
@@ -18032,33 +17601,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1",
       "dependsOn": []
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.3.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.62.2",
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-registry@0.5.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2"
       ]
     },
     {
@@ -18070,21 +17620,9 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.3.4",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-result@0.4.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
       ]
     },
     {
@@ -18118,12 +17656,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows-threading@0.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.2.1"
@@ -18134,16 +17666,6 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.52.0",
         "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#windows@0.61.3",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.61.2",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-future@0.2.1",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-link@0.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0"
       ]
     },
     {
@@ -18158,36 +17680,6 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6",
       "dependsOn": []
-    }
-  ],
-  "vulnerabilities": [
-    {
-      "id": "RUSTSEC-2026-0195",
-      "description": "`NsReader` resolves namespaces by calling `NamespaceResolver::push` for every\n`Start`/`Empty` event *before* the event is returned to the caller. `push`\niterated all `xmlns` / `xmlns:*` attributes on the start tag and, for each one,\nappended the prefix bytes to an internal buffer and pushed a `NamespaceBinding`\n(32 bytes on 64-bit) to an internal `Vec`, with no upper bound on the number of\ndeclarations.\n\n## Impact\n\nA start tag with `N` namespace declarations drove roughly `3\u00d7` the tag's byte\nsize in `NamespaceResolver` heap, allocated *inside* `quick-xml` before the\n`NsReader` consumer ever received the event and could inspect or reject it. A\nconsumer that bounds its *input* size therefore still cannot bound this\nallocation: an `M`-byte start tag yields on the order of `3 \u00d7 M` bytes of\nresolver heap the caller never sees.\n\nOn untrusted XML this lets a remote, unauthenticated attacker force large heap\nallocations with a single start tag. With several `NsReader`s running\nconcurrently on independent inputs (a common server pattern), the allocations\nstack and can exhaust process memory, causing the operating system to kill the\nprocess (OOM). This was confirmed against a real-world RPKI relying party (NLnet\nLabs Routinator), where concurrent RRDP validation workers parsing a crafted\n`snapshot.xml` exceeded the memory limit and the process was OOM-killed.\n\n## Affected code paths\n\nConsumers using `NsReader` (which always calls `NamespaceResolver::push` before\nyielding `Start`/`Empty`), or calling `NamespaceResolver::push` directly. A plain\n`Reader` that does not perform namespace resolution is not affected.\n\n## Remediation\n\nUpgrade to `quick-xml >= 0.41.0`. `NamespaceResolver::push` now rejects a start\ntag that declares more than `DEFAULT_MAX_DECLARATIONS_PER_ELEMENT` (256)\nnamespace bindings, returning the new `NamespaceError::TooManyDeclarations`\ninstead of allocating without limit. The limit is configurable via\n`NamespaceResolver::set_max_declarations_per_element` (use `usize::MAX` to\nrestore the previous unbounded behavior), and `NsReader::resolver_mut()` is\nprovided to reach it.\n\nThere is no clean workaround for `NsReader` consumers before 0.41.0, as the\nallocation happens inside the reader with no configuration knob to cap it.",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0195.html"
-      },
-      "ratings": [],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5"
-        }
-      ]
-    },
-    {
-      "id": "RUSTSEC-2026-0194",
-      "description": "`BytesStart::attributes()` returns an `Attributes` iterator which, by default\n(`with_checks(true)`), rejects a start tag that repeats an attribute name. For\neach attribute yielded, the iterator compared the new name against every name\nseen so far in the same tag using a linear scan, so a start tag with `N`\ndistinct attribute names cost `O(N\u00b2)` byte comparisons. There was no bound on\n`N` other than the size of the buffered start tag.\n\n## Impact\n\nAny code that parses untrusted XML and iterates a start tag's attributes with\nthe default duplicate check enabled can be made to spend CPU time quadratic in\nthe number of attributes on a single tag. Because the check is pure computation\nwith no `.await`/I/O, an I/O-based timeout on the consumer (for example a read\nor request timeout) cannot interrupt it while it runs.\n\nMeasured cost of a single start tag, release build:\n\n| Attributes on one tag | Time |\n|---|---|\n| 80,000  | ~6 s   |\n| 800,000 | ~10 min |\n\nThe cost grows with the square of the attribute count, so a start tag of a few\ntens of megabytes can stall a parsing thread for hours. No memory is exhausted\nand the parser does not crash; the effect is CPU exhaustion on the thread doing\nthe parsing: a single crafted start tag can pin a CPU core for minutes to hours,\ndenying service to that worker. A deployment that places a wall-clock bound on\nparsing, or confines it to a non-critical thread, may consider the availability\nimpact lower.\n\n## Affected code paths\n\n* `BytesStart::attributes()` / `Attributes` iterated with checks enabled (the\n  default), and `BytesStart::try_get_attribute`.\n* `NsReader`, which resolves namespaces by iterating a tag's attributes and so\n  reaches the same check internally.\n\nConsumers that iterate attributes with `.attributes().with_checks(false)` and do\nnot use `NsReader` are not affected.\n\nThis was reported as reachable by a remote, unauthenticated attacker in a\nreal-world RPKI relying party (NLnet Labs Routinator) via a crafted RRDP\n`snapshot.xml`.\n\n## Remediation\n\nUpgrade to `quick-xml >= 0.41.0`, where the duplicate check keeps the linear\nscan for start tags with a small number of attributes and switches to an `O(1)`\nhash pre-filter above a threshold, making the whole tag `O(N)`. The reported\n`AttrError::Duplicated` positions are unchanged.\n\nIf upgrading is not possible and duplicate-name detection is not required,\ndisable it with `.attributes().with_checks(false)` (this does not help\n`NsReader` consumers, which have no equivalent opt-out before 0.41.0).",
-      "source": {
-        "name": "RustSec",
-        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0194.html"
-      },
-      "ratings": [],
-      "affects": [
-        {
-          "ref": "registry+https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5"
-        }
-      ]
     }
   ]
 }

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-07-15T15:42:38Z<br>
+Generated: 2026-07-21T14:29:34Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 459 (69 platform-specific)<br>
+Packages: 467 (70 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
-<br>**[Security advisories](#security-advisories): 7 (2 INFO) across 5 packages**
+<br>**[Security advisories](#security-advisories): 2 across 1 package**
 
 ## Packages
 
@@ -23,15 +23,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [anstyle-parse](https://crates.io/crates/anstyle-parse) | 1.0.0 | MIT OR Apache-2.0 |  |  |
 | [anstyle-query](https://crates.io/crates/anstyle-query) | 1.1.5 | MIT OR Apache-2.0 |  |  |
 | [anstyle-wincon](https://crates.io/crates/anstyle-wincon) | 3.0.11 | MIT OR Apache-2.0 | windows |  |
-| [anyhow](https://crates.io/crates/anyhow) | 1.0.102 | MIT OR Apache-2.0 |  | 1 |
+| [anyhow](https://crates.io/crates/anyhow) | 1.0.104 | MIT OR Apache-2.0 |  |  |
 | [astral-reqwest-middleware](https://crates.io/crates/astral-reqwest-middleware) | 0.5.1 | MIT OR Apache-2.0 |  |  |
-| [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.2 | MIT OR Apache-2.0 |  |  |
+| [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.4 | MIT OR Apache-2.0 |  |  |
 | [astral\_async\_http\_range\_reader](https://crates.io/crates/astral_async_http_range_reader) | 0.11.0 | MIT |  |  |
 | [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.18 | MIT |  |  |
 | [async-compression](https://crates.io/crates/async-compression) | 0.4.42 | MIT OR Apache-2.0 |  |  |
 | [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |  |
 | [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |  |
-| [async-trait](https://crates.io/crates/async-trait) | 0.1.89 | MIT OR Apache-2.0 |  |  |
+| [async-trait](https://crates.io/crates/async-trait) | 0.1.91 | MIT OR Apache-2.0 |  |  |
 | [atomic-waker](https://crates.io/crates/atomic-waker) | 1.1.2 | Apache-2.0 OR MIT |  |  |
 | [autocfg](https://crates.io/crates/autocfg) | 1.5.1 | Apache-2.0 OR MIT |  |  |
 | [backtrace](https://crates.io/crates/backtrace) | 0.3.76 | MIT OR Apache-2.0 |  |  |
@@ -39,24 +39,25 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [base64](https://crates.io/crates/base64) | 0.22.1 | MIT OR Apache-2.0 |  |  |
 | [bit-set](https://crates.io/crates/bit-set) | 0.8.0 | Apache-2.0 OR MIT |  |  |
 | [bit-vec](https://crates.io/crates/bit-vec) | 0.8.0 | Apache-2.0 OR MIT |  |  |
-| [bitflags](https://crates.io/crates/bitflags) | 2.13.0 | MIT OR Apache-2.0 |  |  |
+| [bitflags](https://crates.io/crates/bitflags) | 1.3.2 | MIT OR Apache-2.0 |  |  |
+| [bitflags](https://crates.io/crates/bitflags) | 2.13.1 | MIT OR Apache-2.0 |  |  |
 | [blake2](https://crates.io/crates/blake2) | 0.11.0-rc.6 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.10.4 | MIT OR Apache-2.0 |  |  |
 | [block-buffer](https://crates.io/crates/block-buffer) | 0.12.1 | MIT OR Apache-2.0 |  |  |
 | [boxcar](https://crates.io/crates/boxcar) | 0.2.14 | MIT |  |  |
 | [bs58](https://crates.io/crates/bs58) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.3 | MIT OR Apache-2.0 |  |  |
-| [bytes](https://crates.io/crates/bytes) | 1.11.1 | MIT |  |  |
+| [bytes](https://crates.io/crates/bytes) | 1.12.1 | MIT |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
 | [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.2.64 | MIT OR Apache-2.0 |  |  |
+| [cc](https://crates.io/crates/cc) | 1.3.0 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
-| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.1 | MIT | linux, macos |  |
-| [chacha20](https://crates.io/crates/chacha20) | 0.10.0 | MIT OR Apache-2.0 |  |  |
+| [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.2 | MIT | linux, macos |  |
+| [chacha20](https://crates.io/crates/chacha20) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.45 | MIT OR Apache-2.0 |  |  |
-| [clap](https://crates.io/crates/clap) | 4.6.1 | MIT OR Apache-2.0 |  |  |
-| [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.0 | MIT OR Apache-2.0 |  |  |
-| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.1 | MIT OR Apache-2.0 |  |  |
+| [clap](https://crates.io/crates/clap) | 4.6.3 | MIT OR Apache-2.0 |  |  |
+| [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.2 | MIT OR Apache-2.0 |  |  |
+| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.3 | MIT OR Apache-2.0 |  |  |
 | [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [cmov](https://crates.io/crates/cmov) | 0.5.4 | Apache-2.0 OR MIT |  |  |
 | [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |  |
@@ -64,7 +65,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [compression-codecs](https://crates.io/crates/compression-codecs) | 0.4.38 | MIT OR Apache-2.0 |  |  |
 | [compression-core](https://crates.io/crates/compression-core) | 0.4.32 | MIT OR Apache-2.0 |  |  |
 | [configparser](https://crates.io/crates/configparser) | 3.2.0 | MIT OR LGPL-3.0-or-later | linux |  |
-| [console](https://crates.io/crates/console) | 0.16.3 | MIT |  |  |
+| [console](https://crates.io/crates/console) | 0.16.4 | MIT |  |  |
 | [const-oid](https://crates.io/crates/const-oid) | 0.10.2 | Apache-2.0 OR MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.9.4 | MIT OR Apache-2.0 | macos |  |
@@ -72,9 +73,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |  |
-| [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.6 | MIT OR Apache-2.0 |  |  |
-| [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.18 | MIT OR Apache-2.0 |  | 1 |
-| [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.21 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.7 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.20 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.22 | MIT OR Apache-2.0 |  |  |
 | [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |  |
 | [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT | windows |  |
 | [crypto-common](https://crates.io/crates/crypto-common) | 0.1.7 | MIT OR Apache-2.0 |  |  |
@@ -84,6 +85,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [darling\_core](https://crates.io/crates/darling_core) | 0.23.0 | MIT |  |  |
 | [darling\_macro](https://crates.io/crates/darling_macro) | 0.23.0 | MIT |  |  |
 | [dashmap](https://crates.io/crates/dashmap) | 6.2.1 | MIT |  |  |
+| [defmt](https://crates.io/crates/defmt) | 1.1.1 | MIT OR Apache-2.0 |  |  |
+| [defmt-macros](https://crates.io/crates/defmt-macros) | 1.1.1 | MIT OR Apache-2.0 |  |  |
+| [defmt-parser](https://crates.io/crates/defmt-parser) | 1.0.0 | MIT OR Apache-2.0 |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
 | [digest](https://crates.io/crates/digest) | 0.11.3 | MIT OR Apache-2.0 |  |  |
@@ -100,7 +104,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [erased-serde](https://crates.io/crates/erased-serde) | 0.4.10 | MIT OR Apache-2.0 |  |  |
 | [errno](https://crates.io/crates/errno) | 0.3.14 | MIT OR Apache-2.0 | linux, macos |  |
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.18.0 | MIT |  |  |
-| [fastrand](https://crates.io/crates/fastrand) | 2.4.1 | Apache-2.0 OR MIT |  |  |
+| [fastrand](https://crates.io/crates/fastrand) | 2.5.0 | Apache-2.0 OR MIT |  |  |
 | [figment](https://crates.io/crates/figment) | 0.10.19 | MIT OR Apache-2.0 |  |  |
 | [file\_url](https://crates.io/crates/file_url) | 0.3.1 | BSD-3-Clause |  |  |
 | [filetime](https://crates.io/crates/filetime) | 0.2.29 | MIT OR Apache-2.0 |  |  |
@@ -112,22 +116,22 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [foreign-types](https://crates.io/crates/foreign-types) | 0.3.2 | MIT OR Apache-2.0 | linux |  |
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
 | [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |  |
-| [fs-err](https://crates.io/crates/fs-err) | 3.3.0 | MIT OR Apache-2.0 |  |  |
+| [fs-err](https://crates.io/crates/fs-err) | 3.3.1 | MIT OR Apache-2.0 |  |  |
 | [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |  |
-| [futures](https://crates.io/crates/futures) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-channel](https://crates.io/crates/futures-channel) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-core](https://crates.io/crates/futures-core) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-executor](https://crates.io/crates/futures-executor) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-io](https://crates.io/crates/futures-io) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures](https://crates.io/crates/futures) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-channel](https://crates.io/crates/futures-channel) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-core](https://crates.io/crates/futures-core) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-executor](https://crates.io/crates/futures-executor) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-io](https://crates.io/crates/futures-io) | 0.3.33 | MIT OR Apache-2.0 |  |  |
 | [futures-lite](https://crates.io/crates/futures-lite) | 2.6.1 | Apache-2.0 OR MIT |  |  |
-| [futures-macro](https://crates.io/crates/futures-macro) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-sink](https://crates.io/crates/futures-sink) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-task](https://crates.io/crates/futures-task) | 0.3.32 | MIT OR Apache-2.0 |  |  |
-| [futures-util](https://crates.io/crates/futures-util) | 0.3.32 | MIT OR Apache-2.0 |  |  |
+| [futures-macro](https://crates.io/crates/futures-macro) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-sink](https://crates.io/crates/futures-sink) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-task](https://crates.io/crates/futures-task) | 0.3.33 | MIT OR Apache-2.0 |  |  |
+| [futures-util](https://crates.io/crates/futures-util) | 0.3.33 | MIT OR Apache-2.0 |  |  |
 | [generic-array](https://crates.io/crates/generic-array) | 0.14.7 | MIT |  |  |
 | [getrandom](https://crates.io/crates/getrandom) | 0.2.17 | MIT OR Apache-2.0 |  |  |
 | [getrandom](https://crates.io/crates/getrandom) | 0.3.4 | MIT OR Apache-2.0 |  |  |
-| [getrandom](https://crates.io/crates/getrandom) | 0.4.2 | MIT OR Apache-2.0 |  |  |
+| [getrandom](https://crates.io/crates/getrandom) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 | linux, macos |  |
 | [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |  |
 | [h2](https://crates.io/crates/h2) | 0.4.15 | MIT |  |  |
@@ -141,14 +145,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [hostname](https://crates.io/crates/hostname) | 0.4.2 | MIT |  |  |
 | [http](https://crates.io/crates/http) | 1.4.2 | MIT OR Apache-2.0 |  |  |
 | [http-auth](https://crates.io/crates/http-auth) | 0.1.10 | MIT OR Apache-2.0 |  |  |
-| [http-body](https://crates.io/crates/http-body) | 1.0.1 | MIT |  |  |
-| [http-body-util](https://crates.io/crates/http-body-util) | 0.1.3 | MIT |  |  |
-| [http-content-range](https://crates.io/crates/http-content-range) | 0.2.4 | MIT OR Apache-2.0 |  |  |
+| [http-body](https://crates.io/crates/http-body) | 1.1.0 | MIT |  |  |
+| [http-body-util](https://crates.io/crates/http-body-util) | 0.1.4 | MIT |  |  |
+| [http-content-range](https://crates.io/crates/http-content-range) | 0.2.5 | MIT OR Apache-2.0 |  |  |
 | [httparse](https://crates.io/crates/httparse) | 1.10.1 | MIT OR Apache-2.0 |  |  |
 | [httpdate](https://crates.io/crates/httpdate) | 1.0.3 | MIT OR Apache-2.0 |  |  |
-| [humantime](https://crates.io/crates/humantime) | 2.3.0 | MIT OR Apache-2.0 |  |  |
-| [hybrid-array](https://crates.io/crates/hybrid-array) | 0.4.12 | MIT OR Apache-2.0 |  |  |
-| [hyper](https://crates.io/crates/hyper) | 1.10.1 | MIT |  |  |
+| [humantime](https://crates.io/crates/humantime) | 2.4.0 | MIT OR Apache-2.0 |  |  |
+| [hybrid-array](https://crates.io/crates/hybrid-array) | 0.4.13 | MIT OR Apache-2.0 |  |  |
+| [hyper](https://crates.io/crates/hyper) | 1.11.0 | MIT |  |  |
 | [hyper-rustls](https://crates.io/crates/hyper-rustls) | 0.27.9 | Apache-2.0 OR ISC OR MIT |  |  |
 | [hyper-tls](https://crates.io/crates/hyper-tls) | 0.6.0 | MIT OR Apache-2.0 |  |  |
 | [hyper-util](https://crates.io/crates/hyper-util) | 0.1.20 | MIT |  |  |
@@ -165,7 +169,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [idna\_adapter](https://crates.io/crates/idna_adapter) | 1.2.2 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 1.9.3 | Apache-2.0 OR MIT |  |  |
 | [indexmap](https://crates.io/crates/indexmap) | 2.14.0 | Apache-2.0 OR MIT |  |  |
-| [indicatif](https://crates.io/crates/indicatif) | 0.18.4 | MIT |  |  |
+| [indicatif](https://crates.io/crates/indicatif) | 0.18.6 | MIT |  |  |
 | [inlinable\_string](https://crates.io/crates/inlinable_string) | 0.1.15 | Apache-2.0 OR MIT |  |  |
 | [ipnet](https://crates.io/crates/ipnet) | 2.12.0 | MIT OR Apache-2.0 |  |  |
 | [is-terminal](https://crates.io/crates/is-terminal) | 0.4.17 | MIT |  |  |
@@ -174,14 +178,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
-| [jiff](https://crates.io/crates/jiff) | 0.2.28 | Unlicense OR MIT |  |  |
-| [jobserver](https://crates.io/crates/jobserver) | 0.1.34 | MIT OR Apache-2.0 |  |  |
+| [jiff](https://crates.io/crates/jiff) | 0.2.34 | Unlicense OR MIT |  |  |
+| [jiff-core](https://crates.io/crates/jiff-core) | 0.1.0 | Unlicense OR MIT |  |  |
+| [jobserver](https://crates.io/crates/jobserver) | 0.1.35 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
 | [lazy-regex](https://crates.io/crates/lazy-regex) | 3.6.0 | MIT |  |  |
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.5 | bzip2-1.0.6 |  |  |
-| [libc](https://crates.io/crates/libc) | 0.2.186 | MIT OR Apache-2.0 |  |  |
+| [libc](https://crates.io/crates/libc) | 0.2.188 | MIT OR Apache-2.0 |  |  |
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
@@ -190,15 +195,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [mac\_address](https://crates.io/crates/mac_address) | 1.1.8 | MIT OR Apache-2.0 |  |  |
 | [matchers](https://crates.io/crates/matchers) | 0.2.0 | MIT |  |  |
 | [md-5](https://crates.io/crates/md-5) | 0.11.0 | MIT OR Apache-2.0 |  |  |
-| [memchr](https://crates.io/crates/memchr) | 2.8.2 | Unlicense OR MIT |  |  |
-| [memmap2](https://crates.io/crates/memmap2) | 0.9.10 | MIT OR Apache-2.0 |  | 1 |
+| [memchr](https://crates.io/crates/memchr) | 2.8.3 | Unlicense OR MIT |  |  |
+| [memmap2](https://crates.io/crates/memmap2) | 0.9.11 | MIT OR Apache-2.0 |  |  |
 | [memoffset](https://crates.io/crates/memoffset) | 0.9.1 | MIT | linux, macos |  |
 | [miette](https://crates.io/crates/miette) | 7.6.0 | Apache-2.0 |  |  |
 | [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |  |
 | [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |  |
 | [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |  |
 | [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |  |
-| [mio](https://crates.io/crates/mio) | 1.2.1 | MIT |  |  |
+| [mio](https://crates.io/crates/mio) | 1.2.2 | MIT |  |  |
 | [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |  |
 | [nix](https://crates.io/crates/nix) | 0.29.0 | MIT | linux, macos |  |
 | [nix](https://crates.io/crates/nix) | 0.30.1 | MIT | linux, macos |  |
@@ -238,12 +243,12 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [pin-project-internal](https://crates.io/crates/pin-project-internal) | 1.1.13 | Apache-2.0 OR MIT |  |  |
 | [pin-project-lite](https://crates.io/crates/pin-project-lite) | 0.2.17 | Apache-2.0 OR MIT |  |  |
 | [pkg-config](https://crates.io/crates/pkg-config) | 0.3.33 | MIT OR Apache-2.0 |  |  |
-| [plist](https://crates.io/crates/plist) | 1.9.0 | MIT | macos |  |
-| [portable-atomic](https://crates.io/crates/portable-atomic) | 1.13.1 | Apache-2.0 OR MIT |  |  |
+| [plist](https://crates.io/crates/plist) | 1.10.0 | MIT | macos |  |
+| [portable-atomic](https://crates.io/crates/portable-atomic) | 1.14.0 | Apache-2.0 OR MIT |  |  |
 | [potential\_utf](https://crates.io/crates/potential_utf) | 0.1.5 | Unicode-3.0 |  |  |
 | [powerfmt](https://crates.io/crates/powerfmt) | 0.2.0 | MIT OR Apache-2.0 |  |  |
 | [ppv-lite86](https://crates.io/crates/ppv-lite86) | 0.2.21 | MIT OR Apache-2.0 |  |  |
-| [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.106 | MIT OR Apache-2.0 |  |  |
+| [proc-macro2](https://crates.io/crates/proc-macro2) | 1.0.107 | MIT OR Apache-2.0 |  |  |
 | [proc-macro2-diagnostics](https://crates.io/crates/proc-macro2-diagnostics) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [proptest](https://crates.io/crates/proptest) | 1.11.0 | MIT OR Apache-2.0 |  |  |
 | [prost](https://crates.io/crates/prost) | 0.14.4 | Apache-2.0 |  |  |
@@ -251,10 +256,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
 | [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux | 2 |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.39.4 | MIT | macos | 2 |
-| [quote](https://crates.io/crates/quote) | 1.0.45 | MIT OR Apache-2.0 |  |  |
-| [rand](https://crates.io/crates/rand) | 0.10.1 | MIT OR Apache-2.0 |  |  |
-| [rand](https://crates.io/crates/rand) | 0.9.4 | MIT OR Apache-2.0 |  |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.41.0 | MIT | macos |  |
+| [quote](https://crates.io/crates/quote) | 1.0.47 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.10.2 | MIT OR Apache-2.0 |  |  |
+| [rand](https://crates.io/crates/rand) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_chacha](https://crates.io/crates/rand_chacha) | 0.9.0 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
@@ -262,8 +267,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler](https://crates.io/crates/rattler) | 0.45.0 | BSD-3-Clause |  |  |
 | [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.0 | BSD-3-Clause |  |  |
 | [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.47.2 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.48.0 | BSD-3-Clause |  |  |
 | [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.1 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.3 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.4 | BSD-3-Clause |  |  |
 | [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.1 | BSD-3-Clause |  |  |
 | [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.67 | BSD-3-Clause |  |  |
 | [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.29.0 | BSD-3-Clause |  |  |
@@ -271,14 +277,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.13 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.1 | BSD-3-Clause |  |  |
 | [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.7 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.0 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.1 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
-| [ref-cast](https://crates.io/crates/ref-cast) | 1.0.25 | MIT OR Apache-2.0 |  |  |
-| [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.25 | MIT OR Apache-2.0 |  |  |
-| [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.29 | MIT OR Apache-2.0 |  |  |
-| [regex](https://crates.io/crates/regex) | 1.12.4 | MIT OR Apache-2.0 |  |  |
-| [regex-automata](https://crates.io/crates/regex-automata) | 0.4.14 | MIT OR Apache-2.0 |  |  |
+| [ref-cast](https://crates.io/crates/ref-cast) | 1.0.26 | MIT OR Apache-2.0 |  |  |
+| [ref-cast-impl](https://crates.io/crates/ref-cast-impl) | 1.0.26 | MIT OR Apache-2.0 |  |  |
+| [reflink-copy](https://crates.io/crates/reflink-copy) | 0.1.30 | MIT OR Apache-2.0 |  |  |
+| [regex](https://crates.io/crates/regex) | 1.13.1 | MIT OR Apache-2.0 |  |  |
+| [regex-automata](https://crates.io/crates/regex-automata) | 0.4.16 | MIT OR Apache-2.0 |  |  |
 | [regex-syntax](https://crates.io/crates/regex-syntax) | 0.8.11 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.12.28 | MIT OR Apache-2.0 |  |  |
 | [reqwest](https://crates.io/crates/reqwest) | 0.13.4 | MIT OR Apache-2.0 |  |  |
@@ -288,13 +294,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rlimit](https://crates.io/crates/rlimit) | 0.11.0 | MIT | linux, macos |  |
 | [rpassword](https://crates.io/crates/rpassword) | 7.5.4 | Apache-2.0 |  |  |
 | [rtoolbox](https://crates.io/crates/rtoolbox) | 0.0.5 | Apache-2.0 |  |  |
-| [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.27 | MIT OR Apache-2.0 |  |  |
-| [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.2 | Apache-2.0 OR MIT |  |  |
+| [rustc-demangle](https://crates.io/crates/rustc-demangle) | 0.1.28 | MIT OR Apache-2.0 |  |  |
+| [rustc-hash](https://crates.io/crates/rustc-hash) | 2.1.3 | Apache-2.0 OR MIT |  |  |
 | [rustc\_version](https://crates.io/crates/rustc_version) | 0.4.1 | MIT OR Apache-2.0 |  |  |
 | [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |  |
 | [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux, macos |  |
-| [rustls](https://crates.io/crates/rustls) | 0.23.40 | Apache-2.0 OR ISC OR MIT |  |  |
-| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.14.1 | MIT OR Apache-2.0 |  |  |
+| [rustls](https://crates.io/crates/rustls) | 0.23.42 | Apache-2.0 OR ISC OR MIT |  |  |
+| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.15.0 | MIT OR Apache-2.0 |  |  |
 | [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.13 | ISC |  |  |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
@@ -307,14 +313,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [security-framework-sys](https://crates.io/crates/security-framework-sys) | 2.17.0 | MIT OR Apache-2.0 | macos |  |
 | [self-replace](https://crates.io/crates/self-replace) | 1.5.0 | Apache-2.0 |  |  |
 | [semver](https://crates.io/crates/semver) | 1.0.28 | MIT OR Apache-2.0 |  |  |
-| [serde](https://crates.io/crates/serde) | 1.0.228 | MIT OR Apache-2.0 |  |  |
+| [serde](https://crates.io/crates/serde) | 1.0.229 | MIT OR Apache-2.0 |  |  |
 | [serde-untagged](https://crates.io/crates/serde-untagged) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [serde-value](https://crates.io/crates/serde-value) | 0.7.0 | MIT |  |  |
 | [serde\_bytes](https://crates.io/crates/serde_bytes) | 0.11.19 | MIT OR Apache-2.0 |  |  |
-| [serde\_core](https://crates.io/crates/serde_core) | 1.0.228 | MIT OR Apache-2.0 |  |  |
-| [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.228 | MIT OR Apache-2.0 |  |  |
-| [serde\_json](https://crates.io/crates/serde_json) | 1.0.150 | MIT OR Apache-2.0 |  |  |
-| [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.20 | MIT OR Apache-2.0 |  |  |
+| [serde\_core](https://crates.io/crates/serde_core) | 1.0.229 | MIT OR Apache-2.0 |  |  |
+| [serde\_derive](https://crates.io/crates/serde_derive) | 1.0.229 | MIT OR Apache-2.0 |  |  |
+| [serde\_json](https://crates.io/crates/serde_json) | 1.0.151 | MIT OR Apache-2.0 |  |  |
+| [serde\_repr](https://crates.io/crates/serde_repr) | 0.1.21 | MIT OR Apache-2.0 |  |  |
 | [serde\_spanned](https://crates.io/crates/serde_spanned) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_urlencoded](https://crates.io/crates/serde_urlencoded) | 0.7.1 | MIT OR Apache-2.0 |  |  |
 | [serde\_with](https://crates.io/crates/serde_with) | 3.21.0 | MIT OR Apache-2.0 |  |  |
@@ -326,13 +332,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [shlex](https://crates.io/crates/shlex) | 2.0.1 | MIT OR Apache-2.0 |  |  |
 | [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
-| [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.9 | MIT |  |  |
-| [simd-json](https://crates.io/crates/simd-json) | 0.17.0 | Apache-2.0 OR MIT |  |  |
+| [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.10 | MIT |  |  |
+| [simd-json](https://crates.io/crates/simd-json) | 0.17.3 | Apache-2.0 OR MIT |  |  |
 | [simdutf8](https://crates.io/crates/simdutf8) | 0.1.5 | MIT OR Apache-2.0 |  |  |
-| [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.0 | BSD-3-Clause |  |  |
+| [simple\_spawn\_blocking](https://crates.io/crates/simple_spawn_blocking) | 1.1.1 | BSD-3-Clause |  |  |
 | [slab](https://crates.io/crates/slab) | 0.4.12 | MIT |  |  |
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.2 | MIT OR Apache-2.0 |  |  |
-| [socket2](https://crates.io/crates/socket2) | 0.6.4 | MIT OR Apache-2.0 |  |  |
+| [socket2](https://crates.io/crates/socket2) | 0.6.5 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
 | [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |  |
@@ -342,7 +348,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [supports-color](https://crates.io/crates/supports-color) | 3.0.2 | Apache-2.0 |  |  |
 | [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |  |
 | [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |  |
-| [syn](https://crates.io/crates/syn) | 2.0.118 | MIT OR Apache-2.0 |  |  |
+| [syn](https://crates.io/crates/syn) | 2.0.119 | MIT OR Apache-2.0 |  |  |
+| [syn](https://crates.io/crates/syn) | 3.0.2 | MIT OR Apache-2.0 |  |  |
 | [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |  |
 | [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |  |
 | [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |  |
@@ -353,22 +360,22 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |  |
 | [textwrap](https://crates.io/crates/textwrap) | 0.16.2 | MIT |  |  |
 | [thiserror](https://crates.io/crates/thiserror) | 1.0.69 | MIT OR Apache-2.0 |  |  |
-| [thiserror](https://crates.io/crates/thiserror) | 2.0.18 | MIT OR Apache-2.0 |  |  |
+| [thiserror](https://crates.io/crates/thiserror) | 2.0.19 | MIT OR Apache-2.0 |  |  |
 | [thiserror-impl](https://crates.io/crates/thiserror-impl) | 1.0.69 | MIT OR Apache-2.0 |  |  |
-| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.18 | MIT OR Apache-2.0 |  |  |
-| [thread\_local](https://crates.io/crates/thread_local) | 1.1.9 | MIT OR Apache-2.0 |  |  |
-| [time](https://crates.io/crates/time) | 0.3.49 | MIT OR Apache-2.0 |  |  |
+| [thiserror-impl](https://crates.io/crates/thiserror-impl) | 2.0.19 | MIT OR Apache-2.0 |  |  |
+| [thread\_local](https://crates.io/crates/thread_local) | 1.1.10 | MIT OR Apache-2.0 |  |  |
+| [time](https://crates.io/crates/time) | 0.3.54 | MIT OR Apache-2.0 |  |  |
 | [time-core](https://crates.io/crates/time-core) | 0.1.9 | MIT OR Apache-2.0 |  |  |
-| [time-macros](https://crates.io/crates/time-macros) | 0.2.29 | MIT OR Apache-2.0 |  |  |
+| [time-macros](https://crates.io/crates/time-macros) | 0.2.32 | MIT OR Apache-2.0 |  |  |
 | [tinystr](https://crates.io/crates/tinystr) | 0.8.3 | Unicode-3.0 |  |  |
-| [tinyvec](https://crates.io/crates/tinyvec) | 1.11.0 | Zlib OR Apache-2.0 OR MIT |  |  |
+| [tinyvec](https://crates.io/crates/tinyvec) | 1.12.0 | Zlib OR Apache-2.0 OR MIT |  |  |
 | [tinyvec\_macros](https://crates.io/crates/tinyvec_macros) | 0.1.1 | MIT OR Apache-2.0 OR Zlib |  |  |
-| [tokio](https://crates.io/crates/tokio) | 1.52.3 | MIT |  |  |
-| [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.0 | MIT |  |  |
+| [tokio](https://crates.io/crates/tokio) | 1.53.1 | MIT |  |  |
+| [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.1 | MIT |  |  |
 | [tokio-native-tls](https://crates.io/crates/tokio-native-tls) | 0.3.1 | MIT |  |  |
 | [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |  |
 | [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |  |
-| [tokio-util](https://crates.io/crates/tokio-util) | 0.7.18 | MIT |  |  |
+| [tokio-util](https://crates.io/crates/tokio-util) | 0.7.19 | MIT |  |  |
 | [toml](https://crates.io/crates/toml) | 0.9.12+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml](https://crates.io/crates/toml) | 1.1.3+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml\_datetime](https://crates.io/crates/toml_datetime) | 0.7.5+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
@@ -409,15 +416,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [urlencoding](https://crates.io/crates/urlencoding) | 2.1.3 | MIT |  |  |
 | [utf8\_iter](https://crates.io/crates/utf8_iter) | 1.0.4 | Apache-2.0 OR MIT |  |  |
 | [utf8parse](https://crates.io/crates/utf8parse) | 0.2.2 | Apache-2.0 OR MIT |  |  |
-| [uuid](https://crates.io/crates/uuid) | 1.23.3 | Apache-2.0 OR MIT |  |  |
-| [value-trait](https://crates.io/crates/value-trait) | 0.12.1 | Apache-2.0 OR MIT |  |  |
+| [uuid](https://crates.io/crates/uuid) | 1.24.0 | Apache-2.0 OR MIT |  |  |
+| [value-trait](https://crates.io/crates/value-trait) | 0.12.2 | Apache-2.0 OR MIT |  |  |
 | [vcpkg](https://crates.io/crates/vcpkg) | 0.2.15 | MIT OR Apache-2.0 | linux |  |
 | [version-ranges](https://crates.io/crates/version-ranges) | 0.1.3 | MPL-2.0 |  |  |
 | [version\_check](https://crates.io/crates/version_check) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [wait-timeout](https://crates.io/crates/wait-timeout) | 0.2.1 | MIT OR Apache-2.0 |  |  |
 | [want](https://crates.io/crates/want) | 0.3.1 | MIT |  |  |
 | [webbrowser](https://crates.io/crates/webbrowser) | 1.2.1 | MIT OR Apache-2.0 |  |  |
-| [which](https://crates.io/crates/which) | 8.0.4 | MIT |  |  |
+| [which](https://crates.io/crates/which) | 8.0.5 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 | windows |  |
@@ -436,6 +443,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 | windows |  |
+| [windows-registry](https://crates.io/crates/windows-registry) | 0.6.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 | windows |  |
 | [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 | windows |  |
@@ -448,14 +456,14 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
 | [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
 | [winnow](https://crates.io/crates/winnow) | 0.7.15 | MIT |  |  |
-| [winnow](https://crates.io/crates/winnow) | 1.0.3 | MIT |  |  |
+| [winnow](https://crates.io/crates/winnow) | 1.0.4 | MIT |  |  |
 | [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |  |
 | [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 | linux, macos |  |
-| [xxhash-rust](https://crates.io/crates/xxhash-rust) | 0.8.15 | BSL-1.0 |  |  |
+| [xxhash-rust](https://crates.io/crates/xxhash-rust) | 0.8.18 | BSL-1.0 |  |  |
 | [yansi](https://crates.io/crates/yansi) | 1.0.1 | MIT OR Apache-2.0 |  |  |
 | [yoke](https://crates.io/crates/yoke) | 0.8.3 | Unicode-3.0 |  |  |
 | [yoke-derive](https://crates.io/crates/yoke-derive) | 0.8.2 | Unicode-3.0 |  |  |
-| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |  |  |
+| [zerocopy](https://crates.io/crates/zerocopy) | 0.8.55 | BSD-2-Clause OR Apache-2.0 OR MIT |  |  |
 | [zerofrom](https://crates.io/crates/zerofrom) | 0.1.8 | Unicode-3.0 |  |  |
 | [zerofrom-derive](https://crates.io/crates/zerofrom-derive) | 0.1.7 | Unicode-3.0 |  |  |
 | [zeroize](https://crates.io/crates/zeroize) | 1.9.0 | Apache-2.0 OR MIT |  |  |
@@ -463,8 +471,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [zerovec](https://crates.io/crates/zerovec) | 0.11.6 | Unicode-3.0 |  |  |
 | [zerovec-derive](https://crates.io/crates/zerovec-derive) | 0.11.3 | Unicode-3.0 |  |  |
 | [zip](https://crates.io/crates/zip) | 8.6.0 | MIT |  |  |
-| [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.3 | Zlib |  |  |
-| [zmij](https://crates.io/crates/zmij) | 1.0.21 | MIT |  |  |
+| [zlib-rs](https://crates.io/crates/zlib-rs) | 0.6.6 | Zlib |  |  |
+| [zmij](https://crates.io/crates/zmij) | 1.0.23 | MIT |  |  |
 | [zopfli](https://crates.io/crates/zopfli) | 0.8.3 | Apache-2.0 |  |  |
 | [zstd](https://crates.io/crates/zstd) | 0.13.3 | MIT |  |  |
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
@@ -474,26 +482,21 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
 | --- | --- | --- | :---: | :---: | --- |
-| crossbeam-epoch | 0.9.18 | [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204.html) |  |  |  |
-| quick-xml | 0.37.5 | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) |  |  |  |
 | quick-xml | 0.37.5 | [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html) |  |  |  |
-| quick-xml | 0.39.4 | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) |  |  |  |
-| quick-xml | 0.39.4 | [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html) |  |  |  |
-| anyhow | 1.0.102 | [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html) |  |  | INFO |
-| memmap2 | 0.9.10 | [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) |  |  | INFO |
+| quick-xml | 0.37.5 | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) |  |  |  |
 
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 251 |
+| MIT OR Apache-2.0 | 257 |
 | MIT | 85 |
 | Apache-2.0 OR MIT | 36 |
 | Apache-2.0 | 21 |
-| BSD-3-Clause | 19 |
+| BSD-3-Clause | 20 |
 | Unicode-3.0 | 18 |
+| Unlicense OR MIT | 4 |
 | ISC | 3 |
-| Unlicense OR MIT | 3 |
 | Apache-2.0 OR BSD-2-Clause | 2 |
 | Apache-2.0 OR ISC OR MIT | 2 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 2 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,10 +1,10 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-07-21T14:29:34Z<br>
+Generated: 2026-07-22T13:42:08Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 467 (70 platform-specific)<br>
+Packages: 456 (59 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
-<br>**[Security advisories](#security-advisories): 2 across 1 package**
+<br>**Security advisories: 0 found at this time**
 
 ## Packages
 
@@ -27,7 +27,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [astral-reqwest-middleware](https://crates.io/crates/astral-reqwest-middleware) | 0.5.1 | MIT OR Apache-2.0 |  |  |
 | [astral-tokio-tar](https://crates.io/crates/astral-tokio-tar) | 0.6.4 | MIT OR Apache-2.0 |  |  |
 | [astral\_async\_http\_range\_reader](https://crates.io/crates/astral_async_http_range_reader) | 0.11.0 | MIT |  |  |
-| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.18 | MIT |  |  |
+| [astral\_async\_zip](https://crates.io/crates/astral_async_zip) | 0.0.20 | MIT |  |  |
 | [async-compression](https://crates.io/crates/async-compression) | 0.4.42 | MIT OR Apache-2.0 |  |  |
 | [async-once-cell](https://crates.io/crates/async-once-cell) | 0.5.4 | MIT OR Apache-2.0 |  |  |
 | [async-spooled-tempfile](https://crates.io/crates/async-spooled-tempfile) | 0.1.0 | Apache-2.0 OR MIT |  |  |
@@ -55,9 +55,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.2 | MIT | linux, macos |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [chrono](https://crates.io/crates/chrono) | 0.4.45 | MIT OR Apache-2.0 |  |  |
-| [clap](https://crates.io/crates/clap) | 4.6.3 | MIT OR Apache-2.0 |  |  |
+| [clap](https://crates.io/crates/clap) | 4.6.4 | MIT OR Apache-2.0 |  |  |
 | [clap\_builder](https://crates.io/crates/clap_builder) | 4.6.2 | MIT OR Apache-2.0 |  |  |
-| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.3 | MIT OR Apache-2.0 |  |  |
+| [clap\_derive](https://crates.io/crates/clap_derive) | 4.6.4 | MIT OR Apache-2.0 |  |  |
 | [clap\_lex](https://crates.io/crates/clap_lex) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [cmov](https://crates.io/crates/cmov) | 0.5.4 | Apache-2.0 OR MIT |  |  |
 | [colorchoice](https://crates.io/crates/colorchoice) | 1.0.5 | MIT OR Apache-2.0 |  |  |
@@ -106,7 +106,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [fancy-regex](https://crates.io/crates/fancy-regex) | 0.18.0 | MIT |  |  |
 | [fastrand](https://crates.io/crates/fastrand) | 2.5.0 | Apache-2.0 OR MIT |  |  |
 | [figment](https://crates.io/crates/figment) | 0.10.19 | MIT OR Apache-2.0 |  |  |
-| [file\_url](https://crates.io/crates/file_url) | 0.3.1 | BSD-3-Clause |  |  |
+| [file\_url](https://crates.io/crates/file_url) | 0.3.2 | BSD-3-Clause |  |  |
 | [filetime](https://crates.io/crates/filetime) | 0.2.29 | MIT OR Apache-2.0 |  |  |
 | [find-msvc-tools](https://crates.io/crates/find-msvc-tools) | 0.1.9 | MIT OR Apache-2.0 |  |  |
 | [flate2](https://crates.io/crates/flate2) | 1.1.9 | MIT OR Apache-2.0 |  |  |
@@ -117,7 +117,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [foreign-types-shared](https://crates.io/crates/foreign-types-shared) | 0.1.1 | MIT OR Apache-2.0 | linux |  |
 | [form\_urlencoded](https://crates.io/crates/form_urlencoded) | 1.2.2 | MIT OR Apache-2.0 |  |  |
 | [fs-err](https://crates.io/crates/fs-err) | 3.3.1 | MIT OR Apache-2.0 |  |  |
-| [fs4](https://crates.io/crates/fs4) | 0.13.1 | MIT OR Apache-2.0 |  |  |
+| [fs4](https://crates.io/crates/fs4) | 1.1.0 | MIT OR Apache-2.0 |  |  |
 | [futures](https://crates.io/crates/futures) | 0.3.33 | MIT OR Apache-2.0 |  |  |
 | [futures-channel](https://crates.io/crates/futures-channel) | 0.3.33 | MIT OR Apache-2.0 |  |  |
 | [futures-core](https://crates.io/crates/futures-core) | 0.3.33 | MIT OR Apache-2.0 |  |  |
@@ -133,7 +133,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [getrandom](https://crates.io/crates/getrandom) | 0.3.4 | MIT OR Apache-2.0 |  |  |
 | [getrandom](https://crates.io/crates/getrandom) | 0.4.3 | MIT OR Apache-2.0 |  |  |
 | [gimli](https://crates.io/crates/gimli) | 0.32.3 | MIT OR Apache-2.0 | linux, macos |  |
-| [glob](https://crates.io/crates/glob) | 0.3.3 | MIT OR Apache-2.0 |  |  |
+| [glob](https://crates.io/crates/glob) | 0.3.4 | MIT OR Apache-2.0 |  |  |
 | [h2](https://crates.io/crates/h2) | 0.4.15 | MIT |  |  |
 | [halfbrown](https://crates.io/crates/halfbrown) | 0.4.0 | Apache-2.0 OR MIT |  |  |
 | [hashbrown](https://crates.io/crates/hashbrown) | 0.12.3 | MIT OR Apache-2.0 |  |  |
@@ -177,6 +177,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [is\_terminal\_polyfill](https://crates.io/crates/is_terminal_polyfill) | 1.70.2 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.13.0 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
+| [itertools](https://crates.io/crates/itertools) | 0.15.0 | MIT OR Apache-2.0 |  |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
 | [jiff](https://crates.io/crates/jiff) | 0.2.34 | Unlicense OR MIT |  |  |
 | [jiff-core](https://crates.io/crates/jiff-core) | 0.1.0 | Unlicense OR MIT |  |  |
@@ -186,7 +187,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [lazy-regex-proc\_macros](https://crates.io/crates/lazy-regex-proc_macros) | 3.6.0 | MIT |  |  |
 | [lazy\_static](https://crates.io/crates/lazy_static) | 1.5.0 | MIT OR Apache-2.0 |  |  |
 | [libbz2-rs-sys](https://crates.io/crates/libbz2-rs-sys) | 0.2.5 | bzip2-1.0.6 |  |  |
-| [libc](https://crates.io/crates/libc) | 0.2.188 | MIT OR Apache-2.0 |  |  |
+| [libc](https://crates.io/crates/libc) | 0.2.189 | MIT OR Apache-2.0 |  |  |
 | [linux-raw-sys](https://crates.io/crates/linux-raw-sys) | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux |  |
 | [litemap](https://crates.io/crates/litemap) | 0.8.2 | Unicode-3.0 |  |  |
 | [litrs](https://crates.io/crates/litrs) | 1.0.0 | MIT OR Apache-2.0 |  |  |
@@ -206,7 +207,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [mio](https://crates.io/crates/mio) | 1.2.2 | MIT |  |  |
 | [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |  |
 | [nix](https://crates.io/crates/nix) | 0.29.0 | MIT | linux, macos |  |
-| [nix](https://crates.io/crates/nix) | 0.30.1 | MIT | linux, macos |  |
+| [nix](https://crates.io/crates/nix) | 0.31.3 | MIT | linux, macos |  |
 | [nom](https://crates.io/crates/nom) | 8.0.0 | MIT |  |  |
 | [nom-language](https://crates.io/crates/nom-language) | 0.1.0 | MIT |  |  |
 | [ntapi](https://crates.io/crates/ntapi) | 0.4.3 | Apache-2.0 OR MIT | windows |  |
@@ -233,7 +234,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [parking](https://crates.io/crates/parking) | 2.2.1 | Apache-2.0 OR MIT |  |  |
 | [parking\_lot](https://crates.io/crates/parking_lot) | 0.12.5 | MIT OR Apache-2.0 |  |  |
 | [parking\_lot\_core](https://crates.io/crates/parking_lot_core) | 0.9.12 | MIT OR Apache-2.0 |  |  |
-| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.11 | BSD-3-Clause |  |  |
+| [path\_resolver](https://crates.io/crates/path_resolver) | 0.2.12 | BSD-3-Clause |  |  |
 | [pear](https://crates.io/crates/pear) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pear\_codegen](https://crates.io/crates/pear_codegen) | 0.2.9 | MIT OR Apache-2.0 |  |  |
 | [pep440\_rs](https://crates.io/crates/pep440_rs) | 0.7.3 | Apache-2.0 OR BSD-2-Clause |  |  |
@@ -255,8 +256,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [prost-derive](https://crates.io/crates/prost-derive) | 0.14.4 | Apache-2.0 |  |  |
 | [purl](https://crates.io/crates/purl) | 0.1.6 | MIT |  |  |
 | [quick-error](https://crates.io/crates/quick-error) | 1.2.3 | MIT OR Apache-2.0 |  |  |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.37.5 | MIT | linux | 2 |
-| [quick-xml](https://crates.io/crates/quick-xml) | 0.41.0 | MIT | macos |  |
+| [quick-xml](https://crates.io/crates/quick-xml) | 0.41.0 | MIT | linux, macos |  |
 | [quote](https://crates.io/crates/quote) | 1.0.47 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.10.2 | MIT OR Apache-2.0 |  |  |
 | [rand](https://crates.io/crates/rand) | 0.9.5 | MIT OR Apache-2.0 |  |  |
@@ -264,20 +264,19 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rand\_core](https://crates.io/crates/rand_core) | 0.10.1 | MIT OR Apache-2.0 |  |  |
 | [rand\_core](https://crates.io/crates/rand_core) | 0.9.5 | MIT OR Apache-2.0 |  |  |
 | [rand\_xorshift](https://crates.io/crates/rand_xorshift) | 0.4.0 | MIT OR Apache-2.0 |  |  |
-| [rattler](https://crates.io/crates/rattler) | 0.45.0 | BSD-3-Clause |  |  |
-| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.0 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.47.2 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.48.0 | BSD-3-Clause |  |  |
-| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.1 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.4 | BSD-3-Clause |  |  |
-| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.1 | BSD-3-Clause |  |  |
-| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.67 | BSD-3-Clause |  |  |
-| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.29.0 | BSD-3-Clause |  |  |
-| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.5 | BSD-3-Clause |  |  |
-| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.13 | BSD-3-Clause |  |  |
-| [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.1 | BSD-3-Clause |  |  |
-| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.7 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.1 | BSD-3-Clause |  |  |
+| [rattler](https://crates.io/crates/rattler) | 0.47.1 | BSD-3-Clause |  |  |
+| [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.3 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.48.1 | BSD-3-Clause |  |  |
+| [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.2 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.5 | BSD-3-Clause |  |  |
+| [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.2 | BSD-3-Clause |  |  |
+| [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.70 | BSD-3-Clause |  |  |
+| [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.30.2 | BSD-3-Clause |  |  |
+| [rattler\_package\_streaming](https://crates.io/crates/rattler_package_streaming) | 0.26.8 | BSD-3-Clause |  |  |
+| [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.15 | BSD-3-Clause |  |  |
+| [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.2 | BSD-3-Clause |  |  |
+| [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.10 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.2 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.26 | MIT OR Apache-2.0 |  |  |
@@ -330,7 +329,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [sha2](https://crates.io/crates/sha2) | 0.11.0 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
 | [shlex](https://crates.io/crates/shlex) | 2.0.1 | MIT OR Apache-2.0 |  |  |
-| [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
+| [signal-hook](https://crates.io/crates/signal-hook) | 0.4.4 | MIT OR Apache-2.0 | linux, macos |  |
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
 | [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.10 | MIT |  |  |
 | [simd-json](https://crates.io/crates/simd-json) | 0.17.3 | Apache-2.0 OR MIT |  |  |
@@ -349,7 +348,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [supports-hyperlinks](https://crates.io/crates/supports-hyperlinks) | 3.2.0 | Apache-2.0 |  |  |
 | [supports-unicode](https://crates.io/crates/supports-unicode) | 3.0.0 | Apache-2.0 |  |  |
 | [syn](https://crates.io/crates/syn) | 2.0.119 | MIT OR Apache-2.0 |  |  |
-| [syn](https://crates.io/crates/syn) | 3.0.2 | MIT OR Apache-2.0 |  |  |
+| [syn](https://crates.io/crates/syn) | 3.0.3 | MIT OR Apache-2.0 |  |  |
 | [sync\_wrapper](https://crates.io/crates/sync_wrapper) | 1.0.2 | Apache-2.0 |  |  |
 | [synstructure](https://crates.io/crates/synstructure) | 0.13.2 | MIT |  |  |
 | [sysinfo](https://crates.io/crates/sysinfo) | 0.30.13 | MIT |  |  |
@@ -374,7 +373,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [tokio-macros](https://crates.io/crates/tokio-macros) | 2.7.1 | MIT |  |  |
 | [tokio-native-tls](https://crates.io/crates/tokio-native-tls) | 0.3.1 | MIT |  |  |
 | [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |  |
-| [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.18 | MIT |  |  |
+| [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.19 | MIT |  |  |
 | [tokio-util](https://crates.io/crates/tokio-util) | 0.7.19 | MIT |  |  |
 | [toml](https://crates.io/crates/toml) | 0.9.12+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml](https://crates.io/crates/toml) | 1.1.3+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
@@ -427,32 +426,22 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [which](https://crates.io/crates/which) | 8.0.5 | MIT |  |  |
 | [winapi](https://crates.io/crates/winapi) | 0.3.9 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
-| [windows](https://crates.io/crates/windows) | 0.61.3 | MIT OR Apache-2.0 | windows |  |
 | [windows](https://crates.io/crates/windows) | 0.62.2 | MIT OR Apache-2.0 | windows |  |
-| [windows-collections](https://crates.io/crates/windows-collections) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-collections](https://crates.io/crates/windows-collections) | 0.3.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-core](https://crates.io/crates/windows-core) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
-| [windows-core](https://crates.io/crates/windows-core) | 0.61.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-core](https://crates.io/crates/windows-core) | 0.62.2 | MIT OR Apache-2.0 | windows |  |
-| [windows-future](https://crates.io/crates/windows-future) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-future](https://crates.io/crates/windows-future) | 0.3.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-implement](https://crates.io/crates/windows-implement) | 0.60.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-interface](https://crates.io/crates/windows-interface) | 0.59.3 | MIT OR Apache-2.0 | windows |  |
-| [windows-link](https://crates.io/crates/windows-link) | 0.1.3 | MIT OR Apache-2.0 | windows |  |
 | [windows-link](https://crates.io/crates/windows-link) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
-| [windows-numerics](https://crates.io/crates/windows-numerics) | 0.2.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-numerics](https://crates.io/crates/windows-numerics) | 0.3.1 | MIT OR Apache-2.0 | windows |  |
-| [windows-registry](https://crates.io/crates/windows-registry) | 0.5.3 | MIT OR Apache-2.0 | windows |  |
 | [windows-registry](https://crates.io/crates/windows-registry) | 0.6.1 | MIT OR Apache-2.0 | windows |  |
-| [windows-result](https://crates.io/crates/windows-result) | 0.3.4 | MIT OR Apache-2.0 | windows |  |
 | [windows-result](https://crates.io/crates/windows-result) | 0.4.1 | MIT OR Apache-2.0 | windows |  |
-| [windows-strings](https://crates.io/crates/windows-strings) | 0.4.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-strings](https://crates.io/crates/windows-strings) | 0.5.1 | MIT OR Apache-2.0 | windows |  |
 | [windows-sys](https://crates.io/crates/windows-sys) | 0.52.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-sys](https://crates.io/crates/windows-sys) | 0.59.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-sys](https://crates.io/crates/windows-sys) | 0.61.2 | MIT OR Apache-2.0 | windows |  |
 | [windows-targets](https://crates.io/crates/windows-targets) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
-| [windows-threading](https://crates.io/crates/windows-threading) | 0.1.0 | MIT OR Apache-2.0 | windows |  |
 | [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
 | [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
 | [winnow](https://crates.io/crates/winnow) | 0.7.15 | MIT |  |  |
@@ -478,22 +467,15 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [zstd-safe](https://crates.io/crates/zstd-safe) | 7.2.4 | MIT OR Apache-2.0 |  |  |
 | [zstd-sys](https://crates.io/crates/zstd-sys) | 2.0.16+zstd.1.5.7 | MIT OR Apache-2.0 |  |  |
 
-## Security Advisories
-
-| Package | Version | Advisory | CVSS v2 | CVSS v3 | Severity |
-| --- | --- | --- | :---: | :---: | --- |
-| quick-xml | 0.37.5 | [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html) |  |  |  |
-| quick-xml | 0.37.5 | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) |  |  |  |
-
 ## License Summary
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 257 |
-| MIT | 85 |
-| Apache-2.0 OR MIT | 36 |
+| MIT OR Apache-2.0 | 249 |
+| MIT | 84 |
+| Apache-2.0 OR MIT | 35 |
 | Apache-2.0 | 21 |
-| BSD-3-Clause | 20 |
+| BSD-3-Clause | 19 |
 | Unicode-3.0 | 18 |
 | Unlicense OR MIT | 4 |
 | ISC | 3 |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use miette::miette;
 use crate::VERSION;
 use crate::anaconda_cli;
 use crate::auth;
-use crate::config::Config;
+use crate::config::{self, Config};
 use crate::context::CommandContext;
 use crate::feature;
 use crate::feedback;
@@ -88,7 +88,7 @@ pub async fn execute() {
         tracing::debug!("Failed to spawn telemetry submitter: {}", e);
     }
 
-    if result.is_ok() && !skip_update_check {
+    if result.is_ok() && !skip_update_check && config::update_check_enabled() {
         check_for_update_notification().await;
     }
 
@@ -101,10 +101,6 @@ pub async fn execute() {
 
 async fn check_for_update_notification() {
     use std::time::Duration;
-
-    if !update_notifier::update_check_enabled() {
-        return;
-    }
 
     let ctx = crate::context::CommandContext::new();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ use crate::outerbounds::{self, ObAction, ObCommands};
 use crate::tools;
 use crate::ui::status;
 use crate::update;
+use crate::update_notifier;
 use crate::utils::capitalize_first;
 
 /// Log level for tracing output.
@@ -71,16 +72,56 @@ pub async fn execute() {
         Action::TelemetrySubmit | Action::TelemetryKill | Action::TelemetryStatus
     );
 
+    let skip_update_check = matches!(
+        &action,
+        Action::Update { .. }
+            | Action::CheckForUpdate
+            | Action::ShowAvailableVersions
+            | Action::TelemetrySubmit
+            | Action::TelemetryKill
+            | Action::TelemetryStatus
+    );
+
     let result = action.execute().await;
 
     if !skip_telemetry_spawn && let Err(e) = crate::telemetry::spawn_telemetry_submitter() {
         tracing::debug!("Failed to spawn telemetry submitter: {}", e);
     }
 
+    if result.is_ok() && !skip_update_check {
+        check_for_update_notification().await;
+    }
+
     if let Err(e) = result {
         tracing::error!("Command failed: {}", e);
         eprintln!("{:?}", e);
         std::process::exit(1);
+    }
+}
+
+async fn check_for_update_notification() {
+    use std::time::Duration;
+
+    if !update_notifier::update_check_enabled() {
+        return;
+    }
+
+    let ctx = crate::context::CommandContext::new();
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        update_notifier::check_for_update(&ctx, VERSION),
+    )
+    .await;
+
+    match result {
+        Ok(Some(latest)) => {
+            update_notifier::show_notification(VERSION, &latest);
+        }
+        Ok(None) => {}
+        Err(_) => {
+            tracing::debug!("Update check timed out");
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@
 //! | `ANA_PIP_INDEX_URL`              | `https://repo.anaconda.cloud/repo/anaconda-wheels/simple` | Package index URL for Anaconda wheels |
 //! | `ANA_SELF_UPDATE_URL`            | (Anaconda static URL)      | Update URL; set to `github` for GitHub Releases |
 //! | `ANA_AUTO_UPDATE_TOOLS`          | (per-tool default)         | Auto-update tools on self update; overrides tool defaults |
+//! | `ANA_UPDATE_CHECK`               | `true`                     | Enable background update notifications |
+//! | `ANA_UPDATE_CHECK_INTERVAL_HOURS`| `24`                       | Hours between update checks     |
+//! | `ANA_UPDATE_NOTIFY_INTERVAL_HOURS`| `24`                      | Hours between showing notifications |
 //!
 //! When the `diagnostics` feature is enabled:
 //!

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,33 @@ pub fn telemetry_enabled() -> bool {
         .unwrap_or(true)
 }
 
+/// Check if background update checks are enabled.
+pub fn update_check_enabled() -> bool {
+    std::env::var("ANA_UPDATE_CHECK")
+        .map(|v| parse_bool(&v))
+        .unwrap_or(true)
+}
+
+/// Get the interval between update checks.
+pub fn update_check_interval() -> std::time::Duration {
+    const DEFAULT_HOURS: u64 = 24;
+    let hours = std::env::var("ANA_UPDATE_CHECK_INTERVAL_HOURS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_HOURS);
+    std::time::Duration::from_secs(hours * 3600)
+}
+
+/// Get the interval between showing update notifications.
+pub fn update_notify_interval() -> std::time::Duration {
+    const DEFAULT_HOURS: u64 = 24;
+    let hours = std::env::var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_HOURS);
+    std::time::Duration::from_secs(hours * 3600)
+}
+
 const DEFAULT_DOMAIN: &str = "anaconda.com";
 const DEFAULT_CLIENT_ID: &str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a";
 const DEFAULT_SSL_VERIFY: bool = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod tools;
 mod ua;
 mod ui;
 mod update;
+mod update_notifier;
 mod utils;
 
 pub const VERSION: &str = env!("PKG_VERSION");

--- a/src/update.rs
+++ b/src/update.rs
@@ -219,7 +219,7 @@ async fn fetch_static_releases(
     Ok(releases)
 }
 
-async fn fetch_available_releases(ctx: &CommandContext) -> Result<Vec<Release>, UpdateError> {
+pub(crate) async fn fetch_available_releases(ctx: &CommandContext) -> Result<Vec<Release>, UpdateError> {
     let mut releases: Vec<_> = match &ctx.config.self_update_url {
         Some(base_url) => {
             // Static hosting - releases are already filtered by channel
@@ -253,6 +253,21 @@ pub enum UpdateCheck {
     Available(Release),
     AlreadyUpToDate,
     NoReleases,
+}
+
+/// Fetch the latest version tag from available releases.
+/// Returns the tag name (e.g., "v0.0.10") or an error.
+pub async fn fetch_latest_version(ctx: &CommandContext) -> Result<String, UpdateError> {
+    let releases = fetch_available_releases(ctx).await?;
+    releases
+        .into_iter()
+        .max_by(|a, b| {
+            let va = parse_version(&a.tag_name).unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+            let vb = parse_version(&b.tag_name).unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+            va.cmp(&vb)
+        })
+        .map(|r| r.tag_name)
+        .ok_or_else(|| UpdateError::Http("No releases available".to_string()))
 }
 
 fn find_update(releases: Vec<Release>, current_version: &str) -> Result<UpdateCheck, UpdateError> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -219,7 +219,9 @@ async fn fetch_static_releases(
     Ok(releases)
 }
 
-pub(crate) async fn fetch_available_releases(ctx: &CommandContext) -> Result<Vec<Release>, UpdateError> {
+pub(crate) async fn fetch_available_releases(
+    ctx: &CommandContext,
+) -> Result<Vec<Release>, UpdateError> {
     let mut releases: Vec<_> = match &ctx.config.self_update_url {
         Some(base_url) => {
             // Static hosting - releases are already filtered by channel

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -1,0 +1,337 @@
+//! Background update notification system.
+//!
+//! Checks for new versions and notifies users without blocking CLI execution.
+//! Results are cached to avoid repeated API calls.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::context::CommandContext;
+use crate::paths::ana_home;
+use crate::update::{fetch_latest_version, parse_version};
+
+const CACHE_FILE: &str = "update-cache.json";
+const DEFAULT_CHECK_INTERVAL_HOURS: u64 = 24;
+const DEFAULT_NOTIFY_INTERVAL_HOURS: u64 = 24;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpdateCache {
+    latest_version: String,
+    current_version: String,
+    checked_at: DateTime<Utc>,
+    #[serde(default)]
+    notified_at: Option<DateTime<Utc>>,
+}
+
+fn cache_path() -> PathBuf {
+    ana_home().join(CACHE_FILE)
+}
+
+fn check_interval() -> Duration {
+    let hours = std::env::var("ANA_UPDATE_CHECK_INTERVAL_HOURS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_CHECK_INTERVAL_HOURS);
+    Duration::from_secs(hours * 3600)
+}
+
+fn notify_interval() -> Duration {
+    let hours = std::env::var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_NOTIFY_INTERVAL_HOURS);
+    Duration::from_secs(hours * 3600)
+}
+
+pub fn update_check_enabled() -> bool {
+    std::env::var("ANA_UPDATE_CHECK")
+        .map(|v| {
+            let v = v.trim().to_lowercase();
+            !(v.is_empty() || v == "0" || v == "false")
+        })
+        .unwrap_or(true)
+}
+
+fn read_cache() -> Option<UpdateCache> {
+    let path = cache_path();
+    let contents = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+fn write_cache(cache: &UpdateCache) {
+    let path = cache_path();
+
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        tracing::debug!("Failed to create cache directory: {}", e);
+        return;
+    }
+
+    let temp_path = path.with_extension("json.tmp");
+    let contents = match serde_json::to_string_pretty(cache) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!("Failed to serialize cache: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = fs::write(&temp_path, contents) {
+        tracing::debug!("Failed to write cache temp file: {}", e);
+        return;
+    }
+
+    if let Err(e) = fs::rename(&temp_path, &path) {
+        tracing::debug!("Failed to rename cache file: {}", e);
+        let _ = fs::remove_file(&temp_path);
+    }
+}
+
+fn is_cache_fresh(cache: &UpdateCache, current_version: &str) -> bool {
+    if cache.current_version != current_version {
+        return false;
+    }
+
+    let elapsed = Utc::now().signed_duration_since(cache.checked_at);
+    let interval = check_interval();
+    elapsed.num_seconds() < interval.as_secs() as i64
+}
+
+fn is_newer_version(latest: &str, current: &str) -> bool {
+    let latest_v = match parse_version(latest) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let current_v = match parse_version(current) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    latest_v > current_v
+}
+
+fn should_notify(cache: &UpdateCache) -> bool {
+    let Some(notified_at) = cache.notified_at else {
+        return true;
+    };
+
+    let elapsed = Utc::now().signed_duration_since(notified_at);
+    let interval = notify_interval();
+    elapsed.num_seconds() >= interval.as_secs() as i64
+}
+
+fn mark_notified(cache: &UpdateCache) {
+    let updated = UpdateCache {
+        notified_at: Some(Utc::now()),
+        ..cache.clone()
+    };
+    write_cache(&updated);
+}
+
+/// Check if an update is available and should be notified, using cache when possible.
+/// Returns the latest version string if newer than current and notification is due, None otherwise.
+pub async fn check_for_update(ctx: &CommandContext, current_version: &str) -> Option<String> {
+    if let Some(cache) = read_cache()
+        && is_cache_fresh(&cache, current_version)
+    {
+        if is_newer_version(&cache.latest_version, current_version) && should_notify(&cache) {
+            return Some(cache.latest_version);
+        }
+        return None;
+    }
+
+    let latest = match fetch_latest_version(ctx).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!("Failed to fetch latest version: {}", e);
+            return None;
+        }
+    };
+
+    let cache = UpdateCache {
+        latest_version: latest.clone(),
+        current_version: current_version.to_string(),
+        checked_at: Utc::now(),
+        notified_at: None,
+    };
+    write_cache(&cache);
+
+    if is_newer_version(&latest, current_version) {
+        Some(latest)
+    } else {
+        None
+    }
+}
+
+/// Display update notification to user and record notification time.
+pub fn show_notification(current: &str, latest: &str) {
+    use crate::ui::status;
+
+    if let Some(cache) = read_cache() {
+        mark_notified(&cache);
+    }
+
+    status::blank_line();
+    status::warn(&format!(
+        "A new version of ana is available: {} (you have v{})",
+        status::highlight(latest),
+        current
+    ));
+    status::tip(&format!("Update with: {}", status::highlight("ana self update")));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer_version_newer() {
+        assert!(is_newer_version("v0.0.2", "0.0.1"));
+    }
+
+    #[test]
+    fn test_is_newer_version_same() {
+        assert!(!is_newer_version("v0.0.1", "0.0.1"));
+    }
+
+    #[test]
+    fn test_is_newer_version_older() {
+        assert!(!is_newer_version("v0.0.1", "0.0.2"));
+    }
+
+    #[test]
+    fn test_is_newer_version_invalid_latest() {
+        assert!(!is_newer_version("invalid", "0.0.1"));
+    }
+
+    #[test]
+    fn test_is_newer_version_invalid_current() {
+        assert!(!is_newer_version("v0.0.1", "invalid"));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_same_version_recent() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now(),
+            notified_at: None,
+        };
+        assert!(is_cache_fresh(&cache, "0.0.1"));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_different_version() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now(),
+            notified_at: None,
+        };
+        assert!(!is_cache_fresh(&cache, "0.0.2"));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_old_cache() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now() - chrono::Duration::hours(25),
+            notified_at: None,
+        };
+        assert!(!is_cache_fresh(&cache, "0.0.1"));
+    }
+
+    #[test]
+    fn test_should_notify_never_notified() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now(),
+            notified_at: None,
+        };
+        assert!(should_notify(&cache));
+    }
+
+    #[test]
+    fn test_should_notify_recently_notified() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now(),
+            notified_at: Some(Utc::now()),
+        };
+        assert!(!should_notify(&cache));
+    }
+
+    #[test]
+    fn test_should_notify_old_notification() {
+        let cache = UpdateCache {
+            latest_version: "v0.0.2".to_string(),
+            current_version: "0.0.1".to_string(),
+            checked_at: Utc::now(),
+            notified_at: Some(Utc::now() - chrono::Duration::hours(25)),
+        };
+        assert!(should_notify(&cache));
+    }
+
+    #[test]
+    fn test_update_check_enabled_default() {
+        temp_env::with_var_unset("ANA_UPDATE_CHECK", || {
+            assert!(update_check_enabled());
+        });
+    }
+
+    #[test]
+    fn test_update_check_enabled_false() {
+        temp_env::with_var("ANA_UPDATE_CHECK", Some("false"), || {
+            assert!(!update_check_enabled());
+        });
+    }
+
+    #[test]
+    fn test_update_check_enabled_zero() {
+        temp_env::with_var("ANA_UPDATE_CHECK", Some("0"), || {
+            assert!(!update_check_enabled());
+        });
+    }
+
+    #[test]
+    fn test_update_check_enabled_true() {
+        temp_env::with_var("ANA_UPDATE_CHECK", Some("true"), || {
+            assert!(update_check_enabled());
+        });
+    }
+
+    #[test]
+    fn test_check_interval_default() {
+        temp_env::with_var_unset("ANA_UPDATE_CHECK_INTERVAL_HOURS", || {
+            assert_eq!(check_interval(), Duration::from_secs(24 * 3600));
+        });
+    }
+
+    #[test]
+    fn test_check_interval_custom() {
+        temp_env::with_var("ANA_UPDATE_CHECK_INTERVAL_HOURS", Some("12"), || {
+            assert_eq!(check_interval(), Duration::from_secs(12 * 3600));
+        });
+    }
+
+    #[test]
+    fn test_notify_interval_default() {
+        temp_env::with_var_unset("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", || {
+            assert_eq!(notify_interval(), Duration::from_secs(24 * 3600));
+        });
+    }
+
+    #[test]
+    fn test_notify_interval_custom() {
+        temp_env::with_var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", Some("12"), || {
+            assert_eq!(notify_interval(), Duration::from_secs(12 * 3600));
+        });
+    }
+}

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -5,18 +5,16 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::config;
 use crate::context::CommandContext;
 use crate::paths::ana_home;
 use crate::update::{fetch_latest_version, parse_version};
 
 const CACHE_FILE: &str = "update-cache.json";
-const DEFAULT_CHECK_INTERVAL_HOURS: u64 = 24;
-const DEFAULT_NOTIFY_INTERVAL_HOURS: u64 = 24;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UpdateCache {
@@ -29,31 +27,6 @@ struct UpdateCache {
 
 fn cache_path() -> PathBuf {
     ana_home().join(CACHE_FILE)
-}
-
-fn check_interval() -> Duration {
-    let hours = std::env::var("ANA_UPDATE_CHECK_INTERVAL_HOURS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_CHECK_INTERVAL_HOURS);
-    Duration::from_secs(hours * 3600)
-}
-
-fn notify_interval() -> Duration {
-    let hours = std::env::var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_NOTIFY_INTERVAL_HOURS);
-    Duration::from_secs(hours * 3600)
-}
-
-pub fn update_check_enabled() -> bool {
-    std::env::var("ANA_UPDATE_CHECK")
-        .map(|v| {
-            let v = v.trim().to_lowercase();
-            !(v.is_empty() || v == "0" || v == "false")
-        })
-        .unwrap_or(true)
 }
 
 fn read_cache() -> Option<UpdateCache> {
@@ -98,7 +71,7 @@ fn is_cache_fresh(cache: &UpdateCache, current_version: &str) -> bool {
     }
 
     let elapsed = Utc::now().signed_duration_since(cache.checked_at);
-    let interval = check_interval();
+    let interval = config::update_check_interval();
     elapsed.num_seconds() < interval.as_secs() as i64
 }
 
@@ -120,7 +93,7 @@ fn should_notify(cache: &UpdateCache) -> bool {
     };
 
     let elapsed = Utc::now().signed_duration_since(notified_at);
-    let interval = notify_interval();
+    let interval = config::update_notify_interval();
     elapsed.num_seconds() >= interval.as_secs() as i64
 }
 
@@ -285,56 +258,60 @@ mod tests {
     #[test]
     fn test_update_check_enabled_default() {
         temp_env::with_var_unset("ANA_UPDATE_CHECK", || {
-            assert!(update_check_enabled());
+            assert!(config::update_check_enabled());
         });
     }
 
     #[test]
     fn test_update_check_enabled_false() {
         temp_env::with_var("ANA_UPDATE_CHECK", Some("false"), || {
-            assert!(!update_check_enabled());
+            assert!(!config::update_check_enabled());
         });
     }
 
     #[test]
     fn test_update_check_enabled_zero() {
         temp_env::with_var("ANA_UPDATE_CHECK", Some("0"), || {
-            assert!(!update_check_enabled());
+            assert!(!config::update_check_enabled());
         });
     }
 
     #[test]
     fn test_update_check_enabled_true() {
         temp_env::with_var("ANA_UPDATE_CHECK", Some("true"), || {
-            assert!(update_check_enabled());
+            assert!(config::update_check_enabled());
         });
     }
 
     #[test]
     fn test_check_interval_default() {
+        use std::time::Duration;
         temp_env::with_var_unset("ANA_UPDATE_CHECK_INTERVAL_HOURS", || {
-            assert_eq!(check_interval(), Duration::from_secs(24 * 3600));
+            assert_eq!(config::update_check_interval(), Duration::from_secs(24 * 3600));
         });
     }
 
     #[test]
     fn test_check_interval_custom() {
+        use std::time::Duration;
         temp_env::with_var("ANA_UPDATE_CHECK_INTERVAL_HOURS", Some("12"), || {
-            assert_eq!(check_interval(), Duration::from_secs(12 * 3600));
+            assert_eq!(config::update_check_interval(), Duration::from_secs(12 * 3600));
         });
     }
 
     #[test]
     fn test_notify_interval_default() {
+        use std::time::Duration;
         temp_env::with_var_unset("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", || {
-            assert_eq!(notify_interval(), Duration::from_secs(24 * 3600));
+            assert_eq!(config::update_notify_interval(), Duration::from_secs(24 * 3600));
         });
     }
 
     #[test]
     fn test_notify_interval_custom() {
+        use std::time::Duration;
         temp_env::with_var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", Some("12"), || {
-            assert_eq!(notify_interval(), Duration::from_secs(12 * 3600));
+            assert_eq!(config::update_notify_interval(), Duration::from_secs(12 * 3600));
         });
     }
 }

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -181,7 +181,10 @@ pub fn show_notification(current: &str, latest: &str) {
         status::highlight(latest),
         current
     ));
-    status::tip(&format!("Update with: {}", status::highlight("ana self update")));
+    status::tip(&format!(
+        "Update with: {}",
+        status::highlight("ana self update")
+    ));
 }
 
 #[cfg(test)]

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -287,7 +287,10 @@ mod tests {
     fn test_check_interval_default() {
         use std::time::Duration;
         temp_env::with_var_unset("ANA_UPDATE_CHECK_INTERVAL_HOURS", || {
-            assert_eq!(config::update_check_interval(), Duration::from_secs(24 * 3600));
+            assert_eq!(
+                config::update_check_interval(),
+                Duration::from_secs(24 * 3600)
+            );
         });
     }
 
@@ -295,7 +298,10 @@ mod tests {
     fn test_check_interval_custom() {
         use std::time::Duration;
         temp_env::with_var("ANA_UPDATE_CHECK_INTERVAL_HOURS", Some("12"), || {
-            assert_eq!(config::update_check_interval(), Duration::from_secs(12 * 3600));
+            assert_eq!(
+                config::update_check_interval(),
+                Duration::from_secs(12 * 3600)
+            );
         });
     }
 
@@ -303,7 +309,10 @@ mod tests {
     fn test_notify_interval_default() {
         use std::time::Duration;
         temp_env::with_var_unset("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", || {
-            assert_eq!(config::update_notify_interval(), Duration::from_secs(24 * 3600));
+            assert_eq!(
+                config::update_notify_interval(),
+                Duration::from_secs(24 * 3600)
+            );
         });
     }
 
@@ -311,7 +320,10 @@ mod tests {
     fn test_notify_interval_custom() {
         use std::time::Duration;
         temp_env::with_var("ANA_UPDATE_NOTIFY_INTERVAL_HOURS", Some("12"), || {
-            assert_eq!(config::update_notify_interval(), Duration::from_secs(12 * 3600));
+            assert_eq!(
+                config::update_notify_interval(),
+                Duration::from_secs(12 * 3600)
+            );
         });
     }
 }


### PR DESCRIPTION
## Summary
- Adds a background update notification system that checks for new versions and notifies users
- Caches version checks to avoid repeated API calls (default: 24 hours)
- Rate-limits notifications to avoid nagging users (default: once per 24 hours)
- Silently handles network failures and timeouts (500ms timeout on CLI exit)
- Skips checks for `ana self update` commands (redundant)

<img width="1227" height="695" alt="CleanShot 2026-07-21 at 09 26 56" src="https://github.com/user-attachments/assets/8e269ac2-cfc6-4b93-9820-a970a04d69d3" />

Change `ANA_UPDATE_NOTIFY_INTERVAL_HOURS` to control how often the notification is shown.

New environment variables:
- `ANA_UPDATE_CHECK`: Enable/disable update checks (default: `true`)
- `ANA_UPDATE_CHECK_INTERVAL_HOURS`: Hours between API checks (default: `24`)
- `ANA_UPDATE_NOTIFY_INTERVAL_HOURS`: Hours between showing notifications (default: `24`)

Cache stored at `~/.ana/update-cache.json`.

## Test plan
- [ ] Run `ana whoami` and verify no notification appears on first run (no update available for current version)
- [ ] Manually edit `~/.ana/update-cache.json` to set `latest_version` to a newer version and verify notification appears
- [ ] Run again immediately and verify notification does NOT appear (rate limited)
- [ ] Set `ANA_UPDATE_NOTIFY_INTERVAL_HOURS=0` and verify notification appears on every run
- [ ] Set `ANA_UPDATE_CHECK=false` and verify no checks occur
- [ ] Run `ana self update --check` and verify no duplicate notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)