### PR TITLE
fix: Use default_channels instead of channels for main-x feature

### DIFF
--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -786,9 +786,11 @@ mod tests {
         // Should add all 4 required default_channels plus "defaults" to channels
         assert_eq!(actions.len(), 5);
         // Check that defaults is added to channels
-        assert!(actions
-            .iter()
-            .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels)));
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels))
+        );
     }
 
     #[test]
@@ -799,9 +801,11 @@ mod tests {
 
         // Should add all 4 required default_channels, but not "defaults" to channels
         assert_eq!(actions.len(), 4);
-        assert!(!actions
-            .iter()
-            .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels)));
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels))
+        );
     }
 
     #[test]

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -26,24 +26,22 @@ const ANACONDA_DOWNLOAD_URL: &str = "https://www.anaconda.com/download";
 const REQUIRED_DEFAULT_CHANNELS: &[&str] =
     &[MAIN_X_CHANNEL, MAIN_CHANNEL, MSYS2_CHANNEL, R_CHANNEL];
 
-/// Represents a channel configuration action to be executed for conda.
-enum CondaChannelAction {
-    /// Add a channel to default_channels
+/// Represents a channel configuration action for enabling/disabling main-x via conda.
+enum MainXCondaAction {
+    /// Add a channel to default_channels (used for main-x, main, msys2, r)
     AddDefaultChannel(&'static str),
     /// Add "defaults" to channels list
-    AddDefaultsToChannels,
+    EnsureDefaultsInChannels,
     /// Remove main-x from default_channels
     RemoveMainX,
 }
 
-impl CondaChannelAction {
+impl MainXCondaAction {
     fn command_args(&self) -> (&'static str, &'static str, &'static str) {
         match self {
-            CondaChannelAction::AddDefaultChannel(channel) => {
-                ("--add", "default_channels", channel)
-            }
-            CondaChannelAction::AddDefaultsToChannels => ("--add", "channels", "defaults"),
-            CondaChannelAction::RemoveMainX => ("--remove", "default_channels", MAIN_X_CHANNEL),
+            MainXCondaAction::AddDefaultChannel(channel) => ("--add", "default_channels", channel),
+            MainXCondaAction::EnsureDefaultsInChannels => ("--add", "channels", "defaults"),
+            MainXCondaAction::RemoveMainX => ("--remove", "default_channels", MAIN_X_CHANNEL),
         }
     }
 
@@ -58,7 +56,7 @@ impl CondaChannelAction {
 }
 
 /// Represents a channel configuration action to be executed for pixi.
-enum PixiChannelAction {
+enum MainXPixiAction {
     AddMain,
     AddMainX,
     /// Remove main-x while preserving other channels (especially main).
@@ -66,22 +64,22 @@ enum PixiChannelAction {
     RemoveMainX(Vec<String>),
 }
 
-impl PixiChannelAction {
+impl MainXPixiAction {
     fn command_display(&self) -> String {
         match self {
-            PixiChannelAction::AddMain => {
+            MainXPixiAction::AddMain => {
                 format!(
                     "pixi config prepend --global default-channels {}",
                     MAIN_CHANNEL
                 )
             }
-            PixiChannelAction::AddMainX => {
+            MainXPixiAction::AddMainX => {
                 format!(
                     "pixi config prepend --global default-channels {}",
                     MAIN_X_CHANNEL
                 )
             }
-            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+            MainXPixiAction::RemoveMainX(channels_to_keep) => {
                 format_pixi_remove_main_x_command(channels_to_keep)
             }
         }
@@ -91,19 +89,19 @@ impl PixiChannelAction {
         let cmd = self.command_display();
         status::running(&format!("Running {}", status::highlight(&cmd)));
         match self {
-            PixiChannelAction::AddMain => {
+            MainXPixiAction::AddMain => {
                 run_pixi_config(
                     pixi_bin,
                     &["prepend", "--global", "default-channels", MAIN_CHANNEL],
                 )?;
             }
-            PixiChannelAction::AddMainX => {
+            MainXPixiAction::AddMainX => {
                 run_pixi_config(
                     pixi_bin,
                     &["prepend", "--global", "default-channels", MAIN_X_CHANNEL],
                 )?;
             }
-            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+            MainXPixiAction::RemoveMainX(channels_to_keep) => {
                 execute_pixi_remove_main_x(pixi_bin, channels_to_keep)?;
             }
         }
@@ -196,29 +194,29 @@ fn run_pixi_auth_logout(pixi_bin: &Path) -> miette::Result<()> {
 fn plan_conda_enable_actions(
     channels: &[String],
     default_channels: &[String],
-) -> Vec<CondaChannelAction> {
+) -> Vec<MainXCondaAction> {
     let mut actions = vec![];
 
     // Add any missing required default_channels (in reverse order since --add prepends)
     for &channel in REQUIRED_DEFAULT_CHANNELS.iter().rev() {
         if !default_channels.iter().any(|c| c == channel) {
-            actions.push(CondaChannelAction::AddDefaultChannel(channel));
+            actions.push(MainXCondaAction::AddDefaultChannel(channel));
         }
     }
 
     // Ensure "defaults" is in channels list
     if !channels.iter().any(|c| c == "defaults") {
-        actions.push(CondaChannelAction::AddDefaultsToChannels);
+        actions.push(MainXCondaAction::EnsureDefaultsInChannels);
     }
 
     actions
 }
 
 /// Plan the actions needed to disable main-x channel for conda.
-fn plan_conda_disable_actions(current_channels: &[String]) -> Vec<CondaChannelAction> {
+fn plan_conda_disable_actions(current_channels: &[String]) -> Vec<MainXCondaAction> {
     let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
     if has_main_x {
-        vec![CondaChannelAction::RemoveMainX]
+        vec![MainXCondaAction::RemoveMainX]
     } else {
         vec![]
     }
@@ -228,7 +226,7 @@ fn plan_conda_disable_actions(current_channels: &[String]) -> Vec<CondaChannelAc
 ///
 /// Ensures both main and main-x channels are added with priority main -> main-x.
 /// Since `pixi config prepend` prepends, we add main-x first, then main.
-fn plan_pixi_enable_actions(current_channels: &[String]) -> Vec<PixiChannelAction> {
+fn plan_pixi_enable_actions(current_channels: &[String]) -> Vec<MainXPixiAction> {
     let has_main = current_channels.iter().any(|c| c == MAIN_CHANNEL);
     let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
 
@@ -236,12 +234,12 @@ fn plan_pixi_enable_actions(current_channels: &[String]) -> Vec<PixiChannelActio
 
     // Add main-x first (will be second after main is prepended)
     if !has_main_x {
-        actions.push(PixiChannelAction::AddMainX);
+        actions.push(MainXPixiAction::AddMainX);
     }
 
     // Add main second (prepends, so it ends up first)
     if !has_main {
-        actions.push(PixiChannelAction::AddMain);
+        actions.push(MainXPixiAction::AddMain);
     }
 
     actions
@@ -251,7 +249,7 @@ fn plan_pixi_enable_actions(current_channels: &[String]) -> Vec<PixiChannelActio
 ///
 /// Removes main-x from the channel list while preserving all other channels.
 /// If main-x is the only channel, the result will unset default-channels entirely.
-fn plan_pixi_disable_actions(current_channels: &[String]) -> Vec<PixiChannelAction> {
+fn plan_pixi_disable_actions(current_channels: &[String]) -> Vec<MainXPixiAction> {
     let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
     if has_main_x {
         let channels_to_keep: Vec<String> = current_channels
@@ -259,7 +257,7 @@ fn plan_pixi_disable_actions(current_channels: &[String]) -> Vec<PixiChannelActi
             .filter(|c| *c != MAIN_X_CHANNEL)
             .cloned()
             .collect();
-        vec![PixiChannelAction::RemoveMainX(channels_to_keep)]
+        vec![MainXPixiAction::RemoveMainX(channels_to_keep)]
     } else {
         vec![]
     }
@@ -788,11 +786,9 @@ mod tests {
         // Should add all 4 required default_channels plus "defaults" to channels
         assert_eq!(actions.len(), 5);
         // Check that defaults is added to channels
-        assert!(
-            actions
-                .iter()
-                .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels))
-        );
+        assert!(actions
+            .iter()
+            .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels)));
     }
 
     #[test]
@@ -803,11 +799,9 @@ mod tests {
 
         // Should add all 4 required default_channels, but not "defaults" to channels
         assert_eq!(actions.len(), 4);
-        assert!(
-            !actions
-                .iter()
-                .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels))
-        );
+        assert!(!actions
+            .iter()
+            .any(|a| matches!(a, MainXCondaAction::EnsureDefaultsInChannels)));
     }
 
     #[test]
@@ -858,8 +852,8 @@ mod tests {
 
         // Adds main-x first, then main (so main ends up first after prepending)
         assert_eq!(actions.len(), 2);
-        assert!(matches!(actions[0], PixiChannelAction::AddMainX));
-        assert!(matches!(actions[1], PixiChannelAction::AddMain));
+        assert!(matches!(actions[0], MainXPixiAction::AddMainX));
+        assert!(matches!(actions[1], MainXPixiAction::AddMain));
     }
 
     #[test]
@@ -869,7 +863,7 @@ mod tests {
 
         // Still need to add main
         assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], PixiChannelAction::AddMain));
+        assert!(matches!(actions[0], MainXPixiAction::AddMain));
     }
 
     #[test]
@@ -879,7 +873,7 @@ mod tests {
 
         // Still need to add main-x
         assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], PixiChannelAction::AddMainX));
+        assert!(matches!(actions[0], MainXPixiAction::AddMainX));
     }
 
     #[test]
@@ -891,12 +885,12 @@ mod tests {
     }
 
     // ========================================================================
-    // CondaChannelAction::command_args tests
+    // MainXCondaAction::command_args tests
     // ========================================================================
 
     #[test]
     fn test_conda_channel_action_add_default_channel() {
-        let action = CondaChannelAction::AddDefaultChannel(MAIN_X_CHANNEL);
+        let action = MainXCondaAction::AddDefaultChannel(MAIN_X_CHANNEL);
         let (flag, key, value) = action.command_args();
 
         assert_eq!(flag, "--add");
@@ -906,7 +900,7 @@ mod tests {
 
     #[test]
     fn test_conda_channel_action_add_defaults_to_channels() {
-        let action = CondaChannelAction::AddDefaultsToChannels;
+        let action = MainXCondaAction::EnsureDefaultsInChannels;
         let (flag, key, value) = action.command_args();
 
         assert_eq!(flag, "--add");
@@ -916,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_conda_channel_action_remove_main_x() {
-        let action = CondaChannelAction::RemoveMainX;
+        let action = MainXCondaAction::RemoveMainX;
         let (flag, key, value) = action.command_args();
 
         assert_eq!(flag, "--remove");
@@ -925,12 +919,12 @@ mod tests {
     }
 
     // ========================================================================
-    // PixiChannelAction::command_display tests
+    // MainXPixiAction::command_display tests
     // ========================================================================
 
     #[test]
     fn test_pixi_channel_action_add_main_x_display() {
-        let action = PixiChannelAction::AddMainX;
+        let action = MainXPixiAction::AddMainX;
         let cmd = action.command_display();
 
         assert!(cmd.contains("pixi config prepend"));
@@ -939,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_pixi_channel_action_remove_main_x_display_empty() {
-        let action = PixiChannelAction::RemoveMainX(vec![]);
+        let action = MainXPixiAction::RemoveMainX(vec![]);
         let cmd = action.command_display();
 
         assert!(cmd.contains("pixi config unset"));
@@ -947,7 +941,7 @@ mod tests {
 
     #[test]
     fn test_pixi_channel_action_remove_main_x_display_with_channels() {
-        let action = PixiChannelAction::RemoveMainX(vec![MAIN_CHANNEL.to_string()]);
+        let action = MainXPixiAction::RemoveMainX(vec![MAIN_CHANNEL.to_string()]);
         let cmd = action.command_display();
 
         assert!(cmd.contains("pixi config set"));
@@ -965,7 +959,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
-            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+            MainXPixiAction::RemoveMainX(channels_to_keep) => {
                 assert_eq!(channels_to_keep, &vec![MAIN_CHANNEL.to_string()]);
             }
             _ => panic!("Expected RemoveMainX action"),
@@ -979,7 +973,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
-            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+            MainXPixiAction::RemoveMainX(channels_to_keep) => {
                 assert!(channels_to_keep.is_empty());
             }
             _ => panic!("Expected RemoveMainX action"),
@@ -1005,7 +999,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         match &actions[0] {
-            PixiChannelAction::RemoveMainX(channels_to_keep) => {
+            MainXPixiAction::RemoveMainX(channels_to_keep) => {
                 assert_eq!(
                     channels_to_keep,
                     &vec![MAIN_CHANNEL.to_string(), "conda-forge".to_string()]

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -16,38 +16,41 @@ use crate::ui::status;
 
 const MAIN_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main";
 const MAIN_X_CHANNEL: &str = "https://repo.anaconda.cloud/repo/main-x";
+const MSYS2_CHANNEL: &str = "https://repo.anaconda.cloud/repo/msys2";
+const R_CHANNEL: &str = "https://repo.anaconda.cloud/repo/r";
 const REPO_HOST: &str = "repo.anaconda.cloud";
 const ANACONDA_DOWNLOAD_URL: &str = "https://www.anaconda.com/download";
 
+/// All default channels that should be present when main-x is enabled.
+/// Order matters: main-x should be first (highest priority).
+const REQUIRED_DEFAULT_CHANNELS: &[&str] =
+    &[MAIN_X_CHANNEL, MAIN_CHANNEL, MSYS2_CHANNEL, R_CHANNEL];
+
 /// Represents a channel configuration action to be executed for conda.
 enum CondaChannelAction {
-    AddMain,
-    AddMainX,
+    /// Add a channel to default_channels
+    AddDefaultChannel(&'static str),
+    /// Add "defaults" to channels list
+    AddDefaultsToChannels,
+    /// Remove main-x from default_channels
     RemoveMainX,
 }
 
 impl CondaChannelAction {
-    fn commands(&self) -> Vec<(&'static str, &'static str, &'static str)> {
+    fn command_args(&self) -> (&'static str, &'static str, &'static str) {
         match self {
-            CondaChannelAction::AddMain => {
-                vec![("--add", "default_channels", MAIN_CHANNEL)]
-            }
-            CondaChannelAction::AddMainX => {
-                vec![("--add", "default_channels", MAIN_X_CHANNEL)]
-            }
-            CondaChannelAction::RemoveMainX => {
-                vec![("--remove", "default_channels", MAIN_X_CHANNEL)]
-            }
+            CondaChannelAction::AddDefaultChannel(channel) => ("--add", "default_channels", channel),
+            CondaChannelAction::AddDefaultsToChannels => ("--add", "channels", "defaults"),
+            CondaChannelAction::RemoveMainX => ("--remove", "default_channels", MAIN_X_CHANNEL),
         }
     }
 
     fn execute_with_status(&self, conda_bin: &Path) -> miette::Result<()> {
-        for (flag, key, value) in self.commands() {
-            let cmd = format!("conda config {} {} {}", flag, key, value);
-            status::running(&format!("Running {}", status::highlight(&cmd)));
-            run_conda_config(conda_bin, &[flag, key, value])?;
-            status::finish_running(&format!("Ran {}", status::highlight(&cmd)));
-        }
+        let (flag, key, value) = self.command_args();
+        let cmd = format!("conda config {} {} {}", flag, key, value);
+        status::running(&format!("Running {}", status::highlight(&cmd)));
+        run_conda_config(conda_bin, &[flag, key, value])?;
+        status::finish_running(&format!("Ran {}", status::highlight(&cmd)));
         Ok(())
     }
 }
@@ -186,28 +189,24 @@ fn run_pixi_auth_logout(pixi_bin: &Path) -> miette::Result<()> {
 
 /// Plan the actions needed to enable main-x channel for conda.
 ///
-/// Adds main-x to default_channels. If "defaults" is in channels, we don't need
-/// to add main to default_channels since defaults will use default_channels.
-/// If "defaults" is not in channels, we also add main to default_channels.
+/// Ensures all required default_channels are present (main-x, main, msys2, r)
+/// and that "defaults" is in the channels list.
 fn plan_conda_enable_actions(
     channels: &[String],
     default_channels: &[String],
 ) -> Vec<CondaChannelAction> {
-    let has_defaults_in_channels = channels.iter().any(|c| c == "defaults");
-    let has_main_in_default_channels = default_channels.iter().any(|c| c == MAIN_CHANNEL);
-    let has_main_x_in_default_channels = default_channels.iter().any(|c| c == MAIN_X_CHANNEL);
-
     let mut actions = vec![];
 
-    // Add main-x first (will be second after main is prepended)
-    if !has_main_x_in_default_channels {
-        actions.push(CondaChannelAction::AddMainX);
+    // Add any missing required default_channels (in reverse order since --add prepends)
+    for &channel in REQUIRED_DEFAULT_CHANNELS.iter().rev() {
+        if !default_channels.iter().any(|c| c == channel) {
+            actions.push(CondaChannelAction::AddDefaultChannel(channel));
+        }
     }
 
-    // Add main second (prepends, so it ends up first)
-    // Skip if "defaults" is in channels since it will use default_channels
-    if !has_defaults_in_channels && !has_main_in_default_channels {
-        actions.push(CondaChannelAction::AddMain);
+    // Ensure "defaults" is in channels list
+    if !channels.iter().any(|c| c == "defaults") {
+        actions.push(CondaChannelAction::AddDefaultsToChannels);
     }
 
     actions
@@ -297,10 +296,9 @@ pub async fn enable_main_x_conda(ctx: &CommandContext, force: bool) -> miette::R
     status::blank_line();
     status::info("The following commands will be run:");
     for action in &actions {
-        for (flag, key, value) in action.commands() {
-            let cmd = format!("conda config {} {} {}", flag, key, value);
-            eprintln!("  {}", status::highlight(&cmd));
-        }
+        let (flag, key, value) = action.command_args();
+        let cmd = format!("conda config {} {} {}", flag, key, value);
+        eprintln!("  {}", status::highlight(&cmd));
     }
     status::blank_line();
 
@@ -434,10 +432,9 @@ pub async fn disable_main_x_conda(_ctx: &CommandContext, force: bool) -> miette:
     // Show planned changes
     status::info("The following commands will be run:");
     for action in &actions {
-        for (flag, key, value) in action.commands() {
-            let cmd = format!("conda config {} {} {}", flag, key, value);
-            eprintln!("  {}", status::highlight(&cmd));
-        }
+        let (flag, key, value) = action.command_args();
+        let cmd = format!("conda config {} {} {}", flag, key, value);
+        eprintln!("  {}", status::highlight(&cmd));
     }
     status::blank_line();
 
@@ -786,10 +783,12 @@ mod tests {
         let default_channels: Vec<String> = vec![];
         let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // Adds main-x first, then main (so main ends up first after prepending)
-        assert_eq!(actions.len(), 2);
-        assert!(matches!(actions[0], CondaChannelAction::AddMainX));
-        assert!(matches!(actions[1], CondaChannelAction::AddMain));
+        // Should add all 4 required default_channels plus "defaults" to channels
+        assert_eq!(actions.len(), 5);
+        // Check that defaults is added to channels
+        assert!(actions
+            .iter()
+            .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels)));
     }
 
     #[test]
@@ -798,54 +797,48 @@ mod tests {
         let default_channels: Vec<String> = vec![];
         let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // "defaults" is in channels, so only need to add main-x to default_channels
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], CondaChannelAction::AddMainX));
+        // Should add all 4 required default_channels, but not "defaults" to channels
+        assert_eq!(actions.len(), 4);
+        assert!(!actions
+            .iter()
+            .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels)));
     }
 
     #[test]
-    fn test_plan_conda_enable_actions_conda_forge_and_defaults() {
-        let channels = vec!["conda-forge".to_string(), "defaults".to_string()];
-        let default_channels: Vec<String> = vec![];
-        let actions = plan_conda_enable_actions(&channels, &default_channels);
-
-        // "defaults" is in channels, so only need to add main-x to default_channels
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], CondaChannelAction::AddMainX));
-    }
-
-    #[test]
-    fn test_plan_conda_enable_actions_main_and_main_x_already_present() {
+    fn test_plan_conda_enable_actions_all_present() {
         let channels = vec!["defaults".to_string()];
-        let default_channels = vec![MAIN_CHANNEL.to_string(), MAIN_X_CHANNEL.to_string()];
+        let default_channels = vec![
+            MAIN_X_CHANNEL.to_string(),
+            MAIN_CHANNEL.to_string(),
+            MSYS2_CHANNEL.to_string(),
+            R_CHANNEL.to_string(),
+        ];
         let actions = plan_conda_enable_actions(&channels, &default_channels);
 
         assert!(
             actions.is_empty(),
-            "No actions needed when main-x already in default_channels"
+            "No actions needed when all channels already configured"
         );
     }
 
     #[test]
-    fn test_plan_conda_enable_actions_main_x_only_no_defaults() {
-        let channels: Vec<String> = vec![];
-        let default_channels = vec![MAIN_X_CHANNEL.to_string()];
+    fn test_plan_conda_enable_actions_partial_default_channels() {
+        let channels = vec!["defaults".to_string()];
+        let default_channels = vec![MAIN_X_CHANNEL.to_string(), MAIN_CHANNEL.to_string()];
         let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // No defaults in channels, so need to add main to default_channels
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], CondaChannelAction::AddMain));
+        // Should only add msys2 and r (the missing ones)
+        assert_eq!(actions.len(), 2);
     }
 
     #[test]
-    fn test_plan_conda_enable_actions_main_only() {
+    fn test_plan_conda_enable_actions_main_x_only() {
         let channels = vec!["defaults".to_string()];
-        let default_channels = vec![MAIN_CHANNEL.to_string()];
+        let default_channels = vec![MAIN_X_CHANNEL.to_string()];
         let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // Still need to add main-x
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], CondaChannelAction::AddMainX));
+        // Should add main, msys2, and r (the missing ones)
+        assert_eq!(actions.len(), 3);
     }
 
     // ========================================================================
@@ -892,28 +885,37 @@ mod tests {
     }
 
     // ========================================================================
-    // CondaChannelAction::commands tests
+    // CondaChannelAction::command_args tests
     // ========================================================================
 
     #[test]
-    fn test_conda_channel_action_add_main_x_commands() {
-        let action = CondaChannelAction::AddMainX;
-        let commands = action.commands();
+    fn test_conda_channel_action_add_default_channel() {
+        let action = CondaChannelAction::AddDefaultChannel(MAIN_X_CHANNEL);
+        let (flag, key, value) = action.command_args();
 
-        assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0], ("--add", "default_channels", MAIN_X_CHANNEL));
+        assert_eq!(flag, "--add");
+        assert_eq!(key, "default_channels");
+        assert_eq!(value, MAIN_X_CHANNEL);
     }
 
     #[test]
-    fn test_conda_channel_action_commands_format() {
-        let action = CondaChannelAction::AddMainX;
-        let commands = action.commands();
+    fn test_conda_channel_action_add_defaults_to_channels() {
+        let action = CondaChannelAction::AddDefaultsToChannels;
+        let (flag, key, value) = action.command_args();
 
-        for (flag, key, value) in commands {
-            assert!(flag.starts_with("--"), "Flag should start with --");
-            assert!(!key.is_empty(), "Key should not be empty");
-            assert!(!value.is_empty(), "Value should not be empty");
-        }
+        assert_eq!(flag, "--add");
+        assert_eq!(key, "channels");
+        assert_eq!(value, "defaults");
+    }
+
+    #[test]
+    fn test_conda_channel_action_remove_main_x() {
+        let action = CondaChannelAction::RemoveMainX;
+        let (flag, key, value) = action.command_args();
+
+        assert_eq!(flag, "--remove");
+        assert_eq!(key, "default_channels");
+        assert_eq!(value, MAIN_X_CHANNEL);
     }
 
     // ========================================================================

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -39,7 +39,9 @@ enum CondaChannelAction {
 impl CondaChannelAction {
     fn command_args(&self) -> (&'static str, &'static str, &'static str) {
         match self {
-            CondaChannelAction::AddDefaultChannel(channel) => ("--add", "default_channels", channel),
+            CondaChannelAction::AddDefaultChannel(channel) => {
+                ("--add", "default_channels", channel)
+            }
             CondaChannelAction::AddDefaultsToChannels => ("--add", "channels", "defaults"),
             CondaChannelAction::RemoveMainX => ("--remove", "default_channels", MAIN_X_CHANNEL),
         }
@@ -786,9 +788,11 @@ mod tests {
         // Should add all 4 required default_channels plus "defaults" to channels
         assert_eq!(actions.len(), 5);
         // Check that defaults is added to channels
-        assert!(actions
-            .iter()
-            .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels)));
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels))
+        );
     }
 
     #[test]
@@ -799,9 +803,11 @@ mod tests {
 
         // Should add all 4 required default_channels, but not "defaults" to channels
         assert_eq!(actions.len(), 4);
-        assert!(!actions
-            .iter()
-            .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels)));
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, CondaChannelAction::AddDefaultsToChannels))
+        );
     }
 
     #[test]

--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -27,25 +27,25 @@ enum CondaChannelAction {
 }
 
 impl CondaChannelAction {
-    fn commands(&self) -> Vec<(&'static str, &'static str)> {
+    fn commands(&self) -> Vec<(&'static str, &'static str, &'static str)> {
         match self {
             CondaChannelAction::AddMain => {
-                vec![("--add", MAIN_CHANNEL)]
+                vec![("--add", "default_channels", MAIN_CHANNEL)]
             }
             CondaChannelAction::AddMainX => {
-                vec![("--add", MAIN_X_CHANNEL)]
+                vec![("--add", "default_channels", MAIN_X_CHANNEL)]
             }
             CondaChannelAction::RemoveMainX => {
-                vec![("--remove", MAIN_X_CHANNEL)]
+                vec![("--remove", "default_channels", MAIN_X_CHANNEL)]
             }
         }
     }
 
     fn execute_with_status(&self, conda_bin: &Path) -> miette::Result<()> {
-        for (flag, channel) in self.commands() {
-            let cmd = format!("conda config {} channels {}", flag, channel);
+        for (flag, key, value) in self.commands() {
+            let cmd = format!("conda config {} {} {}", flag, key, value);
             status::running(&format!("Running {}", status::highlight(&cmd)));
-            run_conda_config(conda_bin, &[flag, "channels", channel])?;
+            run_conda_config(conda_bin, &[flag, key, value])?;
             status::finish_running(&format!("Ran {}", status::highlight(&cmd)));
         }
         Ok(())
@@ -186,25 +186,27 @@ fn run_pixi_auth_logout(pixi_bin: &Path) -> miette::Result<()> {
 
 /// Plan the actions needed to enable main-x channel for conda.
 ///
-/// Ensures both main and main-x channels are added with priority main -> main-x.
-/// Since `conda config --add` prepends, we add main-x first, then main.
-/// Note: "defaults" is treated as equivalent to main channel.
-fn plan_conda_enable_actions(current_channels: &[String]) -> Vec<CondaChannelAction> {
-    let has_main = current_channels
-        .iter()
-        .any(|c| c == MAIN_CHANNEL || c == "defaults");
-    let has_main_x = current_channels.iter().any(|c| c == MAIN_X_CHANNEL);
+/// Adds main-x to default_channels. If "defaults" is in channels, we don't need
+/// to add main to default_channels since defaults will use default_channels.
+/// If "defaults" is not in channels, we also add main to default_channels.
+fn plan_conda_enable_actions(
+    channels: &[String],
+    default_channels: &[String],
+) -> Vec<CondaChannelAction> {
+    let has_defaults_in_channels = channels.iter().any(|c| c == "defaults");
+    let has_main_in_default_channels = default_channels.iter().any(|c| c == MAIN_CHANNEL);
+    let has_main_x_in_default_channels = default_channels.iter().any(|c| c == MAIN_X_CHANNEL);
 
     let mut actions = vec![];
 
     // Add main-x first (will be second after main is prepended)
-    if !has_main_x {
+    if !has_main_x_in_default_channels {
         actions.push(CondaChannelAction::AddMainX);
     }
 
     // Add main second (prepends, so it ends up first)
-    // Skip if "defaults" is present since it's equivalent to main
-    if !has_main {
+    // Skip if "defaults" is in channels since it will use default_channels
+    if !has_defaults_in_channels && !has_main_in_default_channels {
         actions.push(CondaChannelAction::AddMain);
     }
 
@@ -282,8 +284,9 @@ pub async fn enable_main_x_conda(ctx: &CommandContext, force: bool) -> miette::R
 
     // Step 2: Determine what changes need to be made
     let conda_bin = find_conda()?;
-    let current_channels = get_configured_channels_conda(&conda_bin)?;
-    let actions = plan_conda_enable_actions(&current_channels);
+    let channels = get_channels_conda(&conda_bin)?;
+    let default_channels = get_default_channels_conda(&conda_bin)?;
+    let actions = plan_conda_enable_actions(&channels, &default_channels);
 
     if actions.is_empty() {
         status::success("Feature already enabled");
@@ -294,8 +297,8 @@ pub async fn enable_main_x_conda(ctx: &CommandContext, force: bool) -> miette::R
     status::blank_line();
     status::info("The following commands will be run:");
     for action in &actions {
-        for (flag, channel) in action.commands() {
-            let cmd = format!("conda config {} channels {}", flag, channel);
+        for (flag, key, value) in action.commands() {
+            let cmd = format!("conda config {} {} {}", flag, key, value);
             eprintln!("  {}", status::highlight(&cmd));
         }
     }
@@ -417,7 +420,7 @@ pub async fn disable_main_x_conda(_ctx: &CommandContext, force: bool) -> miette:
     status::blank_line();
 
     let conda_bin = find_conda()?;
-    let current_channels = get_configured_channels_conda(&conda_bin)?;
+    let current_channels = get_default_channels_conda(&conda_bin)?;
     let actions = plan_conda_disable_actions(&current_channels);
 
     if actions.is_empty() {
@@ -431,8 +434,8 @@ pub async fn disable_main_x_conda(_ctx: &CommandContext, force: bool) -> miette:
     // Show planned changes
     status::info("The following commands will be run:");
     for action in &actions {
-        for (flag, channel) in action.commands() {
-            let cmd = format!("conda config {} channels {}", flag, channel);
+        for (flag, key, value) in action.commands() {
+            let cmd = format!("conda config {} {} {}", flag, key, value);
             eprintln!("  {}", status::highlight(&cmd));
         }
     }
@@ -608,29 +611,37 @@ fn find_pixi() -> miette::Result<std::path::PathBuf> {
 }
 
 /// Get the list of currently configured channels from conda config --show.
+fn get_channels_conda(conda_bin: &Path) -> miette::Result<Vec<String>> {
+    get_conda_config_list(conda_bin, "channels")
+}
+
+/// Get the list of currently configured default_channels from conda config --show.
+fn get_default_channels_conda(conda_bin: &Path) -> miette::Result<Vec<String>> {
+    get_conda_config_list(conda_bin, "default_channels")
+}
+
+/// Get a list config value from conda config --show.
 ///
 /// The output format is:
 /// ```
-/// channels:
-///   - conda-forge
-///   - defaults
+/// <key>:
+///   - value1
+///   - value2
 /// ```
-fn get_configured_channels_conda(conda_bin: &Path) -> miette::Result<Vec<String>> {
+fn get_conda_config_list(conda_bin: &Path, key: &str) -> miette::Result<Vec<String>> {
     let output = Command::new(conda_bin)
-        .args(["config", "--show", "channels"])
+        .args(["config", "--show", key])
         .output()
         .into_diagnostic()
-        .context("failed to run conda config --show channels")?;
+        .context(format!("failed to run conda config --show {}", key))?;
 
     if !output.status.success() {
-        // If command fails, assume no channels configured
         return Ok(vec![]);
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Parse YAML-like output: skip "channels:" line, then extract "  - <channel>" lines
-    let channels: Vec<String> = stdout
+    let values: Vec<String> = stdout
         .lines()
         .filter_map(|line| {
             let trimmed = line.trim();
@@ -642,7 +653,7 @@ fn get_configured_channels_conda(conda_bin: &Path) -> miette::Result<Vec<String>
         })
         .collect();
 
-    Ok(channels)
+    Ok(values)
 }
 /// Get the list of currently configured global default channels from pixi config.
 fn get_configured_channels_pixi(pixi_bin: &Path) -> miette::Result<Vec<String>> {
@@ -771,8 +782,9 @@ mod tests {
 
     #[test]
     fn test_plan_conda_enable_actions_empty_channels() {
-        let current_channels: Vec<String> = vec![];
-        let actions = plan_conda_enable_actions(&current_channels);
+        let channels: Vec<String> = vec![];
+        let default_channels: Vec<String> = vec![];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
         // Adds main-x first, then main (so main ends up first after prepending)
         assert_eq!(actions.len(), 2);
@@ -781,55 +793,55 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_conda_enable_actions_defaults_only() {
-        let current_channels = vec!["defaults".to_string()];
-        let actions = plan_conda_enable_actions(&current_channels);
+    fn test_plan_conda_enable_actions_defaults_in_channels() {
+        let channels = vec!["defaults".to_string()];
+        let default_channels: Vec<String> = vec![];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // "defaults" is equivalent to main, so only need to add main-x
+        // "defaults" is in channels, so only need to add main-x to default_channels
         assert_eq!(actions.len(), 1);
         assert!(matches!(actions[0], CondaChannelAction::AddMainX));
     }
 
     #[test]
     fn test_plan_conda_enable_actions_conda_forge_and_defaults() {
-        let current_channels = vec!["conda-forge".to_string(), "defaults".to_string()];
-        let actions = plan_conda_enable_actions(&current_channels);
+        let channels = vec!["conda-forge".to_string(), "defaults".to_string()];
+        let default_channels: Vec<String> = vec![];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // "defaults" is equivalent to main, so only need to add main-x
+        // "defaults" is in channels, so only need to add main-x to default_channels
         assert_eq!(actions.len(), 1);
         assert!(matches!(actions[0], CondaChannelAction::AddMainX));
     }
 
     #[test]
     fn test_plan_conda_enable_actions_main_and_main_x_already_present() {
-        let current_channels = vec![
-            MAIN_CHANNEL.to_string(),
-            MAIN_X_CHANNEL.to_string(),
-            "conda-forge".to_string(),
-            "defaults".to_string(),
-        ];
-        let actions = plan_conda_enable_actions(&current_channels);
+        let channels = vec!["defaults".to_string()];
+        let default_channels = vec![MAIN_CHANNEL.to_string(), MAIN_X_CHANNEL.to_string()];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
         assert!(
             actions.is_empty(),
-            "No actions needed when main and main-x already configured"
+            "No actions needed when main-x already in default_channels"
         );
     }
 
     #[test]
-    fn test_plan_conda_enable_actions_main_x_only() {
-        let current_channels = vec![MAIN_X_CHANNEL.to_string()];
-        let actions = plan_conda_enable_actions(&current_channels);
+    fn test_plan_conda_enable_actions_main_x_only_no_defaults() {
+        let channels: Vec<String> = vec![];
+        let default_channels = vec![MAIN_X_CHANNEL.to_string()];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
-        // Still need to add main
+        // No defaults in channels, so need to add main to default_channels
         assert_eq!(actions.len(), 1);
         assert!(matches!(actions[0], CondaChannelAction::AddMain));
     }
 
     #[test]
     fn test_plan_conda_enable_actions_main_only() {
-        let current_channels = vec![MAIN_CHANNEL.to_string()];
-        let actions = plan_conda_enable_actions(&current_channels);
+        let channels = vec!["defaults".to_string()];
+        let default_channels = vec![MAIN_CHANNEL.to_string()];
+        let actions = plan_conda_enable_actions(&channels, &default_channels);
 
         // Still need to add main-x
         assert_eq!(actions.len(), 1);
@@ -889,7 +901,7 @@ mod tests {
         let commands = action.commands();
 
         assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0], ("--add", MAIN_X_CHANNEL));
+        assert_eq!(commands[0], ("--add", "default_channels", MAIN_X_CHANNEL));
     }
 
     #[test]
@@ -897,9 +909,10 @@ mod tests {
         let action = CondaChannelAction::AddMainX;
         let commands = action.commands();
 
-        for (flag, channel) in commands {
+        for (flag, key, value) in commands {
             assert!(flag.starts_with("--"), "Flag should start with --");
-            assert!(!channel.is_empty(), "Channel should not be empty");
+            assert!(!key.is_empty(), "Key should not be empty");
+            assert!(!value.is_empty(), "Value should not be empty");
         }
     }
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -13,6 +13,11 @@ from mock_auth_server import MockAuthServer
 
 MAIN_CHANNEL = "https://repo.anaconda.cloud/repo/main"
 MAIN_X_CHANNEL = "https://repo.anaconda.cloud/repo/main-x"
+MSYS2_CHANNEL = "https://repo.anaconda.cloud/repo/msys2"
+R_CHANNEL = "https://repo.anaconda.cloud/repo/r"
+
+# All required default_channels when main-x is enabled
+REQUIRED_DEFAULT_CHANNELS = [MAIN_X_CHANNEL, MAIN_CHANNEL, MSYS2_CHANNEL, R_CHANNEL]
 
 
 def is_conda_available() -> bool:
@@ -610,10 +615,11 @@ class TestMainXEnable:
         feature_env: dict[str, str],
     ) -> None:
         """Enabling main-x when already enabled should succeed with 'already enabled' message."""
-        # Pre-configure main-x in default_channels
+        # Pre-configure all required default_channels
         condarc_path = Path(feature_env["CONDARC"])
+        default_channels_yaml = "\n".join(f"  - {ch}" for ch in REQUIRED_DEFAULT_CHANNELS)
         condarc_path.write_text(
-            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+            f"channels:\n  - defaults\ndefault_channels:\n{default_channels_yaml}\n"
         )
 
         # Login first

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -353,6 +353,25 @@ def get_channels(env: dict[str, str]) -> list[str]:
     return channels
 
 
+def get_default_channels(env: dict[str, str]) -> list[str]:
+    """Get the list of configured default_channels from conda."""
+    result = subprocess.run(
+        ["conda", "config", "--show", "default_channels"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert result.returncode == 0, f"conda config failed: {result.stderr}"
+
+    channels = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("- "):
+            channels.append(line[2:])
+    return channels
+
+
 def get_pixi_channels(env: dict[str, str]) -> list[str]:
     """Get the list of configured default channels from pixi."""
     result = subprocess.run(
@@ -568,9 +587,9 @@ class TestMainXEnable:
         run_ana_feature: AnaRunner,
         feature_env: dict[str, str],
     ) -> None:
-        """Enabling main-x should add the main-x channel to conda config."""
-        # Verify main-x is not in channels initially
-        initial_channels = get_channels(feature_env)
+        """Enabling main-x should add the main-x channel to default_channels."""
+        # Verify main-x is not in default_channels initially
+        initial_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL not in initial_channels
 
         # Login first via mock server (device flow auto-completes)
@@ -581,8 +600,8 @@ class TestMainXEnable:
         result = run_ana_feature("feature", "enable", "main-x", "-f")
         assert result.returncode == 0, f"Enable failed: {result.stderr}"
 
-        # Verify main-x channel was added
-        final_channels = get_channels(feature_env)
+        # Verify main-x channel was added to default_channels
+        final_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL in final_channels
 
     def test_enable_main_x_idempotent(
@@ -591,9 +610,11 @@ class TestMainXEnable:
         feature_env: dict[str, str],
     ) -> None:
         """Enabling main-x when already enabled should succeed with 'already enabled' message."""
-        # Pre-configure main-x channel
+        # Pre-configure main-x in default_channels
         condarc_path = Path(feature_env["CONDARC"])
-        condarc_path.write_text(f"channels:\n  - {MAIN_X_CHANNEL}\n  - defaults\n")
+        condarc_path.write_text(
+            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+        )
 
         # Login first
         login_result = run_ana_feature("login")
@@ -649,21 +670,23 @@ class TestMainXDisable:
         run_ana_feature: AnaRunner,
         feature_env: dict[str, str],
     ) -> None:
-        """Disabling main-x should remove the main-x channel from conda config."""
-        # Pre-configure main-x channel
+        """Disabling main-x should remove the main-x channel from default_channels."""
+        # Pre-configure main-x in default_channels
         condarc_path = Path(feature_env["CONDARC"])
-        condarc_path.write_text(f"channels:\n  - {MAIN_X_CHANNEL}\n  - defaults\n")
+        condarc_path.write_text(
+            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+        )
 
-        # Verify main-x is in channels
-        initial_channels = get_channels(feature_env)
+        # Verify main-x is in default_channels
+        initial_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL in initial_channels
 
         # Disable main-x with force flag
         result = run_ana_feature("feature", "disable", "main-x", "-f")
         assert result.returncode == 0, f"Disable failed: {result.stderr}"
 
-        # Verify main-x channel was removed
-        final_channels = get_channels(feature_env)
+        # Verify main-x channel was removed from default_channels
+        final_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL not in final_channels
 
     def test_disable_main_x_not_enabled(
@@ -672,8 +695,8 @@ class TestMainXDisable:
         feature_env: dict[str, str],
     ) -> None:
         """Disabling main-x when not enabled should succeed with appropriate message."""
-        # Verify main-x is not in channels
-        initial_channels = get_channels(feature_env)
+        # Verify main-x is not in default_channels
+        initial_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL not in initial_channels
 
         result = run_ana_feature("feature", "disable", "main-x", "-f")
@@ -686,25 +709,30 @@ class TestMainXDisable:
         feature_env: dict[str, str],
     ) -> None:
         """Disabling main-x should not affect other configured channels."""
-        # Pre-configure multiple channels including main-x
+        # Pre-configure main-x in default_channels along with main
         condarc_path = Path(feature_env["CONDARC"])
         condarc_path.write_text(
-            f"channels:\n  - {MAIN_X_CHANNEL}\n  - conda-forge\n  - defaults\n"
+            f"channels:\n  - conda-forge\n  - defaults\n"
+            f"default_channels:\n  - {MAIN_X_CHANNEL}\n  - https://repo.anaconda.cloud/repo/main\n"
         )
 
-        initial_channels = get_channels(feature_env)
-        assert "conda-forge" in initial_channels
-        assert "defaults" in initial_channels
+        initial_default_channels = get_default_channels(feature_env)
+        assert MAIN_X_CHANNEL in initial_default_channels
+        assert "https://repo.anaconda.cloud/repo/main" in initial_default_channels
 
         # Disable main-x
         result = run_ana_feature("feature", "disable", "main-x", "-f")
         assert result.returncode == 0
 
-        # Verify other channels are preserved
+        # Verify main channel is preserved in default_channels, main-x is removed
+        final_default_channels = get_default_channels(feature_env)
+        assert "https://repo.anaconda.cloud/repo/main" in final_default_channels
+        assert MAIN_X_CHANNEL not in final_default_channels
+
+        # Verify channels list is untouched
         final_channels = get_channels(feature_env)
         assert "conda-forge" in final_channels
         assert "defaults" in final_channels
-        assert MAIN_X_CHANNEL not in final_channels
 
 
 @requires_conda
@@ -734,9 +762,11 @@ class TestMainXUserInteraction:
         feature_env: dict[str, str],
     ) -> None:
         """Disable should show conda commands and prompt for confirmation."""
-        # Pre-configure main-x
+        # Pre-configure main-x in default_channels
         condarc_path = Path(feature_env["CONDARC"])
-        condarc_path.write_text(f"channels:\n  - {MAIN_X_CHANNEL}\n  - defaults\n")
+        condarc_path.write_text(
+            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+        )
 
         # Run disable without -f, answer 'n' to abort
         result = run_ana_feature("feature", "disable", "main-x", input="n\n")
@@ -747,8 +777,8 @@ class TestMainXUserInteraction:
         # Should abort when user says no
         assert "Aborted" in result.stderr
 
-        # Channel should still be present
-        final_channels = get_channels(feature_env)
+        # Channel should still be present in default_channels
+        final_channels = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL in final_channels
 
 
@@ -770,16 +800,16 @@ class TestMainXEndToEnd:
         enable_result = run_ana_feature("feature", "enable", "main-x", "-f")
         assert enable_result.returncode == 0
 
-        # Step 3: Verify channel was added
-        channels_after_enable = get_channels(feature_env)
+        # Step 3: Verify channel was added to default_channels
+        channels_after_enable = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL in channels_after_enable
 
         # Step 4: Disable main-x
         disable_result = run_ana_feature("feature", "disable", "main-x", "-f")
         assert disable_result.returncode == 0
 
-        # Step 5: Verify channel was removed
-        channels_after_disable = get_channels(feature_env)
+        # Step 5: Verify channel was removed from default_channels
+        channels_after_disable = get_default_channels(feature_env)
         assert MAIN_X_CHANNEL not in channels_after_disable
 
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -617,7 +617,9 @@ class TestMainXEnable:
         """Enabling main-x when already enabled should succeed with 'already enabled' message."""
         # Pre-configure all required default_channels
         condarc_path = Path(feature_env["CONDARC"])
-        default_channels_yaml = "\n".join(f"  - {ch}" for ch in REQUIRED_DEFAULT_CHANNELS)
+        default_channels_yaml = "\n".join(
+            f"  - {ch}" for ch in REQUIRED_DEFAULT_CHANNELS
+        )
         condarc_path.write_text(
             f"channels:\n  - defaults\ndefault_channels:\n{default_channels_yaml}\n"
         )


### PR DESCRIPTION
## Summary
- Changed `ana feature enable main-x` to add main-x to `default_channels` instead of `channels` in `.condarc`
- This ensures main-x is resolved as part of the defaults multi-channel, producing correct channel priority behavior

## Test plan
- [x] Run `ana feature enable main-x` and verify the channel is added to `default_channels` (not `channels`) in `.condarc`
- [x] Run `ana feature disable main-x` and verify the channel is removed from `default_channels`
- [x] Verify conda can resolve packages from main-x correctly with this configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)