### PR TITLE
feat: Add OBP HTTP client to CommandContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "console",
  "dirs",
  "figment",
+ "flate2",
  "futures-util",
  "http 1.4.2",
  "indicatif",
@@ -1286,6 +1287,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "serde_json",
  "uncased",
  "version_check",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "owo-colors",
  "rattler",
  "rattler_cache",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_lock",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -3252,7 +3252,7 @@ dependencies = [
  "parking_lot",
  "path_resolver",
  "rattler_cache",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_menuinst",
  "rattler_networking",
@@ -3292,7 +3292,7 @@ dependencies = [
  "hex",
  "itertools 0.15.0",
  "parking_lot",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -3313,48 +3313,6 @@ name = "rattler_conda_types"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad"
-dependencies = [
- "ahash",
- "core-foundation 0.10.1",
- "dirs",
- "fancy-regex",
- "file_url",
- "fs-err",
- "glob",
- "hex",
- "indexmap 2.14.0",
- "itertools 0.15.0",
- "jiff",
- "lazy-regex",
- "memmap2",
- "nom",
- "nom-language",
- "purl",
- "rattler_digest",
- "rattler_macros",
- "rattler_redaction",
- "regex",
- "serde",
- "serde-untagged",
- "serde_json",
- "serde_repr",
- "serde_with",
- "serde_yaml",
- "simd-json",
- "smallvec",
- "strum",
- "tempfile",
- "thiserror 2.0.19",
- "tracing",
- "typed-path",
- "url",
-]
-
-[[package]]
-name = "rattler_conda_types"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -3414,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.7"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6a9f27e6425559264ac8172a4961646c93d826fe2d3f8219e3a7539b3ea703"
+checksum = "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
 dependencies = [
  "ahash",
  "file_url",
@@ -3425,7 +3383,7 @@ dependencies = [
  "jiff",
  "pep440_rs",
  "pep508_rs",
- "rattler_conda_types 0.49.0",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_solve",
  "serde",
@@ -3466,7 +3424,7 @@ dependencies = [
  "once_cell",
  "plist",
  "quick-xml",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_shell",
  "regex",
  "serde",
@@ -3533,7 +3491,7 @@ dependencies = [
  "http 1.4.2",
  "jiff",
  "num_cpus",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
@@ -3585,7 +3543,7 @@ dependencies = [
  "fs-err",
  "indexmap 2.14.0",
  "itertools 0.15.0",
- "rattler_conda_types 0.48.1",
+ "rattler_conda_types",
  "rattler_pty",
  "serde_json",
  "shlex",
@@ -3597,20 +3555,19 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.0"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
+checksum = "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
 dependencies = [
  "hex",
  "itertools 0.15.0",
  "jiff",
- "rattler_conda_types 0.49.0",
+ "rattler_conda_types",
  "rattler_digest",
  "serde",
  "tempfile",
  "thiserror 2.0.19",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "owo-colors",
  "rattler",
  "rattler_cache",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_lock",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -249,7 +249,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml",
  "toml_edit",
  "tracing",
  "tracing-subscriber",
@@ -659,21 +659,21 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "11.0.1"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
+checksum = "50524592e6bfbb1bf6f94e8184a786f637faeaf1cf37bbe65502b9a2c5c48939"
 dependencies = [
  "semver",
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "url",
 ]
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1177,13 +1177,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1203,9 +1203,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d2c4324d61664107020b79019cf6a6aec153f0b79bc9619ee9e794a5fb021"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
 name = "indexmap"
@@ -2070,9 +2070,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -3252,7 +3252,7 @@ dependencies = [
  "parking_lot",
  "path_resolver",
  "rattler_cache",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_digest",
  "rattler_menuinst",
  "rattler_networking",
@@ -3292,7 +3292,7 @@ dependencies = [
  "hex",
  "itertools 0.15.0",
  "parking_lot",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -3313,6 +3313,48 @@ name = "rattler_conda_types"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38273db000680207c48aa39ae1bcca9babf430c0f4dfb80b7dea9376592ddad"
+dependencies = [
+ "ahash",
+ "core-foundation 0.10.1",
+ "dirs",
+ "fancy-regex",
+ "file_url",
+ "fs-err",
+ "glob",
+ "hex",
+ "indexmap 2.14.0",
+ "itertools 0.15.0",
+ "jiff",
+ "lazy-regex",
+ "memmap2",
+ "nom",
+ "nom-language",
+ "purl",
+ "rattler_digest",
+ "rattler_macros",
+ "rattler_redaction",
+ "regex",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "serde_yaml",
+ "simd-json",
+ "smallvec",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tracing",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "rattler_conda_types"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -3372,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.5"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
+checksum = "af6a9f27e6425559264ac8172a4961646c93d826fe2d3f8219e3a7539b3ea703"
 dependencies = [
  "ahash",
  "file_url",
@@ -3383,7 +3425,7 @@ dependencies = [
  "jiff",
  "pep440_rs",
  "pep508_rs",
- "rattler_conda_types",
+ "rattler_conda_types 0.49.0",
  "rattler_digest",
  "rattler_solve",
  "serde",
@@ -3424,7 +3466,7 @@ dependencies = [
  "once_cell",
  "plist",
  "quick-xml",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_shell",
  "regex",
  "serde",
@@ -3491,7 +3533,7 @@ dependencies = [
  "http 1.4.2",
  "jiff",
  "num_cpus",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
@@ -3543,7 +3585,7 @@ dependencies = [
  "fs-err",
  "indexmap 2.14.0",
  "itertools 0.15.0",
- "rattler_conda_types",
+ "rattler_conda_types 0.48.1",
  "rattler_pty",
  "serde_json",
  "shlex",
@@ -3555,19 +3597,20 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.2.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
+checksum = "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
 dependencies = [
  "hex",
  "itertools 0.15.0",
  "jiff",
- "rattler_conda_types",
+ "rattler_conda_types 0.49.0",
  "rattler_digest",
  "serde",
  "tempfile",
  "thiserror 2.0.19",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3889,9 +3932,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -3963,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4275,7 +4318,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4827,21 +4870,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
@@ -4849,19 +4877,10 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -4880,19 +4899,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5728,12 +5747,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rlimit = "0.11"
 default = []
 diagnostics = ["dep:sentry"]
 unstable = []
+outerbounds-native = []
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 futures-util = "0.3"
 dirs = "6"
-figment = { version = "0.10", features = ["env"] }
+figment = { version = "0.10", features = ["env", "json"] }
+flate2 = "1.0"
 http = "1"
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ miette = { version = "7.6", features = ["fancy"] }
 rattler = { version = "0.47", default-features = false, features = ["indicatif"] }
 rattler_cache = { version = "0.10", default-features = false }
 rattler_conda_types = { version = "0.48", default-features = false }
-rattler_lock = { version = "0.31", default-features = false }
+rattler_lock = { version = "=0.31.5", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "multipart", "native-tls"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form", "query"] }
 rpassword = "7"

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:e967743c-1415-4a59-a387-e22a964d9006",
+  "serialNumber": "urn:uuid:2cf6fac0-dc38-4051-b0fd-7668ee4efe43",
   "metadata": {
-    "timestamp": "2026-07-22T13:42:08Z",
+    "timestamp": "2026-07-28T16:19:47Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -1196,16 +1196,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
-      "author": "Tony Arcieri <bascule@gmail.com>",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.1.0",
       "name": "cargo-lock",
-      "version": "11.0.1",
+      "version": "11.1.0",
       "description": "Self-contained Cargo.lock parser with optional dependency graph analysis",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
+          "content": "50524592e6bfbb1bf6f94e8184a786f637faeaf1cf37bbe65502b9a2c5c48939"
         }
       ],
       "licenses": [
@@ -1213,7 +1212,7 @@
           "expression": "Apache-2.0 OR MIT"
         }
       ],
-      "purl": "pkg:cargo/cargo-lock@11.0.1",
+      "purl": "pkg:cargo/cargo-lock@11.1.0",
       "externalReferences": [
         {
           "type": "website",
@@ -1227,16 +1226,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.4.0",
       "author": "Alex Crichton <alex@alexcrichton.com>",
       "name": "cc",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "description": "A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code. ",
       "scope": "excluded",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+          "content": "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
         }
       ],
       "licenses": [
@@ -1244,7 +1243,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/cc@1.3.0",
+      "purl": "pkg:cargo/cc@1.4.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2410,16 +2409,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
       "author": "Jane Lusby <jlusby@yaah.dev>",
       "name": "displaydoc",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "description": "A derive macro for implementing the display Trait via a doc comment and string interpolation ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+          "content": "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
         }
       ],
       "licenses": [
@@ -2427,7 +2426,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/displaydoc@0.2.6",
+      "purl": "pkg:cargo/displaydoc@0.2.7",
       "externalReferences": [
         {
           "type": "documentation",
@@ -2507,15 +2506,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0",
       "name": "either",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "description": "The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+          "content": "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
         }
       ],
       "licenses": [
@@ -2523,7 +2522,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/either@1.16.0",
+      "purl": "pkg:cargo/either@1.17.0",
       "externalReferences": [
         {
           "type": "documentation",
@@ -5051,16 +5050,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
       "author": "Andrew Gallant <jamslam@gmail.com>",
       "name": "jiff",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "description": "A date-time library that encourages you to jump into the pit of success.  This library is heavily inspired by the Temporal project. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+          "content": "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
         }
       ],
       "licenses": [
@@ -5068,7 +5067,7 @@
           "expression": "Unlicense OR MIT"
         }
       ],
-      "purl": "pkg:cargo/jiff@0.2.34",
+      "purl": "pkg:cargo/jiff@0.2.35",
       "externalReferences": [
         {
           "type": "documentation",
@@ -7593,6 +7592,37 @@
     },
     {
       "type": "library",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
+      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
+      "name": "rattler_conda_types",
+      "version": "0.49.0",
+      "description": "Rust data types for common types used within the Conda ecosystem",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "purl": "pkg:cargo/rattler_conda_types@0.49.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/conda/rattler"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/conda/rattler"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
@@ -7624,16 +7654,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.31.5",
+      "version": "0.31.7",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
+          "content": "af6a9f27e6425559264ac8172a4961646c93d826fe2d3f8219e3a7539b3ea703"
         }
       ],
       "licenses": [
@@ -7641,7 +7671,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.31.5",
+      "purl": "pkg:cargo/rattler_lock@0.31.7",
       "externalReferences": [
         {
           "type": "website",
@@ -7871,16 +7901,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "7.2.2",
+      "version": "9.0.0",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
+          "content": "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
         }
       ],
       "licenses": [
@@ -7888,7 +7918,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@7.2.2",
+      "purl": "pkg:cargo/rattler_solve@9.0.0",
       "externalReferences": [
         {
           "type": "website",
@@ -8573,15 +8603,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
       "name": "rustls-pki-types",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "description": "Shared types for the rustls PKI ecosystem",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+          "content": "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
         }
       ],
       "licenses": [
@@ -8589,7 +8619,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/rustls-pki-types@1.15.0",
+      "purl": "pkg:cargo/rustls-pki-types@1.15.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -8756,16 +8786,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.2",
       "author": "Graham Esau <gesau@hotmail.co.uk>",
       "name": "schemars",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "description": "Generate JSON Schemas from Rust code",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+          "content": "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
         }
       ],
       "licenses": [
@@ -8773,7 +8803,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/schemars@1.2.1",
+      "purl": "pkg:cargo/schemars@1.2.2",
       "externalReferences": [
         {
           "type": "website",
@@ -10823,32 +10853,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
-      "name": "toml",
-      "version": "0.9.12+spec-1.1.0",
-      "description": "A native Rust encoder and decoder of TOML-formatted files and streams. Provides implementations of the standard Serialize/Deserialize traits for TOML data to facilitate deserializing and serializing Rust structures. ",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/toml@0.9.12+spec-1.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/toml-rs/toml"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
       "name": "toml",
       "version": "1.1.3+spec-1.1.0",
@@ -10866,32 +10870,6 @@
         }
       ],
       "purl": "pkg:cargo/toml@1.1.3+spec-1.1.0",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/toml-rs/toml"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
-      "name": "toml_datetime",
-      "version": "0.7.5+spec-1.1.0",
-      "description": "A TOML-compatible datetime type",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT OR Apache-2.0"
-        }
-      ],
-      "purl": "pkg:cargo/toml_datetime@0.7.5+spec-1.1.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -10953,15 +10931,15 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.3+spec-1.1.0",
       "name": "toml_parser",
-      "version": "1.1.2+spec-1.1.0",
+      "version": "1.1.3+spec-1.1.0",
       "description": "Yet another format-preserving TOML parser.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+          "content": "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
         }
       ],
       "licenses": [
@@ -10969,7 +10947,7 @@
           "expression": "MIT OR Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/toml_parser@1.1.2+spec-1.1.0",
+      "purl": "pkg:cargo/toml_parser@1.1.3+spec-1.1.0",
       "externalReferences": [
         {
           "type": "vcs",
@@ -12320,32 +12298,6 @@
         {
           "type": "vcs",
           "url": "https://github.com/harryfei/which-rs.git"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15",
-      "name": "winnow",
-      "version": "0.7.15",
-      "description": "A byte-oriented, zero-copy, parser combinators library",
-      "scope": "excluded",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:cargo/winnow@0.7.15",
-      "externalReferences": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/winnow-rs/winnow"
         }
       ]
     },
@@ -14170,6 +14122,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#console@0.16.4",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#figment@0.10.19",
+        "registry+https://github.com/rust-lang/crates.io-index#flate2@1.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
@@ -14181,7 +14134,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler@0.47.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
@@ -14247,7 +14200,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#anaconda-anon-usage@0.8.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
-        "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
+        "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
@@ -14490,16 +14443,16 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.0.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cargo-lock@11.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#semver@1.0.28",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
-        "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#cc@1.4.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#find-msvc-tools@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.35",
@@ -14769,11 +14722,11 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.107",
         "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.47",
-        "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.119"
+        "registry+https://github.com/rust-lang/crates.io-index#syn@3.0.3"
       ]
     },
     {
@@ -14787,7 +14740,7 @@
       "dependsOn": []
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0",
       "dependsOn": []
     },
     {
@@ -14839,6 +14792,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#pear@0.2.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#uncased@0.9.10",
         "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.5"
       ]
@@ -15217,7 +15171,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_collections@2.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
         "registry+https://github.com/rust-lang/crates.io-index#potential_utf@0.1.5",
         "registry+https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
@@ -15228,7 +15182,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
         "registry+https://github.com/rust-lang/crates.io-index#litemap@0.8.2",
         "registry+https://github.com/rust-lang/crates.io-index#tinystr@0.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
@@ -15268,7 +15222,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#icu_provider@2.2.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
         "registry+https://github.com/rust-lang/crates.io-index#icu_locale_core@2.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#writeable@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
@@ -15347,19 +15301,19 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.13.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0"
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.14.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0"
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0"
       ]
     },
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0"
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0"
       ]
     },
     {
@@ -15373,7 +15327,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#defmt@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#jiff-core@0.1.0",
@@ -15616,7 +15570,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.117",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
@@ -15969,7 +15923,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#indicatif@0.18.6",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
@@ -16042,7 +15996,46 @@
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
+        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
+        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
+        "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
+        "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
+        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
+        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
+        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
+        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
+        "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
+        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
+        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+      ]
+    },
+    {
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
+      "dependsOn": [
+        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
+        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
+        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
+        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
+        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.4",
+        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
+        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
         "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
         "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
         "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
@@ -16086,18 +16079,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
@@ -16186,7 +16179,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures@0.3.33",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
@@ -16242,17 +16235,18 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.34",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
+        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
+        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
     },
     {
@@ -16265,7 +16259,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.12.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#either@1.16.0",
+        "registry+https://github.com/rust-lang/crates.io-index#either@1.17.0",
         "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.13.0"
       ]
     },
@@ -16347,7 +16341,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
@@ -16379,7 +16373,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#native-tls@0.2.18",
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
@@ -16402,7 +16396,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.189",
@@ -16461,7 +16455,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
       ]
@@ -16470,7 +16464,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ring@0.17.14",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#untrusted@0.9.0"
       ]
     },
@@ -16478,7 +16472,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.42",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.21.4",
-        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rustls-pki-types@1.15.1",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-webpki@0.103.13",
         "registry+https://github.com/rust-lang/crates.io-index#subtle@2.6.1",
         "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.9.0"
@@ -16507,7 +16501,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20",
         "registry+https://github.com/rust-lang/crates.io-index#ref-cast@1.0.26",
@@ -16622,7 +16616,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#schemars@0.9.0",
-        "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.1",
+        "registry+https://github.com/rust-lang/crates.io-index#schemars@1.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
         "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.21.0",
@@ -16911,7 +16905,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tinystr@0.8.3",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
         "registry+https://github.com/rust-lang/crates.io-index#zerovec@0.11.6"
       ]
     },
@@ -16983,33 +16977,15 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@0.9.12+spec-1.1.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.2+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#toml@1.1.3+spec-1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#serde_spanned@1.1.1",
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.1.1+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.3+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.2+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
-      ]
-    },
-    {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.5+spec-1.1.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#serde_core@1.0.229"
       ]
     },
     {
@@ -17023,13 +16999,13 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_datetime@1.1.1+spec-1.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.3+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#toml_writer@1.1.2+spec-1.1.0",
         "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.2+spec-1.1.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#toml_parser@1.1.3+spec-1.1.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4"
       ]
