### PR TITLE
fix: Warn when disabling main-x leaves it enabled for the other tool

### DIFF
--- a/src/feature/main_x.rs
+++ b/src/feature/main_x.rs
@@ -406,6 +406,56 @@ pub async fn enable_main_x_pixi(ctx: &CommandContext, force: bool) -> miette::Re
     Ok(())
 }
 
+/// Best-effort check for whether main-x is currently enabled for conda.
+///
+/// Returns `false` if conda isn't installed or the check otherwise fails,
+/// since this is only used to decide whether to print an informational
+/// warning, not to drive any state-changing behavior.
+fn is_main_x_enabled_conda() -> bool {
+    find_conda()
+        .and_then(|conda_bin| get_default_channels_conda(&conda_bin))
+        .map(|channels| channels.iter().any(|c| c == MAIN_X_CHANNEL))
+        .unwrap_or(false)
+}
+
+/// Best-effort check for whether main-x is currently enabled for pixi.
+///
+/// Returns `false` if pixi isn't installed or the check otherwise fails,
+/// since this is only used to decide whether to print an informational
+/// warning, not to drive any state-changing behavior.
+fn is_main_x_enabled_pixi() -> bool {
+    find_pixi()
+        .and_then(|pixi_bin| get_configured_channels_pixi(&pixi_bin))
+        .map(|channels| channels.iter().any(|c| c == MAIN_X_CHANNEL))
+        .unwrap_or(false)
+}
+
+/// Warn if main-x is still enabled for a tool other than the one that was
+/// just acted on, so `ana feature disable main-x` (with no flag, or with
+/// the flag for the tool that was already disabled) doesn't read as "fully
+/// disabled" when it only ever touches one tool's configuration.
+fn warn_if_main_x_enabled_elsewhere(other_tool: &str, other_tool_flag: &str) {
+    let still_enabled = match other_tool {
+        "conda" => is_main_x_enabled_conda(),
+        "pixi" => is_main_x_enabled_pixi(),
+        _ => false,
+    };
+
+    if still_enabled {
+        status::blank_line();
+        status::warn(&format!(
+            "{} is still enabled for {}.",
+            status::highlight("main-x"),
+            other_tool
+        ));
+        status::info(&format!(
+            "To disable for {}, run: {}",
+            other_tool,
+            status::highlight(&format!("ana feature disable main-x {}", other_tool_flag))
+        ));
+    }
+}
+
 /// Disable main-x channel configuration for conda.
 ///
 /// This command removes the main-x channel from conda configuration.
@@ -423,9 +473,10 @@ pub async fn disable_main_x_conda(_ctx: &CommandContext, force: bool) -> miette:
 
     if actions.is_empty() {
         status::success(&format!(
-            "{} feature is not enabled",
+            "{} feature is not enabled for conda",
             status::highlight("main-x")
         ));
+        warn_if_main_x_enabled_elsewhere("pixi", "--pixi");
         return Ok(());
     }
 
@@ -453,6 +504,8 @@ pub async fn disable_main_x_conda(_ctx: &CommandContext, force: bool) -> miette:
     status::info("To re-enable, run:");
     eprintln!("  {}", status::highlight("ana feature enable main-x"));
 
+    warn_if_main_x_enabled_elsewhere("pixi", "--pixi");
+
     Ok(())
 }
 
@@ -476,6 +529,7 @@ pub async fn disable_main_x_pixi(_ctx: &CommandContext, force: bool) -> miette::
             "{} feature is not enabled for pixi",
             status::highlight("main-x")
         ));
+        warn_if_main_x_enabled_elsewhere("conda", "--conda");
         return Ok(());
     }
 
@@ -512,6 +566,8 @@ pub async fn disable_main_x_pixi(_ctx: &CommandContext, force: bool) -> miette::
         "  {}",
         status::highlight("ana feature enable main-x --pixi")
     );
