### PR TITLE
feat: Display release notes after self update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "sha2 0.11.0",
  "temp-env",
  "tempfile",
+ "termimad",
  "thiserror 2.0.19",
  "tokio",
  "toml 1.1.3+spec-1.1.0",
@@ -844,6 +845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +907,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,9 +996,13 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.13.1",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
  "rustix",
+ "signal-hook 0.3.18",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -2376,6 +2447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de632ee829aec3a874d18a4192eae64a0460b3a45c54ed556b334f6fe5a1d62f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,7 +3595,7 @@ checksum = "ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328"
 dependencies = [
  "libc",
  "nix 0.31.3",
- "signal-hook",
+ "signal-hook 0.4.4",
  "tokio",
 ]
 
@@ -4344,12 +4424,33 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -4447,6 +4548,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"
@@ -4621,6 +4728,22 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termimad"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 2.0.19",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 opentelemetry = "0.31.0"
 owo-colors = { version = "4", features = ["supports-colors"] }
 url = "2.5.8"
+termimad = "0.35.1"
 
 [dev-dependencies]
 temp-env = "0.3"

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:e967743c-1415-4a59-a387-e22a964d9006",
+  "serialNumber": "urn:uuid:48e43374-6db2-4020-89a5-e6198a00728a",
   "metadata": {
-    "timestamp": "2026-07-22T13:42:08Z",
+    "timestamp": "2026-07-24T14:26:16Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -1755,6 +1755,60 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "author": "rutrum <dave@rutrum.net>",
+      "name": "convert_case",
+      "version": "0.10.0",
+      "description": "Convert strings into any case",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/convert_case@0.10.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/rutrum/convert-case"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#coolor@1.1.0",
+      "author": "dystroy <denys.seguret@gmail.com>",
+      "name": "coolor",
+      "version": "1.1.0",
+      "description": "conversion between color formats",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/coolor@1.1.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/coolor"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "author": "RustCrypto Developers",
       "name": "cpufeatures",
@@ -1844,6 +1898,84 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crokey-proc_macros@1.4.0",
+      "author": "Canop <cano.petrole@gmail.com>",
+      "name": "crokey-proc_macros",
+      "version": "1.4.0",
+      "description": "proc macros for the crokey crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/crokey-proc_macros@1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crokey@1.4.0",
+      "author": "dystroy <denys.seguret@gmail.com>",
+      "name": "crokey",
+      "version": "1.4.0",
+      "description": "Parse and describe keys - helping incorporate keybindings in terminal applications",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/crokey@1.4.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/crokey"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.16",
+      "name": "crossbeam-channel",
+      "version": "0.5.16",
+      "description": "Multi-producer multi-consumer channels for message passing",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam-channel@0.5.16",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
       "name": "crossbeam-deque",
       "version": "0.8.7",
@@ -1904,6 +2036,36 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.13",
+      "name": "crossbeam-queue",
+      "version": "0.3.13",
+      "description": "Concurrent queues",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam-queue@0.3.13",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22",
       "name": "crossbeam-utils",
       "version": "0.8.22",
@@ -1925,6 +2087,36 @@
         {
           "type": "website",
           "url": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam@0.8.4",
+      "name": "crossbeam",
+      "version": "0.8.4",
+      "description": "Tools for concurrent programming",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/crossbeam@0.8.4",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/crossbeam-rs/crossbeam"
         },
         {
           "type": "vcs",
@@ -2289,6 +2481,68 @@
         {
           "type": "vcs",
           "url": "https://github.com/jhpratt/deranged"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more-impl",
+      "version": "2.1.1",
+      "description": "Internal implementation of `derive_more` crate",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more-impl@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "author": "Jelte Fennema <github-tech@jeltef.nl>",
+      "name": "derive_more",
+      "version": "2.1.1",
+      "description": "Adds #[derive(x)] macros for more traits",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/derive_more@2.1.1",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/derive_more"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/JelteF/derive_more"
         }
       ]
     },
@@ -5722,6 +5976,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/abonander/mime_guess"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#minimad@0.16.0",
+      "author": "dystroy <denys.seguret@gmail.com>",
+      "name": "minimad",
+      "version": "0.16.0",
+      "description": "light Markdown parser",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "de632ee829aec3a874d18a4192eae64a0460b3a45c54ed556b334f6fe5a1d62f"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/minimad@0.16.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/minimad"
         }
       ]
     },
@@ -9445,6 +9726,43 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-mio@0.2.5",
+      "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>",
+      "name": "signal-hook-mio",
+      "version": "0.2.5",
+      "description": "MIO support for signal-hook",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT OR Apache-2.0"
+        }
+      ],
+      "purl": "pkg:cargo/signal-hook-mio@0.2.5",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/signal-hook-mio"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/vorner/signal-hook"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
       "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>",
       "name": "signal-hook-registry",
@@ -9467,6 +9785,43 @@
         {
           "type": "documentation",
           "url": "https://docs.rs/signal-hook-registry"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/vorner/signal-hook"
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:ana:platforms",
+          "value": "linux,macos"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>",
+      "name": "signal-hook",
+      "version": "0.3.18",
+      "description": "Unix signal handling",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "purl": "pkg:cargo/signal-hook@0.3.18",
+      "externalReferences": [
+        {
+          "type": "documentation",
+          "url": "https://docs.rs/signal-hook"
         },
         {
           "type": "vcs",
@@ -9761,6 +10116,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/storyyeller/stable_deref_trait"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#strict@0.2.0",
+      "author": "dystroy <denys.seguret@gmail.com>",
+      "name": "strict",
+      "version": "0.2.0",
+      "description": "collections with strict bounds",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/strict@0.2.0",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/strict"
         }
       ]
     },
