### PR TITLE
ci: Specify AzureSignTool version

### DIFF
--- a/.github/actions/sign-windows/action.yaml
+++ b/.github/actions/sign-windows/action.yaml
@@ -44,10 +44,13 @@ runs:
       shell: pwsh
 
     - name: Get AzureSignTool
+      env:
+        # renovate: datasource=nuget depName=azuresigntool
+        AZURE_SIGNTOOL_VERSION: 7.0.1
       run: |
         # Get AzureSignTool
         if (-not (Get-Command AzureSignTool -ErrorAction SilentlyContinue)) {
-            dotnet tool install --global AzureSignTool
+            dotnet tool install --global AzureSignTool --version $env:AZURE_SIGNTOOL_VERSION
         }
       shell: pwsh
 

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       "matchStrings": [
         "# renovate: datasource=conda depName=(?<depName>.*?)\\n[\\w-]+ = \"==(?<currentValue>[\\d.]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update generic versions in composite actions",
+      "managerFilePatterns": [
+        "action\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+\\w+_VERSION:\\s*(?<currentValue>.*)"
+      ]
     }
   ],
   "extends": [


### PR DESCRIPTION
## Summary

Specify the version of AzureSignTool to install to improve supply chain security. NuGet does not support hash pinning as far as I know, so version pinning is as close as we can get for now.