+
+    warn_if_main_x_enabled_elsewhere("conda", "--conda");
 
     Ok(())
 }

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -172,6 +172,59 @@ def pixi_feature_env(
 
 
 @pytest.fixture
+def conda_and_pixi_feature_env(
+    conda_isolated_env: dict[str, str],
+    pixi_isolated_env: dict[str, str],
+    mock_auth_server: MockAuthServer,
+    keyring_path: Path,
+) -> dict[str, str]:
+    """Environment for cross-tool main-x tests: isolated conda AND pixi
+    together, so checks against one tool's config never see the other
+    tool's real, ambient (non-test) configuration on the machine running
+    the tests.
+    """
+    return {
+        **conda_isolated_env,
+        **pixi_isolated_env,
+        "ANA_DOMAIN": mock_auth_server.domain,
+        "ANA_KEYRING_PATH": str(keyring_path),
+        "ANA_OPEN_BROWSER": "false",
+        "ANA_USE_HTTPS": "false",
+    }
+
+
+@pytest.fixture
+def run_ana_conda_and_pixi_feature(
+    ana_binary: Path | None,
+    conda_and_pixi_feature_env: dict[str, str],
+) -> AnaRunner:
+    """Provide a function to run ana with isolated conda AND pixi configs."""
+    if ana_binary is None:
+        pytest.skip(
+            "ana binary not found. Build with 'pixi run build-release' or set ANA_BINARY_PATH"
+        )
+
+    def _run(
+        *args: str,
+        env: dict[str, str] | None = None,
+        input: str | None = None,
+        cwd: Path | str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        merged_env = {**conda_and_pixi_feature_env, **(env or {})}
+        return subprocess.run(
+            [str(ana_binary), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=merged_env,
+            input=input,
+            cwd=cwd,
+        )
+
+    return _run
+
+
+@pytest.fixture
 def pip_isolated_env(fake_home: Path, env_isolated: dict[str, str]) -> dict[str, str]:
     """Provide an environment with isolated pip configuration.
 
@@ -1078,6 +1131,115 @@ class TestMainXPixiDisable:
         assert MAIN_X_CHANNEL not in final_channels, "main-x should be removed"
         assert MAIN_CHANNEL in final_channels, "main channel should be preserved"
         assert "conda-forge" in final_channels, "conda-forge should be preserved"
+
+
+@requires_conda
+@requires_pixi
+class TestMainXDisableCrossToolWarning:
+    """Regression tests for CLI-621: disabling main-x for one tool (conda or
+    pixi) must warn if the other tool still has it enabled, instead of
+    reporting "not enabled" in a way that reads as fully disabled.
+    """
+
+    def test_disable_conda_warns_when_pixi_still_enabled(
+        self,
+        run_ana_conda_and_pixi_feature: AnaRunner,
+        conda_and_pixi_feature_env: dict[str, str],
+    ) -> None:
+        # Enable main-x for pixi only (conda's default_channels stays clean).
+        subprocess.run(
+            [
+                "pixi",
+                "config",
+                "prepend",
+                "--global",
+                "default-channels",
+                MAIN_X_CHANNEL,
+            ],
+            env=conda_and_pixi_feature_env,
+            check=True,
+        )
+        assert MAIN_X_CHANNEL in get_pixi_channels(conda_and_pixi_feature_env)
+        assert MAIN_X_CHANNEL not in get_default_channels(conda_and_pixi_feature_env)
+
+        # Disable via the conda-default path (no --pixi flag).
+        result = run_ana_conda_and_pixi_feature("feature", "disable", "main-x", "-f")
+        assert result.returncode == 0
+
+        assert "not enabled for conda" in result.stderr.lower()
+        assert "still enabled for pixi" in result.stderr.lower()
+        assert "--pixi" in result.stderr
+
+        # pixi's config must be untouched by the conda-only disable.
+        assert MAIN_X_CHANNEL in get_pixi_channels(conda_and_pixi_feature_env)
+
+    def test_disable_pixi_warns_when_conda_still_enabled(
+        self,
+        run_ana_conda_and_pixi_feature: AnaRunner,
+        conda_and_pixi_feature_env: dict[str, str],
+    ) -> None:
+        # Enable main-x for conda only (pixi's config stays clean).
+        condarc_path = Path(conda_and_pixi_feature_env["CONDARC"])
+        condarc_path.write_text(
+            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+        )
+        assert MAIN_X_CHANNEL in get_default_channels(conda_and_pixi_feature_env)
+        assert MAIN_X_CHANNEL not in get_pixi_channels(conda_and_pixi_feature_env)
+
+        result = run_ana_conda_and_pixi_feature(
+            "feature", "disable", "main-x", "--pixi", "-f"
+        )
+        assert result.returncode == 0
+
+        assert "not enabled for pixi" in result.stderr.lower()
+        assert "still enabled for conda" in result.stderr.lower()
+        assert "--conda" in result.stderr
+
+        # conda's config must be untouched by the pixi-only disable.
+        assert MAIN_X_CHANNEL in get_default_channels(conda_and_pixi_feature_env)
+
+    def test_disable_conda_no_warning_when_pixi_also_disabled(
+        self,
+        run_ana_conda_and_pixi_feature: AnaRunner,
+    ) -> None:
+        """No false-positive warning when neither tool has main-x enabled."""
+        result = run_ana_conda_and_pixi_feature("feature", "disable", "main-x", "-f")
+        assert result.returncode == 0
+        assert "not enabled for conda" in result.stderr.lower()
+        assert "still enabled for pixi" not in result.stderr.lower()
+
+    def test_disable_conda_still_warns_after_actually_removing_channel(
+        self,
+        run_ana_conda_and_pixi_feature: AnaRunner,
+        conda_and_pixi_feature_env: dict[str, str],
+    ) -> None:
+        """The warning fires on the "successfully disabled" path too, not
+        just the "already not enabled" early-return path."""
+        condarc_path = Path(conda_and_pixi_feature_env["CONDARC"])
+        condarc_path.write_text(
+            f"channels:\n  - defaults\ndefault_channels:\n  - {MAIN_X_CHANNEL}\n"
+        )
+        subprocess.run(
+            [
+                "pixi",
+                "config",
+                "prepend",
+                "--global",
+                "default-channels",
+                MAIN_X_CHANNEL,
+            ],
+            env=conda_and_pixi_feature_env,
+            check=True,
+        )
+
+        result = run_ana_conda_and_pixi_feature("feature", "disable", "main-x", "-f")
+        assert result.returncode == 0
+
+        # conda's channel was actually removed...
+        assert MAIN_X_CHANNEL not in get_default_channels(conda_and_pixi_feature_env)
+        # ...but pixi's was left alone, so the warning should still show.
+        assert "still enabled for pixi" in result.stderr.lower()
+        assert MAIN_X_CHANNEL in get_pixi_channels(conda_and_pixi_feature_env)
 
 
 @requires_pixi


### PR DESCRIPTION
## Summary
- Fixes a misleading message reported in CLI-621: when `main-x` was enabled for pixi via `--pixi` but disabled without any flag (defaulting to conda), the CLI printed `✓ main-x feature is not enabled` — reading as if the feature was fully disabled, when pixi's config was actually untouched.
- `disable_main_x_conda` and `disable_main_x_pixi` now each do a best-effort check of the *other* tool's main-x state after acting on their own, and print a warning with the exact follow-up command if it's still enabled there:
  ```
  ✓ main-x feature is not enabled for conda

  ! main-x is still enabled for pixi.
  To disable for pixi, run: ana feature disable main-x --pixi
  ```
- Fixed both directions (conda-default → warn about pixi, and `--pixi` → warn about conda) since they share the same root cause and the mirror case wasn't reported but would have hit the identical bug.
- The check is best-effort: if the other tool isn't installed or the check fails, no warning is printed (never blocks or errors the actual disable operation).

## Test plan
- [x] Manually reproduced the exact repro steps from CLI-621 (enable via `--pixi`, disable without flag) — confirmed pixi's config is untouched and the new warning fires with the exact expected wording
- [x] Manually verified the mirror direction, the "no warning when both clean" case, and the "warning still fires after actually disabling" case
- [x] Added `TestMainXDisableCrossToolWarning` (4 new tests) to `tests/test_feature.py` covering all of the above with isolated conda + pixi configs
- [x] `pixi run cargo test` — 283 passed
- [x] `pixi run pytest tests/test_feature.py -k MainX` — 17 passed, 8 skipped (pre-existing, gated on `ANA_TEST_API_KEY`)
- [x] `pixi run cargo clippy --all-targets` — clean
- [x] `pixi run cargo fmt --check` — clean
- [x] `pre-commit run --files src/feature/main_x.rs tests/test_feature.py` — clean

Jira: [CLI-621](https://anaconda.atlassian.net/browse/CLI-621)

[CLI-621]: https://anaconda.atlassian.net/browse/CLI-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