@@ -10250,6 +10632,33 @@
         {
           "type": "vcs",
           "url": "https://github.com/Stebalien/tempfile"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#termimad@0.35.1",
+      "author": "dystroy <denys.seguret@gmail.com>",
+      "name": "termimad",
+      "version": "0.35.1",
+      "description": "Markdown Renderer for the Terminal",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "MIT"
+        }
+      ],
+      "purl": "pkg:cargo/termimad@0.35.1",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/Canop/termimad"
         }
       ]
     },
@@ -14192,6 +14601,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
+        "registry+https://github.com/rust-lang/crates.io-index#termimad@0.35.1",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
         "registry+https://github.com/rust-lang/crates.io-index#tokio@1.53.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
@@ -14610,6 +15020,18 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.13.3"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#coolor@1.1.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
@@ -14628,6 +15050,32 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crokey-proc_macros@1.4.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#strict@0.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crokey@1.4.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crokey-proc_macros@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#strict@0.2.0"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.16",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20",
@@ -14641,17 +15089,37 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.13",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22",
       "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#crossbeam@0.8.4",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.16",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.7",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.20",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.13",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.22"
+      ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#crossterm@0.29.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.13.1",
         "registry+https://github.com/rust-lang/crates.io-index#crossterm_winapi@0.9.1",
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.5",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook-mio@0.2.5",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
         "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
       ]
     },
@@ -14736,6 +15204,22 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.5.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#convert_case@0.10.0",
+        "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
+        "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
+        "registry+https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1",
+        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#derive_more@2.1.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#derive_more-impl@2.1.1"
       ]
     },
     {
@@ -15511,6 +15995,12 @@
       ]
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#minimad@0.16.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#adler2@2.0.1",
@@ -15521,6 +16011,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
+        "registry+https://github.com/rust-lang/crates.io-index#log@0.4.33",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
       ]
     },
