### PR TITLE
test: Add coverage for ana tool download miniconda

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -72,7 +72,7 @@ class TestToolHelp:
         assert "miniconda" in result.stdout.lower()
 
 
-class TestToolDownloadMiniconda:
+class TestToolDownloadCommand:
     """Tests for 'ana tool download miniconda' subcommand.
 
     These cases only cover paths that don't require a real network call:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,7 +12,8 @@ from helpers import AnaRunner
 IS_WINDOWS = sys.platform == "win32"
 PIXI_BIN = "pixi.exe" if IS_WINDOWS else "pixi"
 
-# Mirrors the (os, arch) -> filename table in src/installer/mod.rs::detect_target.
+# Maps Python (sys.platform, platform.machine()) values to installer filenames
+# produced by src/installer/mod.rs::detect_target.
 _MINICONDA_FILENAMES = {
     ("darwin", "arm64"): "Miniconda3-latest-MacOSX-arm64.sh",
     ("darwin", "x86_64"): "Miniconda3-latest-MacOSX-x86_64.sh",
@@ -95,12 +96,13 @@ class TestToolDownloadCommand:
         """The pre-flight existence check runs before any network call, so this
         is safe to test without a mock server."""
         existing = tmp_path / _expected_miniconda_filename()
-        existing.touch()
+        sentinel = b"do-not-overwrite"
+        existing.write_bytes(sentinel)
 
         result = run_ana("tool", "download", "miniconda", cwd=tmp_path)
         assert result.returncode != 0
         assert "already exists" in result.stderr.lower()
-        assert existing.exists()  # untouched, not overwritten
+        assert existing.read_bytes() == sentinel
 
 
 class TestToolInstallPixi:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,28 @@ from helpers import AnaRunner
 
 IS_WINDOWS = sys.platform == "win32"
 PIXI_BIN = "pixi.exe" if IS_WINDOWS else "pixi"
+
+# Mirrors the (os, arch) -> filename table in src/installer/mod.rs::detect_target.
+_MINICONDA_FILENAMES = {
+    ("darwin", "arm64"): "Miniconda3-latest-MacOSX-arm64.sh",
+    ("darwin", "x86_64"): "Miniconda3-latest-MacOSX-x86_64.sh",
+    ("linux", "x86_64"): "Miniconda3-latest-Linux-x86_64.sh",
+    ("linux", "aarch64"): "Miniconda3-latest-Linux-aarch64.sh",
+    ("win32", "x86_64"): "Miniconda3-latest-Windows-x86_64.exe",
+    ("win32", "amd64"): "Miniconda3-latest-Windows-x86_64.exe",
+}
+
+
+def _expected_miniconda_filename() -> str:
+    """The installer filename ana would pick for the current platform."""
+    key = (sys.platform, platform.machine().lower())
+    filename = _MINICONDA_FILENAMES.get(key)
+    if filename is None:
+        raise RuntimeError(
+            f"no known miniconda filename for platform {key}; "
+            "update _MINICONDA_FILENAMES to match src/installer/mod.rs"
+        )
+    return filename
 
 
 class TestToolHelp:
@@ -42,6 +65,42 @@ class TestToolHelp:
         result = run_ana("tool", "download", "--help")
         assert result.returncode == 0
         assert "miniconda" in result.stdout.lower()
+
+    def test_tool_download_no_args_shows_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("tool", "download")
+        assert result.returncode == 0
+        assert "miniconda" in result.stdout.lower()
+
+
+class TestToolDownloadMiniconda:
+    """Tests for 'ana tool download miniconda' subcommand.
+
+    These cases only cover paths that don't require a real network call:
+    ana tool download miniconda always fetches from the hardcoded
+    https://repo.anaconda.com/miniconda/ (no env var or flag override
+    exists yet to redirect it to a mock server), so actual download,
+    checksum verification, and checksum-mismatch behavior aren't covered
+    here. See src/installer/mod.rs for that logic and its Rust unit tests.
+    """
+
+    def test_download_unknown_installer_errors(self, run_ana: AnaRunner) -> None:
+        result = run_ana("tool", "download", "nonexistent-installer")
+        assert result.returncode != 0
+        assert "only miniconda is currently supported" in result.stderr.lower()
+        assert "nonexistent-installer" in result.stderr
+
+    def test_download_fails_when_destination_already_exists(
+        self, run_ana: AnaRunner, tmp_path: Path
+    ) -> None:
+        """The pre-flight existence check runs before any network call, so this
+        is safe to test without a mock server."""
+        existing = tmp_path / _expected_miniconda_filename()
+        existing.touch()
+
+        result = run_ana("tool", "download", "miniconda", cwd=tmp_path)
+        assert result.returncode != 0
+        assert "already exists" in result.stderr.lower()
+        assert existing.exists()  # untouched, not overwritten
 
 
 class TestToolInstallPixi:


### PR DESCRIPTION
## Summary
Adds `TestToolDownloadMiniconda` to `tests/test_tools.py`, covering paths that don't require a real network call:

- **Negative:** unknown installer name (e.g. `ana tool download nonexistent-installer`) is rejected with a clear error
- **Negative:** pre-flight "destination file already exists" check (runs before any network request, per `src/installer/mod.rs`) — verifies error message and that the existing file is left untouched
- **Positive:** `--help` / no-args shows usage and exits 0

**Known gap, not covered here:** the actual "download + verify SHA256 checksum + succeed" happy path, and checksum-mismatch handling. `installer::run()` accepts an optional `base_url` override internally, but the CLI call site in `src/cli.rs` always passes `None`, which falls back to the hardcoded `https://repo.anaconda.com/miniconda/`. There's no env var or flag to redirect it to a mock server in tests today — same category of gap as `ANA_OPEN_BROWSER` found in `ana self feedback` (PR #337). Flagging to devs as a follow-up (e.g. an `ANA_MINICONDA_BASE_URL` override) so we can safely test the download/checksum paths, including both success and checksum-mismatch failure, without hitting the real network in CI.

## Test plan
- [x] `pixi run pytest tests/test_tools.py -v` — 26 passed
- [x] `pixi run cargo clippy --all-targets` — clean
- [x] `pre-commit run --files tests/test_tools.py` — all hooks pass
- [ ] CI: verify green on all 4 platforms (no network dependency in these tests, so no platform-specific risk expected)