### PR TITLE
test: Add coverage for ana org command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,12 +100,6 @@ class TestSubcommandHelp:
         assert "COMMANDS" in result.stdout
         assert "api-key" in result.stdout
 
-    def test_org_help(self, run_ana: AnaRunner) -> None:
-        result = run_ana("org", "--help")
-        assert result.returncode == 0
-        assert "Interact with anaconda.org" in result.stdout
-        assert "Usage: ana org" in result.stdout
-
 
 class TestVersion:
     """Tests for --version output."""

--- a/tests/test_org.py
+++ b/tests/test_org.py
@@ -1,0 +1,58 @@
+"""Integration tests for the 'ana org' command.
+
+ana org forwards its arguments to the anaconda-cli package's `anaconda org`
+subcommand (see src/tools/run.rs::run_tool_binary), which must be installed
+separately via `ana tool install anaconda-cli` (or `ana bootstrap`). That
+install takes real time (~1 minute, pulls ~200 packages via pixi), so the
+cases here only cover what's reachable without it: help text (clap handles
+--help itself, before any passthrough) and the "not installed" error path,
+which is the first thing every real invocation hits in the isolated test
+environment.
+"""
+
+from __future__ import annotations
+
+from helpers import AnaRunner
+
+
+class TestOrg:
+    """Tests for 'ana org' command."""
+
+    def test_org_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("org", "--help")
+        assert result.returncode == 0
+        assert "Interact with anaconda.org" in result.stdout
+        assert "Usage: ana org" in result.stdout
+
+    def test_org_short_help(self, run_ana: AnaRunner) -> None:
+        result = run_ana("org", "-h")
+        assert result.returncode == 0
+        assert "Interact with anaconda.org" in result.stdout
+
+    def test_org_fails_when_anaconda_cli_not_installed(
+        self, run_ana: AnaRunner
+    ) -> None:
+        result = run_ana("org", "whoami")
+        assert result.returncode == 1
+        assert "anaconda" in result.stderr.lower()
+        assert "not found" in result.stderr.lower()
+        assert "ana tool install anaconda-cli" in result.stderr
+
+    def test_org_no_args_fails_when_anaconda_cli_not_installed(
+        self, run_ana: AnaRunner
+    ) -> None:
+        """With no args, ana org still tries to invoke the proxied binary
+        (there's no bare-command help to fall back to)."""
+        result = run_ana("org")
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()
+
+    def test_org_forwards_hyphenated_args_without_local_parsing(
+        self, run_ana: AnaRunner
+    ) -> None:
+        """Hyphenated args (allow_hyphen_values) reach the same "not
+        installed" error rather than being misinterpreted as ana's own
+        flags."""
+        result = run_ana("org", "--token", "fake-token", "-c", "conda-forge")
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- Moves the existing `test_org_help` out of `tests/test_cli.py` into a new dedicated `tests/test_org.py`, and adds coverage for `ana org`:
  - `--help` / `-h` (both handled by clap directly, before any passthrough)
  - **Negative:** invoking a real subcommand (e.g. `ana org whoami`) when `anaconda-cli` isn't installed fails with the expected "not found... Run `ana tool install anaconda-cli` first" error and exit code 1
  - **Negative:** no-args invocation hits the same "not installed" error (no bare-command help fallback)
  - Hyphenated args (`--token`, `-c`) are forwarded without being misinterpreted as ana's own flags, per `allow_hyphen_values`
- **Known gap, not covered here:** actual passthrough execution against a real installed `anaconda-cli` (e.g. verifying `ana org whoami` genuinely forwards to and runs the real `anaconda org whoami`). I verified this manually and it works correctly, but installing `anaconda-cli` for real takes ~1 minute (pulls ~200 packages via pixi, same tool `ana bootstrap` uses), so it's left out to keep this test file fast. Happy to add a slower opt-in test class for this if the team wants it.

## Test plan
- [x] `pixi run pytest tests/test_org.py -v` — 5 passed
- [x] `pixi run cargo clippy --all-targets` — clean
- [x] `pre-commit run --files tests/test_org.py tests/test_cli.py` — all hooks pass
- [ ] CI: verify green on all 4 platforms

Note: while running the full `tests/test_cli.py` suite locally I hit an unrelated pre-existing flake in `TestSelfUpdateGitHubFallback::test_update_check_shows_status` (a real GitHub release published during testing changed the expected output). Confirmed via `git stash` that it reproduces identically on `main` and is unrelated to this diff.