@@ -17311,10 +17287,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@0.7.15",
-      "dependsOn": []
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#winnow@1.0.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.3"
@@ -17381,7 +17353,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zerotrie@0.2.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.6",
+        "registry+https://github.com/rust-lang/crates.io-index#displaydoc@0.2.7",
         "registry+https://github.com/rust-lang/crates.io-index#yoke@0.8.3",
         "registry+https://github.com/rust-lang/crates.io-index#zerofrom@0.1.8"
       ]
@@ -17440,7 +17412,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#zstd-sys@2.0.16+zstd.1.5.7",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#cc@1.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#cc@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.33"
       ]
     },

--- a/SBOM.json
+++ b/SBOM.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:2cf6fac0-dc38-4051-b0fd-7668ee4efe43",
+  "serialNumber": "urn:uuid:d70be4a9-ac52-413d-8b75-833108b26847",
   "metadata": {
-    "timestamp": "2026-07-28T16:19:47Z",
+    "timestamp": "2026-07-28T17:31:22Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -7592,37 +7592,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
-      "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
-      "name": "rattler_conda_types",
-      "version": "0.49.0",
-      "description": "Rust data types for common types used within the Conda ecosystem",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
-        }
-      ],
-      "licenses": [
-        {
-          "expression": "BSD-3-Clause"
-        }
-      ],
-      "purl": "pkg:cargo/rattler_conda_types@0.49.0",
-      "externalReferences": [
-        {
-          "type": "website",
-          "url": "https://github.com/conda/rattler"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/conda/rattler"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_digest",
@@ -7654,16 +7623,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_lock",
-      "version": "0.31.7",
+      "version": "0.31.5",
       "description": "Rust data types for conda lock",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "af6a9f27e6425559264ac8172a4961646c93d826fe2d3f8219e3a7539b3ea703"
+          "content": "8fe9a3957959deda6a8e601007c683639e6fd268db4919cd5ec89d3d94553e82"
         }
       ],
       "licenses": [
@@ -7671,7 +7640,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_lock@0.31.7",
+      "purl": "pkg:cargo/rattler_lock@0.31.5",
       "externalReferences": [
         {
           "type": "website",
@@ -7901,16 +7870,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
       "author": "Bas Zalmstra <zalmstra.bas@gmail.com>",
       "name": "rattler_solve",
-      "version": "9.0.0",
+      "version": "7.2.2",
       "description": "A crate to solve conda environments",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
+          "content": "766e32dc5827da2adb0a0cb774da99ddf097dbec632a2ee74ed32ba55b2203a3"
         }
       ],
       "licenses": [
@@ -7918,7 +7887,7 @@
           "expression": "BSD-3-Clause"
         }
       ],