@@ -16675,10 +17166,25 @@
       "dependsOn": []
     },
     {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-mio@0.2.5",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
+        "registry+https://github.com/rust-lang/crates.io-index#mio@1.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18"
+      ]
+    },
+    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#errno@0.3.14",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#signal-hook@0.3.18",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
+        "registry+https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.8"
       ]
     },
     {
@@ -16732,6 +17238,10 @@
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#strict@0.2.0",
       "dependsOn": []
     },
     {
@@ -16836,6 +17346,19 @@
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
         "registry+https://github.com/rust-lang/crates.io-index#rustix@1.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.61.2"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#termimad@0.35.1",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#coolor@1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#crokey@1.4.0",
+        "registry+https://github.com/rust-lang/crates.io-index#crossbeam@0.8.4",
+        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#minimad@0.16.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.14"
       ]
     },
     {

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-07-22T13:42:08Z<br>
+Generated: 2026-07-24T14:26:16Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 456 (59 platform-specific)<br>
+Packages: 470 (61 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -67,14 +67,21 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [configparser](https://crates.io/crates/configparser) | 3.2.0 | MIT OR LGPL-3.0-or-later | linux |  |
 | [console](https://crates.io/crates/console) | 0.16.4 | MIT |  |  |
 | [const-oid](https://crates.io/crates/const-oid) | 0.10.2 | Apache-2.0 OR MIT |  |  |
+| [convert\_case](https://crates.io/crates/convert_case) | 0.10.0 | MIT |  |  |
+| [coolor](https://crates.io/crates/coolor) | 1.1.0 | MIT |  |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.10.1 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation](https://crates.io/crates/core-foundation) | 0.9.4 | MIT OR Apache-2.0 | macos |  |
 | [core-foundation-sys](https://crates.io/crates/core-foundation-sys) | 0.8.7 | MIT OR Apache-2.0 | macos |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.2.17 | MIT OR Apache-2.0 |  |  |
 | [cpufeatures](https://crates.io/crates/cpufeatures) | 0.3.0 | MIT OR Apache-2.0 |  |  |
 | [crc32fast](https://crates.io/crates/crc32fast) | 1.5.0 | MIT OR Apache-2.0 |  |  |
+| [crokey](https://crates.io/crates/crokey) | 1.4.0 | MIT |  |  |
+| [crokey-proc\_macros](https://crates.io/crates/crokey-proc_macros) | 1.4.0 | MIT |  |  |
+| [crossbeam](https://crates.io/crates/crossbeam) | 0.8.4 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-channel](https://crates.io/crates/crossbeam-channel) | 0.5.16 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-deque](https://crates.io/crates/crossbeam-deque) | 0.8.7 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-epoch](https://crates.io/crates/crossbeam-epoch) | 0.9.20 | MIT OR Apache-2.0 |  |  |
+| [crossbeam-queue](https://crates.io/crates/crossbeam-queue) | 0.3.13 | MIT OR Apache-2.0 |  |  |
 | [crossbeam-utils](https://crates.io/crates/crossbeam-utils) | 0.8.22 | MIT OR Apache-2.0 |  |  |
 | [crossterm](https://crates.io/crates/crossterm) | 0.29.0 | MIT |  |  |
 | [crossterm\_winapi](https://crates.io/crates/crossterm_winapi) | 0.9.1 | MIT | windows |  |
@@ -89,6 +96,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [defmt-macros](https://crates.io/crates/defmt-macros) | 1.1.1 | MIT OR Apache-2.0 |  |  |
 | [defmt-parser](https://crates.io/crates/defmt-parser) | 1.0.0 | MIT OR Apache-2.0 |  |  |
 | [deranged](https://crates.io/crates/deranged) | 0.5.8 | MIT OR Apache-2.0 |  |  |
+| [derive\_more](https://crates.io/crates/derive_more) | 2.1.1 | MIT |  |  |
+| [derive\_more-impl](https://crates.io/crates/derive_more-impl) | 2.1.1 | MIT |  |  |
 | [digest](https://crates.io/crates/digest) | 0.10.7 | MIT OR Apache-2.0 |  |  |
 | [digest](https://crates.io/crates/digest) | 0.11.3 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
@@ -203,6 +212,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [miette-derive](https://crates.io/crates/miette-derive) | 7.6.0 | Apache-2.0 |  |  |
 | [mime](https://crates.io/crates/mime) | 0.3.17 | MIT OR Apache-2.0 |  |  |
 | [mime\_guess](https://crates.io/crates/mime_guess) | 2.0.5 | MIT |  |  |
+| [minimad](https://crates.io/crates/minimad) | 0.16.0 | MIT |  |  |
 | [miniz\_oxide](https://crates.io/crates/miniz_oxide) | 0.8.9 | MIT OR Zlib OR Apache-2.0 |  |  |
 | [mio](https://crates.io/crates/mio) | 1.2.2 | MIT |  |  |
 | [native-tls](https://crates.io/crates/native-tls) | 0.2.18 | MIT OR Apache-2.0 |  |  |
@@ -329,7 +339,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [sha2](https://crates.io/crates/sha2) | 0.11.0 | MIT OR Apache-2.0 |  |  |
 | [sharded-slab](https://crates.io/crates/sharded-slab) | 0.1.7 | MIT |  |  |
 | [shlex](https://crates.io/crates/shlex) | 2.0.1 | MIT OR Apache-2.0 |  |  |
+| [signal-hook](https://crates.io/crates/signal-hook) | 0.3.18 | Apache-2.0 OR MIT | linux, macos |  |
 | [signal-hook](https://crates.io/crates/signal-hook) | 0.4.4 | MIT OR Apache-2.0 | linux, macos |  |
+| [signal-hook-mio](https://crates.io/crates/signal-hook-mio) | 0.2.5 | MIT OR Apache-2.0 | linux, macos |  |
 | [signal-hook-registry](https://crates.io/crates/signal-hook-registry) | 1.4.8 | MIT OR Apache-2.0 | linux, macos |  |
 | [simd-adler32](https://crates.io/crates/simd-adler32) | 0.3.10 | MIT |  |  |
 | [simd-json](https://crates.io/crates/simd-json) | 0.17.3 | Apache-2.0 OR MIT |  |  |
@@ -339,6 +351,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [smallvec](https://crates.io/crates/smallvec) | 1.15.2 | MIT OR Apache-2.0 |  |  |
 | [socket2](https://crates.io/crates/socket2) | 0.6.5 | MIT OR Apache-2.0 |  |  |
 | [stable\_deref\_trait](https://crates.io/crates/stable_deref_trait) | 1.2.1 | MIT OR Apache-2.0 |  |  |
+| [strict](https://crates.io/crates/strict) | 0.2.0 | MIT |  |  |
 | [strsim](https://crates.io/crates/strsim) | 0.11.1 | MIT |  |  |
 | [strum](https://crates.io/crates/strum) | 0.28.0 | MIT |  |  |
 | [strum\_macros](https://crates.io/crates/strum_macros) | 0.28.0 | MIT |  |  |
@@ -356,6 +369,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [system-configuration-sys](https://crates.io/crates/system-configuration-sys) | 0.6.0 | MIT OR Apache-2.0 | macos |  |
 | [tar](https://crates.io/crates/tar) | 0.4.46 | MIT OR Apache-2.0 |  |  |
 | [tempfile](https://crates.io/crates/tempfile) | 3.27.0 | MIT OR Apache-2.0 |  |  |
+| [termimad](https://crates.io/crates/termimad) | 0.35.1 | MIT |  |  |
 | [terminal\_size](https://crates.io/crates/terminal_size) | 0.4.4 | MIT OR Apache-2.0 |  |  |
 | [textwrap](https://crates.io/crates/textwrap) | 0.16.2 | MIT |  |  |
 | [thiserror](https://crates.io/crates/thiserror) | 1.0.69 | MIT OR Apache-2.0 |  |  |
@@ -471,9 +485,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 249 |
-| MIT | 84 |
-| Apache-2.0 OR MIT | 35 |
+| MIT OR Apache-2.0 | 253 |
+| MIT | 93 |
+| Apache-2.0 OR MIT | 36 |
 | Apache-2.0 | 21 |
 | BSD-3-Clause | 19 |
 | Unicode-3.0 | 18 |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,7 @@ pub async fn execute() {
         Action::Update { .. }
             | Action::CheckForUpdate
             | Action::ShowAvailableVersions
+            | Action::ShowChangelog { .. }
             | Action::TelemetrySubmit
             | Action::TelemetryKill
             | Action::TelemetryStatus
@@ -153,6 +154,9 @@ pub enum Action {
     },
     CheckForUpdate,
     ShowAvailableVersions,
+    ShowChangelog {
+        version: Option<String>,
+    },
     Bootstrap,
     OrgProxy {
         args: Vec<String>,
@@ -227,6 +231,7 @@ impl Action {
             Action::Update { .. } => "self.update",
             Action::CheckForUpdate => "self.update.check",
             Action::ShowAvailableVersions => "self.update.list",
+            Action::ShowChangelog { .. } => "self.changelog",
             Action::Bootstrap => "bootstrap",
             Action::OrgProxy { .. } => "org",
             #[cfg(unix)]
@@ -363,6 +368,10 @@ impl Action {
             }
             Action::ShowAvailableVersions => {
                 update::show_available_versions(ctx, VERSION).await;
+                Ok(())
+            }
+            Action::ShowChangelog { version } => {
+                crate::release_notes::show_changelog(ctx, VERSION, version).await;
                 Ok(())
             }
             Action::UserAgent { prefix } => {
@@ -645,6 +654,7 @@ pub fn parse() -> (Action, LogLevel) {
                 }
             }
             Some(SelfCommands::UserAgent { prefix }) => Action::UserAgent { prefix },
+            Some(SelfCommands::Changelog { version }) => Action::ShowChangelog { version },
         },
         Some(Commands::Org { args }) => Action::OrgProxy { args },
         Some(Commands::Mcp { command }) => match command {
@@ -1076,6 +1086,12 @@ enum SelfCommands {
         /// Optional conda prefix to use for AAU tokens
         #[arg(long)]
         prefix: Option<String>,
+    },
+
+    /// Show what's new in a release
+    Changelog {
+        /// Version to show changelog for (defaults to latest)
+        version: Option<String>,
     },
 }
 

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -74,6 +74,16 @@ pub(super) fn get_subcommand_examples(path: &str) -> Option<Vec<HelpExample>> {
                 command: format!("ana self update v{}", crate::VERSION),
             },
         ]),
+        "self changelog" => Some(vec![
+            HelpExample {
+                desc: "Show changelog for the latest version".to_string(),
+                command: "ana self changelog".to_string(),
+            },
+            HelpExample {
+                desc: "Show changelog for a specific version".to_string(),
+                command: "ana self changelog v0.2.0".to_string(),
+            },
+        ]),
         _ => None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod mcp;
 mod outerbounds;
 mod paths;
 mod qr;
+mod release_notes;
 mod table;
 mod telemetry;
 mod tools;

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -31,18 +31,19 @@ pub struct ChangeEntry {
 }
 
 fn build_release_notes_url(base_url: &str, channel: &str, tag: &str) -> String {
-    format!("{}/releases/{}/{}/release-notes.json", base_url, channel, tag)
+    format!(
+        "{}/releases/{}/{}/release-notes.json",
+        base_url, channel, tag
+    )
 }
 
 pub async fn fetch_release_notes(
     ctx: &CommandContext,
     tag: &str,
 ) -> Result<ReleaseNotes, UpdateError> {
-    let base_url = ctx
-        .config
-        .self_update_url
-        .as_deref()
-        .ok_or_else(|| UpdateError::Http("Release notes not available for GitHub releases".to_string()))?;
+    let base_url = ctx.config.self_update_url.as_deref().ok_or_else(|| {
+        UpdateError::Http("Release notes not available for GitHub releases".to_string())
+    })?;
 
     let channel = if ctx.config.include_prereleases {
         "dev"
@@ -73,7 +74,9 @@ pub async fn fetch_release_notes(
 }
 
 fn strip_conventional_prefix(description: &str) -> &str {
-    let prefixes = ["fix: ", "feat: ", "chore: ", "refac: ", "docs: ", "test: ", "build: ", "ci: "];
+    let prefixes = [
+        "fix: ", "feat: ", "chore: ", "refac: ", "docs: ", "test: ", "build: ", "ci: ",
+    ];
     for prefix in prefixes {
         if let Some(stripped) = description.strip_prefix(prefix) {
             return stripped;

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -1,0 +1,206 @@
+//! Release notes fetching and display.
+//!
+//! Fetches structured release notes from anaconda.sh and displays them
+//! in a user-friendly format after updates.
+
+use serde::Deserialize;
+
+use crate::context::CommandContext;
+use crate::errors::UpdateError;
+use crate::ui::status;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReleaseNotes {
+    #[serde(default)]
+    pub sections: Sections,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Sections {
+    #[serde(default, rename = "what's_changed")]
+    pub whats_changed: Vec<ChangeEntry>,
+    #[serde(default)]
+    pub bug_fixes: Vec<ChangeEntry>,
+    #[serde(default)]
+    pub new_features: Vec<ChangeEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChangeEntry {
+    pub description: String,
+}
+
+fn build_release_notes_url(base_url: &str, channel: &str, tag: &str) -> String {
+    format!("{}/releases/{}/{}/release-notes.json", base_url, channel, tag)
+}
+
+pub async fn fetch_release_notes(
+    ctx: &CommandContext,
+    tag: &str,
+) -> Result<ReleaseNotes, UpdateError> {
+    let base_url = ctx
+        .config
+        .self_update_url
+        .as_deref()
+        .ok_or_else(|| UpdateError::Http("Release notes not available for GitHub releases".to_string()))?;
+
+    let channel = if ctx.config.include_prereleases {
+        "dev"
+    } else {
+        "stable"
+    };
+
+    let url = build_release_notes_url(base_url, channel, tag);
+
+    let response = ctx
+        .download_client()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| UpdateError::Http(e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(UpdateError::Http(format!(
+            "Failed to fetch release notes: {}",
+            response.status()
+        )));
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| UpdateError::Http(e.to_string()))
+}
+
+fn strip_conventional_prefix(description: &str) -> &str {
+    let prefixes = ["fix: ", "feat: ", "chore: ", "refac: ", "docs: ", "test: ", "build: ", "ci: "];
+    for prefix in prefixes {
+        if let Some(stripped) = description.strip_prefix(prefix) {
+            return stripped;
+        }
+    }
+    if let Some(pos) = description.find("): ") {
+        return &description[pos + 3..];
+    }
+    description
+}
+
+pub fn display_release_notes(notes: &ReleaseNotes) {
+    let has_features = !notes.sections.new_features.is_empty();
+    let has_fixes = !notes.sections.bug_fixes.is_empty();
+    let has_changes = !notes.sections.whats_changed.is_empty();
+
+    if !has_features && !has_fixes && !has_changes {
+        return;
+    }
+
+    eprintln!();
+    eprintln!("  {}", status::section("WHAT'S NEW"));
+
+    if has_features {
+        for entry in &notes.sections.new_features {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  {} {}", status::highlight("•"), desc);
+        }
+    }
+
+    if has_fixes {
+        for entry in &notes.sections.bug_fixes {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  {} {}", status::dim("•"), desc);
+        }
+    }
+
+    if has_changes {
+        for entry in &notes.sections.whats_changed {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  {} {}", status::dim("•"), desc);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_release_notes_url() {
+        let url = build_release_notes_url("https://anaconda.sh", "stable", "v0.2.3");
+        assert_eq!(
+            url,
+            "https://anaconda.sh/releases/stable/v0.2.3/release-notes.json"
+        );
+    }
+
+    #[test]
+    fn test_build_release_notes_url_dev_channel() {
+        let url = build_release_notes_url("https://anaconda.sh", "dev", "v0.2.4.dev1");
+        assert_eq!(
+            url,
+            "https://anaconda.sh/releases/dev/v0.2.4.dev1/release-notes.json"
+        );
+    }
+
+    #[test]
+    fn test_strip_conventional_prefix_fix() {
+        assert_eq!(
+            strip_conventional_prefix("fix: Clarify shell restart needed"),
+            "Clarify shell restart needed"
+        );
+    }
+
+    #[test]
+    fn test_strip_conventional_prefix_feat() {
+        assert_eq!(
+            strip_conventional_prefix("feat: Add new feature"),
+            "Add new feature"
+        );
+    }
+
+    #[test]
+    fn test_strip_conventional_prefix_with_scope() {
+        assert_eq!(
+            strip_conventional_prefix("chore(deps): Update dependencies"),
+            "Update dependencies"
+        );
+    }
+
+    #[test]
+    fn test_strip_conventional_prefix_no_prefix() {
+        assert_eq!(
+            strip_conventional_prefix("Just a description"),
+            "Just a description"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_release_notes() {
+        let json = r#"{
+            "tag": "v0.2.3",
+            "sections": {
+                "bug_fixes": [
+                    {"description": "fix: Something broken", "author": "test", "pr_number": 1}
+                ],
+                "new_features": [
+                    {"description": "feat: Cool feature", "author": "test", "pr_number": 2}
+                ]
+            }
+        }"#;
+
+        let notes: ReleaseNotes = serde_json::from_str(json).unwrap();
+        assert_eq!(notes.sections.bug_fixes.len(), 1);
+        assert_eq!(notes.sections.new_features.len(), 1);
+    }
+
+    #[test]
+    fn test_deserialize_release_notes_empty_sections() {
+        let json = r#"{
+            "tag": "v0.2.3",
+            "sections": {}
+        }"#;
+
+        let notes: ReleaseNotes = serde_json::from_str(json).unwrap();
+        assert!(notes.sections.bug_fixes.is_empty());
+        assert!(notes.sections.new_features.is_empty());
+    }
+}

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -102,10 +102,28 @@ fn strip_html_comments(body: &str) -> String {
     result.trim().to_string()
 }
 
+fn ensure_blank_lines_before_headers(body: &str) -> String {
+    let mut result = String::with_capacity(body.len() + 100);
+    let mut prev_line_blank = true;
+
+    for line in body.lines() {
+        let is_header = line.starts_with('#');
+        if is_header && !prev_line_blank {
+            result.push('\n');
+        }
+        result.push_str(line);
+        result.push('\n');
+        prev_line_blank = line.trim().is_empty();
+    }
+
+    result
+}
+
 fn render_markdown(body: &str) {
     let clean_body = strip_html_comments(body);
+    let spaced_body = ensure_blank_lines_before_headers(&clean_body);
     let skin = make_skin();
-    let text = skin.text(&clean_body, None);
+    let text = skin.text(&spaced_body, None);
     let rendered = text.to_string();
 
     for line in rendered.lines() {

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -128,22 +128,23 @@ pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version
         eprintln!("  {}", status::section(&format!("CHANGELOG {}", tag)));
     }
 
-    display_changelog_sections(&notes);
+    if has_notable_changes(&notes) {
+        display_changelog_sections(&notes);
+    } else {
+        eprintln!();
+        eprintln!("  {}", status::dim("No notable changes."));
+    }
     eprintln!();
 }
 
+fn has_notable_changes(notes: &ReleaseNotes) -> bool {
+    !notes.sections.new_features.is_empty()
+        || !notes.sections.bug_fixes.is_empty()
+        || !notes.sections.whats_changed.is_empty()
+}
+
 fn display_changelog_sections(notes: &ReleaseNotes) {
-    let has_features = !notes.sections.new_features.is_empty();
-    let has_fixes = !notes.sections.bug_fixes.is_empty();
-    let has_changes = !notes.sections.whats_changed.is_empty();
-
-    if !has_features && !has_fixes && !has_changes {
-        eprintln!();
-        eprintln!("  {}", status::dim("No notable changes."));
-        return;
-    }
-
-    if has_features {
+    if !notes.sections.new_features.is_empty() {
         eprintln!();
         eprintln!("  {}", status::highlight("New Features"));
         for entry in &notes.sections.new_features {
@@ -152,7 +153,7 @@ fn display_changelog_sections(notes: &ReleaseNotes) {
         }
     }
 
-    if has_fixes {
+    if !notes.sections.bug_fixes.is_empty() {
         eprintln!();
         eprintln!("  {}", status::highlight("Bug Fixes"));
         for entry in &notes.sections.bug_fixes {
@@ -161,7 +162,7 @@ fn display_changelog_sections(notes: &ReleaseNotes) {
         }
     }
 
-    if has_changes {
+    if !notes.sections.whats_changed.is_empty() {
         eprintln!();
         eprintln!("  {}", status::highlight("Changes"));
         for entry in &notes.sections.whats_changed {
@@ -172,37 +173,13 @@ fn display_changelog_sections(notes: &ReleaseNotes) {
 }
 
 pub fn display_release_notes(notes: &ReleaseNotes) {
-    let has_features = !notes.sections.new_features.is_empty();
-    let has_fixes = !notes.sections.bug_fixes.is_empty();
-    let has_changes = !notes.sections.whats_changed.is_empty();
-
-    if !has_features && !has_fixes && !has_changes {
+    if !has_notable_changes(notes) {
         return;
     }
 
     eprintln!();
     eprintln!("  {}", status::section("WHAT'S NEW"));
-
-    if has_features {
-        for entry in &notes.sections.new_features {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  {} {}", status::highlight("•"), desc);
-        }
-    }
-
-    if has_fixes {
-        for entry in &notes.sections.bug_fixes {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  {} {}", status::dim("•"), desc);
-        }
-    }
-
-    if has_changes {
-        for entry in &notes.sections.whats_changed {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  {} {}", status::dim("•"), desc);
-        }
-    }
+    display_changelog_sections(notes);
 }
 
 #[cfg(test)]

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -63,7 +63,8 @@ fn make_skin() -> MadSkin {
     let mut skin = MadSkin::default();
     skin.set_headers_fg(termimad::crossterm::style::Color::Green);
     skin.bold.set_fg(termimad::crossterm::style::Color::Blue);
-    skin.italic.set_fg(termimad::crossterm::style::Color::DarkGrey);
+    skin.italic
+        .set_fg(termimad::crossterm::style::Color::DarkGrey);
     skin
 }
 

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -88,6 +88,91 @@ fn strip_conventional_prefix(description: &str) -> &str {
     description
 }
 
+pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version: Option<String>) {
+    let tag = match version {
+        Some(v) => {
+            if v.starts_with('v') {
+                v
+            } else {
+                format!("v{}", v)
+            }
+        }
+        None => {
+            match crate::update::fetch_latest_version(ctx).await {
+                Ok(v) => v,
+                Err(e) => {
+                    status::error(&format!("Failed to fetch latest version: {}", e));
+                    return;
+                }
+            }
+        }
+    };
+
+    let notes = match fetch_release_notes(ctx, &tag).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::debug!("Failed to fetch release notes: {}", e);
+            status::error(&format!("No changelog available for {}", tag));
+            return;
+        }
+    };
+
+    let is_current = tag.trim_start_matches('v') == current_version;
+
+    eprintln!();
+    if is_current {
+        eprintln!(
+            "  {} {}",
+            status::section(&format!("CHANGELOG {}", tag)),
+            status::dim("(current)")
+        );
+    } else {
+        eprintln!("  {}", status::section(&format!("CHANGELOG {}", tag)));
+    }
+
+    display_changelog_sections(&notes);
+    eprintln!();
+}
+
+fn display_changelog_sections(notes: &ReleaseNotes) {
+    let has_features = !notes.sections.new_features.is_empty();
+    let has_fixes = !notes.sections.bug_fixes.is_empty();
+    let has_changes = !notes.sections.whats_changed.is_empty();
+
+    if !has_features && !has_fixes && !has_changes {
+        eprintln!();
+        eprintln!("  {}", status::dim("No notable changes."));
+        return;
+    }
+
+    if has_features {
+        eprintln!();
+        eprintln!("  {}", status::highlight("New Features"));
+        for entry in &notes.sections.new_features {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  • {}", desc);
+        }
+    }
+
+    if has_fixes {
+        eprintln!();
+        eprintln!("  {}", status::highlight("Bug Fixes"));
+        for entry in &notes.sections.bug_fixes {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  • {}", desc);
+        }
+    }
+
+    if has_changes {
+        eprintln!();
+        eprintln!("  {}", status::highlight("Changes"));
+        for entry in &notes.sections.whats_changed {
+            let desc = strip_conventional_prefix(&entry.description);
+            eprintln!("  • {}", desc);
+        }
+    }
+}
+
 pub fn display_release_notes(notes: &ReleaseNotes) {
     let has_features = !notes.sections.new_features.is_empty();
     let has_fixes = !notes.sections.bug_fixes.is_empty();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -97,15 +97,13 @@ pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version
                 format!("v{}", v)
             }
         }
-        None => {
-            match crate::update::fetch_latest_version(ctx).await {
-                Ok(v) => v,
-                Err(e) => {
-                    status::error(&format!("Failed to fetch latest version: {}", e));
-                    return;
-                }
+        None => match crate::update::fetch_latest_version(ctx).await {
+            Ok(v) => v,
+            Err(e) => {
+                status::error(&format!("Failed to fetch latest version: {}", e));
+                return;
             }
-        }
+        },
     };
 
     let notes = match fetch_release_notes(ctx, &tag).await {

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -106,7 +106,11 @@ fn render_markdown(body: &str) {
     let clean_body = strip_html_comments(body);
     let skin = make_skin();
     let text = skin.text(&clean_body, None);
-    eprint!("{}", text);
+    let rendered = text.to_string();
+
+    for line in rendered.lines() {
+        eprintln!("\t{}", line);
+    }
 }
 
 pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version: Option<String>) {

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -1,9 +1,10 @@
 //! Release notes fetching and display.
 //!
-//! Fetches structured release notes from anaconda.sh and displays them
-//! in a user-friendly format after updates.
+//! Fetches release notes from anaconda.sh and renders the markdown body
+//! in the terminal.
 
 use serde::Deserialize;
+use termimad::MadSkin;
 
 use crate::context::CommandContext;
 use crate::errors::UpdateError;
@@ -12,22 +13,7 @@ use crate::ui::status;
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReleaseNotes {
     #[serde(default)]
-    pub sections: Sections,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct Sections {
-    #[serde(default, rename = "what's_changed")]
-    pub whats_changed: Vec<ChangeEntry>,
-    #[serde(default)]
-    pub bug_fixes: Vec<ChangeEntry>,
-    #[serde(default)]
-    pub new_features: Vec<ChangeEntry>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct ChangeEntry {
-    pub description: String,
+    pub body: String,
 }
 
 fn build_release_notes_url(base_url: &str, channel: &str, tag: &str) -> String {
@@ -73,19 +59,53 @@ pub async fn fetch_release_notes(
         .map_err(|e| UpdateError::Http(e.to_string()))
 }
 
-fn strip_conventional_prefix(description: &str) -> &str {
-    let prefixes = [
-        "fix: ", "feat: ", "chore: ", "refac: ", "docs: ", "test: ", "build: ", "ci: ",
-    ];
-    for prefix in prefixes {
-        if let Some(stripped) = description.strip_prefix(prefix) {
-            return stripped;
+fn make_skin() -> MadSkin {
+    let mut skin = MadSkin::default();
+    skin.set_headers_fg(termimad::crossterm::style::Color::Green);
+    skin.bold.set_fg(termimad::crossterm::style::Color::Blue);
+    skin.italic.set_fg(termimad::crossterm::style::Color::DarkGrey);
+    skin
+}
+
+fn strip_html_comments(body: &str) -> String {
+    let mut result = String::with_capacity(body.len());
+    let mut chars = body.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '<'
+            && chars.peek() == Some(&'!')
+            && chars.clone().take(3).collect::<String>() == "!--"
+        {
+            // Skip until -->
+            chars.next(); // !
+            chars.next(); // -
+            chars.next(); // -
+            loop {
+                match chars.next() {
+                    Some('-') if chars.peek() == Some(&'-') => {
+                        chars.next(); // second -
+                        if chars.peek() == Some(&'>') {
+                            chars.next(); // >
+                            break;
+                        }
+                    }
+                    None => break,
+                    _ => {}
+                }
+            }
+        } else {
+            result.push(c);
         }
     }
-    if let Some(pos) = description.find("): ") {
-        return &description[pos + 3..];
-    }
-    description
+
+    result.trim().to_string()
+}
+
+fn render_markdown(body: &str) {
+    let clean_body = strip_html_comments(body);
+    let skin = make_skin();
+    let text = skin.text(&clean_body, None);
+    eprint!("{}", text);
 }
 
 pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version: Option<String>) {
@@ -127,59 +147,25 @@ pub async fn show_changelog(ctx: &CommandContext, current_version: &str, version
     } else {
         eprintln!("  {}", status::section(&format!("CHANGELOG {}", tag)));
     }
+    eprintln!();
 
-    if has_notable_changes(&notes) {
-        display_changelog_sections(&notes);
+    if notes.body.is_empty() {
+        eprintln!("  {}", status::dim("No changelog available."));
     } else {
-        eprintln!();
-        eprintln!("  {}", status::dim("No notable changes."));
+        render_markdown(&notes.body);
     }
     eprintln!();
 }
 
-fn has_notable_changes(notes: &ReleaseNotes) -> bool {
-    !notes.sections.new_features.is_empty()
-        || !notes.sections.bug_fixes.is_empty()
-        || !notes.sections.whats_changed.is_empty()
-}
-
-fn display_changelog_sections(notes: &ReleaseNotes) {
-    if !notes.sections.new_features.is_empty() {
-        eprintln!();
-        eprintln!("  {}", status::highlight("New Features"));
-        for entry in &notes.sections.new_features {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  • {}", desc);
-        }
-    }
-
-    if !notes.sections.bug_fixes.is_empty() {
-        eprintln!();
-        eprintln!("  {}", status::highlight("Bug Fixes"));
-        for entry in &notes.sections.bug_fixes {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  • {}", desc);
-        }
-    }
-
-    if !notes.sections.whats_changed.is_empty() {
-        eprintln!();
-        eprintln!("  {}", status::highlight("Changes"));
-        for entry in &notes.sections.whats_changed {
-            let desc = strip_conventional_prefix(&entry.description);
-            eprintln!("  • {}", desc);
-        }
-    }
-}
-
 pub fn display_release_notes(notes: &ReleaseNotes) {
-    if !has_notable_changes(notes) {
+    if notes.body.is_empty() {
         return;
     }
 
     eprintln!();
     eprintln!("  {}", status::section("WHAT'S NEW"));
-    display_changelog_sections(notes);
+    eprintln!();
+    render_markdown(&notes.body);
 }
 
 #[cfg(test)]
@@ -205,65 +191,20 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_conventional_prefix_fix() {
-        assert_eq!(
-            strip_conventional_prefix("fix: Clarify shell restart needed"),
-            "Clarify shell restart needed"
-        );
-    }
-
-    #[test]
-    fn test_strip_conventional_prefix_feat() {
-        assert_eq!(
-            strip_conventional_prefix("feat: Add new feature"),
-            "Add new feature"
-        );
-    }
-
-    #[test]
-    fn test_strip_conventional_prefix_with_scope() {
-        assert_eq!(
-            strip_conventional_prefix("chore(deps): Update dependencies"),
-            "Update dependencies"
-        );
-    }
-
-    #[test]
-    fn test_strip_conventional_prefix_no_prefix() {
-        assert_eq!(
-            strip_conventional_prefix("Just a description"),
-            "Just a description"
-        );
-    }
-
-    #[test]
     fn test_deserialize_release_notes() {
-        let json = r#"{
-            "tag": "v0.2.3",
-            "sections": {
-                "bug_fixes": [
-                    {"description": "fix: Something broken", "author": "test", "pr_number": 1}
-                ],
-                "new_features": [
-                    {"description": "feat: Cool feature", "author": "test", "pr_number": 2}
-                ]
-            }
-        }"#;
+        let json = r###"{"tag": "v0.2.3", "body": "## Changes\n\n* fix: Something"}"###;
 
         let notes: ReleaseNotes = serde_json::from_str(json).unwrap();
-        assert_eq!(notes.sections.bug_fixes.len(), 1);
-        assert_eq!(notes.sections.new_features.len(), 1);
+        assert!(notes.body.contains("Changes"));
     }
 
     #[test]
-    fn test_deserialize_release_notes_empty_sections() {
+    fn test_deserialize_release_notes_empty_body() {
         let json = r#"{
-            "tag": "v0.2.3",
-            "sections": {}
+            "tag": "v0.2.3"
         }"#;
 
         let notes: ReleaseNotes = serde_json::from_str(json).unwrap();
-        assert!(notes.sections.bug_fixes.is_empty());
-        assert!(notes.sections.new_features.is_empty());
+        assert!(notes.body.is_empty());
     }
 }

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -109,7 +109,7 @@ fn render_markdown(body: &str) {
     let rendered = text.to_string();
 
     for line in rendered.lines() {
-        eprintln!("\t{}", line);
+        eprintln!("    {}", line);
     }
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -381,8 +381,13 @@ pub async fn check_for_update(ctx: &CommandContext, current_version: &str) {
                 match apply_update(ctx, &release).await {
                     Ok(()) => {
                         update_installed_tools();
-                        print_update_success(ctx, current_version, &release.tag_name, start.elapsed())
-                            .await;
+                        print_update_success(
+                            ctx,
+                            current_version,
+                            &release.tag_name,
+                            start.elapsed(),
+                        )
+                        .await;
                     }
                     Err(e) => {
                         tracing::error!("Failed to update: {}", e);
@@ -526,7 +531,8 @@ pub async fn run_update(
         match apply_update(ctx, &release).await {
             Ok(()) => {
                 update_installed_tools();
-                print_update_success(ctx, current_version, &release.tag_name, start.elapsed()).await;
+                print_update_success(ctx, current_version, &release.tag_name, start.elapsed())
+                    .await;
             }
             Err(e) => {
                 tracing::error!("Failed to update: {}", e);
@@ -550,8 +556,13 @@ pub async fn run_update(
                 match apply_update(ctx, &release).await {
                     Ok(()) => {
                         update_installed_tools();
-                        print_update_success(ctx, current_version, &release.tag_name, start.elapsed())
-                            .await;
+                        print_update_success(
+                            ctx,
+                            current_version,
+                            &release.tag_name,
+                            start.elapsed(),
+                        )
+                        .await;
                     }
                     Err(e) => {
                         tracing::error!("Failed to update: {}", e);

--- a/src/update.rs
+++ b/src/update.rs
@@ -381,7 +381,8 @@ pub async fn check_for_update(ctx: &CommandContext, current_version: &str) {
                 match apply_update(ctx, &release).await {
                     Ok(()) => {
                         update_installed_tools();
-                        print_update_success(current_version, &release.tag_name, start.elapsed());
+                        print_update_success(ctx, current_version, &release.tag_name, start.elapsed())
+                            .await;
                     }
                     Err(e) => {
                         tracing::error!("Failed to update: {}", e);
@@ -406,8 +407,15 @@ pub async fn check_for_update(ctx: &CommandContext, current_version: &str) {
     }
 }
 
-fn print_update_success(current_version: &str, new_version: &str, elapsed: std::time::Duration) {
+async fn print_update_success(
+    ctx: &CommandContext,
+    current_version: &str,
+    new_version: &str,
+    elapsed: std::time::Duration,
+) {
+    use crate::release_notes::{display_release_notes, fetch_release_notes};
     use crate::ui::status;
+
     eprintln!();
     eprintln!(
         "  {} {}",
@@ -415,6 +423,12 @@ fn print_update_success(current_version: &str, new_version: &str, elapsed: std::
         status::dim(&format!("{:.1}s", elapsed.as_secs_f64()))
     );
     eprintln!("  was v{} → now {}", current_version, new_version);
+
+    match fetch_release_notes(ctx, new_version).await {
+        Ok(notes) => display_release_notes(&notes),
+        Err(e) => tracing::debug!("Failed to fetch release notes: {}", e),
+    }
+
     eprintln!();
 }
 
@@ -512,7 +526,7 @@ pub async fn run_update(
         match apply_update(ctx, &release).await {
             Ok(()) => {
                 update_installed_tools();
-                print_update_success(current_version, &release.tag_name, start.elapsed());
+                print_update_success(ctx, current_version, &release.tag_name, start.elapsed()).await;
             }
             Err(e) => {
                 tracing::error!("Failed to update: {}", e);
@@ -536,7 +550,8 @@ pub async fn run_update(
                 match apply_update(ctx, &release).await {
                     Ok(()) => {
                         update_installed_tools();
-                        print_update_success(current_version, &release.tag_name, start.elapsed());
+                        print_update_success(ctx, current_version, &release.tag_name, start.elapsed())
+                            .await;
                     }
                     Err(e) => {
                         tracing::error!("Failed to update: {}", e);


### PR DESCRIPTION
## Summary
Fetches and displays structured release notes from anaconda.sh after a successful `ana self update`, showing users what's new in the version they just installed.

- Adds `src/release_notes.rs` module for fetching and formatting release notes
- Integrates into the update flow to display after successful updates
- Shows new features (highlighted) and bug fixes (dimmed) in a "WHAT'S NEW" section
- Strips conventional commit prefixes for cleaner display
- Silently handles fetch failures (doesn't break update flow)

Example output after update:

<img width="1389" height="1002" alt="CleanShot 2026-07-24 at 09 32 01" src="https://github.com/user-attachments/assets/81c284f0-f29b-4788-b9cc-bb67d2685f48" />

<img width="1393" height="805" alt="CleanShot 2026-07-24 at 09 32 37" src="https://github.com/user-attachments/assets/cd959cc8-2dc0-4177-a006-dfdfa1ad4858" />


## Test plan
- [ ] Run `ana self update` when a new version is available
- [ ] Verify release notes display after successful update
- [ ] Test with version that has no release notes (should complete silently)
- [ ] Run `cargo test release_notes` to verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)