-      "purl": "pkg:cargo/rattler_solve@9.0.0",
+      "purl": "pkg:cargo/rattler_solve@7.2.2",
       "externalReferences": [
         {
           "type": "website",
@@ -14134,7 +14103,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rattler@0.47.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_cache@0.10.3",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest-middleware@0.5.2",
         "registry+https://github.com/rust-lang/crates.io-index#reqwest@0.13.4",
         "registry+https://github.com/rust-lang/crates.io-index#rlimit@0.11.0",
@@ -16023,45 +15992,6 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
-      "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index#dirs@6.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#fancy-regex@0.18.0",
-        "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#fs-err@3.3.1",
-        "registry+https://github.com/rust-lang/crates.io-index#glob@0.3.4",
-        "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
-        "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
-        "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
-        "registry+https://github.com/rust-lang/crates.io-index#lazy-regex@3.6.0",
-        "registry+https://github.com/rust-lang/crates.io-index#memmap2@0.9.11",
-        "registry+https://github.com/rust-lang/crates.io-index#nom-language@0.1.0",
-        "registry+https://github.com/rust-lang/crates.io-index#nom@8.0.0",
-        "registry+https://github.com/rust-lang/crates.io-index#purl@0.1.6",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_macros@1.1.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_redaction@0.2.2",
-        "registry+https://github.com/rust-lang/crates.io-index#regex@1.13.1",
-        "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
-        "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.151",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_repr@0.1.21",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.21.0",
-        "registry+https://github.com/rust-lang/crates.io-index#serde_yaml@0.9.34+deprecated",
-        "registry+https://github.com/rust-lang/crates.io-index#simd-json@0.17.3",
-        "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.2",
-        "registry+https://github.com/rust-lang/crates.io-index#strum@0.28.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
-        "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#typed-path@0.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
-      ]
-    },
-    {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#blake2@0.11.0-rc.6",
@@ -16079,7 +16009,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.7",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_lock@0.31.5",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
         "registry+https://github.com/rust-lang/crates.io-index#file_url@0.3.2",
@@ -16088,9 +16018,9 @@
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
         "registry+https://github.com/rust-lang/crates.io-index#pep440_rs@0.7.3",
         "registry+https://github.com/rust-lang/crates.io-index#pep508_rs@0.9.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.9",
         "registry+https://github.com/rust-lang/crates.io-index#serde-value@0.7.0",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
@@ -16235,18 +16165,17 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@9.0.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#rattler_solve@7.2.2",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#itertools@0.15.0",
         "registry+https://github.com/rust-lang/crates.io-index#jiff@0.2.35",
-        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.49.0",
+        "registry+https://github.com/rust-lang/crates.io-index#rattler_conda_types@0.48.1",
         "registry+https://github.com/rust-lang/crates.io-index#rattler_digest@1.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.229",
         "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.27.0",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.19",
-        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
-        "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
+        "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
     {

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-07-22T13:42:08Z<br>
+Generated: 2026-07-28T16:19:47Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 456 (59 platform-specific)<br>
+Packages: 454 (59 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -49,8 +49,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [bumpalo](https://crates.io/crates/bumpalo) | 3.20.3 | MIT OR Apache-2.0 |  |  |
 | [bytes](https://crates.io/crates/bytes) | 1.12.1 | MIT |  |  |
 | [bzip2](https://crates.io/crates/bzip2) | 0.6.1 | MIT OR Apache-2.0 |  |  |
-| [cargo-lock](https://crates.io/crates/cargo-lock) | 11.0.1 | Apache-2.0 OR MIT |  |  |
-| [cc](https://crates.io/crates/cc) | 1.3.0 | MIT OR Apache-2.0 |  |  |
+| [cargo-lock](https://crates.io/crates/cargo-lock) | 11.1.0 | Apache-2.0 OR MIT |  |  |
+| [cc](https://crates.io/crates/cc) | 1.4.0 | MIT OR Apache-2.0 |  |  |
 | [cfg-if](https://crates.io/crates/cfg-if) | 1.0.4 | MIT OR Apache-2.0 |  |  |
 | [cfg\_aliases](https://crates.io/crates/cfg_aliases) | 0.2.2 | MIT | linux, macos |  |
 | [chacha20](https://crates.io/crates/chacha20) | 0.10.1 | MIT OR Apache-2.0 |  |  |
@@ -93,10 +93,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [digest](https://crates.io/crates/digest) | 0.11.3 | MIT OR Apache-2.0 |  |  |
 | [dirs](https://crates.io/crates/dirs) | 6.0.0 | MIT OR Apache-2.0 |  |  |
 | [dirs-sys](https://crates.io/crates/dirs-sys) | 0.5.0 | MIT OR Apache-2.0 |  |  |
-| [displaydoc](https://crates.io/crates/displaydoc) | 0.2.6 | MIT OR Apache-2.0 |  |  |
+| [displaydoc](https://crates.io/crates/displaydoc) | 0.2.7 | MIT OR Apache-2.0 |  |  |
 | [document-features](https://crates.io/crates/document-features) | 0.2.12 | MIT OR Apache-2.0 |  |  |
 | [dyn-clone](https://crates.io/crates/dyn-clone) | 1.0.20 | MIT OR Apache-2.0 |  |  |
-| [either](https://crates.io/crates/either) | 1.16.0 | MIT OR Apache-2.0 |  |  |
+| [either](https://crates.io/crates/either) | 1.17.0 | MIT OR Apache-2.0 |  |  |
 | [encode\_unicode](https://crates.io/crates/encode_unicode) | 1.0.0 | Apache-2.0 OR MIT | windows |  |
 | [encoding\_rs](https://crates.io/crates/encoding_rs) | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause |  |  |
 | [enum\_dispatch](https://crates.io/crates/enum_dispatch) | 0.3.13 | MIT OR Apache-2.0 |  |  |
@@ -179,7 +179,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [itertools](https://crates.io/crates/itertools) | 0.14.0 | MIT OR Apache-2.0 |  |  |
 | [itertools](https://crates.io/crates/itertools) | 0.15.0 | MIT OR Apache-2.0 |  |  |
 | [itoa](https://crates.io/crates/itoa) | 1.0.18 | MIT OR Apache-2.0 |  |  |
-| [jiff](https://crates.io/crates/jiff) | 0.2.34 | Unlicense OR MIT |  |  |
+| [jiff](https://crates.io/crates/jiff) | 0.2.35 | Unlicense OR MIT |  |  |
 | [jiff-core](https://crates.io/crates/jiff-core) | 0.1.0 | Unlicense OR MIT |  |  |
 | [jobserver](https://crates.io/crates/jobserver) | 0.1.35 | MIT OR Apache-2.0 |  |  |
 | [known-folders](https://crates.io/crates/known-folders) | 1.4.2 | Apache-2.0 OR MIT | windows |  |
@@ -267,8 +267,9 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler](https://crates.io/crates/rattler) | 0.47.1 | BSD-3-Clause |  |  |
 | [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.3 | BSD-3-Clause |  |  |
 | [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.48.1 | BSD-3-Clause |  |  |
+| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.49.0 | BSD-3-Clause |  |  |
 | [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.2 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.5 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.7 | BSD-3-Clause |  |  |
 | [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.2 | BSD-3-Clause |  |  |
 | [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.70 | BSD-3-Clause |  |  |
 | [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.30.2 | BSD-3-Clause |  |  |
@@ -276,7 +277,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.15 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.2 | BSD-3-Clause |  |  |
 | [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.10 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.2 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 9.0.0 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.26 | MIT OR Apache-2.0 |  |  |
@@ -299,13 +300,13 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rustc\_version\_runtime](https://crates.io/crates/rustc_version_runtime) | 0.3.0 | MIT |  |  |
 | [rustix](https://crates.io/crates/rustix) | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | linux, macos |  |
 | [rustls](https://crates.io/crates/rustls) | 0.23.42 | Apache-2.0 OR ISC OR MIT |  |  |
-| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.15.0 | MIT OR Apache-2.0 |  |  |
+| [rustls-pki-types](https://crates.io/crates/rustls-pki-types) | 1.15.1 | MIT OR Apache-2.0 |  |  |
 | [rustls-webpki](https://crates.io/crates/rustls-webpki) | 0.103.13 | ISC |  |  |
 | [rusty-fork](https://crates.io/crates/rusty-fork) | 0.3.1 | MIT OR Apache-2.0 |  |  |
 | [ryu](https://crates.io/crates/ryu) | 1.0.23 | Apache-2.0 OR BSL-1.0 |  |  |
 | [schannel](https://crates.io/crates/schannel) | 0.1.29 | MIT | windows |  |
 | [schemars](https://crates.io/crates/schemars) | 0.9.0 | MIT |  |  |
-| [schemars](https://crates.io/crates/schemars) | 1.2.1 | MIT |  |  |
+| [schemars](https://crates.io/crates/schemars) | 1.2.2 | MIT |  |  |
 | [scopeguard](https://crates.io/crates/scopeguard) | 1.2.0 | MIT OR Apache-2.0 |  |  |
 | [secrecy](https://crates.io/crates/secrecy) | 0.10.3 | Apache-2.0 OR MIT |  |  |
 | [security-framework](https://crates.io/crates/security-framework) | 3.7.0 | MIT OR Apache-2.0 | macos |  |
@@ -375,12 +376,10 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [tokio-rustls](https://crates.io/crates/tokio-rustls) | 0.26.4 | MIT OR Apache-2.0 |  |  |
 | [tokio-stream](https://crates.io/crates/tokio-stream) | 0.1.19 | MIT |  |  |
 | [tokio-util](https://crates.io/crates/tokio-util) | 0.7.19 | MIT |  |  |
-| [toml](https://crates.io/crates/toml) | 0.9.12+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml](https://crates.io/crates/toml) | 1.1.3+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
-| [toml\_datetime](https://crates.io/crates/toml_datetime) | 0.7.5+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml\_datetime](https://crates.io/crates/toml_datetime) | 1.1.1+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml\_edit](https://crates.io/crates/toml_edit) | 0.25.13+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
-| [toml\_parser](https://crates.io/crates/toml_parser) | 1.1.2+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
+| [toml\_parser](https://crates.io/crates/toml_parser) | 1.1.3+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [toml\_writer](https://crates.io/crates/toml_writer) | 1.1.2+spec-1.1.0 | MIT OR Apache-2.0 |  |  |
 | [tonic](https://crates.io/crates/tonic) | 0.14.6 | MIT |  |  |
 | [tonic-prost](https://crates.io/crates/tonic-prost) | 0.14.6 | MIT |  |  |
@@ -444,7 +443,6 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [windows-targets](https://crates.io/crates/windows-targets) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
 | [windows-threading](https://crates.io/crates/windows-threading) | 0.2.1 | MIT OR Apache-2.0 | windows |  |
 | [windows\_x86\_64\_msvc](https://crates.io/crates/windows_x86_64_msvc) | 0.52.6 | MIT OR Apache-2.0 | windows |  |
-| [winnow](https://crates.io/crates/winnow) | 0.7.15 | MIT |  |  |
 | [winnow](https://crates.io/crates/winnow) | 1.0.4 | MIT |  |  |
 | [writeable](https://crates.io/crates/writeable) | 0.6.3 | Unicode-3.0 |  |  |
 | [xattr](https://crates.io/crates/xattr) | 1.6.1 | MIT OR Apache-2.0 | linux, macos |  |
@@ -471,11 +469,11 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 
 | License | Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 249 |
-| MIT | 84 |
+| MIT OR Apache-2.0 | 247 |
+| MIT | 83 |
 | Apache-2.0 OR MIT | 35 |
 | Apache-2.0 | 21 |
-| BSD-3-Clause | 19 |
+| BSD-3-Clause | 20 |
 | Unicode-3.0 | 18 |
 | Unlicense OR MIT | 4 |
 | ISC | 3 |

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,8 +1,8 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-07-28T16:19:47Z<br>
+Generated: 2026-07-28T17:31:22Z<br>
 Format: CycloneDX 1.4<br>
-Packages: 454 (59 platform-specific)<br>
+Packages: 453 (59 platform-specific)<br>
 Platforms: linux-aarch64, linux-x86_64, macos, windows
 <br>**Security advisories: 0 found at this time**
 
@@ -267,9 +267,8 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler](https://crates.io/crates/rattler) | 0.47.1 | BSD-3-Clause |  |  |
 | [rattler\_cache](https://crates.io/crates/rattler_cache) | 0.10.3 | BSD-3-Clause |  |  |
 | [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.48.1 | BSD-3-Clause |  |  |
-| [rattler\_conda\_types](https://crates.io/crates/rattler_conda_types) | 0.49.0 | BSD-3-Clause |  |  |
 | [rattler\_digest](https://crates.io/crates/rattler_digest) | 1.3.2 | BSD-3-Clause |  |  |
-| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.7 | BSD-3-Clause |  |  |
+| [rattler\_lock](https://crates.io/crates/rattler_lock) | 0.31.5 | BSD-3-Clause |  |  |
 | [rattler\_macros](https://crates.io/crates/rattler_macros) | 1.1.2 | BSD-3-Clause |  |  |
 | [rattler\_menuinst](https://crates.io/crates/rattler_menuinst) | 0.2.70 | BSD-3-Clause |  |  |
 | [rattler\_networking](https://crates.io/crates/rattler_networking) | 0.30.2 | BSD-3-Clause |  |  |
@@ -277,7 +276,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | [rattler\_pty](https://crates.io/crates/rattler_pty) | 0.2.15 | BSD-3-Clause |  |  |
 | [rattler\_redaction](https://crates.io/crates/rattler_redaction) | 0.2.2 | BSD-3-Clause |  |  |
 | [rattler\_shell](https://crates.io/crates/rattler_shell) | 0.27.10 | BSD-3-Clause |  |  |
-| [rattler\_solve](https://crates.io/crates/rattler_solve) | 9.0.0 | BSD-3-Clause |  |  |
+| [rattler\_solve](https://crates.io/crates/rattler_solve) | 7.2.2 | BSD-3-Clause |  |  |
 | [rayon](https://crates.io/crates/rayon) | 1.12.0 | MIT OR Apache-2.0 |  |  |
 | [rayon-core](https://crates.io/crates/rayon-core) | 1.13.0 | MIT OR Apache-2.0 |  |  |
 | [ref-cast](https://crates.io/crates/ref-cast) | 1.0.26 | MIT OR Apache-2.0 |  |  |
@@ -473,7 +472,7 @@ Platforms: linux-aarch64, linux-x86_64, macos, windows
 | MIT | 83 |
 | Apache-2.0 OR MIT | 35 |
 | Apache-2.0 | 21 |
-| BSD-3-Clause | 20 |
+| BSD-3-Clause | 19 |
 | Unicode-3.0 | 18 |
 | Unlicense OR MIT | 4 |
 | ISC | 3 |

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,7 @@ cmd = "python scripts/with_version.py cargo auditable build"
 description = "Build the standalone Rust binary in debug mode"
 
 [tasks.build-release]
-cmd = "python scripts/with_version.py cargo auditable build --release"
+cmd = "python scripts/with_version.py cargo auditable build --release --locked"
 description = "Build the standalone Rust binary in release mode"
 
 [tasks.test]
@@ -48,7 +48,7 @@ cmd = "python scripts/with_version.py cargo test -- --show-output"
 description = "Run the unit tests"
 
 [tasks.test-release]
-cmd = "python scripts/with_version.py cargo test --release"
+cmd = "python scripts/with_version.py cargo test --release --locked"
 depends-on = ["build-release"]
 description = "Run the unit tests in release mode"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -217,9 +217,7 @@ impl CommandContext {
     /// Callers must build full URLs using `outerbounds_config().metaflow.obp_api_server_url()`
     /// or `obp_auth_server_url()` as the base.
     #[cfg(feature = "outerbounds-native")]
-    pub fn obp_client(
-        &self,
-    ) -> Result<&reqwest_middleware::ClientWithMiddleware, &ConfigError> {
+    pub fn obp_client(&self) -> Result<&reqwest_middleware::ClientWithMiddleware, &ConfigError> {
         self.outerbounds_config()?;
 
         Ok(self.obp_client.get_or_init(|| {

--- a/src/context.rs
+++ b/src/context.rs
@@ -196,8 +196,11 @@ impl CommandContext {
 
                 // Block on the async init_config using the current tokio runtime
                 tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current()
-                        .block_on(init_config(self, &config_dir, profile.as_deref()))
+                    tokio::runtime::Handle::current().block_on(init_config(
+                        self,
+                        &config_dir,
+                        profile.as_deref(),
+                    ))
                 })
             })
             .as_ref()

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,6 +16,9 @@ use crate::config::Config;
 use crate::http::{self, Client};
 use crate::telemetry::{SerializableValue, TelemetryEvent};
 
+#[cfg(feature = "outerbounds-native")]
+use crate::outerbounds_native::{ConfigError, ResolvedConfig};
+
 /// Telemetry context for collecting command-specific attributes.
 #[derive(Debug, Default)]
 pub struct TelemetryContext {
@@ -101,6 +104,9 @@ pub struct CommandContext {
     download_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Unauthenticated client (lazy initialized).
     unauthenticated_client: OnceLock<Client>,
+    /// Outerbounds/Metaflow configuration (lazy initialized, feature-gated).
+    #[cfg(feature = "outerbounds-native")]
+    outerbounds_config: OnceLock<Result<ResolvedConfig, ConfigError>>,
 }
 
 impl CommandContext {
@@ -129,6 +135,8 @@ impl CommandContext {
             github_client: OnceLock::new(),
             download_client: OnceLock::new(),
             unauthenticated_client: OnceLock::new(),
+            #[cfg(feature = "outerbounds-native")]
+            outerbounds_config: OnceLock::new(),
         }
     }
 
@@ -171,6 +179,29 @@ impl CommandContext {
             .expect("failed to create unauthenticated client")
         })
     }
+
+    /// Get the Outerbounds/Metaflow configuration (lazy loaded, blocking).
+    ///
+    /// Returns the resolved config which may include remote-fetched values.
+    /// The result is cached after the first call. If a remote fetch is needed,
+    /// this will block the current thread until it completes.
+    #[cfg(feature = "outerbounds-native")]
+    pub fn outerbounds_config(&self) -> Result<&ResolvedConfig, &ConfigError> {
+        use crate::outerbounds_native::{current_profile, default_config_dir, init_config};
+
+        self.outerbounds_config
+            .get_or_init(|| {
+                let config_dir = default_config_dir();
+                let profile = current_profile();
+
+                // Block on the async init_config using the current tokio runtime
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current()
+                        .block_on(init_config(self, &config_dir, profile.as_deref()))
+                })
+            })
+            .as_ref()
+    }
 }
 
 impl Default for CommandContext {
@@ -193,6 +224,8 @@ impl CommandContext {
             github_client: OnceLock::new(),
             download_client: OnceLock::new(),
             unauthenticated_client: OnceLock::new(),
+            #[cfg(feature = "outerbounds-native")]
+            outerbounds_config: OnceLock::new(),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -107,6 +107,9 @@ pub struct CommandContext {
     /// Outerbounds/Metaflow configuration (lazy initialized, feature-gated).
     #[cfg(feature = "outerbounds-native")]
     outerbounds_config: OnceLock<Result<ResolvedConfig, ConfigError>>,
+    /// Outerbounds Platform API client (lazy initialized, feature-gated).
+    #[cfg(feature = "outerbounds-native")]
+    obp_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
 }
 
 impl CommandContext {
@@ -137,6 +140,8 @@ impl CommandContext {
             unauthenticated_client: OnceLock::new(),
             #[cfg(feature = "outerbounds-native")]
             outerbounds_config: OnceLock::new(),
+            #[cfg(feature = "outerbounds-native")]
+            obp_client: OnceLock::new(),
         }
     }
 
@@ -205,6 +210,32 @@ impl CommandContext {
             })
             .as_ref()
     }
+
+    /// Get or create an Outerbounds Platform API client.
+    ///
+    /// Uses `x-api-key` header authentication from the resolved Outerbounds config.
+    /// Callers must build full URLs using `outerbounds_config().metaflow.obp_api_server_url()`
+    /// or `obp_auth_server_url()` as the base.
+    #[cfg(feature = "outerbounds-native")]
+    pub fn obp_client(
+        &self,
+    ) -> Result<&reqwest_middleware::ClientWithMiddleware, &ConfigError> {
+        self.outerbounds_config()?;
+
+        Ok(self.obp_client.get_or_init(|| {
+            let api_key = self
+                .outerbounds_config
+                .get()
+                .and_then(|r| r.as_ref().ok())
+                .and_then(|c| c.metaflow.service_auth_key.as_deref())
+                .unwrap_or("");
+
+            http::build_client(
+                reqwest::Client::builder().default_headers(http::x_api_key_header(api_key)),
+            )
+            .expect("failed to create OBP client")
+        }))
+    }
 }
 
 impl Default for CommandContext {
@@ -229,6 +260,8 @@ impl CommandContext {
             unauthenticated_client: OnceLock::new(),
             #[cfg(feature = "outerbounds-native")]
             outerbounds_config: OnceLock::new(),
+            #[cfg(feature = "outerbounds-native")]
+            obp_client: OnceLock::new(),
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -173,6 +173,16 @@ pub fn bearer_header(token: &str) -> reqwest::header::HeaderMap {
     headers
 }
 
+/// Create a `HeaderMap` with a sensitive `x-api-key` header.
+#[allow(dead_code)]
+pub fn x_api_key_header(key: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    let mut value = reqwest::header::HeaderValue::from_str(key).unwrap();
+    value.set_sensitive(true);
+    headers.insert("x-api-key", value);
+    headers
+}
+
 /// Get Cloudflare Zero Trust headers if environment variables are set.
 /// Returns None if either CF_ACCESS_CLIENT_ID or CF_ACCESS_CLIENT_SECRET is missing.
 pub fn cloudflare_headers() -> Option<reqwest::header::HeaderMap> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod installer;
 mod mcp;
 #[cfg(unix)]
 mod outerbounds;
+mod outerbounds_native;
 mod paths;
 mod qr;
 mod table;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod installer;
 mod mcp;
 #[cfg(unix)]
 mod outerbounds;
+#[cfg(feature = "outerbounds-native")]
 mod outerbounds_native;
 mod paths;
 mod qr;

--- a/src/outerbounds_native/config/mod.rs
+++ b/src/outerbounds_native/config/mod.rs
@@ -8,5 +8,5 @@ pub use reader::{
 };
 pub use types::{MetaflowConfig, ObConfig, ResolvedConfig};
 pub use writer::{
-    config_exists, decode_config, encode_config, write_config, ConfigType, DecodedConfig,
+    ConfigType, DecodedConfig, config_exists, decode_config, encode_config, write_config,
 };

--- a/src/outerbounds_native/config/mod.rs
+++ b/src/outerbounds_native/config/mod.rs
@@ -1,0 +1,12 @@
+mod reader;
+mod types;
+mod writer;
+
+pub use reader::{
+    current_profile, default_config_dir, default_ob_config_dir, init_config, metaflow_config_path,
+    ob_config_path, read_metaflow_config, read_ob_config,
+};
+pub use types::{MetaflowConfig, ObConfig, ResolvedConfig};
+pub use writer::{
+    config_exists, decode_config, encode_config, write_config, ConfigType, DecodedConfig,
+};

--- a/src/outerbounds_native/config/reader.rs
+++ b/src/outerbounds_native/config/reader.rs
@@ -3,8 +3,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
-use figment::providers::{Format, Json, Serialized};
 use figment::Figment;
+use figment::providers::{Format, Json, Serialized};
 
 use crate::context::CommandContext;
 use crate::outerbounds_native::errors::ConfigError;
@@ -177,45 +177,44 @@ pub async fn init_config(
         .or(local_config.obp_metaflow_config_url.as_deref())
         .map(String::from);
 
-    let (metaflow, source_url) = match remote_url {
-        Some(url) => {
-            // Check cache first
-            {
-                let cache = REMOTE_CONFIG_CACHE.lock().unwrap();
-                if let Some(cached) = cache.get(&url) {
-                    return Ok(ResolvedConfig {
-                        metaflow: cached.clone(),
-                        ob: ob_config,
-                        profile: profile.map(String::from),
-                        source_url: Some(url),
-                    });
+    let (metaflow, source_url) =
+        match remote_url {
+            Some(url) => {
+                // Check cache first
+                {
+                    let cache = REMOTE_CONFIG_CACHE.lock().unwrap();
+                    if let Some(cached) = cache.get(&url) {
+                        return Ok(ResolvedConfig {
+                            metaflow: cached.clone(),
+                            ob: ob_config,
+                            profile: profile.map(String::from),
+                            source_url: Some(url),
+                        });
+                    }
                 }
-            }
 
-            // Need auth key to fetch remote config
-            let auth_key =
-                local_config
-                    .service_auth_key
-                    .as_ref()
-                    .ok_or_else(|| ConfigError::MissingKey {
+                // Need auth key to fetch remote config
+                let auth_key = local_config.service_auth_key.as_ref().ok_or_else(|| {
+                    ConfigError::MissingKey {
                         key: "METAFLOW_SERVICE_AUTH_KEY".to_string(),
-                    })?;
+                    }
+                })?;
 
-            let mut remote_config = fetch_remote_config(ctx, &url, auth_key).await?;
+                let mut remote_config = fetch_remote_config(ctx, &url, auth_key).await?;
 
-            // Preserve the config URL in the resolved config
-            remote_config.obp_metaflow_config_url = Some(url.clone());
+                // Preserve the config URL in the resolved config
+                remote_config.obp_metaflow_config_url = Some(url.clone());
 
-            // Cache it
-            {
-                let mut cache = REMOTE_CONFIG_CACHE.lock().unwrap();
-                cache.insert(url.clone(), remote_config.clone());
+                // Cache it
+                {
+                    let mut cache = REMOTE_CONFIG_CACHE.lock().unwrap();
+                    cache.insert(url.clone(), remote_config.clone());
+                }
+
+                (remote_config, Some(url))
             }
-
-            (remote_config, Some(url))
-        }
-        None => (local_config, None),
-    };
+            None => (local_config, None),
+        };
 
     Ok(ResolvedConfig {
         metaflow,
@@ -631,7 +630,9 @@ mod tests {
         )
         .unwrap();
 
-        let resolved = init_config(&ctx, dir.path(), Some("staging")).await.unwrap();
+        let resolved = init_config(&ctx, dir.path(), Some("staging"))
+            .await
+            .unwrap();
 
         assert_eq!(resolved.profile, Some("staging".to_string()));
         assert_eq!(

--- a/src/outerbounds_native/config/reader.rs
+++ b/src/outerbounds_native/config/reader.rs
@@ -1,0 +1,680 @@
+use std::collections::HashMap;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+
+use figment::providers::{Format, Json, Serialized};
+use figment::Figment;
+
+use crate::context::CommandContext;
+use crate::outerbounds_native::errors::ConfigError;
+
+use super::types::{MetaflowConfig, ObConfig, ResolvedConfig};
+
+/// Cache for remote metaflow configs, keyed by URL
+static REMOTE_CONFIG_CACHE: LazyLock<Mutex<HashMap<String, MetaflowConfig>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Get the default metaflow config directory path.
+/// Respects METAFLOW_HOME env var, defaults to ~/.metaflowconfig
+pub fn default_config_dir() -> PathBuf {
+    env::var("METAFLOW_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".metaflowconfig")
+        })
+}
+
+/// Get the default OB config directory path.
+/// Respects OBP_CONFIG_DIR env var, falls back to metaflow config dir
+pub fn default_ob_config_dir() -> PathBuf {
+    env::var("OBP_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| default_config_dir())
+}
+
+/// Get the current profile from METAFLOW_PROFILE env var
+pub fn current_profile() -> Option<String> {
+    env::var("METAFLOW_PROFILE").ok().filter(|s| !s.is_empty())
+}
+
+/// Get the metaflow config file path for a given profile
+pub fn metaflow_config_path(config_dir: &Path, profile: Option<&str>) -> PathBuf {
+    let filename = match profile {
+        Some(p) if !p.is_empty() => format!("config_{}.json", p),
+        _ => "config.json".to_string(),
+    };
+    config_dir.join(filename)
+}
+
+/// Get the OB config file path for a given profile
+pub fn ob_config_path(config_dir: &Path, profile: Option<&str>) -> PathBuf {
+    let filename = match profile {
+        Some(p) if !p.is_empty() => format!("ob_config_{}.json", p),
+        _ => "ob_config.json".to_string(),
+    };
+    config_dir.join(filename)
+}
+
+/// Read metaflow config from filesystem.
+pub fn read_metaflow_config(
+    config_dir: &Path,
+    profile: Option<&str>,
+) -> Result<MetaflowConfig, ConfigError> {
+    let path = metaflow_config_path(config_dir, profile);
+
+    if !path.exists() {
+        return Err(ConfigError::NotFound { path });
+    }
+
+    Figment::new()
+        .merge(Serialized::defaults(MetaflowConfig::default()))
+        .merge(Json::file(&path))
+        .extract()
+        .map_err(|e| ConfigError::ParseFailed {
+            path,
+            reason: e.to_string(),
+        })
+}
+
+/// Read OB config from filesystem.
+/// Returns Ok(None) if file doesn't exist (unless OBP_CONFIG_DIR is explicitly set).
+pub fn read_ob_config(
+    config_dir: &Path,
+    profile: Option<&str>,
+) -> Result<Option<ObConfig>, ConfigError> {
+    let path = ob_config_path(config_dir, profile);
+
+    if !path.exists() {
+        if env::var("OBP_CONFIG_DIR").is_ok() {
+            return Err(ConfigError::ObpConfigDirMissing {
+                path: config_dir.to_path_buf(),
+            });
+        }
+        return Ok(None);
+    }
+
+    let config: ObConfig = Figment::new()
+        .merge(Json::file(&path))
+        .extract()
+        .map_err(|e| ConfigError::ParseFailed {
+            path,
+            reason: e.to_string(),
+        })?;
+
+    // Validate required key if file exists
+    if config.config_url().is_none() {
+        return Err(ConfigError::ObConfigMissingKey {
+            key: "OB_CURRENT_PERIMETER_MF_CONFIG_URL".to_string(),
+        });
+    }
+
+    Ok(Some(config))
+}
+
+/// Fetch remote config from URL using auth token.
+async fn fetch_remote_config(
+    ctx: &CommandContext,
+    url: &str,
+    auth_key: &str,
+) -> Result<MetaflowConfig, ConfigError> {
+    let response = ctx
+        .unauthenticated_client(std::time::Duration::from_secs(30))
+        .get(url)
+        .header("x-api-key", auth_key)
+        .send()
+        .await
+        .map_err(|e| ConfigError::RemoteFetchFailed {
+            url: url.to_string(),
+            source: e,
+        })?;
+
+    if !response.status().is_success() {
+        return Err(ConfigError::RemoteFetchFailed {
+            url: url.to_string(),
+            source: reqwest_middleware::Error::from(response.error_for_status().unwrap_err()),
+        });
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RemoteConfigResponse {
+        config: MetaflowConfig,
+    }
+
+    let remote: RemoteConfigResponse =
+        response
+            .json()
+            .await
+            .map_err(|e| ConfigError::RemoteFetchFailed {
+                url: url.to_string(),
+                source: reqwest_middleware::Error::from(e),
+            })?;
+
+    Ok(remote.config)
+}
+
+/// Initialize config, fetching from remote URL if configured.
+///
+/// Resolution order:
+/// 1. Read local metaflow config from filesystem
+/// 2. Check ob_config.json for perimeter-specific URL
+/// 3. If URL found (in ob_config or metaflow config), fetch remote config
+/// 4. Cache remote config by URL
+pub async fn init_config(
+    ctx: &CommandContext,
+    config_dir: &Path,
+    profile: Option<&str>,
+) -> Result<ResolvedConfig, ConfigError> {
+    let local_config = read_metaflow_config(config_dir, profile)?;
+    let ob_config = read_ob_config(config_dir, profile)?;
+
+    // Determine if we need to fetch remote config
+    let remote_url = ob_config
+        .as_ref()
+        .and_then(|ob| ob.config_url())
+        .or(local_config.obp_metaflow_config_url.as_deref())
+        .map(String::from);
+
+    let (metaflow, source_url) = match remote_url {
+        Some(url) => {
+            // Check cache first
+            {
+                let cache = REMOTE_CONFIG_CACHE.lock().unwrap();
+                if let Some(cached) = cache.get(&url) {
+                    return Ok(ResolvedConfig {
+                        metaflow: cached.clone(),
+                        ob: ob_config,
+                        profile: profile.map(String::from),
+                        source_url: Some(url),
+                    });
+                }
+            }
+
+            // Need auth key to fetch remote config
+            let auth_key =
+                local_config
+                    .service_auth_key
+                    .as_ref()
+                    .ok_or_else(|| ConfigError::MissingKey {
+                        key: "METAFLOW_SERVICE_AUTH_KEY".to_string(),
+                    })?;
+
+            let mut remote_config = fetch_remote_config(ctx, &url, auth_key).await?;
+
+            // Preserve the config URL in the resolved config
+            remote_config.obp_metaflow_config_url = Some(url.clone());
+
+            // Cache it
+            {
+                let mut cache = REMOTE_CONFIG_CACHE.lock().unwrap();
+                cache.insert(url.clone(), remote_config.clone());
+            }
+
+            (remote_config, Some(url))
+        }
+        None => (local_config, None),
+    };
+
+    Ok(ResolvedConfig {
+        metaflow,
+        ob: ob_config,
+        profile: profile.map(String::from),
+        source_url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::config::Config;
+    use crate::http::Client;
+
+    fn setup_temp_dir() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn test_config(keyring_path: PathBuf, domain: &str) -> Config {
+        Config {
+            domain: domain.to_string(),
+            client_id: "test-client".to_string(),
+            ssl_verify: true,
+            open_browser: false,
+            keyring_path,
+            use_https: true,
+            metrics_endpoint: "https://metrics.example.com".to_string(),
+            metrics_public_endpoint: "https://public.metrics.example.com".to_string(),
+            metrics_export_interval_ms: 1000,
+            metrics_console_exporter: false,
+            metrics_skip_internet_check: true,
+            include_prereleases: false,
+            pip_index_url: "https://example.com/simple".to_string(),
+            self_update_url: Some("https://example.com".to_string()),
+            auto_update_tools: None,
+            #[cfg(feature = "diagnostics")]
+            sentry_disabled: true,
+            #[cfg(feature = "diagnostics")]
+            sentry_environment: "test".to_string(),
+        }
+    }
+
+    fn setup_test_context(mock_server: &MockServer) -> (CommandContext, TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring_path = dir.path().join("keyring");
+        let config = test_config(keyring_path, "test.example.com");
+
+        let client = Client::new(reqwest::Client::builder(), mock_server.uri()).unwrap();
+        let ctx = CommandContext::with_client(config, client);
+
+        (ctx, dir)
+    }
+
+    #[test]
+    fn test_metaflow_config_path_default_profile() {
+        let dir = PathBuf::from("/mf");
+        assert_eq!(
+            metaflow_config_path(&dir, None),
+            PathBuf::from("/mf/config.json")
+        );
+        assert_eq!(
+            metaflow_config_path(&dir, Some("")),
+            PathBuf::from("/mf/config.json")
+        );
+    }
+
+    #[test]
+    fn test_metaflow_config_path_named_profile() {
+        let dir = PathBuf::from("/mf");
+        assert_eq!(
+            metaflow_config_path(&dir, Some("prod")),
+            PathBuf::from("/mf/config_prod.json")
+        );
+    }
+
+    #[test]
+    fn test_ob_config_path_default_profile() {
+        let dir = PathBuf::from("/mf");
+        assert_eq!(
+            ob_config_path(&dir, None),
+            PathBuf::from("/mf/ob_config.json")
+        );
+    }
+
+    #[test]
+    fn test_ob_config_path_named_profile() {
+        let dir = PathBuf::from("/mf");
+        assert_eq!(
+            ob_config_path(&dir, Some("staging")),
+            PathBuf::from("/mf/ob_config_staging.json")
+        );
+    }
+
+    #[test]
+    fn test_read_metaflow_config_not_found() {
+        let tmp = setup_temp_dir();
+        let result = read_metaflow_config(tmp.path(), None);
+        assert!(matches!(result, Err(ConfigError::NotFound { .. })));
+    }
+
+    #[test]
+    fn test_read_metaflow_config_success() {
+        let tmp = setup_temp_dir();
+        let config_path = tmp.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{
+                "METAFLOW_SERVICE_AUTH_KEY": "test-token",
+                "OBP_API_SERVER": "api.example.com"
+            }"#,
+        )
+        .unwrap();
+
+        let config = read_metaflow_config(tmp.path(), None).unwrap();
+        assert_eq!(config.service_auth_key, Some("test-token".to_string()));
+        assert_eq!(config.obp_api_server, Some("api.example.com".to_string()));
+    }
+
+    #[test]
+    fn test_read_metaflow_config_with_profile() {
+        let tmp = setup_temp_dir();
+        let config_path = tmp.path().join("config_prod.json");
+        fs::write(
+            &config_path,
+            r#"{"METAFLOW_SERVICE_AUTH_KEY": "prod-token"}"#,
+        )
+        .unwrap();
+
+        let config = read_metaflow_config(tmp.path(), Some("prod")).unwrap();
+        assert_eq!(config.service_auth_key, Some("prod-token".to_string()));
+    }
+
+    #[test]
+    fn test_read_metaflow_config_preserves_unknown_fields() {
+        let tmp = setup_temp_dir();
+        let config_path = tmp.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{
+                "METAFLOW_SERVICE_AUTH_KEY": "token",
+                "SOME_FUTURE_KEY": "future-value"
+            }"#,
+        )
+        .unwrap();
+
+        let config = read_metaflow_config(tmp.path(), None).unwrap();
+        assert_eq!(
+            config.extra.get("SOME_FUTURE_KEY").and_then(|v| v.as_str()),
+            Some("future-value")
+        );
+    }
+
+    #[test]
+    fn test_read_ob_config_not_found_ok() {
+        let tmp = setup_temp_dir();
+        let result = read_ob_config(tmp.path(), None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_ob_config_success() {
+        let tmp = setup_temp_dir();
+        let config_path = tmp.path().join("ob_config.json");
+        fs::write(
+            &config_path,
+            r#"{
+                "OB_CURRENT_PERIMETER": "prod",
+                "OB_CURRENT_PERIMETER_MF_CONFIG_URL": "https://example.com/config"
+            }"#,
+        )
+        .unwrap();
+
+        let config = read_ob_config(tmp.path(), None).unwrap().unwrap();
+        assert_eq!(config.current_perimeter, Some("prod".to_string()));
+        assert_eq!(config.config_url(), Some("https://example.com/config"));
+    }
+
+    #[test]
+    fn test_read_ob_config_legacy_url_key() {
+        let tmp = setup_temp_dir();
+        let config_path = tmp.path().join("ob_config.json");
+        fs::write(
+            &config_path,
+            r#"{
+                "OB_CURRENT_PERIMETER": "prod",
+                "OB_CURRENT_PERIMETER_URL": "https://legacy.example.com/config"
+            }"#,
+        )
+        .unwrap();
+
+        let config = read_ob_config(tmp.path(), None).unwrap().unwrap();
+        assert_eq!(
+            config.config_url(),
+            Some("https://legacy.example.com/config")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_remote_config_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/config"))
+            .and(header("x-api-key", "test-auth-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "config": {
+                    "METAFLOW_SERVICE_AUTH_KEY": "remote-token",
+                    "OBP_API_SERVER": "remote-api.example.com"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let (ctx, _dir) = setup_test_context(&mock_server);
+        let url = format!("{}/config", mock_server.uri());
+
+        let config = fetch_remote_config(&ctx, &url, "test-auth-key")
+            .await
+            .unwrap();
+
+        assert_eq!(config.service_auth_key, Some("remote-token".to_string()));
+        assert_eq!(
+            config.obp_api_server,
+            Some("remote-api.example.com".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_remote_config_unauthorized() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/config"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock_server)
+            .await;
+
+        let (ctx, _dir) = setup_test_context(&mock_server);
+        let url = format!("{}/config", mock_server.uri());
+
+        let result = fetch_remote_config(&ctx, &url, "bad-key").await;
+
+        assert!(matches!(result, Err(ConfigError::RemoteFetchFailed { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_init_config_local_only() {
+        let mock_server = MockServer::start().await;
+        let (ctx, dir) = setup_test_context(&mock_server);
+
+        let config_path = dir.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{"METAFLOW_SERVICE_AUTH_KEY": "local-token"}"#,
+        )
+        .unwrap();
+
+        let resolved = init_config(&ctx, dir.path(), None).await.unwrap();
+
+        assert_eq!(
+            resolved.metaflow.service_auth_key,
+            Some("local-token".to_string())
+        );
+        assert!(resolved.ob.is_none());
+        assert!(resolved.source_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_init_config_fetches_from_ob_config_url() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/remote-config"))
+            .and(header("x-api-key", "local-auth"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "config": {
+                    "METAFLOW_SERVICE_AUTH_KEY": "remote-token",
+                    "OBP_API_SERVER": "remote-api.example.com"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let (ctx, dir) = setup_test_context(&mock_server);
+
+        let metaflow_path = dir.path().join("config.json");
+        fs::write(
+            &metaflow_path,
+            r#"{"METAFLOW_SERVICE_AUTH_KEY": "local-auth"}"#,
+        )
+        .unwrap();
+
+        let ob_path = dir.path().join("ob_config.json");
+        let remote_url = format!("{}/remote-config", mock_server.uri());
+        fs::write(
+            &ob_path,
+            serde_json::json!({
+                "OB_CURRENT_PERIMETER": "prod",
+                "OB_CURRENT_PERIMETER_MF_CONFIG_URL": remote_url
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let resolved = init_config(&ctx, dir.path(), None).await.unwrap();
+
+        assert_eq!(
+            resolved.metaflow.service_auth_key,
+            Some("remote-token".to_string())
+        );
+        assert_eq!(
+            resolved.metaflow.obp_api_server,
+            Some("remote-api.example.com".to_string())
+        );
+        assert!(resolved.ob.is_some());
+        assert!(resolved.source_url.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_init_config_uses_cache() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/cached-config"))
+            .and(header("x-api-key", "local-auth"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "config": {
+                    "METAFLOW_SERVICE_AUTH_KEY": "cached-token"
+                }
+            })))
+            .expect(1) // Should only be called once
+            .mount(&mock_server)
+            .await;
+
+        let (ctx, dir) = setup_test_context(&mock_server);
+
+        let metaflow_path = dir.path().join("config.json");
+        fs::write(
+            &metaflow_path,
+            r#"{"METAFLOW_SERVICE_AUTH_KEY": "local-auth"}"#,
+        )
+        .unwrap();
+
+        let ob_path = dir.path().join("ob_config.json");
+        let remote_url = format!("{}/cached-config", mock_server.uri());
+        fs::write(
+            &ob_path,
+            serde_json::json!({
+                "OB_CURRENT_PERIMETER": "prod",
+                "OB_CURRENT_PERIMETER_MF_CONFIG_URL": remote_url
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // First call - hits the server
+        let resolved1 = init_config(&ctx, dir.path(), None).await.unwrap();
+        assert_eq!(
+            resolved1.metaflow.service_auth_key,
+            Some("cached-token".to_string())
+        );
+
+        // Second call - should use cache (mock expects only 1 call)
+        let resolved2 = init_config(&ctx, dir.path(), None).await.unwrap();
+        assert_eq!(
+            resolved2.metaflow.service_auth_key,
+            Some("cached-token".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_config_missing_auth_key() {
+        let mock_server = MockServer::start().await;
+        let (ctx, dir) = setup_test_context(&mock_server);
+
+        // Local config without auth key
+        let metaflow_path = dir.path().join("config.json");
+        fs::write(&metaflow_path, r#"{"OBP_API_SERVER": "api.example.com"}"#).unwrap();
+
+        // OB config with remote URL - will fail because no auth key
+        let ob_path = dir.path().join("ob_config.json");
+        fs::write(
+            &ob_path,
+            r#"{
+                "OB_CURRENT_PERIMETER": "prod",
+                "OB_CURRENT_PERIMETER_MF_CONFIG_URL": "https://example.com/config"
+            }"#,
+        )
+        .unwrap();
+
+        let result = init_config(&ctx, dir.path(), None).await;
+
+        assert!(matches!(result, Err(ConfigError::MissingKey { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_resolved_config_fields() {
+        let mock_server = MockServer::start().await;
+        let (ctx, dir) = setup_test_context(&mock_server);
+
+        let config_path = dir.path().join("config_staging.json");
+        fs::write(
+            &config_path,
+            r#"{"METAFLOW_SERVICE_AUTH_KEY": "staging-token"}"#,
+        )
+        .unwrap();
+
+        let resolved = init_config(&ctx, dir.path(), Some("staging")).await.unwrap();
+
+        assert_eq!(resolved.profile, Some("staging".to_string()));
+        assert_eq!(
+            resolved.metaflow.service_auth_key,
+            Some("staging-token".to_string())
+        );
+    }
+
+    #[test]
+    fn test_default_config_dir_returns_path() {
+        let dir = default_config_dir();
+        // Should end with .metaflowconfig (unless METAFLOW_HOME is set)
+        let dir_str = dir.to_string_lossy();
+        assert!(
+            dir_str.ends_with(".metaflowconfig") || env::var("METAFLOW_HOME").is_ok(),
+            "Expected path ending in .metaflowconfig, got: {}",
+            dir_str
+        );
+    }
+
+    #[test]
+    fn test_default_ob_config_dir_returns_path() {
+        let dir = default_ob_config_dir();
+        // Should be a valid path
+        assert!(!dir.to_string_lossy().is_empty());
+        // If OBP_CONFIG_DIR not set, should match default_config_dir
+        if env::var("OBP_CONFIG_DIR").is_err() {
+            assert_eq!(dir, default_config_dir());
+        }
+    }
+
+    #[test]
+    fn test_current_profile_returns_option() {
+        let profile = current_profile();
+        // Should return None if METAFLOW_PROFILE not set, or Some if set
+        if let Ok(val) = env::var("METAFLOW_PROFILE") {
+            if val.is_empty() {
+                assert!(profile.is_none());
+            } else {
+                assert_eq!(profile, Some(val));
+            }
+        } else {
+            assert!(profile.is_none());
+        }
+    }
+}

--- a/src/outerbounds_native/config/reader.rs
+++ b/src/outerbounds_native/config/reader.rs
@@ -1,19 +1,122 @@
 use std::collections::HashMap;
 use std::env;
+use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, SystemTime};
 
 use figment::Figment;
 use figment::providers::{Format, Json, Serialized};
+use serde::{Deserialize, Serialize};
 
 use crate::context::CommandContext;
 use crate::outerbounds_native::errors::ConfigError;
 
 use super::types::{MetaflowConfig, ObConfig, ResolvedConfig};
 
-/// Cache for remote metaflow configs, keyed by URL
+/// Default TTL for cached remote configs (1 hour)
+const CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// In-memory cache for remote metaflow configs, keyed by URL
 static REMOTE_CONFIG_CACHE: LazyLock<Mutex<HashMap<String, MetaflowConfig>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Cached config with timestamp for TTL checking
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedConfig {
+    config: MetaflowConfig,
+    #[serde(with = "system_time_serde")]
+    cached_at: SystemTime,
+}
+
+mod system_time_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let duration = time.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
+        duration.as_secs().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(UNIX_EPOCH + Duration::from_secs(secs))
+    }
+}
+
+impl CachedConfig {
+    fn new(config: MetaflowConfig) -> Self {
+        Self {
+            config,
+            cached_at: SystemTime::now(),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.cached_at
+            .elapsed()
+            .map(|elapsed| elapsed > CACHE_TTL)
+            .unwrap_or(true)
+    }
+}
+
+/// Get the cache directory for remote configs
+fn cache_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join(".cache")
+}
+
+/// Generate a cache filename from a URL
+fn cache_filename(url: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut hasher);
+    format!("remote_config_{:x}.json", hasher.finish())
+}
+
+/// Read cached config from disk if it exists and is not expired
+fn read_disk_cache(config_dir: &Path, url: &str) -> Option<MetaflowConfig> {
+    let cache_path = cache_dir(config_dir).join(cache_filename(url));
+
+    let content = fs::read_to_string(&cache_path).ok()?;
+    let cached: CachedConfig = serde_json::from_str(&content).ok()?;
+
+    if cached.is_expired() {
+        // Clean up expired cache file
+        let _ = fs::remove_file(&cache_path);
+        return None;
+    }
+
+    Some(cached.config)
+}
+
+/// Write config to disk cache
+fn write_disk_cache(config_dir: &Path, url: &str, config: &MetaflowConfig) {
+    let cache_path = cache_dir(config_dir).join(cache_filename(url));
+
+    // Ensure cache directory exists
+    if let Err(e) = fs::create_dir_all(cache_dir(config_dir)) {
+        log::debug!("Failed to create cache directory: {}", e);
+        return;
+    }
+
+    let cached = CachedConfig::new(config.clone());
+    match serde_json::to_string_pretty(&cached) {
+        Ok(content) => {
+            if let Err(e) = fs::write(&cache_path, content) {
+                log::debug!("Failed to write config cache: {}", e);
+            }
+        }
+        Err(e) => {
+            log::debug!("Failed to serialize config for cache: {}", e);
+        }
+    }
+}
 
 /// Get the default metaflow config directory path.
 /// Respects METAFLOW_HOME env var, defaults to ~/.metaflowconfig
@@ -180,7 +283,7 @@ pub async fn init_config(
     let (metaflow, source_url) =
         match remote_url {
             Some(url) => {
-                // Check cache first
+                // Check in-memory cache first
                 {
                     let cache = REMOTE_CONFIG_CACHE.lock().unwrap();
                     if let Some(cached) = cache.get(&url) {
@@ -191,6 +294,21 @@ pub async fn init_config(
                             source_url: Some(url),
                         });
                     }
+                }
+
+                // Check disk cache (with TTL)
+                if let Some(cached) = read_disk_cache(config_dir, &url) {
+                    // Populate in-memory cache
+                    {
+                        let mut cache = REMOTE_CONFIG_CACHE.lock().unwrap();
+                        cache.insert(url.clone(), cached.clone());
+                    }
+                    return Ok(ResolvedConfig {
+                        metaflow: cached,
+                        ob: ob_config,
+                        profile: profile.map(String::from),
+                        source_url: Some(url),
+                    });
                 }
 
                 // Need auth key to fetch remote config
@@ -205,7 +323,10 @@ pub async fn init_config(
                 // Preserve the config URL in the resolved config
                 remote_config.obp_metaflow_config_url = Some(url.clone());
 
-                // Cache it
+                // Cache to disk
+                write_disk_cache(config_dir, &url, &remote_config);
+
+                // Cache in memory
                 {
                     let mut cache = REMOTE_CONFIG_CACHE.lock().unwrap();
                     cache.insert(url.clone(), remote_config.clone());
@@ -677,5 +798,68 @@ mod tests {
         } else {
             assert!(profile.is_none());
         }
+    }
+
+    #[test]
+    fn test_cache_filename_deterministic() {
+        let url = "https://example.com/config";
+        let filename1 = cache_filename(url);
+        let filename2 = cache_filename(url);
+        assert_eq!(filename1, filename2);
+        assert!(filename1.starts_with("remote_config_"));
+        assert!(filename1.ends_with(".json"));
+    }
+
+    #[test]
+    fn test_cache_filename_different_urls() {
+        let filename1 = cache_filename("https://example.com/config1");
+        let filename2 = cache_filename("https://example.com/config2");
+        assert_ne!(filename1, filename2);
+    }
+
+    #[test]
+    fn test_disk_cache_roundtrip() {
+        let tmp = setup_temp_dir();
+        let url = "https://example.com/test-config";
+        let config = MetaflowConfig {
+            service_auth_key: Some("test-key".into()),
+            obp_api_server: Some("api.example.com".into()),
+            ..Default::default()
+        };
+
+        // Write to cache
+        write_disk_cache(tmp.path(), url, &config);
+
+        // Read from cache
+        let cached = read_disk_cache(tmp.path(), url);
+        assert!(cached.is_some());
+
+        let cached = cached.unwrap();
+        assert_eq!(cached.service_auth_key, Some("test-key".into()));
+        assert_eq!(cached.obp_api_server, Some("api.example.com".into()));
+    }
+
+    #[test]
+    fn test_disk_cache_missing_returns_none() {
+        let tmp = setup_temp_dir();
+        let cached = read_disk_cache(tmp.path(), "https://nonexistent.com/config");
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_cached_config_not_expired() {
+        let config = MetaflowConfig::default();
+        let cached = CachedConfig::new(config);
+        assert!(!cached.is_expired());
+    }
+
+    #[test]
+    fn test_cached_config_expired() {
+        let config = MetaflowConfig::default();
+        let cached = CachedConfig {
+            config,
+            cached_at: SystemTime::now() - Duration::from_secs(2 * 60 * 60), // 2 hours ago
+        };
+        assert!(cached.is_expired());
     }
 }

--- a/src/outerbounds_native/config/types.rs
+++ b/src/outerbounds_native/config/types.rs
@@ -1,0 +1,269 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Metaflow config stored in ~/.metaflowconfig/config.json (or config_{profile}.json)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetaflowConfig {
+    // Authentication
+    #[serde(
+        rename = "METAFLOW_SERVICE_AUTH_KEY",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_auth_key: Option<String>,
+
+    // OBP servers
+    #[serde(rename = "OBP_API_SERVER", skip_serializing_if = "Option::is_none")]
+    pub obp_api_server: Option<String>,
+
+    #[serde(rename = "OBP_AUTH_SERVER", skip_serializing_if = "Option::is_none")]
+    pub obp_auth_server: Option<String>,
+
+    #[serde(
+        rename = "OBP_METAFLOW_CONFIG_URL",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub obp_metaflow_config_url: Option<String>,
+
+    // Metaflow service
+    #[serde(rename = "METAFLOW_SERVICE_URL", skip_serializing_if = "Option::is_none")]
+    pub service_url: Option<String>,
+
+    #[serde(rename = "METAFLOW_UI_URL", skip_serializing_if = "Option::is_none")]
+    pub ui_url: Option<String>,
+
+    // Datastore
+    #[serde(
+        rename = "METAFLOW_DEFAULT_DATASTORE",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_datastore: Option<String>,
+
+    #[serde(
+        rename = "METAFLOW_DATASTORE_SYSROOT_S3",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub datastore_sysroot_s3: Option<String>,
+
+    #[serde(
+        rename = "METAFLOW_DATATOOLS_S3ROOT",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub datatools_s3root: Option<String>,
+
+    // Kubernetes
+    #[serde(
+        rename = "METAFLOW_KUBERNETES_NAMESPACE",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub kubernetes_namespace: Option<String>,
+
+    #[serde(
+        rename = "METAFLOW_KUBERNETES_SANDBOX_INIT_SCRIPT",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub kubernetes_sandbox_init_script: Option<String>,
+
+    // Defaults
+    #[serde(
+        rename = "METAFLOW_DEFAULT_METADATA",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_metadata: Option<String>,
+
+    #[serde(
+        rename = "METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_aws_client_provider: Option<String>,
+
+    // Perimeter (sometimes included in metaflow config)
+    #[serde(rename = "OBP_PERIMETER", skip_serializing_if = "Option::is_none")]
+    pub obp_perimeter: Option<String>,
+
+    // Forward compatibility: capture any unknown fields
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl MetaflowConfig {
+    /// Get the OBP API server URL with https:// prefix
+    pub fn obp_api_server_url(&self) -> Option<String> {
+        self.obp_api_server.as_ref().map(|s| sanitize_url(s))
+    }
+
+    /// Get the OBP auth server URL with https:// prefix
+    pub fn obp_auth_server_url(&self) -> Option<String> {
+        self.obp_auth_server.as_ref().map(|s| sanitize_url(s))
+    }
+}
+
+/// OB-specific config stored in ~/.metaflowconfig/ob_config.json (or ob_config_{profile}.json)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ObConfig {
+    #[serde(
+        rename = "OB_CURRENT_PERIMETER",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub current_perimeter: Option<String>,
+
+    #[serde(
+        rename = "OB_CURRENT_PERIMETER_MF_CONFIG_URL",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub perimeter_config_url: Option<String>,
+
+    /// Legacy key for backwards compatibility with workstations
+    #[serde(
+        rename = "OB_CURRENT_PERIMETER_URL",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub perimeter_url_legacy: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl ObConfig {
+    /// Get the perimeter config URL, checking both current and legacy keys
+    pub fn config_url(&self) -> Option<&str> {
+        self.perimeter_config_url
+            .as_deref()
+            .or(self.perimeter_url_legacy.as_deref())
+    }
+}
+
+/// Resolved configuration after potentially fetching from remote URL
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    pub metaflow: MetaflowConfig,
+    pub ob: Option<ObConfig>,
+    pub profile: Option<String>,
+    /// The URL the config was fetched from, if any
+    pub source_url: Option<String>,
+}
+
+/// Ensure URL has https:// prefix and no trailing slash
+fn sanitize_url(url: &str) -> String {
+    let url = if url.starts_with("https://") || url.starts_with("http://") {
+        url.to_string()
+    } else {
+        format!("https://{}", url)
+    };
+    url.trim_end_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metaflow_config_serde_roundtrip() {
+        let config = MetaflowConfig {
+            service_auth_key: Some("secret-token".into()),
+            obp_api_server: Some("api.example.com".into()),
+            obp_auth_server: Some("auth.example.com".into()),
+            default_datastore: Some("s3".into()),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let parsed: MetaflowConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.service_auth_key, Some("secret-token".into()));
+        assert_eq!(parsed.obp_api_server, Some("api.example.com".into()));
+        assert_eq!(parsed.default_datastore, Some("s3".into()));
+    }
+
+    #[test]
+    fn metaflow_config_preserves_unknown_fields() {
+        let json = r#"{
+            "METAFLOW_SERVICE_AUTH_KEY": "token",
+            "SOME_FUTURE_KEY": "future-value",
+            "ANOTHER_KEY": 123
+        }"#;
+
+        let config: MetaflowConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.service_auth_key, Some("token".into()));
+        assert_eq!(
+            config.extra.get("SOME_FUTURE_KEY").and_then(|v| v.as_str()),
+            Some("future-value")
+        );
+        assert_eq!(
+            config.extra.get("ANOTHER_KEY").and_then(|v| v.as_i64()),
+            Some(123)
+        );
+
+        // Roundtrip preserves unknown fields
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains("SOME_FUTURE_KEY"));
+        assert!(serialized.contains("ANOTHER_KEY"));
+    }
+
+    #[test]
+    fn ob_config_url_precedence() {
+        // New key takes precedence
+        let config = ObConfig {
+            current_perimeter: Some("prod".into()),
+            perimeter_config_url: Some("https://new.url".into()),
+            perimeter_url_legacy: Some("https://old.url".into()),
+            extra: HashMap::new(),
+        };
+        assert_eq!(config.config_url(), Some("https://new.url"));
+
+        // Falls back to legacy
+        let config = ObConfig {
+            current_perimeter: Some("prod".into()),
+            perimeter_config_url: None,
+            perimeter_url_legacy: Some("https://old.url".into()),
+            extra: HashMap::new(),
+        };
+        assert_eq!(config.config_url(), Some("https://old.url"));
+
+        // None if neither set
+        let config = ObConfig::default();
+        assert!(config.config_url().is_none());
+    }
+
+    #[test]
+    fn sanitize_url_adds_https() {
+        assert_eq!(sanitize_url("api.example.com"), "https://api.example.com");
+        assert_eq!(
+            sanitize_url("https://api.example.com"),
+            "https://api.example.com"
+        );
+        assert_eq!(
+            sanitize_url("http://api.example.com"),
+            "http://api.example.com"
+        );
+    }
+
+    #[test]
+    fn sanitize_url_removes_trailing_slash() {
+        assert_eq!(sanitize_url("api.example.com/"), "https://api.example.com");
+        assert_eq!(
+            sanitize_url("https://api.example.com/"),
+            "https://api.example.com"
+        );
+    }
+
+    #[test]
+    fn obp_server_url_helpers() {
+        let config = MetaflowConfig {
+            obp_api_server: Some("api.example.com".into()),
+            obp_auth_server: Some("https://auth.example.com/".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.obp_api_server_url(),
+            Some("https://api.example.com".into())
+        );
+        assert_eq!(
+            config.obp_auth_server_url(),
+            Some("https://auth.example.com".into())
+        );
+    }
+}

--- a/src/outerbounds_native/config/types.rs
+++ b/src/outerbounds_native/config/types.rs
@@ -27,7 +27,10 @@ pub struct MetaflowConfig {
     pub obp_metaflow_config_url: Option<String>,
 
     // Metaflow service
-    #[serde(rename = "METAFLOW_SERVICE_URL", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "METAFLOW_SERVICE_URL",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub service_url: Option<String>,
 
     #[serde(rename = "METAFLOW_UI_URL", skip_serializing_if = "Option::is_none")]

--- a/src/outerbounds_native/config/writer.rs
+++ b/src/outerbounds_native/config/writer.rs
@@ -1,0 +1,721 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use base64::prelude::*;
+use flate2::read::ZlibDecoder;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::outerbounds_native::errors::ConfigError;
+
+use super::reader::{default_config_dir, default_ob_config_dir};
+use super::types::{MetaflowConfig, ObConfig};
+
+/// Type of config encoding
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigType {
+    /// Config values are inline in the encoded string
+    Inline,
+    /// Config should be fetched from AWS Secrets Manager
+    AwsSecretsManager { arn: String, region: String },
+}
+
+/// Decoded configuration from a base64+zlib magic string
+#[derive(Debug, Clone)]
+pub struct DecodedConfig {
+    pub config_type: ConfigType,
+    pub config: MetaflowConfig,
+    pub perimeter: Option<String>,
+}
+
+/// Intermediate struct for parsing the raw decoded JSON
+#[derive(Debug, Deserialize)]
+struct RawDecodedConfig {
+    #[serde(rename = "OB_CONFIG_TYPE")]
+    config_type: Option<String>,
+
+    #[serde(rename = "OBP_PERIMETER")]
+    perimeter: Option<String>,
+
+    #[serde(rename = "OBP_METAFLOW_CONFIG_URL")]
+    metaflow_config_url: Option<String>,
+
+    #[serde(rename = "METAFLOW_SERVICE_AUTH_KEY")]
+    service_auth_key: Option<String>,
+
+    // AWS Secrets Manager fields
+    #[serde(rename = "AWS_SECRETS_MANAGER_SECRET_ARN")]
+    aws_secret_arn: Option<String>,
+
+    #[serde(rename = "AWS_SECRETS_MANAGER_REGION")]
+    aws_region: Option<String>,
+
+    #[serde(flatten)]
+    extra: HashMap<String, Value>,
+}
+
+/// Decode a base64+zlib compressed config string.
+///
+/// The string may have a prefix like "ob-1.0:" which is stripped before decoding.
+pub fn decode_config(encoded: &str) -> Result<DecodedConfig, ConfigError> {
+    // Strip prefix if present (e.g., "ob-1.0:base64data")
+    let encoded = encoded.split(':').next_back().unwrap_or(encoded);
+
+    // Base64 decode
+    let compressed = BASE64_STANDARD
+        .decode(encoded.trim())
+        .map_err(|e| ConfigError::DecodeFailed(format!("base64 decode failed: {}", e)))?;
+
+    // Zlib decompress
+    let mut decoder = ZlibDecoder::new(&compressed[..]);
+    let mut json_bytes = Vec::new();
+    std::io::Read::read_to_end(&mut decoder, &mut json_bytes)
+        .map_err(|e| ConfigError::DecodeFailed(format!("zlib decompress failed: {}", e)))?;
+
+    // Parse JSON
+    let raw: RawDecodedConfig = serde_json::from_slice(&json_bytes)
+        .map_err(|e| ConfigError::DecodeFailed(format!("JSON parse failed: {}", e)))?;
+
+    // Determine config type
+    let config_type = match raw.config_type.as_deref() {
+        Some("aws-secrets-manager") => {
+            let arn = raw.aws_secret_arn.ok_or_else(|| {
+                ConfigError::DecodeFailed(
+                    "AWS_SECRETS_MANAGER_SECRET_ARN required for aws-secrets-manager config type"
+                        .to_string(),
+                )
+            })?;
+            let region = raw.aws_region.ok_or_else(|| {
+                ConfigError::DecodeFailed(
+                    "AWS_SECRETS_MANAGER_REGION required for aws-secrets-manager config type"
+                        .to_string(),
+                )
+            })?;
+            ConfigType::AwsSecretsManager { arn, region }
+        }
+        Some("inline") | None => ConfigType::Inline,
+        Some(other) => {
+            return Err(ConfigError::InvalidConfigType {
+                config_type: other.to_string(),
+            })
+        }
+    };
+
+    // Build MetaflowConfig from the decoded data
+    let config = if raw.metaflow_config_url.is_some() {
+        // If URL is present, only keep URL and auth key
+        MetaflowConfig {
+            obp_metaflow_config_url: raw.metaflow_config_url,
+            service_auth_key: raw.service_auth_key,
+            ..Default::default()
+        }
+    } else {
+        // Rebuild full config from all fields
+        let mut extra = raw.extra;
+
+        // Add known fields back to extra for serialization into MetaflowConfig
+        if let Some(key) = raw.service_auth_key {
+            extra.insert("METAFLOW_SERVICE_AUTH_KEY".to_string(), Value::String(key));
+        }
+        if let Some(url) = raw.metaflow_config_url {
+            extra.insert("OBP_METAFLOW_CONFIG_URL".to_string(), Value::String(url));
+        }
+
+        serde_json::from_value(Value::Object(extra.into_iter().collect()))
+            .map_err(|e| ConfigError::DecodeFailed(format!("Failed to build config: {}", e)))?
+    };
+
+    Ok(DecodedConfig {
+        config_type,
+        config,
+        perimeter: raw.perimeter,
+    })
+}
+
+/// Encode a config to base64+zlib format (for testing/roundtrip verification)
+pub fn encode_config(config: &HashMap<String, Value>) -> Result<String, ConfigError> {
+    let json = serde_json::to_vec(config)
+        .map_err(|e| ConfigError::DecodeFailed(format!("JSON serialize failed: {}", e)))?;
+
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder
+        .write_all(&json)
+        .map_err(|e| ConfigError::DecodeFailed(format!("zlib compress failed: {}", e)))?;
+    let compressed = encoder
+        .finish()
+        .map_err(|e| ConfigError::DecodeFailed(format!("zlib finish failed: {}", e)))?;
+
+    Ok(BASE64_STANDARD.encode(compressed))
+}
+
+/// Write decoded config to the filesystem.
+///
+/// Returns the path to the written config file.
+pub fn write_config(
+    decoded: &DecodedConfig,
+    profile: Option<&str>,
+    config_dir_override: Option<&Path>,
+) -> Result<PathBuf, ConfigError> {
+    let base_dir = config_dir_override
+        .map(PathBuf::from)
+        .unwrap_or_else(default_config_dir);
+
+    // Ensure directory exists
+    fs::create_dir_all(&base_dir).map_err(|e| ConfigError::WriteFailed {
+        path: base_dir.clone(),
+        source: e,
+    })?;
+
+    // Determine config file path
+    let filename = match profile {
+        Some(p) if !p.is_empty() => format!("config_{}.json", p),
+        _ => "config.json".to_string(),
+    };
+    let config_path = base_dir.join(&filename);
+
+    // Write metaflow config
+    let json = serde_json::to_string_pretty(&decoded.config)
+        .map_err(|e| ConfigError::DecodeFailed(format!("JSON serialize failed: {}", e)))?;
+
+    fs::write(&config_path, json).map_err(|e| ConfigError::WriteFailed {
+        path: config_path.clone(),
+        source: e,
+    })?;
+
+    // Write ob_config.json if perimeter and URL are present
+    if let (Some(perimeter), Some(url)) = (
+        &decoded.perimeter,
+        decoded.config.obp_metaflow_config_url.as_ref(),
+    ) {
+        let ob_dir = default_ob_config_dir();
+        fs::create_dir_all(&ob_dir).map_err(|e| ConfigError::WriteFailed {
+            path: ob_dir.clone(),
+            source: e,
+        })?;
+
+        let ob_filename = match profile {
+            Some(p) if !p.is_empty() => format!("ob_config_{}.json", p),
+            _ => "ob_config.json".to_string(),
+        };
+        let ob_config_path = ob_dir.join(&ob_filename);
+
+        let ob_config = ObConfig {
+            current_perimeter: Some(perimeter.clone()),
+            perimeter_config_url: Some(url.clone()),
+            perimeter_url_legacy: None,
+            extra: HashMap::new(),
+        };
+
+        let ob_json = serde_json::to_string_pretty(&ob_config)
+            .map_err(|e| ConfigError::DecodeFailed(format!("JSON serialize failed: {}", e)))?;
+
+        fs::write(&ob_config_path, ob_json).map_err(|e| ConfigError::WriteFailed {
+            path: ob_config_path,
+            source: e,
+        })?;
+    }
+
+    Ok(config_path)
+}
+
+/// Check if a config file already exists for the given profile.
+pub fn config_exists(profile: Option<&str>, config_dir_override: Option<&Path>) -> bool {
+    let base_dir = config_dir_override
+        .map(PathBuf::from)
+        .unwrap_or_else(default_config_dir);
+
+    let filename = match profile {
+        Some(p) if !p.is_empty() => format!("config_{}.json", p),
+        _ => "config.json".to_string(),
+    };
+
+    base_dir.join(filename).exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup_temp_dir() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn make_test_config() -> HashMap<String, Value> {
+        let mut config = HashMap::new();
+        config.insert(
+            "METAFLOW_SERVICE_AUTH_KEY".to_string(),
+            Value::String("test-token".to_string()),
+        );
+        config.insert(
+            "OBP_API_SERVER".to_string(),
+            Value::String("api.example.com".to_string()),
+        );
+        config
+    }
+
+    /// Sample config from Python test suite (test_config_writer.py)
+    fn sample_metaflow_config() -> HashMap<String, Value> {
+        serde_json::from_str(
+            r#"{
+                "METAFLOW_ARGO_EVENTS_EVENT": "metaflow-event",
+                "METAFLOW_ARGO_EVENTS_EVENT_BUS": "default",
+                "METAFLOW_ARGO_EVENTS_EVENT_SOURCE": "argo-events-webhook",
+                "METAFLOW_ARGO_EVENTS_WEBHOOK_URL": "http://argo-events-webhook-eventsource-svc.jobs-default:12000/metaflow-event",
+                "METAFLOW_ARGO_WORKFLOWS_ENV_VARS_TO_SKIP": "METAFLOW_SERVICE_HEADERS",
+                "METAFLOW_ARGO_WORKFLOWS_KUBERNETES_SECRETS": "argo-workflows-default-service-principal-credentials",
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION": "us-west-2",
+                "METAFLOW_DATASTORE_SYSROOT_S3": "s3://obp-4bh26o-metaflow/metaflow",
+                "METAFLOW_DATATOOLS_S3ROOT": "s3://obp-4bh26o-metaflow/data",
+                "METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER": "obp",
+                "METAFLOW_DEFAULT_CONTAINER_REGISTRY": "public.ecr.aws/docker/library",
+                "METAFLOW_DEFAULT_DATASTORE": "s3",
+                "METAFLOW_DEFAULT_METADATA": "service",
+                "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE": "aws-secrets-manager",
+                "METAFLOW_KUBERNETES_CONTAINER_IMAGE": "006988687827.dkr.ecr.us-west-2.amazonaws.com/obptask-python:master-39509478-1675983838",
+                "METAFLOW_KUBERNETES_NAMESPACE": "jobs-default",
+                "METAFLOW_KUBERNETES_SANDBOX_INIT_SCRIPT": "eval $(curl https://outerbounds-public.s3.us-west-2.amazonaws.com/platform/kubernetes_auth_shim.py | OBP_AUTH_SERVER=auth.dev-latest.outerbounds.xyz python3 )",
+                "METAFLOW_OTEL_ENDPOINT": "https://tracing.dev-latest.outerbounds.xyz/v1/traces",
+                "METAFLOW_SERVICE_AUTH_KEY": "<REDACTED>",
+                "METAFLOW_SERVICE_URL": "https://metadata.dev-latest.outerbounds.xyz/",
+                "METAFLOW_UI_URL": "https://ui.dev-latest.outerbounds.xyz/",
+                "METAFLOW_USER": "jackie@outerbounds.co",
+                "OBP_AUTH_SERVER": "auth.dev-latest.outerbounds.xyz",
+                "OBP_API_SERVER": "api.dev-latest.outerbounds.xyz"
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let original = make_test_config();
+        let encoded = encode_config(&original).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        assert_eq!(
+            decoded.config.service_auth_key,
+            Some("test-token".to_string())
+        );
+        assert_eq!(
+            decoded.config.obp_api_server,
+            Some("api.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_decode_strips_prefix() {
+        let original = make_test_config();
+        let encoded = encode_config(&original).unwrap();
+        let prefixed = format!("ob-1.0:{}", encoded);
+
+        let decoded = decode_config(&prefixed).unwrap();
+        assert_eq!(
+            decoded.config.service_auth_key,
+            Some("test-token".to_string())
+        );
+    }
+
+    #[test]
+    fn test_decode_inline_config_type() {
+        let mut config = make_test_config();
+        config.insert(
+            "OB_CONFIG_TYPE".to_string(),
+            Value::String("inline".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        assert_eq!(decoded.config_type, ConfigType::Inline);
+    }
+
+    #[test]
+    fn test_decode_default_config_type_is_inline() {
+        let config = make_test_config();
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        assert_eq!(decoded.config_type, ConfigType::Inline);
+    }
+
+    #[test]
+    fn test_decode_aws_secrets_manager_config_type() {
+        let mut config = HashMap::new();
+        config.insert(
+            "OB_CONFIG_TYPE".to_string(),
+            Value::String("aws-secrets-manager".to_string()),
+        );
+        config.insert(
+            "AWS_SECRETS_MANAGER_SECRET_ARN".to_string(),
+            Value::String(
+                "arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret".to_string(),
+            ),
+        );
+        config.insert(
+            "AWS_SECRETS_MANAGER_REGION".to_string(),
+            Value::String("us-east-1".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        assert!(matches!(
+            decoded.config_type,
+            ConfigType::AwsSecretsManager { .. }
+        ));
+        if let ConfigType::AwsSecretsManager { arn, region } = decoded.config_type {
+            assert!(arn.contains("my-secret"));
+            assert_eq!(region, "us-east-1");
+        }
+    }
+
+    #[test]
+    fn test_decode_aws_secrets_manager_missing_arn() {
+        let mut config = HashMap::new();
+        config.insert(
+            "OB_CONFIG_TYPE".to_string(),
+            Value::String("aws-secrets-manager".to_string()),
+        );
+        config.insert(
+            "AWS_SECRETS_MANAGER_REGION".to_string(),
+            Value::String("us-east-1".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let result = decode_config(&encoded);
+
+        assert!(matches!(result, Err(ConfigError::DecodeFailed(_))));
+    }
+
+    #[test]
+    fn test_decode_invalid_config_type() {
+        let mut config = HashMap::new();
+        config.insert(
+            "OB_CONFIG_TYPE".to_string(),
+            Value::String("unknown-type".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let result = decode_config(&encoded);
+
+        assert!(matches!(result, Err(ConfigError::InvalidConfigType { .. })));
+    }
+
+    #[test]
+    fn test_decode_with_perimeter() {
+        let mut config = make_test_config();
+        config.insert(
+            "OBP_PERIMETER".to_string(),
+            Value::String("production".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        assert_eq!(decoded.perimeter, Some("production".to_string()));
+    }
+
+    #[test]
+    fn test_decode_with_metaflow_config_url() {
+        let mut config = HashMap::new();
+        config.insert(
+            "METAFLOW_SERVICE_AUTH_KEY".to_string(),
+            Value::String("token".to_string()),
+        );
+        config.insert(
+            "OBP_METAFLOW_CONFIG_URL".to_string(),
+            Value::String("https://example.com/config".to_string()),
+        );
+        config.insert(
+            "OBP_API_SERVER".to_string(),
+            Value::String("should-be-ignored".to_string()),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        // When URL is present, only URL and auth key should be kept
+        assert_eq!(decoded.config.service_auth_key, Some("token".to_string()));
+        assert_eq!(
+            decoded.config.obp_metaflow_config_url,
+            Some("https://example.com/config".to_string())
+        );
+        // Other fields should not be present
+        assert!(decoded.config.obp_api_server.is_none());
+    }
+
+    #[test]
+    fn test_decode_invalid_base64() {
+        let result = decode_config("not-valid-base64!!!");
+        assert!(matches!(result, Err(ConfigError::DecodeFailed(_))));
+    }
+
+    #[test]
+    fn test_decode_invalid_zlib() {
+        let invalid = BASE64_STANDARD.encode(b"not compressed data");
+        let result = decode_config(&invalid);
+        assert!(matches!(result, Err(ConfigError::DecodeFailed(_))));
+    }
+
+    #[test]
+    fn test_write_config_creates_file() {
+        let tmp = setup_temp_dir();
+        let decoded = DecodedConfig {
+            config_type: ConfigType::Inline,
+            config: MetaflowConfig {
+                service_auth_key: Some("test-token".to_string()),
+                obp_api_server: Some("api.example.com".to_string()),
+                ..Default::default()
+            },
+            perimeter: None,
+        };
+
+        let path = write_config(&decoded, None, Some(tmp.path())).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(path, tmp.path().join("config.json"));
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("test-token"));
+        assert!(contents.contains("api.example.com"));
+    }
+
+    #[test]
+    fn test_write_config_with_profile() {
+        let tmp = setup_temp_dir();
+        let decoded = DecodedConfig {
+            config_type: ConfigType::Inline,
+            config: MetaflowConfig {
+                service_auth_key: Some("prod-token".to_string()),
+                ..Default::default()
+            },
+            perimeter: None,
+        };
+
+        let path = write_config(&decoded, Some("prod"), Some(tmp.path())).unwrap();
+
+        assert_eq!(path, tmp.path().join("config_prod.json"));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_write_config_creates_ob_config_when_perimeter_and_url() {
+        let tmp = setup_temp_dir();
+
+        temp_env::with_vars(
+            [
+                ("METAFLOW_HOME", Some(tmp.path().to_str().unwrap())),
+                ("OBP_CONFIG_DIR", None::<&str>),
+            ],
+            || {
+                let decoded = DecodedConfig {
+                    config_type: ConfigType::Inline,
+                    config: MetaflowConfig {
+                        service_auth_key: Some("token".to_string()),
+                        obp_metaflow_config_url: Some("https://example.com/config".to_string()),
+                        ..Default::default()
+                    },
+                    perimeter: Some("production".to_string()),
+                };
+
+                write_config(&decoded, None, Some(tmp.path())).unwrap();
+
+                // Check ob_config.json was created
+                let ob_config_path = tmp.path().join("ob_config.json");
+                assert!(ob_config_path.exists());
+
+                let ob_contents = fs::read_to_string(&ob_config_path).unwrap();
+                assert!(ob_contents.contains("production"));
+                assert!(ob_contents.contains("https://example.com/config"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_config_exists() {
+        let tmp = setup_temp_dir();
+
+        assert!(!config_exists(None, Some(tmp.path())));
+
+        fs::write(tmp.path().join("config.json"), "{}").unwrap();
+        assert!(config_exists(None, Some(tmp.path())));
+
+        assert!(!config_exists(Some("prod"), Some(tmp.path())));
+
+        fs::write(tmp.path().join("config_prod.json"), "{}").unwrap();
+        assert!(config_exists(Some("prod"), Some(tmp.path())));
+    }
+
+    // Tests matching Python test suite (test_config_writer.py)
+
+    #[test]
+    fn test_serialization_roundtrip_matches_python() {
+        // From Python: test_serialization - tests various data types
+        let test_cases: Vec<HashMap<String, Value>> = vec![
+            HashMap::new(),
+            {
+                let mut m = HashMap::new();
+                m.insert("KEY1".to_string(), Value::String("VALUE1".to_string()));
+                m.insert("KEY2".to_string(), Value::Number(2.into()));
+                m
+            },
+        ];
+
+        for original in test_cases {
+            let encoded = encode_config(&original).unwrap();
+            let decoded = decode_config(&encoded).unwrap();
+
+            // Check all original keys are present in decoded config
+            for (key, value) in &original {
+                let decoded_value = decoded
+                    .config
+                    .extra
+                    .get(key)
+                    .expect(&format!("Missing key: {}", key));
+                assert_eq!(decoded_value, value, "Mismatch for key: {}", key);
+            }
+        }
+    }
+
+    #[test]
+    fn test_metaflow_config_inline_matches_python() {
+        // From Python: test_metaflow_config_inline
+        let config = sample_metaflow_config();
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        // Verify known fields
+        assert_eq!(
+            decoded.config.service_auth_key,
+            Some("<REDACTED>".to_string())
+        );
+        assert_eq!(
+            decoded.config.obp_api_server,
+            Some("api.dev-latest.outerbounds.xyz".to_string())
+        );
+        assert_eq!(
+            decoded.config.obp_auth_server,
+            Some("auth.dev-latest.outerbounds.xyz".to_string())
+        );
+        assert_eq!(
+            decoded.config.service_url,
+            Some("https://metadata.dev-latest.outerbounds.xyz/".to_string())
+        );
+        assert_eq!(
+            decoded.config.ui_url,
+            Some("https://ui.dev-latest.outerbounds.xyz/".to_string())
+        );
+        assert_eq!(decoded.config.default_datastore, Some("s3".to_string()));
+        assert_eq!(decoded.config.default_metadata, Some("service".to_string()));
+        assert_eq!(
+            decoded.config.kubernetes_namespace,
+            Some("jobs-default".to_string())
+        );
+        assert_eq!(
+            decoded.config.datastore_sysroot_s3,
+            Some("s3://obp-4bh26o-metaflow/metaflow".to_string())
+        );
+        assert_eq!(
+            decoded.config.datatools_s3root,
+            Some("s3://obp-4bh26o-metaflow/data".to_string())
+        );
+        assert_eq!(
+            decoded.config.default_aws_client_provider,
+            Some("obp".to_string())
+        );
+
+        // Verify extra fields are preserved
+        assert_eq!(
+            decoded
+                .config
+                .extra
+                .get("METAFLOW_ARGO_EVENTS_EVENT")
+                .and_then(|v| v.as_str()),
+            Some("metaflow-event")
+        );
+        assert_eq!(
+            decoded
+                .config
+                .extra
+                .get("METAFLOW_USER")
+                .and_then(|v| v.as_str()),
+            Some("jackie@outerbounds.co")
+        );
+    }
+
+    #[test]
+    fn test_prefixed_config_matches_python() {
+        // From Python: test_aws_secrets_manager uses "not-a-secret:" prefix
+        let config = sample_metaflow_config();
+        let encoded = encode_config(&config).unwrap();
+        let prefixed = format!("not-a-secret:{}", encoded);
+
+        let decoded = decode_config(&prefixed).unwrap();
+        assert_eq!(
+            decoded.config.service_auth_key,
+            Some("<REDACTED>".to_string())
+        );
+    }
+
+    #[test]
+    fn test_aws_secrets_manager_config_type_matches_python() {
+        // From Python: test_aws_secrets_manager - tests aws-secrets-manager config type parsing
+        // Note: We don't test actual AWS calls, just the config type detection
+        let mut config = HashMap::new();
+        config.insert(
+            "OB_CONFIG_TYPE".to_string(),
+            Value::String("aws-secrets-manager".to_string()),
+        );
+        config.insert(
+            "AWS_SECRETS_MANAGER_REGION".to_string(),
+            Value::String("us-west-2".to_string()),
+        );
+        config.insert(
+            "AWS_SECRETS_MANAGER_SECRET_ARN".to_string(),
+            Value::String(
+                "arn:aws:secretsmanager:us-west-2:123456789012:secret:unique-boo".to_string(),
+            ),
+        );
+
+        let encoded = encode_config(&config).unwrap();
+        let decoded = decode_config(&encoded).unwrap();
+
+        match decoded.config_type {
+            ConfigType::AwsSecretsManager { arn, region } => {
+                assert_eq!(region, "us-west-2");
+                assert!(arn.contains("unique-boo"));
+            }
+            _ => panic!("Expected AwsSecretsManager config type"),
+        }
+    }
+
+    #[test]
+    fn test_decode_python_generated_string() {
+        // This string was generated by Python using the same algorithm:
+        // json.dumps(config) -> zlib.compress() -> base64.b64encode()
+        // Config: {
+        //   "METAFLOW_SERVICE_AUTH_KEY": "test-key-12345",
+        //   "OBP_API_SERVER": "api.test.outerbounds.xyz",
+        //   "OBP_AUTH_SERVER": "auth.test.outerbounds.xyz"
+        // }
+        let python_encoded = "eJyrVvJ1DXF08/EPjw92DQrzdHaNdwwN8Yj3do1UslJQKkktLtHNTq3UNTQyNjFV0lFQ8ncKiHcM8ASrdg0CqUksyNQDqdPLLy1JLUrKL81LKdarqKyCqwaZh6S8tCQDu/paANrTLQM=";
+
+        let decoded = decode_config(python_encoded).unwrap();
+
+        assert_eq!(
+            decoded.config.service_auth_key,
+            Some("test-key-12345".to_string())
+        );
+        assert_eq!(
+            decoded.config.obp_api_server,
+            Some("api.test.outerbounds.xyz".to_string())
+        );
+        assert_eq!(
+            decoded.config.obp_auth_server,
+            Some("auth.test.outerbounds.xyz".to_string())
+        );
+    }
+}

--- a/src/outerbounds_native/config/writer.rs
+++ b/src/outerbounds_native/config/writer.rs
@@ -99,7 +99,7 @@ pub fn decode_config(encoded: &str) -> Result<DecodedConfig, ConfigError> {
         Some(other) => {
             return Err(ConfigError::InvalidConfigType {
                 config_type: other.to_string(),
-            })
+            });
         }
     };
 
@@ -554,15 +554,12 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip_matches_python() {
         // From Python: test_serialization - tests various data types
-        let test_cases: Vec<HashMap<String, Value>> = vec![
-            HashMap::new(),
-            {
-                let mut m = HashMap::new();
-                m.insert("KEY1".to_string(), Value::String("VALUE1".to_string()));
-                m.insert("KEY2".to_string(), Value::Number(2.into()));
-                m
-            },
-        ];
+        let test_cases: Vec<HashMap<String, Value>> = vec![HashMap::new(), {
+            let mut m = HashMap::new();
+            m.insert("KEY1".to_string(), Value::String("VALUE1".to_string()));
+            m.insert("KEY2".to_string(), Value::Number(2.into()));
+            m
+        }];
 
         for original in test_cases {
             let encoded = encode_config(&original).unwrap();

--- a/src/outerbounds_native/errors.rs
+++ b/src/outerbounds_native/errors.rs
@@ -87,7 +87,9 @@ pub enum ServicePrincipalError {
     #[error("GitHub Actions environment not detected")]
     #[diagnostic(
         code(ana::ob::sp::not_gha),
-        help("Ensure ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL are set, and 'id-token: write' permission is granted")
+        help(
+            "Ensure ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL are set, and 'id-token: write' permission is granted"
+        )
     )]
     NotGitHubActions,
 

--- a/src/outerbounds_native/errors.rs
+++ b/src/outerbounds_native/errors.rs
@@ -1,0 +1,148 @@
+use std::path::PathBuf;
+
+use miette::Diagnostic;
+use thiserror::Error;
+
+#[derive(Error, Debug, Diagnostic)]
+pub enum ConfigError {
+    #[error("Config file not found: {path}")]
+    #[diagnostic(code(ana::ob::config_not_found))]
+    NotFound { path: PathBuf },
+
+    #[error("Failed to read config file: {path}")]
+    #[diagnostic(code(ana::ob::config_read_failed))]
+    ReadFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to parse config file {path}: {reason}")]
+    #[diagnostic(code(ana::ob::config_parse_failed))]
+    ParseFailed { path: PathBuf, reason: String },
+
+    #[error("Failed to write config file: {path}")]
+    #[diagnostic(code(ana::ob::config_write_failed))]
+    WriteFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to decode configuration string")]
+    #[diagnostic(
+        code(ana::ob::decode_failed),
+        help("Ensure the config string is valid base64+zlib compressed JSON")
+    )]
+    DecodeFailed(String),
+
+    #[error("Missing required config key: {key}")]
+    #[diagnostic(code(ana::ob::missing_key))]
+    MissingKey { key: String },
+
+    #[error("Invalid config type: {config_type}")]
+    #[diagnostic(code(ana::ob::invalid_config_type))]
+    InvalidConfigType { config_type: String },
+
+    #[error("Failed to fetch remote config from {url}")]
+    #[diagnostic(code(ana::ob::remote_fetch_failed))]
+    RemoteFetchFailed {
+        url: String,
+        #[source]
+        source: reqwest_middleware::Error,
+    },
+
+    #[error("OBP_CONFIG_DIR is set to {path} but no ob_config.json exists there")]
+    #[diagnostic(code(ana::ob::obp_config_dir_missing))]
+    ObpConfigDirMissing { path: PathBuf },
+
+    #[error("ob_config.json exists but missing required key: {key}")]
+    #[diagnostic(code(ana::ob::ob_config_missing_key))]
+    ObConfigMissingKey { key: String },
+}
+
+#[derive(Error, Debug, Diagnostic)]
+pub enum ServicePrincipalError {
+    #[error("Missing --name")]
+    #[diagnostic(
+        code(ana::ob::sp::missing_name),
+        help("Provide it on the command line or via --from-obproject-toml")
+    )]
+    MissingName,
+
+    #[error("Missing --deployment-domain")]
+    #[diagnostic(
+        code(ana::ob::sp::missing_domain),
+        help("Provide it on the command line or via --from-obproject-toml")
+    )]
+    MissingDeploymentDomain,
+
+    #[error("No JWT token provided")]
+    #[diagnostic(
+        code(ana::ob::sp::no_jwt),
+        help("Provide --jwt-token or use --github-actions in CI")
+    )]
+    NoJwtToken,
+
+    #[error("GitHub Actions environment not detected")]
+    #[diagnostic(
+        code(ana::ob::sp::not_gha),
+        help("Ensure ACTIONS_ID_TOKEN_REQUEST_TOKEN and ACTIONS_ID_TOKEN_REQUEST_URL are set, and 'id-token: write' permission is granted")
+    )]
+    NotGitHubActions,
+
+    #[error("Failed to fetch GitHub Actions JWT")]
+    #[diagnostic(code(ana::ob::sp::gha_jwt_failed))]
+    GitHubActionsJwtFailed {
+        #[source]
+        source: reqwest_middleware::Error,
+    },
+
+    #[error("Failed to exchange JWT for origin token")]
+    #[diagnostic(code(ana::ob::sp::origin_token_failed))]
+    OriginTokenFailed {
+        #[source]
+        source: reqwest_middleware::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_principal_error_messages() {
+        assert_eq!(
+            ServicePrincipalError::MissingName.to_string(),
+            "Missing --name"
+        );
+        assert_eq!(
+            ServicePrincipalError::MissingDeploymentDomain.to_string(),
+            "Missing --deployment-domain"
+        );
+        assert_eq!(
+            ServicePrincipalError::NoJwtToken.to_string(),
+            "No JWT token provided"
+        );
+        assert_eq!(
+            ServicePrincipalError::NotGitHubActions.to_string(),
+            "GitHub Actions environment not detected"
+        );
+    }
+
+    #[test]
+    fn test_config_error_messages() {
+        let err = ConfigError::NotFound {
+            path: PathBuf::from("/tmp/config.json"),
+        };
+        assert!(err.to_string().contains("/tmp/config.json"));
+
+        let err = ConfigError::MissingKey {
+            key: "API_KEY".to_string(),
+        };
+        assert!(err.to_string().contains("API_KEY"));
+
+        let err = ConfigError::DecodeFailed("bad input".to_string());
+        assert!(err.to_string().contains("decode"));
+    }
+}

--- a/src/outerbounds_native/mod.rs
+++ b/src/outerbounds_native/mod.rs
@@ -2,9 +2,9 @@ pub mod config;
 mod errors;
 
 pub use config::{
-    config_exists, current_profile, decode_config, default_config_dir, default_ob_config_dir,
-    encode_config, init_config, metaflow_config_path, ob_config_path, read_metaflow_config,
-    read_ob_config, write_config, ConfigType, DecodedConfig, MetaflowConfig, ObConfig,
-    ResolvedConfig,
+    ConfigType, DecodedConfig, MetaflowConfig, ObConfig, ResolvedConfig, config_exists,
+    current_profile, decode_config, default_config_dir, default_ob_config_dir, encode_config,
+    init_config, metaflow_config_path, ob_config_path, read_metaflow_config, read_ob_config,
+    write_config,
 };
 pub use errors::{ConfigError, ServicePrincipalError};

--- a/src/outerbounds_native/mod.rs
+++ b/src/outerbounds_native/mod.rs
@@ -1,0 +1,10 @@
+pub mod config;
+mod errors;
+
+pub use config::{
+    config_exists, current_profile, decode_config, default_config_dir, default_ob_config_dir,
+    encode_config, init_config, metaflow_config_path, ob_config_path, read_metaflow_config,
+    read_ob_config, write_config, ConfigType, DecodedConfig, MetaflowConfig, ObConfig,
+    ResolvedConfig,
+};
+pub use errors::{ConfigError, ServicePrincipalError};


### PR DESCRIPTION
## Summary
- Add `x_api_key_header()` helper in `http.rs` for OBP authentication pattern
- Add `obp_client()` method to `CommandContext` that returns a client with `x-api-key` auth
- Follows the `github_client()` pattern - callers build full URLs from config

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo clippy --features outerbounds-native` passes
- [x] `cargo test --features outerbounds-native` passes (335 tests)

Stacked on #149