### PR TITLE
feat: Add native Outerbounds Platform integration via obn subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,13 +228,14 @@ dependencies = [
  "log",
  "miette",
  "opentelemetry",
+ "outerbounds",
  "owo-colors",
  "rattler",
  "rattler_cache",
  "rattler_conda_types",
  "rattler_lock",
  "reqwest 0.13.4",
- "reqwest-middleware",
+ "reqwest-middleware 0.5.2",
  "rlimit",
  "rpassword",
  "self-replace",
@@ -249,7 +250,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "toml 1.1.3+spec-1.1.0",
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -369,6 +370,15 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -507,6 +517,516 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "sha1 0.10.7",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.2",
+ "p256",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.15",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.11.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.42",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +1051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +1067,16 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -643,6 +1179,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytestring"
@@ -764,6 +1310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1391,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -894,6 +1455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1519,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1087,11 +1670,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1134,7 +1728,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1144,7 +1740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1167,7 +1763,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1201,16 +1797,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468 0.7.0",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1263,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,6 +1920,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1938,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "serde_json",
  "uncased",
  "version_check",
 ]
@@ -1416,6 +2063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +2178,7 @@ dependencies = [
  "serde",
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1577,6 +2231,36 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "h2"
@@ -1637,6 +2321,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.4.2",
+ "httpdate",
+ "mime",
+ "sha1 0.10.7",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +2361,33 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hostname"
@@ -1697,6 +2432,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
@@ -1714,7 +2460,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1753,6 +2499,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -1761,9 +2531,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.15",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1774,17 +2544,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021e0ae20c08eadc94d0bdafdeda66d4f0858541c146ae6e46b219bfe58497e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.4.2",
+ "hyper 1.11.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
- "rustls",
+ "log",
+ "rustls 0.23.42",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.11.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1796,7 +2616,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1815,8 +2635,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body",
- "hyper",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2024,7 +2844,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2179,12 +2999,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "known-folders"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "kube"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.9",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.42",
+ "rustls-pemfile",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.4.2",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2283,6 +3194,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +3236,12 @@ dependencies = [
  "cfg-if",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2484,7 +3416,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2492,6 +3424,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2852,6 +3793,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "outerbounds"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-sdk-secretsmanager",
+ "aws-sdk-sts",
+ "base64 0.22.1",
+ "chrono",
+ "dirs",
+ "figment",
+ "flate2",
+ "hex",
+ "http 1.4.2",
+ "k8s-openapi",
+ "kube",
+ "libc",
+ "md5",
+ "miette",
+ "reqwest 0.12.28",
+ "reqwest-middleware 0.4.2",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
+ "tar",
+ "thiserror 2.0.19",
+ "tokio",
+ "toml 0.8.23",
+ "walkdir",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +3842,18 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.2",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2929,6 +3924,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3993,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +4059,22 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3060,6 +4132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3154,6 +4235,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.42",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.42",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.5",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,6 +4344,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -3219,6 +4365,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3693,12 +4848,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.15",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.11.0",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -3707,6 +4862,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3714,6 +4871,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -3721,6 +4879,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3734,12 +4893,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.15",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.11.0",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -3768,6 +4927,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.2",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-middleware"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
@@ -3788,6 +4962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
  "rand 0.10.2",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3875,7 +5059,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -3884,11 +5080,35 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3897,7 +5117,18 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3906,6 +5137,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3982,6 +5214,30 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -4247,6 +5503,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4312,6 +5577,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,6 +5653,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4446,6 +5743,22 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -4626,7 +5939,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4636,7 +5949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4794,11 +6107,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.42",
  "tokio",
 ]
 
@@ -4831,13 +6154,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -4852,11 +6187,20 @@ checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4875,6 +6219,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4900,6 +6258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4915,7 +6279,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project",
@@ -4948,8 +6312,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4959,19 +6325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
+ "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -5090,6 +6459,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5195,7 +6570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der",
+ "der 0.8.1",
  "log",
  "native-tls",
  "percent-encoding",
@@ -5305,6 +6680,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -5463,6 +6844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,7 +6883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5738,6 +7128,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -5760,7 +7153,7 @@ dependencies = [
  "futures",
  "http 1.4.2",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -5792,6 +7185,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ rlimit = "0.11"
 [features]
 # Diagnostics (Sentry) is opt-in. Enable with `cargo build --features diagnostics`.
 # Unstable features are hidden and disabled by default.
+# OBP (Outerbounds Platform) enables native Rust implementations of outerbounds commands.
 default = []
 diagnostics = ["dep:sentry"]
 unstable = []
+obp = ["dep:outerbounds"]
 
 [dependencies]
 anaconda-anon-usage = { version = "0.8.0-pre.9", features = ["rattler", "reqwest"] }
@@ -54,6 +56,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 opentelemetry = "0.31.0"
 owo-colors = { version = "4", features = ["supports-colors"] }
 url = "2.5.8"
+outerbounds = { path = "../ob-cli-lib", features = ["aws", "kubernetes"], optional = true }
 
 [dev-dependencies]
 temp-env = "0.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,8 @@ use crate::fetch::api_fetch;
 use crate::help;
 use crate::installer;
 use crate::mcp::{self, McpAction, McpCommands};
+#[cfg(feature = "obp")]
+use crate::native_outerbounds::{ObnAction, ObnCommands};
 #[cfg(unix)]
 use crate::outerbounds::{self, ObAction, ObCommands};
 use crate::tools;
@@ -165,6 +167,8 @@ pub enum Action {
     ObAutoConfigure {
         instance: String,
     },
+    #[cfg(feature = "obp")]
+    Obn(ObnAction),
     McpRun {
         args: Vec<String>,
     },
@@ -233,6 +237,8 @@ impl Action {
             Action::ObProxy { .. } => "ob",
             #[cfg(unix)]
             Action::ObAutoConfigure { .. } => "ob.configure.auto",
+            #[cfg(feature = "obp")]
+            Action::Obn(_) => "obn",
             Action::McpRun { .. } => "mcp",
             Action::UserAgent { .. } => "user-agent",
             Action::OpenFeedback => "feedback",
@@ -326,6 +332,8 @@ impl Action {
             Action::ObAutoConfigure { instance } => {
                 outerbounds::auto_configure(ctx, &instance).await
             }
+            #[cfg(feature = "obp")]
+            Action::Obn(action) => crate::native_outerbounds::run(ctx, action).await,
             Action::ToolInstall { name } => {
                 tools::install::install_tool(ctx, &name).await?;
                 Ok(())
@@ -679,6 +687,11 @@ pub fn parse() -> (Action, LogLevel) {
                 },
             }
         }
+        #[cfg(feature = "obp")]
+        Some(Commands::Obn { command }) => match command {
+            None => Action::ShowSubcommandHelp("obn".to_string()),
+            Some(cmd) => Action::Obn(cmd.into_action()),
+        },
         Some(Commands::Tool { command }) => match command {
             None => Action::ShowSubcommandHelp("tool".to_string()),
             Some(ToolCommands::Install { name }) => Action::ToolInstall { name },
@@ -969,6 +982,18 @@ enum Commands {
     Ob {
         #[command(subcommand)]
         command: Option<ObCommands>,
+    },
+
+    /// Outerbounds platform CLI (native Rust implementation)
+    #[cfg(feature = "obp")]
+    #[command(
+        subcommand_required = false,
+        arg_required_else_help = false,
+        override_usage = "ana obn <command> [options]"
+    )]
+    Obn {
+        #[command(subcommand)]
+        command: Option<ObnCommands>,
     },
 
     /// Manage tools

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -168,7 +168,11 @@ pub enum Action {
         instance: String,
     },
     #[cfg(feature = "obp")]
-    Obn(ObnAction),
+    Obn {
+        action: ObnAction,
+        config_dir: String,
+        profile: Option<String>,
+    },
     McpRun {
         args: Vec<String>,
     },
@@ -238,7 +242,7 @@ impl Action {
             #[cfg(unix)]
             Action::ObAutoConfigure { .. } => "ob.configure.auto",
             #[cfg(feature = "obp")]
-            Action::Obn(_) => "obn",
+            Action::Obn { .. } => "obn",
             Action::McpRun { .. } => "mcp",
             Action::UserAgent { .. } => "user-agent",
             Action::OpenFeedback => "feedback",
@@ -333,7 +337,11 @@ impl Action {
                 outerbounds::auto_configure(ctx, &instance).await
             }
             #[cfg(feature = "obp")]
-            Action::Obn(action) => crate::native_outerbounds::run(ctx, action).await,
+            Action::Obn {
+                action,
+                config_dir,
+                profile,
+            } => crate::native_outerbounds::run(ctx, action, &config_dir, profile.as_deref()).await,
             Action::ToolInstall { name } => {
                 tools::install::install_tool(ctx, &name).await?;
                 Ok(())
@@ -688,9 +696,17 @@ pub fn parse() -> (Action, LogLevel) {
             }
         }
         #[cfg(feature = "obp")]
-        Some(Commands::Obn { command }) => match command {
+        Some(Commands::Obn {
+            config_dir,
+            profile,
+            command,
+        }) => match command {
             None => Action::ShowSubcommandHelp("obn".to_string()),
-            Some(cmd) => Action::Obn(cmd.into_action()),
+            Some(cmd) => Action::Obn {
+                action: cmd.into_action(),
+                config_dir,
+                profile,
+            },
         },
         Some(Commands::Tool { command }) => match command {
             None => Action::ShowSubcommandHelp("tool".to_string()),
@@ -1008,9 +1024,17 @@ enum Commands {
     #[command(
         subcommand_required = false,
         arg_required_else_help = false,
-        override_usage = "ana obn <command> [options]"
+        override_usage = "ana obn [OPTIONS] <command> [options]"
     )]
     Obn {
+        /// Path to Metaflow configuration directory
+        #[arg(long, short = 'd', default_value = "~/.metaflowconfig", global = true)]
+        config_dir: String,
+
+        /// Configure a named profile. Activate by setting METAFLOW_PROFILE env var
+        #[arg(long, short = 'p', global = true)]
+        profile: Option<String>,
+
         #[command(subcommand)]
         command: Option<ObnCommands>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -784,6 +784,25 @@ fn handle_parse_error(e: clap::Error) -> (Action, LogLevel) {
         return (Action::ShowVersion, LogLevel::Off);
     }
 
+    // If user passed --help/-h but clap errored on missing required args,
+    // show help instead of the error
+    if e.kind() == clap::error::ErrorKind::MissingRequiredArgument {
+        let args: Vec<String> = std::env::args().collect();
+        if args.iter().any(|a| a == "--help" || a == "-h") {
+            // Extract subcommand path from args (skip binary name and flags)
+            let path: Vec<&str> = args
+                .iter()
+                .skip(1)
+                .filter(|a| !a.starts_with('-'))
+                .map(|s| s.as_str())
+                .collect();
+            if path.is_empty() {
+                return (Action::ShowHelp, LogLevel::Off);
+            }
+            return (Action::ShowSubcommandHelp(path.join(" ")), LogLevel::Off);
+        }
+    }
+
     print_clap_error(&e);
     std::process::exit(2);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,8 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use opentelemetry::Value;
+#[cfg(feature = "obp")]
+use tokio::sync::OnceCell;
 
 use crate::VERSION;
 use crate::config::Config;
@@ -101,6 +103,9 @@ pub struct CommandContext {
     download_client: OnceLock<reqwest_middleware::ClientWithMiddleware>,
     /// Unauthenticated client (lazy initialized).
     unauthenticated_client: OnceLock<Client>,
+    /// Outerbounds client (lazy initialized, async).
+    #[cfg(feature = "obp")]
+    outerbounds_client: OnceCell<outerbounds::Outerbounds>,
 }
 
 impl CommandContext {
@@ -129,6 +134,8 @@ impl CommandContext {
             github_client: OnceLock::new(),
             download_client: OnceLock::new(),
             unauthenticated_client: OnceLock::new(),
+            #[cfg(feature = "obp")]
+            outerbounds_client: OnceCell::const_new(),
         }
     }
 
@@ -171,6 +178,18 @@ impl CommandContext {
             .expect("failed to create unauthenticated client")
         })
     }
+
+    /// Get or create the Outerbounds client (async initialization).
+    #[cfg(feature = "obp")]
+    pub async fn outerbounds_client(&self) -> miette::Result<&outerbounds::Outerbounds> {
+        self.outerbounds_client
+            .get_or_try_init(|| async {
+                outerbounds::Outerbounds::new(None, None)
+                    .await
+                    .map_err(|e| miette::miette!("Failed to initialize Outerbounds client: {}", e))
+            })
+            .await
+    }
 }
 
 impl Default for CommandContext {
@@ -193,6 +212,8 @@ impl CommandContext {
             github_client: OnceLock::new(),
             download_client: OnceLock::new(),
             unauthenticated_client: OnceLock::new(),
+            #[cfg(feature = "obp")]
+            outerbounds_client: OnceCell::const_new(),
         }
     }
 }

--- a/src/help/data.rs
+++ b/src/help/data.rs
@@ -21,7 +21,7 @@ pub(super) const HELP_SECTIONS: &[HelpSection] = &[
             "tool",
             // Hiding bootstrap, as it's synonymous to `ana tool install anaconda-cli`
             // "bootstrap",
-            "feature", "api", "mcp", "ob",
+            "feature", "api", "mcp", "ob", "obn",
             // TODO(mattkram): Hiding config from help until we fully implement CRUD
             // "config",
             "self",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod http;
 mod input;
 mod installer;
 mod mcp;
+#[cfg(feature = "obp")]
+mod native_outerbounds;
 #[cfg(unix)]
 mod outerbounds;
 mod paths;

--- a/src/native_outerbounds/app.rs
+++ b/src/native_outerbounds/app.rs
@@ -1,5 +1,5 @@
-use miette::{Result, miette};
-use outerbounds::CapsuleFilters;
+use miette::{miette, Result};
+use outerbounds::{CapsuleFilters, Tag};
 
 use crate::context::CommandContext;
 use crate::ui::status;
@@ -28,21 +28,52 @@ async fn get_api_context(ctx: &CommandContext) -> Result<(String, String)> {
     Ok((api_url, perimeter))
 }
 
+fn parse_tags(tags: &[String]) -> Vec<Tag> {
+    tags.iter()
+        .filter_map(|t| {
+            let parts: Vec<&str> = t.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                Some(Tag {
+                    key: parts[0].to_string(),
+                    value: parts[1].to_string(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn list(
     ctx: &CommandContext,
-    perimeter_override: Option<&str>,
-    name_filter: Option<&str>,
+    project: Option<&str>,
+    branch: Option<&str>,
+    name: Option<&str>,
+    tags: &[String],
+    format: Option<&str>,
+    auth_type: Option<&str>,
 ) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
-    let (api_url, default_perimeter) = get_api_context(ctx).await?;
-    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+    let (api_url, perimeter) = get_api_context(ctx).await?;
 
     let filters = CapsuleFilters {
-        name: name_filter.map(|s| s.to_string()),
-        ..Default::default()
+        project: project.map(|s| s.to_string()),
+        branch: branch.map(|s| s.to_string()),
+        name: name.map(|s| s.to_string()),
+        id: None,
+        auth_type: auth_type.map(|s| s.to_string()),
+        tags: parse_tags(tags),
     };
 
-    let capsules = ob.app().list(&api_url, perimeter, filters).await?;
+    let capsules = ob.app().list(&api_url, &perimeter, filters).await?;
+
+    if format == Some("json") {
+        let json = serde_json::to_string_pretty(&capsules)
+            .map_err(|e| miette!("Failed to serialize: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
 
     if capsules.is_empty() {
         println!("No apps found");
@@ -77,12 +108,19 @@ pub async fn list(
     Ok(())
 }
 
-pub async fn info(ctx: &CommandContext, id: &str, perimeter_override: Option<&str>) -> Result<()> {
+pub async fn info(ctx: &CommandContext, id: &str, format: Option<&str>) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
-    let (api_url, default_perimeter) = get_api_context(ctx).await?;
-    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+    let (api_url, perimeter) = get_api_context(ctx).await?;
 
-    let app_info = ob.app().info(&api_url, perimeter, id).await?;
+    let app_info = ob.app().info(&api_url, &perimeter, id).await?;
+
+    if format == Some("json") {
+        let json = serde_json::to_string_pretty(&app_info)
+            .map_err(|e| miette!("Failed to serialize: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
+
     let capsule = &app_info.capsule;
 
     println!("App ID: {}", capsule.id);
@@ -143,16 +181,11 @@ pub async fn info(ctx: &CommandContext, id: &str, perimeter_override: Option<&st
     Ok(())
 }
 
-pub async fn delete(
-    ctx: &CommandContext,
-    ids: &[String],
-    perimeter_override: Option<&str>,
-) -> Result<()> {
+pub async fn delete(ctx: &CommandContext, ids: &[String]) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
-    let (api_url, default_perimeter) = get_api_context(ctx).await?;
-    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+    let (api_url, perimeter) = get_api_context(ctx).await?;
 
-    let results = ob.app().delete(&api_url, perimeter, ids).await?;
+    let results = ob.app().delete(&api_url, &perimeter, ids).await?;
 
     for result in &results {
         if result.success {
@@ -170,18 +203,16 @@ pub async fn logs(
     ctx: &CommandContext,
     id: &str,
     worker_id: Option<&str>,
-    perimeter_override: Option<&str>,
     previous: bool,
 ) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
-    let (api_url, default_perimeter) = get_api_context(ctx).await?;
-    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+    let (api_url, perimeter) = get_api_context(ctx).await?;
 
     // If no worker_id provided, get the first worker
     let worker = match worker_id {
         Some(w) => w.to_string(),
         None => {
-            let app_info = ob.app().info(&api_url, perimeter, id).await?;
+            let app_info = ob.app().info(&api_url, &perimeter, id).await?;
             app_info
                 .workers
                 .first()
@@ -192,7 +223,7 @@ pub async fn logs(
 
     let logs = ob
         .app()
-        .logs(&api_url, perimeter, id, &worker, previous)
+        .logs(&api_url, &perimeter, id, &worker, previous)
         .await?;
 
     for log_line in &logs {

--- a/src/native_outerbounds/app.rs
+++ b/src/native_outerbounds/app.rs
@@ -1,4 +1,4 @@
-use miette::{miette, Result};
+use miette::{Result, miette};
 use outerbounds::CapsuleFilters;
 
 use crate::context::CommandContext;
@@ -20,11 +20,10 @@ async fn get_api_context(ctx: &CommandContext) -> Result<(String, String)> {
         .ok_or_else(|| miette!("OBP_API_SERVER not found in config"))?
         .clone();
 
-    let perimeter = ob
-        .perimeter()
-        .show_current()
-        .await?
-        .ok_or_else(|| miette!("No perimeter set. Run 'ana obn perimeter switch <id>' first."))?;
+    let perimeter =
+        ob.perimeter().show_current().await?.ok_or_else(|| {
+            miette!("No perimeter set. Run 'ana obn perimeter switch <id>' first.")
+        })?;
 
     Ok((api_url, perimeter))
 }
@@ -57,7 +56,13 @@ pub async fn list(
         let ready = capsule
             .status
             .as_ref()
-            .map(|s| if s.ready_to_serve_traffic { "Yes" } else { "No" })
+            .map(|s| {
+                if s.ready_to_serve_traffic {
+                    "Yes"
+                } else {
+                    "No"
+                }
+            })
             .unwrap_or("unknown");
         let created = capsule
             .metadata

--- a/src/native_outerbounds/app.rs
+++ b/src/native_outerbounds/app.rs
@@ -1,4 +1,4 @@
-use miette::{miette, Result};
+use miette::{Result, miette};
 use outerbounds::{CapsuleFilters, Tag};
 
 use crate::context::CommandContext;

--- a/src/native_outerbounds/app.rs
+++ b/src/native_outerbounds/app.rs
@@ -1,0 +1,200 @@
+use miette::{miette, Result};
+use outerbounds::CapsuleFilters;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+use super::output::{create_table, print_table};
+
+/// Helper to get api_url and perimeter from config
+async fn get_api_context(ctx: &CommandContext) -> Result<(String, String)> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let config = ob
+        .config()
+        .ok_or_else(|| miette!("Config not loaded. Run 'ana obn configure' first."))?;
+
+    let api_url = config
+        .obp_api_server
+        .as_ref()
+        .ok_or_else(|| miette!("OBP_API_SERVER not found in config"))?
+        .clone();
+
+    let perimeter = ob
+        .perimeter()
+        .show_current()
+        .await?
+        .ok_or_else(|| miette!("No perimeter set. Run 'ana obn perimeter switch <id>' first."))?;
+
+    Ok((api_url, perimeter))
+}
+
+pub async fn list(
+    ctx: &CommandContext,
+    perimeter_override: Option<&str>,
+    name_filter: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let (api_url, default_perimeter) = get_api_context(ctx).await?;
+    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+
+    let filters = CapsuleFilters {
+        name: name_filter.map(|s| s.to_string()),
+        ..Default::default()
+    };
+
+    let capsules = ob.app().list(&api_url, perimeter, filters).await?;
+
+    if capsules.is_empty() {
+        println!("No apps found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["ID", "Name", "Ready", "Created"]);
+
+    for capsule in &capsules {
+        let name = capsule.spec.display_name.as_deref().unwrap_or("-");
+        let ready = capsule
+            .status
+            .as_ref()
+            .map(|s| if s.ready_to_serve_traffic { "Yes" } else { "No" })
+            .unwrap_or("unknown");
+        let created = capsule
+            .metadata
+            .as_ref()
+            .and_then(|m| m.created_at.as_deref())
+            .unwrap_or("-");
+
+        table.add_row(vec![&capsule.id, name, ready, created]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn info(ctx: &CommandContext, id: &str, perimeter_override: Option<&str>) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let (api_url, default_perimeter) = get_api_context(ctx).await?;
+    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+
+    let app_info = ob.app().info(&api_url, perimeter, id).await?;
+    let capsule = &app_info.capsule;
+
+    println!("App ID: {}", capsule.id);
+
+    if let Some(ref name) = capsule.spec.display_name {
+        println!("Name: {}", name);
+    }
+
+    if let Some(ref status_info) = capsule.status {
+        let ready_str = if status_info.ready_to_serve_traffic {
+            "Ready"
+        } else {
+            "Not Ready"
+        };
+        println!("Status: {}", ready_str);
+
+        if status_info.update_in_progress {
+            println!("Update in progress: Yes");
+        }
+
+        if let Some(ref version) = status_info.currently_served_version {
+            println!("Current version: {}", version);
+        }
+
+        if let Some(replicas) = status_info.available_replicas {
+            println!("Available replicas: {}", replicas);
+        }
+
+        if let Some(ref access) = status_info.access_info
+            && let Some(ref url) = access.out_of_cluster_url
+        {
+            println!("URL: {}", url);
+        }
+    }
+
+    if let Some(ref metadata) = capsule.metadata {
+        if let Some(ref created) = metadata.created_at {
+            println!("Created: {}", created);
+        }
+        if let Some(ref modified) = metadata.last_modified_at {
+            println!("Last modified: {}", modified);
+        }
+    }
+
+    // Print workers
+    if !app_info.workers.is_empty() {
+        println!("\nWorkers:");
+        let mut table = create_table(&["ID", "Phase", "Version"]);
+        for worker in &app_info.workers {
+            let worker_id = worker.worker_id.as_deref().unwrap_or("-");
+            let phase = worker.phase.as_deref().unwrap_or("-");
+            let version = worker.version.as_deref().unwrap_or("-");
+            table.add_row(vec![worker_id, phase, version]);
+        }
+        print_table(table);
+    }
+
+    Ok(())
+}
+
+pub async fn delete(
+    ctx: &CommandContext,
+    ids: &[String],
+    perimeter_override: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let (api_url, default_perimeter) = get_api_context(ctx).await?;
+    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+
+    let results = ob.app().delete(&api_url, perimeter, ids).await?;
+
+    for result in &results {
+        if result.success {
+            status::success(&format!("Deleted app: {}", result.id));
+        } else {
+            let err = result.error.as_deref().unwrap_or("Unknown error");
+            status::warn(&format!("Failed to delete {}: {}", result.id, err));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn logs(
+    ctx: &CommandContext,
+    id: &str,
+    worker_id: Option<&str>,
+    perimeter_override: Option<&str>,
+    previous: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let (api_url, default_perimeter) = get_api_context(ctx).await?;
+    let perimeter = perimeter_override.unwrap_or(&default_perimeter);
+
+    // If no worker_id provided, get the first worker
+    let worker = match worker_id {
+        Some(w) => w.to_string(),
+        None => {
+            let app_info = ob.app().info(&api_url, perimeter, id).await?;
+            app_info
+                .workers
+                .first()
+                .and_then(|w| w.worker_id.clone())
+                .ok_or_else(|| miette!("No workers found for app {}", id))?
+        }
+    };
+
+    let logs = ob
+        .app()
+        .logs(&api_url, perimeter, id, &worker, previous)
+        .await?;
+
+    for log_line in &logs {
+        if let Some(ref msg) = log_line.message {
+            println!("{}", msg);
+        }
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/check.rs
+++ b/src/native_outerbounds/check.rs
@@ -6,22 +6,33 @@ use crate::ui::status;
 
 pub async fn check(
     ctx: &CommandContext,
+    no_config: bool,
+    output: Option<&str>,
     workstation: bool,
-    python: bool,
     latency: bool,
+    latency_requests: u32,
+    latency_timeout: f64,
 ) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
 
     let opts = CheckOptions {
-        no_config: false,
+        no_config,
         workstation,
-        python,
+        python: false, // Python checks are handled differently in the Python CLI
         latency,
-        latency_requests: 10,
-        latency_timeout: 10.0,
+        latency_requests,
+        latency_timeout,
     };
 
     let response = ob.check().check(opts).await?;
+
+    // Handle JSON output format
+    if output == Some("json") {
+        let json = serde_json::to_string_pretty(&response)
+            .map_err(|e| miette::miette!("Failed to serialize response: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
 
     for result in &response.data.steps {
         let icon = match result.status {
@@ -33,7 +44,7 @@ pub async fn check(
         println!("{} {}: {}", icon, result.name, result.message);
 
         if !result.help.is_empty() {
-            println!("    Help: {}", result.help);
+            tracing::debug!("Help: {}", result.help);
         }
     }
 
@@ -55,7 +66,7 @@ pub async fn check(
                 println!("no successful requests");
             }
             for err in &lat.errors {
-                println!("    Error: {}", err);
+                tracing::debug!("Error: {}", err);
             }
         }
     }

--- a/src/native_outerbounds/check.rs
+++ b/src/native_outerbounds/check.rs
@@ -1,0 +1,79 @@
+use miette::Result;
+use outerbounds::{CheckOptions, CheckStatus};
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+pub async fn check(
+    ctx: &CommandContext,
+    workstation: bool,
+    python: bool,
+    latency: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let opts = CheckOptions {
+        no_config: false,
+        workstation,
+        python,
+        latency,
+        latency_requests: 10,
+        latency_timeout: 10.0,
+    };
+
+    let response = ob.check().check(opts).await?;
+
+    for result in &response.data.steps {
+        let icon = match result.status {
+            CheckStatus::Ok => "✓",
+            CheckStatus::Fail => "✗",
+            CheckStatus::Warn => "⚠",
+        };
+
+        println!("{} {}: {}", icon, result.name, result.message);
+
+        if !result.help.is_empty() {
+            println!("    Help: {}", result.help);
+        }
+    }
+
+    // Print latency results if available
+    if !response.latency.is_empty() {
+        println!("\nLatency results:");
+        for lat in &response.latency {
+            print!("  {}: ", lat.endpoint);
+            if let (Some(min), Some(max), Some(avg)) = (lat.min_ms, lat.max_ms, lat.avg_ms) {
+                println!(
+                    "min={:.1}ms, max={:.1}ms, avg={:.1}ms ({}/{} succeeded)",
+                    min,
+                    max,
+                    avg,
+                    lat.success_count,
+                    lat.success_count + lat.error_count
+                );
+            } else {
+                println!("no successful requests");
+            }
+            for err in &lat.errors {
+                println!("    Error: {}", err);
+            }
+        }
+    }
+
+    match response.status {
+        CheckStatus::Ok => {
+            status::blank_line();
+            status::success("All checks passed!");
+        }
+        CheckStatus::Warn => {
+            status::blank_line();
+            status::warn("Some checks have warnings");
+        }
+        CheckStatus::Fail => {
+            status::blank_line();
+            status::warn("Some checks failed");
+        }
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/commands.rs
+++ b/src/native_outerbounds/commands.rs
@@ -7,8 +7,6 @@ pub enum ObnAction {
     // Configure
     Configure {
         encoded_config: String,
-        config_dir: String,
-        profile: Option<String>,
         echo: bool,
         force: bool,
     },
@@ -18,8 +16,6 @@ pub enum ObnAction {
         perimeter: Option<String>,
         jwt_token: Option<String>,
         github_actions: bool,
-        config_dir: String,
-        profile: Option<String>,
         echo: bool,
         force: bool,
     },
@@ -38,8 +34,6 @@ pub enum ObnAction {
     PerimeterList,
     PerimeterShowCurrent,
     PerimeterSwitch {
-        config_dir: String,
-        profile: Option<String>,
         output: Option<String>,
         id: Option<String>,
         force: bool,
@@ -159,14 +153,6 @@ pub enum ObnCommands {
         /// Base64-encoded configuration string
         encoded_config: String,
 
-        /// Path to Metaflow configuration directory
-        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
-        config_dir: String,
-
-        /// Configure a named profile. Activate the profile by setting METAFLOW_PROFILE environment variable
-        #[arg(long, short = 'p')]
-        profile: Option<String>,
-
         /// Print decoded configuration to stdout
         #[arg(long, short = 'e')]
         echo: bool,
@@ -188,7 +174,7 @@ pub enum ObnCommands {
         deployment_domain: Option<String>,
 
         /// The name of the perimeter to authenticate the service principal in
-        #[arg(long, short = 'p')]
+        #[arg(long)]
         perimeter: Option<String>,
 
         /// The JWT token that will be used to authenticate against the OBP Auth Server
@@ -198,14 +184,6 @@ pub enum ObnCommands {
         /// Set if the command is being run in a GitHub Actions environment
         #[arg(long)]
         github_actions: bool,
-
-        /// Path to Metaflow configuration directory
-        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
-        config_dir: String,
-
-        /// Configure a named profile. Activate the profile by setting METAFLOW_PROFILE environment variable
-        #[arg(long)]
-        profile: Option<String>,
 
         /// Print decoded configuration to stdout
         #[arg(long, short = 'e')]
@@ -304,14 +282,6 @@ pub enum PerimeterCommands {
 
     /// Switch current perimeter
     Switch {
-        /// Path to Metaflow configuration directory
-        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
-        config_dir: String,
-
-        /// The named metaflow profile in which your workstation exists
-        #[arg(long, short = 'p')]
-        profile: Option<String>,
-
         /// Show output in the specified format
         #[arg(long, short = 'o')]
         output: Option<String>,
@@ -528,7 +498,7 @@ pub enum TutorialsCommands {
         url: String,
 
         /// Destination directory (defaults to current directory)
-        #[arg(long, short = 'd')]
+        #[arg(long)]
         destination: Option<String>,
 
         /// Expected SHA256 hash for verification
@@ -610,14 +580,10 @@ impl ObnCommands {
         match self {
             ObnCommands::Configure {
                 encoded_config,
-                config_dir,
-                profile,
                 echo,
                 force,
             } => ObnAction::Configure {
                 encoded_config,
-                config_dir,
-                profile,
                 echo,
                 force,
             },
@@ -627,8 +593,6 @@ impl ObnCommands {
                 perimeter,
                 jwt_token,
                 github_actions,
-                config_dir,
-                profile,
                 echo,
                 force,
             } => ObnAction::ServicePrincipalConfigure {
@@ -637,8 +601,6 @@ impl ObnCommands {
                 perimeter,
                 jwt_token,
                 github_actions,
-                config_dir,
-                profile,
                 echo,
                 force,
             },

--- a/src/native_outerbounds/commands.rs
+++ b/src/native_outerbounds/commands.rs
@@ -1,0 +1,721 @@
+use clap::Subcommand;
+
+#[derive(Debug)]
+pub enum ObnAction {
+    ShowHelp(String),
+
+    // Configure
+    Configure {
+        encoded_config: String,
+        echo: bool,
+        force: bool,
+    },
+    ServicePrincipalConfigure {
+        name: Option<String>,
+        deployment_domain: Option<String>,
+        perimeter: Option<String>,
+        jwt_token: Option<String>,
+        github_actions: bool,
+        echo: bool,
+        force: bool,
+    },
+
+    // Check
+    Check {
+        workstation: bool,
+        python: bool,
+        latency: bool,
+    },
+
+    // Perimeter
+    PerimeterList,
+    PerimeterShowCurrent,
+    PerimeterSwitch {
+        perimeter_id: String,
+        force: bool,
+    },
+
+    // App
+    AppList {
+        perimeter: Option<String>,
+        name: Option<String>,
+    },
+    AppInfo {
+        id: String,
+        perimeter: Option<String>,
+    },
+    AppDelete {
+        ids: Vec<String>,
+        perimeter: Option<String>,
+    },
+    AppLogs {
+        id: String,
+        worker_id: Option<String>,
+        perimeter: Option<String>,
+        previous: bool,
+    },
+
+    // Integrations
+    IntegrationsList {
+        perimeter: Option<String>,
+    },
+    IntegrationsGet {
+        name: String,
+        perimeter: Option<String>,
+    },
+    IntegrationsDelete {
+        name: String,
+        perimeter: Option<String>,
+    },
+    IntegrationsListPrivatePypi {
+        perimeter: Option<String>,
+    },
+    IntegrationsListPrivateConda {
+        perimeter: Option<String>,
+    },
+
+    // FlowProject
+    FlowprojectGetMetadata {
+        project: String,
+        branch: String,
+    },
+    FlowprojectDeleteMetadata {
+        project: String,
+        branch: String,
+    },
+    FlowprojectListTemplates {
+        project: String,
+        branch: String,
+    },
+    FlowprojectTeardownBranch {
+        project: String,
+        branch: String,
+        dry_run: bool,
+    },
+
+    // Secrets
+    SecretsGetMetadata {
+        integration_name: String,
+    },
+    SecretsGet {
+        integration_name: String,
+        json: bool,
+    },
+    SecretsGetMany {
+        integration_names: Vec<String>,
+        json: bool,
+    },
+
+    // Tutorials
+    TutorialsPull {
+        url: String,
+        destination: Option<String>,
+        verify_hash: Option<String>,
+        force: bool,
+    },
+
+    // Workstations
+    WorkstationsList,
+    WorkstationsHibernate {
+        workstation_id: String,
+    },
+    WorkstationsRestart {
+        workstation_id: String,
+    },
+    WorkstationsGenerateToken,
+    WorkstationsGetNamespace {
+        workstation_id: String,
+    },
+    WorkstationsGetLinks,
+    WorkstationsConfigureKubeconfig {
+        binary_path: Option<String>,
+        kubeconfig_path: Option<String>,
+    },
+    WorkstationsPrepareSsh {
+        workstation_id: String,
+    },
+    WorkstationsInstallKubectl {
+        install_dir: Option<String>,
+        version: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ObnCommands {
+    /// Decode and save Outerbounds Platform configuration
+    Configure {
+        /// Base64-encoded configuration string
+        encoded_config: String,
+
+        /// Print decoded configuration to stdout
+        #[arg(long, short = 'e')]
+        echo: bool,
+
+        /// Overwrite existing configuration without confirmation
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
+
+    /// Authenticate service principals using JWT (for CI/CD)
+    #[command(name = "service-principal-configure")]
+    ServicePrincipalConfigure {
+        /// Name of the service principal
+        #[arg(long, short = 'n')]
+        name: Option<String>,
+
+        /// Full domain of the target OBP deployment (e.g., 'foo.obp.outerbounds.com')
+        #[arg(long)]
+        deployment_domain: Option<String>,
+
+        /// Perimeter to authenticate in (defaults to 'default')
+        #[arg(long, short = 'p')]
+        perimeter: Option<String>,
+
+        /// JWT token for authentication
+        #[arg(long, short = 't')]
+        jwt_token: Option<String>,
+
+        /// Use GitHub Actions OIDC to get JWT token
+        #[arg(long)]
+        github_actions: bool,
+
+        /// Print configuration to stdout
+        #[arg(long, short = 'e')]
+        echo: bool,
+
+        /// Overwrite existing configuration without confirmation
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
+
+    /// Check packages and configuration for compatibility
+    Check {
+        /// Include workstation-specific checks
+        #[arg(long)]
+        workstation: bool,
+
+        /// Include Python package checks
+        #[arg(long)]
+        python: bool,
+
+        /// Run latency checks
+        #[arg(long)]
+        latency: bool,
+    },
+
+    /// Manage perimeters
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Perimeter {
+        #[command(subcommand)]
+        command: Option<PerimeterCommands>,
+    },
+
+    /// Commands for managing deployed apps
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    App {
+        #[command(subcommand)]
+        command: Option<AppCommands>,
+    },
+
+    /// Manage resource integrations
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Integrations {
+        #[command(subcommand)]
+        command: Option<IntegrationsCommands>,
+    },
+
+    /// Commands for pushing Deployments metadata
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Flowproject {
+        #[command(subcommand)]
+        command: Option<FlowprojectCommands>,
+    },
+
+    /// Fetch secrets from cloud secret managers
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Secrets {
+        #[command(subcommand)]
+        command: Option<SecretsCommands>,
+    },
+
+    /// Download tutorial content
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Tutorials {
+        #[command(subcommand)]
+        command: Option<TutorialsCommands>,
+    },
+
+    /// Manage cloud workstations
+    #[command(subcommand_required = false, arg_required_else_help = false)]
+    Workstations {
+        #[command(subcommand)]
+        command: Option<WorkstationsCommands>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PerimeterCommands {
+    /// List all available perimeters
+    List,
+
+    /// Show the currently active perimeter
+    #[command(name = "show-current")]
+    ShowCurrent,
+
+    /// Switch to a different perimeter
+    Switch {
+        /// Perimeter ID to switch to
+        perimeter_id: String,
+
+        /// Force switch without confirmation
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AppCommands {
+    /// List apps in the Outerbounds Platform
+    List {
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+
+        /// Filter by app name
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Get detailed information about an app
+    Info {
+        /// App ID
+        id: String,
+
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// Delete one or more apps
+    Delete {
+        /// App IDs to delete
+        #[arg(required = true)]
+        ids: Vec<String>,
+
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// Get logs for an app worker
+    Logs {
+        /// App ID
+        id: String,
+
+        /// Worker ID (defaults to first worker)
+        #[arg(long)]
+        worker_id: Option<String>,
+
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+
+        /// Get logs from previous container instance
+        #[arg(long)]
+        previous: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum IntegrationsCommands {
+    /// List all resource integrations
+    List {
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// Get a specific resource integration
+    Get {
+        /// Integration name
+        name: String,
+
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// Delete a resource integration
+    Delete {
+        /// Integration name
+        name: String,
+
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// List all private PyPI repositories
+    #[command(name = "list-private-pypi")]
+    ListPrivatePypi {
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+
+    /// List all private Conda channels
+    #[command(name = "list-private-conda")]
+    ListPrivateConda {
+        /// Override the current perimeter
+        #[arg(long)]
+        perimeter: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum FlowprojectCommands {
+    /// Get flowproject metadata for a project/branch
+    #[command(name = "get-metadata")]
+    GetMetadata {
+        /// Project name
+        #[arg(long)]
+        project: String,
+
+        /// Branch name
+        #[arg(long)]
+        branch: String,
+    },
+
+    /// Delete flowproject metadata for a project/branch
+    #[command(name = "delete-metadata")]
+    DeleteMetadata {
+        /// Project name
+        #[arg(long)]
+        project: String,
+
+        /// Branch name
+        #[arg(long)]
+        branch: String,
+    },
+
+    /// List deployed workflow templates for a project/branch
+    #[command(name = "list-templates")]
+    ListTemplates {
+        /// Project name
+        #[arg(long)]
+        project: String,
+
+        /// Branch name
+        #[arg(long)]
+        branch: String,
+    },
+
+    /// Tear down all deployed resources for a project/branch
+    #[command(name = "teardown-branch")]
+    TeardownBranch {
+        /// Project name
+        #[arg(long)]
+        project: String,
+
+        /// Branch name
+        #[arg(long)]
+        branch: String,
+
+        /// Show what would be deleted without actually deleting
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SecretsCommands {
+    /// Get secret metadata (backend type, resource ID)
+    #[command(name = "get-metadata")]
+    GetMetadata {
+        /// Integration name
+        integration_name: String,
+    },
+
+    /// Fetch secret values from cloud secret manager
+    Get {
+        /// Integration name
+        integration_name: String,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Fetch multiple secrets at once
+    #[command(name = "get-many")]
+    GetMany {
+        /// Integration names
+        #[arg(required = true)]
+        integration_names: Vec<String>,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TutorialsCommands {
+    /// Download and extract tutorials
+    Pull {
+        /// URL to download tutorials from
+        url: String,
+
+        /// Destination directory (defaults to current directory)
+        #[arg(long, short = 'd')]
+        destination: Option<String>,
+
+        /// Expected SHA256 hash for verification
+        #[arg(long)]
+        verify_hash: Option<String>,
+
+        /// Overwrite existing files
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WorkstationsCommands {
+    /// List all workstations
+    List,
+
+    /// Hibernate a workstation
+    Hibernate {
+        /// Workstation ID
+        workstation_id: String,
+    },
+
+    /// Restart a workstation
+    Restart {
+        /// Workstation ID
+        workstation_id: String,
+    },
+
+    /// Generate kubectl ExecCredential token
+    #[command(name = "generate-token")]
+    GenerateToken,
+
+    /// Get Kubernetes namespace for a workstation
+    #[command(name = "get-namespace")]
+    GetNamespace {
+        /// Workstation ID
+        workstation_id: String,
+    },
+
+    /// Get relevant links (Metaflow UI, etc.)
+    #[command(name = "get-links")]
+    GetLinks,
+
+    /// Configure kubeconfig for workstation access
+    #[command(name = "configure-kubeconfig")]
+    ConfigureKubeconfig {
+        /// Path to ana binary (for exec credential plugin)
+        #[arg(long)]
+        binary_path: Option<String>,
+
+        /// Path to kubeconfig file
+        #[arg(long)]
+        kubeconfig_path: Option<String>,
+    },
+
+    /// Configure SSH access to a workstation
+    #[command(name = "prepare-ssh")]
+    PrepareSsh {
+        /// Workstation ID
+        workstation_id: String,
+    },
+
+    /// Install kubectl binary
+    #[command(name = "install-kubectl")]
+    InstallKubectl {
+        /// Installation directory
+        #[arg(long)]
+        install_dir: Option<String>,
+
+        /// kubectl version to install
+        #[arg(long)]
+        version: Option<String>,
+    },
+}
+
+impl ObnCommands {
+    pub fn into_action(self) -> ObnAction {
+        match self {
+            ObnCommands::Configure {
+                encoded_config,
+                echo,
+                force,
+            } => ObnAction::Configure {
+                encoded_config,
+                echo,
+                force,
+            },
+            ObnCommands::ServicePrincipalConfigure {
+                name,
+                deployment_domain,
+                perimeter,
+                jwt_token,
+                github_actions,
+                echo,
+                force,
+            } => ObnAction::ServicePrincipalConfigure {
+                name,
+                deployment_domain,
+                perimeter,
+                jwt_token,
+                github_actions,
+                echo,
+                force,
+            },
+            ObnCommands::Check {
+                workstation,
+                python,
+                latency,
+            } => ObnAction::Check {
+                workstation,
+                python,
+                latency,
+            },
+            ObnCommands::Perimeter { command } => match command {
+                None => ObnAction::ShowHelp("obn perimeter".to_string()),
+                Some(PerimeterCommands::List) => ObnAction::PerimeterList,
+                Some(PerimeterCommands::ShowCurrent) => ObnAction::PerimeterShowCurrent,
+                Some(PerimeterCommands::Switch { perimeter_id, force }) => {
+                    ObnAction::PerimeterSwitch { perimeter_id, force }
+                }
+            },
+            ObnCommands::App { command } => match command {
+                None => ObnAction::ShowHelp("obn app".to_string()),
+                Some(AppCommands::List { perimeter, name }) => {
+                    ObnAction::AppList { perimeter, name }
+                }
+                Some(AppCommands::Info { id, perimeter }) => ObnAction::AppInfo { id, perimeter },
+                Some(AppCommands::Delete { ids, perimeter }) => {
+                    ObnAction::AppDelete { ids, perimeter }
+                }
+                Some(AppCommands::Logs {
+                    id,
+                    worker_id,
+                    perimeter,
+                    previous,
+                }) => ObnAction::AppLogs {
+                    id,
+                    worker_id,
+                    perimeter,
+                    previous,
+                },
+            },
+            ObnCommands::Integrations { command } => match command {
+                None => ObnAction::ShowHelp("obn integrations".to_string()),
+                Some(IntegrationsCommands::List { perimeter }) => {
+                    ObnAction::IntegrationsList { perimeter }
+                }
+                Some(IntegrationsCommands::Get { name, perimeter }) => {
+                    ObnAction::IntegrationsGet { name, perimeter }
+                }
+                Some(IntegrationsCommands::Delete { name, perimeter }) => {
+                    ObnAction::IntegrationsDelete { name, perimeter }
+                }
+                Some(IntegrationsCommands::ListPrivatePypi { perimeter }) => {
+                    ObnAction::IntegrationsListPrivatePypi { perimeter }
+                }
+                Some(IntegrationsCommands::ListPrivateConda { perimeter }) => {
+                    ObnAction::IntegrationsListPrivateConda { perimeter }
+                }
+            },
+            ObnCommands::Flowproject { command } => match command {
+                None => ObnAction::ShowHelp("obn flowproject".to_string()),
+                Some(FlowprojectCommands::GetMetadata { project, branch }) => {
+                    ObnAction::FlowprojectGetMetadata { project, branch }
+                }
+                Some(FlowprojectCommands::DeleteMetadata { project, branch }) => {
+                    ObnAction::FlowprojectDeleteMetadata { project, branch }
+                }
+                Some(FlowprojectCommands::ListTemplates { project, branch }) => {
+                    ObnAction::FlowprojectListTemplates { project, branch }
+                }
+                Some(FlowprojectCommands::TeardownBranch {
+                    project,
+                    branch,
+                    dry_run,
+                }) => ObnAction::FlowprojectTeardownBranch {
+                    project,
+                    branch,
+                    dry_run,
+                },
+            },
+            ObnCommands::Secrets { command } => match command {
+                None => ObnAction::ShowHelp("obn secrets".to_string()),
+                Some(SecretsCommands::GetMetadata { integration_name }) => {
+                    ObnAction::SecretsGetMetadata { integration_name }
+                }
+                Some(SecretsCommands::Get {
+                    integration_name,
+                    json,
+                }) => ObnAction::SecretsGet {
+                    integration_name,
+                    json,
+                },
+                Some(SecretsCommands::GetMany {
+                    integration_names,
+                    json,
+                }) => ObnAction::SecretsGetMany {
+                    integration_names,
+                    json,
+                },
+            },
+            ObnCommands::Tutorials { command } => match command {
+                None => ObnAction::ShowHelp("obn tutorials".to_string()),
+                Some(TutorialsCommands::Pull {
+                    url,
+                    destination,
+                    verify_hash,
+                    force,
+                }) => ObnAction::TutorialsPull {
+                    url,
+                    destination,
+                    verify_hash,
+                    force,
+                },
+            },
+            ObnCommands::Workstations { command } => match command {
+                None => ObnAction::ShowHelp("obn workstations".to_string()),
+                Some(WorkstationsCommands::List) => ObnAction::WorkstationsList,
+                Some(WorkstationsCommands::Hibernate { workstation_id }) => {
+                    ObnAction::WorkstationsHibernate { workstation_id }
+                }
+                Some(WorkstationsCommands::Restart { workstation_id }) => {
+                    ObnAction::WorkstationsRestart { workstation_id }
+                }
+                Some(WorkstationsCommands::GenerateToken) => ObnAction::WorkstationsGenerateToken,
+                Some(WorkstationsCommands::GetNamespace { workstation_id }) => {
+                    ObnAction::WorkstationsGetNamespace { workstation_id }
+                }
+                Some(WorkstationsCommands::GetLinks) => ObnAction::WorkstationsGetLinks,
+                Some(WorkstationsCommands::ConfigureKubeconfig {
+                    binary_path,
+                    kubeconfig_path,
+                }) => ObnAction::WorkstationsConfigureKubeconfig {
+                    binary_path,
+                    kubeconfig_path,
+                },
+                Some(WorkstationsCommands::PrepareSsh { workstation_id }) => {
+                    ObnAction::WorkstationsPrepareSsh { workstation_id }
+                }
+                Some(WorkstationsCommands::InstallKubectl {
+                    install_dir,
+                    version,
+                }) => ObnAction::WorkstationsInstallKubectl {
+                    install_dir,
+                    version,
+                },
+            },
+        }
+    }
+}

--- a/src/native_outerbounds/commands.rs
+++ b/src/native_outerbounds/commands.rs
@@ -7,6 +7,8 @@ pub enum ObnAction {
     // Configure
     Configure {
         encoded_config: String,
+        config_dir: String,
+        profile: Option<String>,
         echo: bool,
         force: bool,
     },
@@ -16,42 +18,52 @@ pub enum ObnAction {
         perimeter: Option<String>,
         jwt_token: Option<String>,
         github_actions: bool,
+        config_dir: String,
+        profile: Option<String>,
         echo: bool,
         force: bool,
     },
 
     // Check
     Check {
+        no_config: bool,
+        output: Option<String>,
         workstation: bool,
-        python: bool,
         latency: bool,
+        latency_requests: u32,
+        latency_timeout: f64,
     },
 
     // Perimeter
     PerimeterList,
     PerimeterShowCurrent,
     PerimeterSwitch {
-        perimeter_id: String,
+        config_dir: String,
+        profile: Option<String>,
+        output: Option<String>,
+        id: Option<String>,
         force: bool,
     },
 
     // App
     AppList {
-        perimeter: Option<String>,
+        project: Option<String>,
+        branch: Option<String>,
         name: Option<String>,
+        tags: Vec<String>,
+        format: Option<String>,
+        auth_type: Option<String>,
     },
     AppInfo {
         id: String,
-        perimeter: Option<String>,
+        format: Option<String>,
     },
     AppDelete {
         ids: Vec<String>,
-        perimeter: Option<String>,
     },
     AppLogs {
         id: String,
         worker_id: Option<String>,
-        perimeter: Option<String>,
         previous: bool,
     },
 
@@ -142,65 +154,93 @@ pub enum ObnAction {
 
 #[derive(Subcommand, Debug)]
 pub enum ObnCommands {
-    /// Decode and save Outerbounds Platform configuration
+    /// Decode Outerbounds Platform configuration strings
     Configure {
         /// Base64-encoded configuration string
         encoded_config: String,
+
+        /// Path to Metaflow configuration directory
+        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
+        config_dir: String,
+
+        /// Configure a named profile. Activate the profile by setting METAFLOW_PROFILE environment variable
+        #[arg(long, short = 'p')]
+        profile: Option<String>,
 
         /// Print decoded configuration to stdout
         #[arg(long, short = 'e')]
         echo: bool,
 
-        /// Overwrite existing configuration without confirmation
+        /// Force overwrite of existing configuration
         #[arg(long, short = 'f')]
         force: bool,
     },
 
-    /// Authenticate service principals using JWT (for CI/CD)
+    /// Authenticate service principals using JWT minted by their IDPs and configure Metaflow
     #[command(name = "service-principal-configure")]
     ServicePrincipalConfigure {
-        /// Name of the service principal
+        /// The name of service principals to authenticate
         #[arg(long, short = 'n')]
         name: Option<String>,
 
-        /// Full domain of the target OBP deployment (e.g., 'foo.obp.outerbounds.com')
+        /// The full domain of the target Outerbounds Platform deployment (eg. 'foo.obp.outerbounds.com')
         #[arg(long)]
         deployment_domain: Option<String>,
 
-        /// Perimeter to authenticate in (defaults to 'default')
+        /// The name of the perimeter to authenticate the service principal in
         #[arg(long, short = 'p')]
         perimeter: Option<String>,
 
-        /// JWT token for authentication
+        /// The JWT token that will be used to authenticate against the OBP Auth Server
         #[arg(long, short = 't')]
         jwt_token: Option<String>,
 
-        /// Use GitHub Actions OIDC to get JWT token
+        /// Set if the command is being run in a GitHub Actions environment
         #[arg(long)]
         github_actions: bool,
 
-        /// Print configuration to stdout
+        /// Path to Metaflow configuration directory
+        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
+        config_dir: String,
+
+        /// Configure a named profile. Activate the profile by setting METAFLOW_PROFILE environment variable
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Print decoded configuration to stdout
         #[arg(long, short = 'e')]
         echo: bool,
 
-        /// Overwrite existing configuration without confirmation
+        /// Force overwrite of existing configuration
         #[arg(long, short = 'f')]
         force: bool,
     },
 
-    /// Check packages and configuration for compatibility
+    /// Check packages and configuration for common errors
     Check {
-        /// Include workstation-specific checks
-        #[arg(long)]
+        /// Skip validating local Metaflow configuration
+        #[arg(long, short = 'n')]
+        no_config: bool,
+
+        /// Show output in the specified format
+        #[arg(long, short = 'o')]
+        output: Option<String>,
+
+        /// Check whether all workstation dependencies are installed correctly
+        #[arg(long, short = 'w')]
         workstation: bool,
 
-        /// Include Python package checks
-        #[arg(long)]
-        python: bool,
-
-        /// Run latency checks
-        #[arg(long)]
+        /// Check API latency for Workstations, Auth Server, and EKS endpoints
+        #[arg(long, short = 'l')]
         latency: bool,
+
+        /// Number of requests per endpoint for latency check
+        #[arg(long, default_value = "10")]
+        latency_requests: u32,
+
+        /// Connection timeout in seconds for latency check requests
+        #[arg(long, default_value = "10.0")]
+        latency_timeout: f64,
     },
 
     /// Manage perimeters
@@ -258,16 +298,29 @@ pub enum PerimeterCommands {
     /// List all available perimeters
     List,
 
-    /// Show the currently active perimeter
+    /// Show current perimeter
     #[command(name = "show-current")]
     ShowCurrent,
 
-    /// Switch to a different perimeter
+    /// Switch current perimeter
     Switch {
-        /// Perimeter ID to switch to
-        perimeter_id: String,
+        /// Path to Metaflow configuration directory
+        #[arg(long, short = 'd', default_value = "~/.metaflowconfig")]
+        config_dir: String,
 
-        /// Force switch without confirmation
+        /// The named metaflow profile in which your workstation exists
+        #[arg(long, short = 'p')]
+        profile: Option<String>,
+
+        /// Show output in the specified format
+        #[arg(long, short = 'o')]
+        output: Option<String>,
+
+        /// Perimeter name to switch to
+        #[arg(long)]
+        id: Option<String>,
+
+        /// Force change the existing perimeter
         #[arg(long, short = 'f')]
         force: bool,
     },
@@ -277,37 +330,49 @@ pub enum PerimeterCommands {
 pub enum AppCommands {
     /// List apps in the Outerbounds Platform
     List {
-        /// Override the current perimeter
+        /// Filter apps by project
         #[arg(long)]
-        perimeter: Option<String>,
+        project: Option<String>,
 
-        /// Filter by app name
+        /// Filter apps by branch
+        #[arg(long)]
+        branch: Option<String>,
+
+        /// Filter apps by name
         #[arg(long)]
         name: Option<String>,
+
+        /// Filter apps by tag. Format KEY=VALUE
+        #[arg(long = "tag", value_name = "KEY=VALUE")]
+        tags: Vec<String>,
+
+        /// Format the output
+        #[arg(long, value_parser = ["json", "text"])]
+        format: Option<String>,
+
+        /// Filter apps by Auth type
+        #[arg(long, value_parser = ["Browser", "API", "BrowserAndApi"])]
+        auth_type: Option<String>,
     },
 
-    /// Get detailed information about an app
+    /// Get detailed information about an app from the Outerbounds Platform
     Info {
         /// App ID
         id: String,
 
-        /// Override the current perimeter
-        #[arg(long)]
-        perimeter: Option<String>,
+        /// Format the output
+        #[arg(long, value_parser = ["json", "text"])]
+        format: Option<String>,
     },
 
-    /// Delete one or more apps
+    /// Delete an app/apps from the Outerbounds Platform
     Delete {
         /// App IDs to delete
         #[arg(required = true)]
         ids: Vec<String>,
-
-        /// Override the current perimeter
-        #[arg(long)]
-        perimeter: Option<String>,
     },
 
-    /// Get logs for an app worker
+    /// Get logs for an app worker from the Outerbounds Platform
     Logs {
         /// App ID
         id: String,
@@ -315,10 +380,6 @@ pub enum AppCommands {
         /// Worker ID (defaults to first worker)
         #[arg(long)]
         worker_id: Option<String>,
-
-        /// Override the current perimeter
-        #[arg(long)]
-        perimeter: Option<String>,
 
         /// Get logs from previous container instance
         #[arg(long)]
@@ -549,10 +610,14 @@ impl ObnCommands {
         match self {
             ObnCommands::Configure {
                 encoded_config,
+                config_dir,
+                profile,
                 echo,
                 force,
             } => ObnAction::Configure {
                 encoded_config,
+                config_dir,
+                profile,
                 echo,
                 force,
             },
@@ -562,6 +627,8 @@ impl ObnCommands {
                 perimeter,
                 jwt_token,
                 github_actions,
+                config_dir,
+                profile,
                 echo,
                 force,
             } => ObnAction::ServicePrincipalConfigure {
@@ -570,48 +637,60 @@ impl ObnCommands {
                 perimeter,
                 jwt_token,
                 github_actions,
+                config_dir,
+                profile,
                 echo,
                 force,
             },
             ObnCommands::Check {
+                no_config,
+                output,
                 workstation,
-                python,
                 latency,
+                latency_requests,
+                latency_timeout,
             } => ObnAction::Check {
+                no_config,
+                output,
                 workstation,
-                python,
                 latency,
+                latency_requests,
+                latency_timeout,
             },
             ObnCommands::Perimeter { command } => match command {
                 None => ObnAction::ShowHelp("obn perimeter".to_string()),
                 Some(PerimeterCommands::List) => ObnAction::PerimeterList,
                 Some(PerimeterCommands::ShowCurrent) => ObnAction::PerimeterShowCurrent,
-                Some(PerimeterCommands::Switch {
-                    perimeter_id,
-                    force,
-                }) => ObnAction::PerimeterSwitch {
-                    perimeter_id,
-                    force,
-                },
+                Some(PerimeterCommands::Switch { output, id, force }) => {
+                    ObnAction::PerimeterSwitch { output, id, force }
+                }
             },
             ObnCommands::App { command } => match command {
                 None => ObnAction::ShowHelp("obn app".to_string()),
-                Some(AppCommands::List { perimeter, name }) => {
-                    ObnAction::AppList { perimeter, name }
-                }
-                Some(AppCommands::Info { id, perimeter }) => ObnAction::AppInfo { id, perimeter },
-                Some(AppCommands::Delete { ids, perimeter }) => {
-                    ObnAction::AppDelete { ids, perimeter }
-                }
+                Some(AppCommands::List {
+                    project,
+                    branch,
+                    name,
+                    tags,
+                    format,
+                    auth_type,
+                }) => ObnAction::AppList {
+                    project,
+                    branch,
+                    name,
+                    tags,
+                    format,
+                    auth_type,
+                },
+                Some(AppCommands::Info { id, format }) => ObnAction::AppInfo { id, format },
+                Some(AppCommands::Delete { ids }) => ObnAction::AppDelete { ids },
                 Some(AppCommands::Logs {
                     id,
                     worker_id,
-                    perimeter,
                     previous,
                 }) => ObnAction::AppLogs {
                     id,
                     worker_id,
-                    perimeter,
                     previous,
                 },
             },

--- a/src/native_outerbounds/commands.rs
+++ b/src/native_outerbounds/commands.rs
@@ -586,9 +586,13 @@ impl ObnCommands {
                 None => ObnAction::ShowHelp("obn perimeter".to_string()),
                 Some(PerimeterCommands::List) => ObnAction::PerimeterList,
                 Some(PerimeterCommands::ShowCurrent) => ObnAction::PerimeterShowCurrent,
-                Some(PerimeterCommands::Switch { perimeter_id, force }) => {
-                    ObnAction::PerimeterSwitch { perimeter_id, force }
-                }
+                Some(PerimeterCommands::Switch {
+                    perimeter_id,
+                    force,
+                }) => ObnAction::PerimeterSwitch {
+                    perimeter_id,
+                    force,
+                },
             },
             ObnCommands::App { command } => match command {
                 None => ObnAction::ShowHelp("obn app".to_string()),

--- a/src/native_outerbounds/configure.rs
+++ b/src/native_outerbounds/configure.rs
@@ -1,5 +1,5 @@
-use miette::{miette, Result};
-use outerbounds::{get_ci_jwt, ServicePrincipalParams};
+use miette::{Result, miette};
+use outerbounds::{ServicePrincipalParams, get_ci_jwt};
 
 use crate::context::CommandContext;
 use crate::ui::status;
@@ -11,7 +11,10 @@ pub async fn configure(
     force: bool,
 ) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
-    let result = ob.configure().configure(encoded_config, echo, force).await?;
+    let result = ob
+        .configure()
+        .configure(encoded_config, echo, force)
+        .await?;
 
     status::success(&format!("Configuration saved to {}", result.config_path));
 

--- a/src/native_outerbounds/configure.rs
+++ b/src/native_outerbounds/configure.rs
@@ -1,0 +1,80 @@
+use miette::{miette, Result};
+use outerbounds::{get_ci_jwt, ServicePrincipalParams};
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+pub async fn configure(
+    ctx: &CommandContext,
+    encoded_config: &str,
+    echo: bool,
+    force: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let result = ob.configure().configure(encoded_config, echo, force).await?;
+
+    status::success(&format!("Configuration saved to {}", result.config_path));
+
+    if echo {
+        println!("\nDecoded configuration:");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&result.config).unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn service_principal_configure(
+    ctx: &CommandContext,
+    name: Option<&str>,
+    deployment_domain: Option<&str>,
+    perimeter: Option<&str>,
+    jwt_token: Option<&str>,
+    github_actions: bool,
+    echo: bool,
+    force: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    // Get JWT token - either from argument or GitHub Actions OIDC
+    let token = match jwt_token {
+        Some(t) => t.to_string(),
+        None if github_actions => {
+            // Need to determine audience from deployment domain
+            let domain = deployment_domain.ok_or_else(|| {
+                miette!("--deployment-domain is required when using --github-actions")
+            })?;
+            let audience = format!("https://auth.{}/origin", domain);
+            get_ci_jwt(&audience).await?
+        }
+        None => {
+            return Err(miette!(
+                "Either --jwt-token or --github-actions must be specified"
+            ));
+        }
+    };
+
+    let name = name
+        .ok_or_else(|| miette!("--name is required"))?
+        .to_string();
+    let deployment_domain = deployment_domain
+        .ok_or_else(|| miette!("--deployment-domain is required"))?
+        .to_string();
+
+    let params = ServicePrincipalParams::new(name, deployment_domain, perimeter, token);
+
+    let result = ob
+        .configure()
+        .service_principal_configure(&params, echo, force)
+        .await?;
+
+    status::success(&format!(
+        "Service principal configuration saved to {}",
+        result.config_path
+    ));
+
+    Ok(())
+}

--- a/src/native_outerbounds/configure.rs
+++ b/src/native_outerbounds/configure.rs
@@ -1,15 +1,16 @@
 use std::path::Path;
 
-use miette::{miette, Result};
-use outerbounds::{get_ci_jwt, Outerbounds, ServicePrincipalParams};
+use miette::{Result, miette};
+use outerbounds::{Outerbounds, ServicePrincipalParams, get_ci_jwt};
 
 use crate::ui::status;
 
 fn expand_tilde(path: &str) -> String {
     if path.starts_with("~/")
-        && let Some(home) = dirs::home_dir() {
-            return path.replacen("~", &home.to_string_lossy(), 1);
-        }
+        && let Some(home) = dirs::home_dir()
+    {
+        return path.replacen("~", &home.to_string_lossy(), 1);
+    }
     path.to_string()
 }
 

--- a/src/native_outerbounds/configure.rs
+++ b/src/native_outerbounds/configure.rs
@@ -1,22 +1,37 @@
-use miette::{Result, miette};
-use outerbounds::{ServicePrincipalParams, get_ci_jwt};
+use std::path::Path;
 
-use crate::context::CommandContext;
+use miette::{miette, Result};
+use outerbounds::{get_ci_jwt, Outerbounds, ServicePrincipalParams};
+
 use crate::ui::status;
 
+fn expand_tilde(path: &str) -> String {
+    if path.starts_with("~/")
+        && let Some(home) = dirs::home_dir() {
+            return path.replacen("~", &home.to_string_lossy(), 1);
+        }
+    path.to_string()
+}
+
 pub async fn configure(
-    ctx: &CommandContext,
     encoded_config: &str,
+    config_dir: &str,
+    profile: Option<&str>,
     echo: bool,
     force: bool,
 ) -> Result<()> {
-    let ob = ctx.outerbounds_client().await?;
+    let config_path = expand_tilde(config_dir);
+    let ob = Outerbounds::without_config(Some(Path::new(&config_path)), profile);
+
     let result = ob
         .configure()
         .configure(encoded_config, echo, force)
-        .await?;
+        .await
+        .map_err(|e| miette!("{}", e))?;
 
-    status::success(&format!("Configuration saved to {}", result.config_path));
+    if result.written {
+        status::success(&format!("Configuration saved to {}", result.config_path));
+    }
 
     if echo {
         println!("\nDecoded configuration:");
@@ -31,16 +46,18 @@ pub async fn configure(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn service_principal_configure(
-    ctx: &CommandContext,
     name: Option<&str>,
     deployment_domain: Option<&str>,
     perimeter: Option<&str>,
     jwt_token: Option<&str>,
     github_actions: bool,
+    config_dir: &str,
+    profile: Option<&str>,
     echo: bool,
     force: bool,
 ) -> Result<()> {
-    let ob = ctx.outerbounds_client().await?;
+    let config_path = expand_tilde(config_dir);
+    let ob = Outerbounds::without_config(Some(Path::new(&config_path)), profile);
 
     // Get JWT token - either from argument or GitHub Actions OIDC
     let token = match jwt_token {
@@ -51,7 +68,7 @@ pub async fn service_principal_configure(
                 miette!("--deployment-domain is required when using --github-actions")
             })?;
             let audience = format!("https://auth.{}/origin", domain);
-            get_ci_jwt(&audience).await?
+            get_ci_jwt(&audience).await.map_err(|e| miette!("{}", e))?
         }
         None => {
             return Err(miette!(
@@ -72,7 +89,8 @@ pub async fn service_principal_configure(
     let result = ob
         .configure()
         .service_principal_configure(&params, echo, force)
-        .await?;
+        .await
+        .map_err(|e| miette!("{}", e))?;
 
     status::success(&format!(
         "Service principal configuration saved to {}",

--- a/src/native_outerbounds/flowproject.rs
+++ b/src/native_outerbounds/flowproject.rs
@@ -1,0 +1,189 @@
+use miette::Result;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+use super::output::{create_table, print_table};
+
+pub async fn get_metadata(ctx: &CommandContext, project: &str, branch: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let metadata = ob.flowproject().get_metadata(project, branch).await?;
+
+    match metadata {
+        Some(m) => {
+            let proj = m.project.as_deref().unwrap_or("-");
+            let br = m.branch.as_deref().unwrap_or("-");
+            println!("Project: {}", proj);
+            println!("Branch: {}", br);
+
+            if !m.workflows.is_empty() {
+                println!("\nWorkflows:");
+                let mut table = create_table(&["Flow Name", "Template ID"]);
+                for wf in &m.workflows {
+                    let name = wf.flow_name.as_deref().unwrap_or("-");
+                    let template_id = wf.flow_template_id.as_deref().unwrap_or("-");
+                    table.add_row(vec![name, template_id]);
+                }
+                print_table(table);
+            }
+
+            if !m.data.is_empty() {
+                println!("\nData Assets:");
+                let mut table = create_table(&["ID", "Name"]);
+                for asset in &m.data {
+                    let id = asset.id.as_deref().unwrap_or("-");
+                    let name = asset.name.as_deref().unwrap_or("-");
+                    table.add_row(vec![id, name]);
+                }
+                print_table(table);
+            }
+
+            if !m.models.is_empty() {
+                println!("\nModel Assets:");
+                let mut table = create_table(&["ID", "Name"]);
+                for asset in &m.models {
+                    let id = asset.id.as_deref().unwrap_or("-");
+                    let name = asset.name.as_deref().unwrap_or("-");
+                    table.add_row(vec![id, name]);
+                }
+                print_table(table);
+            }
+        }
+        None => {
+            println!("No metadata found for {}/{}", project, branch);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn delete_metadata(ctx: &CommandContext, project: &str, branch: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob.flowproject().delete_metadata(project, branch).await?;
+
+    if result.success {
+        status::success(&format!(
+            "Deleted metadata for {}/{}",
+            result.project, result.branch
+        ));
+    } else {
+        println!("No metadata found for {}/{}", result.project, result.branch);
+    }
+
+    Ok(())
+}
+
+pub async fn list_templates(ctx: &CommandContext, project: &str, branch: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let templates = ob.flowproject().list_templates(project, branch).await?;
+
+    if templates.is_empty() {
+        println!("No workflow templates found for {}/{}", project, branch);
+        return Ok(());
+    }
+
+    println!("Workflow Templates:");
+    for template in &templates {
+        println!("  - {}", template);
+    }
+
+    Ok(())
+}
+
+pub async fn teardown_branch(
+    ctx: &CommandContext,
+    project: &str,
+    branch: &str,
+    dry_run: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob
+        .flowproject()
+        .teardown_branch(project, branch, dry_run)
+        .await?;
+
+    if dry_run {
+        println!("Dry run for {}/{}:", result.project, result.branch);
+        println!("\nWould delete:");
+    } else {
+        println!("Teardown for {}/{}:", result.project, result.branch);
+        println!("\nDeleted:");
+    }
+
+    if !result.templates_found.is_empty() || !result.templates_deleted.is_empty() {
+        let templates = if dry_run {
+            &result.templates_found
+        } else {
+            &result.templates_deleted
+        };
+        if !templates.is_empty() {
+            println!("\nWorkflow Templates:");
+            for name in templates {
+                println!("  - {}", name);
+            }
+        }
+    }
+
+    if !result.data_assets_found.is_empty() || !result.data_assets_deleted.is_empty() {
+        let assets = if dry_run {
+            &result.data_assets_found
+        } else {
+            &result.data_assets_deleted
+        };
+        if !assets.is_empty() {
+            println!("\nData Assets:");
+            for name in assets {
+                println!("  - {}", name);
+            }
+        }
+    }
+
+    if !result.model_assets_found.is_empty() || !result.model_assets_deleted.is_empty() {
+        let assets = if dry_run {
+            &result.model_assets_found
+        } else {
+            &result.model_assets_deleted
+        };
+        if !assets.is_empty() {
+            println!("\nModel Assets:");
+            for name in assets {
+                println!("  - {}", name);
+            }
+        }
+    }
+
+    if !result.apps_found.is_empty() || !result.apps_deleted.is_empty() {
+        let apps = if dry_run {
+            &result.apps_found
+        } else {
+            &result.apps_deleted
+        };
+        if !apps.is_empty() {
+            println!("\nApps:");
+            for name in apps {
+                println!("  - {}", name);
+            }
+        }
+    }
+
+    if result.has_metadata {
+        if dry_run {
+            println!("\nFlowproject metadata: would be deleted");
+        } else if result.metadata_deleted {
+            println!("\nFlowproject metadata: deleted");
+        }
+    }
+
+    if !result.errors.is_empty() {
+        println!("\nErrors:");
+        for err in &result.errors {
+            println!("  - {}", err);
+        }
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/integrations.rs
+++ b/src/native_outerbounds/integrations.rs
@@ -1,0 +1,156 @@
+use miette::Result;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+use super::output::{create_table, print_table};
+
+pub async fn list(ctx: &CommandContext, perimeter_override: Option<&str>) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob.integrations().list_in_perimeter(perimeter_override).await?;
+
+    if result.integrations.is_empty() {
+        println!("No integrations found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["Name", "Type", "Status", "Description"]);
+
+    for integration in &result.integrations {
+        let desc = if integration.integration_description.len() > 40 {
+            format!("{}...", &integration.integration_description[..37])
+        } else {
+            integration.integration_description.clone()
+        };
+        table.add_row(vec![
+            &integration.integration_name,
+            &integration.integration_type,
+            &integration.integration_status,
+            &desc,
+        ]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn get(
+    ctx: &CommandContext,
+    name: &str,
+    perimeter_override: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let integration = ob
+        .integrations()
+        .get_in_perimeter(name, perimeter_override)
+        .await?;
+
+    println!("Name: {}", integration.integration_name);
+    println!("Type: {}", integration.integration_type);
+    println!("Status: {}", integration.integration_status);
+
+    if !integration.integration_description.is_empty() {
+        println!("Description: {}", integration.integration_description);
+    }
+
+    if integration.integration_has_secrets {
+        println!("Has secrets: Yes");
+        if let Some(ref keys) = integration.integration_secret_keys {
+            println!("Secret keys: {}", keys.join(", "));
+        }
+    }
+
+    if !integration.integration_spec.is_null() {
+        println!(
+            "\nSpec:\n{}",
+            serde_json::to_string_pretty(&integration.integration_spec).unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn delete(
+    ctx: &CommandContext,
+    name: &str,
+    perimeter_override: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob
+        .integrations()
+        .delete_in_perimeter(name, perimeter_override)
+        .await?;
+
+    if result.success {
+        status::success(&format!("Deleted integration: {}", result.name));
+    } else {
+        status::warn(&format!("Failed to delete integration: {}", result.name));
+    }
+
+    Ok(())
+}
+
+pub async fn list_private_pypi(
+    ctx: &CommandContext,
+    perimeter_override: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let repos = ob
+        .integrations()
+        .list_private_pypi_repositories_in_perimeter(perimeter_override)
+        .await?;
+
+    if repos.is_empty() {
+        println!("No private PyPI repositories found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["Repository Name", "Host Integration", "Default"]);
+
+    for repo in &repos {
+        let is_default = if repo.is_default { "Yes" } else { "" };
+        table.add_row(vec![
+            &repo.repository_name,
+            &repo.host_integration_name,
+            is_default,
+        ]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn list_private_conda(
+    ctx: &CommandContext,
+    perimeter_override: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let channels = ob
+        .integrations()
+        .list_private_conda_channels_in_perimeter(perimeter_override)
+        .await?;
+
+    if channels.is_empty() {
+        println!("No private Conda channels found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["Channel Name", "Host Integration", "Default"]);
+
+    for channel in &channels {
+        let is_default = if channel.is_default { "Yes" } else { "" };
+        table.add_row(vec![
+            &channel.channel_name,
+            &channel.host_integration_name,
+            is_default,
+        ]);
+    }
+
+    print_table(table);
+    Ok(())
+}

--- a/src/native_outerbounds/integrations.rs
+++ b/src/native_outerbounds/integrations.rs
@@ -8,7 +8,10 @@ use super::output::{create_table, print_table};
 pub async fn list(ctx: &CommandContext, perimeter_override: Option<&str>) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
 
-    let result = ob.integrations().list_in_perimeter(perimeter_override).await?;
+    let result = ob
+        .integrations()
+        .list_in_perimeter(perimeter_override)
+        .await?;
 
     if result.integrations.is_empty() {
         println!("No integrations found");
@@ -35,11 +38,7 @@ pub async fn list(ctx: &CommandContext, perimeter_override: Option<&str>) -> Res
     Ok(())
 }
 
-pub async fn get(
-    ctx: &CommandContext,
-    name: &str,
-    perimeter_override: Option<&str>,
-) -> Result<()> {
+pub async fn get(ctx: &CommandContext, name: &str, perimeter_override: Option<&str>) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
 
     let integration = ob

--- a/src/native_outerbounds/mod.rs
+++ b/src/native_outerbounds/mod.rs
@@ -1,0 +1,17 @@
+mod commands;
+mod output;
+mod run;
+
+// Command modules
+mod app;
+mod check;
+mod configure;
+mod flowproject;
+mod integrations;
+mod perimeter;
+mod secrets;
+mod tutorials;
+mod workstations;
+
+pub use commands::{ObnAction, ObnCommands};
+pub use run::run;

--- a/src/native_outerbounds/output.rs
+++ b/src/native_outerbounds/output.rs
@@ -1,4 +1,4 @@
-use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, ContentArrangement, Table};
+use comfy_table::{Cell, ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 
 pub fn create_table(headers: &[&str]) -> Table {
     let mut table = Table::new();

--- a/src/native_outerbounds/output.rs
+++ b/src/native_outerbounds/output.rs
@@ -1,0 +1,16 @@
+use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, ContentArrangement, Table};
+
+pub fn create_table(headers: &[&str]) -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL_CONDENSED)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+
+    let header_cells: Vec<Cell> = headers.iter().map(Cell::new).collect();
+    table.set_header(header_cells);
+    table
+}
+
+pub fn print_table(table: Table) {
+    println!("{table}");
+}

--- a/src/native_outerbounds/perimeter.rs
+++ b/src/native_outerbounds/perimeter.rs
@@ -1,9 +1,20 @@
-use miette::Result;
+use std::path::Path;
+
+use miette::{miette, Result};
+use outerbounds::Outerbounds;
 
 use crate::context::CommandContext;
 use crate::ui::status;
 
 use super::output::{create_table, print_table};
+
+fn expand_tilde(path: &str) -> String {
+    if path.starts_with("~/")
+        && let Some(home) = dirs::home_dir() {
+            return path.replacen("~", &home.to_string_lossy(), 1);
+        }
+    path.to_string()
+}
 
 pub async fn list(ctx: &CommandContext) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
@@ -36,9 +47,32 @@ pub async fn show_current(ctx: &CommandContext) -> Result<()> {
     Ok(())
 }
 
-pub async fn switch(ctx: &CommandContext, perimeter_id: &str, force: bool) -> Result<()> {
-    let ob = ctx.outerbounds_client().await?;
-    let result = ob.perimeter().switch(perimeter_id, force).await?;
+pub async fn switch(
+    config_dir: &str,
+    profile: Option<&str>,
+    output: Option<&str>,
+    id: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    let perimeter_id = id.ok_or_else(|| miette!("--id is required"))?;
+
+    let config_path = expand_tilde(config_dir);
+    let ob = Outerbounds::new(Some(Path::new(&config_path)), profile)
+        .await
+        .map_err(|e| miette!("{}", e))?;
+
+    let result = ob
+        .perimeter()
+        .switch(perimeter_id, force)
+        .await
+        .map_err(|e| miette!("{}", e))?;
+
+    if output == Some("json") {
+        let json = serde_json::to_string_pretty(&result)
+            .map_err(|e| miette!("Failed to serialize response: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
 
     if result.success {
         status::success(&format!("Switched to perimeter: {}", result.perimeter));

--- a/src/native_outerbounds/perimeter.rs
+++ b/src/native_outerbounds/perimeter.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use miette::{miette, Result};
+use miette::{Result, miette};
 use outerbounds::Outerbounds;
 
 use crate::context::CommandContext;
@@ -10,9 +10,10 @@ use super::output::{create_table, print_table};
 
 fn expand_tilde(path: &str) -> String {
     if path.starts_with("~/")
-        && let Some(home) = dirs::home_dir() {
-            return path.replacen("~", &home.to_string_lossy(), 1);
-        }
+        && let Some(home) = dirs::home_dir()
+    {
+        return path.replacen("~", &home.to_string_lossy(), 1);
+    }
     path.to_string()
 }
 

--- a/src/native_outerbounds/perimeter.rs
+++ b/src/native_outerbounds/perimeter.rs
@@ -1,0 +1,50 @@
+use miette::Result;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+use super::output::{create_table, print_table};
+
+pub async fn list(ctx: &CommandContext) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let result = ob.perimeter().list().await?;
+
+    let mut table = create_table(&["ID", "Current"]);
+
+    for perimeter in result.perimeters {
+        let is_current = if perimeter.active { "✓" } else { "" };
+        table.add_row(vec![&perimeter.id, is_current]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn show_current(ctx: &CommandContext) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let current = ob.perimeter().show_current().await?;
+
+    match current {
+        Some(perimeter_id) => {
+            println!("Current perimeter: {}", perimeter_id);
+        }
+        None => {
+            println!("No perimeter currently set");
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn switch(ctx: &CommandContext, perimeter_id: &str, force: bool) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+    let result = ob.perimeter().switch(perimeter_id, force).await?;
+
+    if result.success {
+        status::success(&format!("Switched to perimeter: {}", result.perimeter));
+    } else {
+        println!("Already on perimeter: {}", result.perimeter);
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/run.rs
+++ b/src/native_outerbounds/run.rs
@@ -1,0 +1,188 @@
+use miette::Result;
+
+use super::commands::ObnAction;
+use super::{app, check, configure, flowproject, integrations, perimeter, secrets, tutorials, workstations};
+use crate::context::CommandContext;
+use crate::help;
+
+pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
+    match action {
+        ObnAction::ShowHelp(path) => {
+            help::print_subcommand_help(&get_subcommand(&path), &path);
+            Ok(())
+        }
+        ObnAction::Configure {
+            encoded_config,
+            echo,
+            force,
+        } => configure::configure(ctx, &encoded_config, echo, force).await,
+        ObnAction::ServicePrincipalConfigure {
+            name,
+            deployment_domain,
+            perimeter,
+            jwt_token,
+            github_actions,
+            echo,
+            force,
+        } => {
+            configure::service_principal_configure(
+                ctx,
+                name.as_deref(),
+                deployment_domain.as_deref(),
+                perimeter.as_deref(),
+                jwt_token.as_deref(),
+                github_actions,
+                echo,
+                force,
+            )
+            .await
+        }
+        ObnAction::Check {
+            workstation,
+            python,
+            latency,
+        } => check::check(ctx, workstation, python, latency).await,
+        ObnAction::PerimeterList => perimeter::list(ctx).await,
+        ObnAction::PerimeterShowCurrent => perimeter::show_current(ctx).await,
+        ObnAction::PerimeterSwitch { perimeter_id, force } => {
+            perimeter::switch(ctx, &perimeter_id, force).await
+        }
+        ObnAction::AppList { perimeter, name } => {
+            app::list(ctx, perimeter.as_deref(), name.as_deref()).await
+        }
+        ObnAction::AppInfo { id, perimeter } => app::info(ctx, &id, perimeter.as_deref()).await,
+        ObnAction::AppDelete { ids, perimeter } => {
+            app::delete(ctx, &ids, perimeter.as_deref()).await
+        }
+        ObnAction::AppLogs {
+            id,
+            worker_id,
+            perimeter,
+            previous,
+        } => app::logs(ctx, &id, worker_id.as_deref(), perimeter.as_deref(), previous).await,
+        ObnAction::IntegrationsList { perimeter } => {
+            integrations::list(ctx, perimeter.as_deref()).await
+        }
+        ObnAction::IntegrationsGet { name, perimeter } => {
+            integrations::get(ctx, &name, perimeter.as_deref()).await
+        }
+        ObnAction::IntegrationsDelete { name, perimeter } => {
+            integrations::delete(ctx, &name, perimeter.as_deref()).await
+        }
+        ObnAction::IntegrationsListPrivatePypi { perimeter } => {
+            integrations::list_private_pypi(ctx, perimeter.as_deref()).await
+        }
+        ObnAction::IntegrationsListPrivateConda { perimeter } => {
+            integrations::list_private_conda(ctx, perimeter.as_deref()).await
+        }
+
+        // Flowproject
+        ObnAction::FlowprojectGetMetadata { project, branch } => {
+            flowproject::get_metadata(ctx, &project, &branch).await
+        }
+        ObnAction::FlowprojectDeleteMetadata { project, branch } => {
+            flowproject::delete_metadata(ctx, &project, &branch).await
+        }
+        ObnAction::FlowprojectListTemplates { project, branch } => {
+            flowproject::list_templates(ctx, &project, &branch).await
+        }
+        ObnAction::FlowprojectTeardownBranch {
+            project,
+            branch,
+            dry_run,
+        } => flowproject::teardown_branch(ctx, &project, &branch, dry_run).await,
+
+        // Secrets
+        ObnAction::SecretsGetMetadata { integration_name } => {
+            secrets::get_metadata(ctx, &integration_name).await
+        }
+        ObnAction::SecretsGet {
+            integration_name,
+            json,
+        } => secrets::get(ctx, &integration_name, json).await,
+        ObnAction::SecretsGetMany {
+            integration_names,
+            json,
+        } => secrets::get_many(ctx, &integration_names, json).await,
+
+        // Tutorials
+        ObnAction::TutorialsPull {
+            url,
+            destination,
+            verify_hash,
+            force,
+        } => {
+            tutorials::pull(
+                ctx,
+                &url,
+                destination.as_deref(),
+                verify_hash.as_deref(),
+                force,
+            )
+            .await
+        }
+
+        // Workstations
+        ObnAction::WorkstationsList => workstations::list(ctx).await,
+        ObnAction::WorkstationsHibernate { workstation_id } => {
+            workstations::hibernate(ctx, &workstation_id).await
+        }
+        ObnAction::WorkstationsRestart { workstation_id } => {
+            workstations::restart(ctx, &workstation_id).await
+        }
+        ObnAction::WorkstationsGenerateToken => workstations::generate_token(ctx).await,
+        ObnAction::WorkstationsGetNamespace { workstation_id } => {
+            workstations::get_namespace(ctx, &workstation_id).await
+        }
+        ObnAction::WorkstationsGetLinks => workstations::get_links(ctx).await,
+        ObnAction::WorkstationsConfigureKubeconfig {
+            binary_path,
+            kubeconfig_path,
+        } => {
+            workstations::configure_kubeconfig(
+                ctx,
+                binary_path.as_deref(),
+                kubeconfig_path.as_deref(),
+            )
+            .await
+        }
+        ObnAction::WorkstationsPrepareSsh { workstation_id } => {
+            workstations::prepare_ssh(ctx, &workstation_id).await
+        }
+        ObnAction::WorkstationsInstallKubectl {
+            install_dir,
+            version,
+        } => workstations::install_kubectl(ctx, install_dir.as_deref(), version.as_deref()).await,
+    }
+}
+
+fn get_subcommand(path: &str) -> clap::Command {
+    use clap::CommandFactory;
+
+    #[derive(clap::Parser)]
+    struct DummyCli {
+        #[command(subcommand)]
+        command: super::commands::ObnCommands,
+    }
+
+    let parts: Vec<&str> = path.split_whitespace().collect();
+    let mut cmd = DummyCli::command();
+
+    // Skip "obn" prefix if present
+    let parts = if parts.first() == Some(&"obn") {
+        &parts[1..]
+    } else {
+        &parts[..]
+    };
+
+    for part in parts {
+        let subcmd = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == *part)
+            .cloned()
+            .unwrap_or_else(|| cmd.clone());
+        cmd = subcmd;
+    }
+
+    cmd
+}

--- a/src/native_outerbounds/run.rs
+++ b/src/native_outerbounds/run.rs
@@ -7,7 +7,12 @@ use super::{
 use crate::context::CommandContext;
 use crate::help;
 
-pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
+pub async fn run(
+    ctx: &CommandContext,
+    action: ObnAction,
+    config_dir: &str,
+    profile: Option<&str>,
+) -> Result<()> {
     match action {
         ObnAction::ShowHelp(path) => {
             help::print_subcommand_help(&get_subcommand(&path), &path);
@@ -17,7 +22,7 @@ pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
             encoded_config,
             echo,
             force,
-        } => configure::configure(ctx, &encoded_config, echo, force).await,
+        } => configure::configure(&encoded_config, config_dir, profile, echo, force).await,
         ObnAction::ServicePrincipalConfigure {
             name,
             deployment_domain,
@@ -28,50 +33,68 @@ pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
             force,
         } => {
             configure::service_principal_configure(
-                ctx,
                 name.as_deref(),
                 deployment_domain.as_deref(),
                 perimeter.as_deref(),
                 jwt_token.as_deref(),
                 github_actions,
+                config_dir,
+                profile,
                 echo,
                 force,
             )
             .await
         }
         ObnAction::Check {
+            no_config,
+            output,
             workstation,
-            python,
             latency,
-        } => check::check(ctx, workstation, python, latency).await,
-        ObnAction::PerimeterList => perimeter::list(ctx).await,
-        ObnAction::PerimeterShowCurrent => perimeter::show_current(ctx).await,
-        ObnAction::PerimeterSwitch {
-            perimeter_id,
-            force,
-        } => perimeter::switch(ctx, &perimeter_id, force).await,
-        ObnAction::AppList { perimeter, name } => {
-            app::list(ctx, perimeter.as_deref(), name.as_deref()).await
-        }
-        ObnAction::AppInfo { id, perimeter } => app::info(ctx, &id, perimeter.as_deref()).await,
-        ObnAction::AppDelete { ids, perimeter } => {
-            app::delete(ctx, &ids, perimeter.as_deref()).await
-        }
-        ObnAction::AppLogs {
-            id,
-            worker_id,
-            perimeter,
-            previous,
+            latency_requests,
+            latency_timeout,
         } => {
-            app::logs(
+            check::check(
                 ctx,
-                &id,
-                worker_id.as_deref(),
-                perimeter.as_deref(),
-                previous,
+                no_config,
+                output.as_deref(),
+                workstation,
+                latency,
+                latency_requests,
+                latency_timeout,
             )
             .await
         }
+        ObnAction::PerimeterList => perimeter::list(ctx).await,
+        ObnAction::PerimeterShowCurrent => perimeter::show_current(ctx).await,
+        ObnAction::PerimeterSwitch { output, id, force } => {
+            perimeter::switch(config_dir, profile, output.as_deref(), id.as_deref(), force).await
+        }
+        ObnAction::AppList {
+            project,
+            branch,
+            name,
+            tags,
+            format,
+            auth_type,
+        } => {
+            app::list(
+                ctx,
+                project.as_deref(),
+                branch.as_deref(),
+                name.as_deref(),
+                &tags,
+                format.as_deref(),
+                auth_type.as_deref(),
+            )
+            .await
+        }
+        ObnAction::AppInfo { id, format } => app::info(ctx, &id, format.as_deref()).await,
+        ObnAction::AppDelete { ids } => app::delete(ctx, &ids).await,
+        ObnAction::AppLogs {
+            id,
+            worker_id,
+            previous,
+        } => app::logs(ctx, &id, worker_id.as_deref(), previous).await,
         ObnAction::IntegrationsList { perimeter } => {
             integrations::list(ctx, perimeter.as_deref()).await
         }

--- a/src/native_outerbounds/run.rs
+++ b/src/native_outerbounds/run.rs
@@ -1,7 +1,9 @@
 use miette::Result;
 
 use super::commands::ObnAction;
-use super::{app, check, configure, flowproject, integrations, perimeter, secrets, tutorials, workstations};
+use super::{
+    app, check, configure, flowproject, integrations, perimeter, secrets, tutorials, workstations,
+};
 use crate::context::CommandContext;
 use crate::help;
 
@@ -44,9 +46,10 @@ pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
         } => check::check(ctx, workstation, python, latency).await,
         ObnAction::PerimeterList => perimeter::list(ctx).await,
         ObnAction::PerimeterShowCurrent => perimeter::show_current(ctx).await,
-        ObnAction::PerimeterSwitch { perimeter_id, force } => {
-            perimeter::switch(ctx, &perimeter_id, force).await
-        }
+        ObnAction::PerimeterSwitch {
+            perimeter_id,
+            force,
+        } => perimeter::switch(ctx, &perimeter_id, force).await,
         ObnAction::AppList { perimeter, name } => {
             app::list(ctx, perimeter.as_deref(), name.as_deref()).await
         }
@@ -59,7 +62,16 @@ pub async fn run(ctx: &CommandContext, action: ObnAction) -> Result<()> {
             worker_id,
             perimeter,
             previous,
-        } => app::logs(ctx, &id, worker_id.as_deref(), perimeter.as_deref(), previous).await,
+        } => {
+            app::logs(
+                ctx,
+                &id,
+                worker_id.as_deref(),
+                perimeter.as_deref(),
+                previous,
+            )
+            .await
+        }
         ObnAction::IntegrationsList { perimeter } => {
             integrations::list(ctx, perimeter.as_deref()).await
         }

--- a/src/native_outerbounds/secrets.rs
+++ b/src/native_outerbounds/secrets.rs
@@ -1,0 +1,51 @@
+use miette::Result;
+use outerbounds::SecretFormat;
+
+use crate::context::CommandContext;
+
+pub async fn get_metadata(ctx: &CommandContext, integration_name: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let metadata = ob.secrets().get_metadata(integration_name).await?;
+
+    println!("Integration: {}", integration_name);
+    println!("Backend type: {}", metadata.secret_backend_type);
+    println!("Resource ID: {}", metadata.secret_resource_id);
+
+    Ok(())
+}
+
+pub async fn get(ctx: &CommandContext, integration_name: &str, json: bool) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let secret = ob.secrets().get(integration_name).await?;
+
+    let format = if json {
+        SecretFormat::Json
+    } else {
+        SecretFormat::Text
+    };
+
+    let output = outerbounds::format_secrets(&[secret], format);
+    println!("{}", output);
+
+    Ok(())
+}
+
+pub async fn get_many(ctx: &CommandContext, integration_names: &[String], json: bool) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let names: Vec<&str> = integration_names.iter().map(|s| s.as_str()).collect();
+    let secrets = ob.secrets().get_many(&names).await?;
+
+    let format = if json {
+        SecretFormat::Json
+    } else {
+        SecretFormat::Text
+    };
+
+    let output = outerbounds::format_secrets(&secrets, format);
+    println!("{}", output);
+
+    Ok(())
+}

--- a/src/native_outerbounds/secrets.rs
+++ b/src/native_outerbounds/secrets.rs
@@ -32,7 +32,11 @@ pub async fn get(ctx: &CommandContext, integration_name: &str, json: bool) -> Re
     Ok(())
 }
 
-pub async fn get_many(ctx: &CommandContext, integration_names: &[String], json: bool) -> Result<()> {
+pub async fn get_many(
+    ctx: &CommandContext,
+    integration_names: &[String],
+    json: bool,
+) -> Result<()> {
     let ob = ctx.outerbounds_client().await?;
 
     let names: Vec<&str> = integration_names.iter().map(|s| s.as_str()).collect();

--- a/src/native_outerbounds/tutorials.rs
+++ b/src/native_outerbounds/tutorials.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use miette::Result;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+pub async fn pull(
+    ctx: &CommandContext,
+    url: &str,
+    destination: Option<&str>,
+    verify_hash: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let dest = destination.unwrap_or(".");
+    let dest_path = Path::new(dest);
+
+    let result = ob
+        .tutorials()
+        .pull_with_hash(url, dest_path, verify_hash, force)
+        .await?;
+
+    status::success(&format!("Downloaded tutorials to {}", dest));
+
+    if result.files_extracted > 0 {
+        println!("Files extracted: {}", result.files_extracted);
+    }
+    if result.files_skipped > 0 {
+        println!("Files skipped (already exist): {}", result.files_skipped);
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/workstations.rs
+++ b/src/native_outerbounds/workstations.rs
@@ -1,0 +1,206 @@
+use std::path::Path;
+
+use miette::Result;
+
+use crate::context::CommandContext;
+use crate::ui::status;
+
+use super::output::{create_table, print_table};
+
+pub async fn list(ctx: &CommandContext) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob.workstations().list().await?;
+
+    if result.workstations.is_empty() {
+        println!("No workstations found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["ID", "Name", "Status", "Namespace"]);
+
+    for ws in &result.workstations {
+        let name = ws
+            .spec
+            .as_ref()
+            .and_then(|s| s.workstation_name.as_deref())
+            .unwrap_or("-");
+        let ws_status = ws
+            .status
+            .as_ref()
+            .and_then(|s| s.status_code.as_deref())
+            .unwrap_or("unknown");
+        let namespace = ws
+            .kubernetes_metadata
+            .as_ref()
+            .and_then(|m| m.workstation_pod_namespace.as_deref())
+            .unwrap_or("-");
+        table.add_row(vec![&ws.instance_id, name, ws_status, namespace]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn hibernate(ctx: &CommandContext, workstation_id: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob.workstations().hibernate(workstation_id).await?;
+
+    if result.success {
+        status::success(&format!("Hibernating workstation: {}", workstation_id));
+        if let Some(ref msg) = result.message {
+            println!("{}", msg);
+        }
+    } else {
+        let msg = result.message.as_deref().unwrap_or("Unknown error");
+        status::warn(&format!(
+            "Failed to hibernate {}: {}",
+            workstation_id, msg
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn restart(ctx: &CommandContext, workstation_id: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob.workstations().restart(workstation_id).await?;
+
+    if result.success {
+        status::success(&format!("Restarting workstation: {}", workstation_id));
+        if let Some(ref msg) = result.message {
+            println!("{}", msg);
+        }
+    } else {
+        let msg = result.message.as_deref().unwrap_or("Unknown error");
+        status::warn(&format!(
+            "Failed to restart {}: {}",
+            workstation_id, msg
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn generate_token(ctx: &CommandContext) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let credential = ob.workstations().generate_token().await?;
+
+    let json = serde_json::to_string_pretty(&credential)
+        .map_err(|e| miette::miette!("Failed to serialize credential: {}", e))?;
+    println!("{}", json);
+
+    Ok(())
+}
+
+pub async fn get_namespace(ctx: &CommandContext, workstation_id: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let namespace = ob.workstations().get_namespace(workstation_id).await?;
+    println!("{}", namespace);
+
+    Ok(())
+}
+
+pub async fn get_links(ctx: &CommandContext) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let links = ob.workstations().get_relevant_links()?;
+
+    if links.is_empty() {
+        println!("No relevant links found");
+        return Ok(());
+    }
+
+    let mut table = create_table(&["Label", "URL"]);
+
+    for link in &links {
+        table.add_row(vec![&link.label, &link.url]);
+    }
+
+    print_table(table);
+    Ok(())
+}
+
+pub async fn configure_kubeconfig(
+    ctx: &CommandContext,
+    binary_path: Option<&str>,
+    kubeconfig_path: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let binary = binary_path.unwrap_or("ana");
+    let kube_path = kubeconfig_path.map(Path::new);
+
+    ob.workstations()
+        .configure_kubeconfig(binary, kube_path)
+        .await?;
+
+    status::success("Kubeconfig configured for workstation access");
+
+    Ok(())
+}
+
+pub async fn prepare_ssh(ctx: &CommandContext, workstation_id: &str) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let result = ob
+        .workstations()
+        .prepare_ssh_access_local(workstation_id)
+        .await?;
+
+    status::success("SSH access prepared");
+    println!("Workstation: {}", result.workstation_id);
+    println!("Namespace: {}", result.namespace);
+    println!("Private key: {}", result.private_key_path.display());
+    println!("Public key: {}", result.public_key_path.display());
+
+    if result.ssh_config_updated {
+        println!("SSH config updated");
+    }
+
+    println!("\nTo connect:");
+    println!("  ssh {}", result.ssh_host);
+
+    Ok(())
+}
+
+pub async fn install_kubectl(
+    ctx: &CommandContext,
+    install_dir: Option<&str>,
+    version: Option<&str>,
+) -> Result<()> {
+    let ob = ctx.outerbounds_client().await?;
+
+    let dir = install_dir.map(Path::new);
+    let result = ob.workstations().install_kubectl(dir, version).await?;
+
+    if result.already_installed {
+        println!(
+            "kubectl already installed at {}",
+            result.install_path.display()
+        );
+    } else {
+        status::success(&format!(
+            "kubectl installed to {}",
+            result.install_path.display()
+        ));
+    }
+
+    if result.path_modified {
+        println!("PATH was modified");
+    }
+
+    if result.reload_required {
+        println!("Please reload your shell or run: source ~/.bashrc (or ~/.zshrc)");
+    }
+
+    if !result.message.is_empty() {
+        println!("{}", result.message);
+    }
+
+    Ok(())
+}

--- a/src/native_outerbounds/workstations.rs
+++ b/src/native_outerbounds/workstations.rs
@@ -54,10 +54,7 @@ pub async fn hibernate(ctx: &CommandContext, workstation_id: &str) -> Result<()>
         }
     } else {
         let msg = result.message.as_deref().unwrap_or("Unknown error");
-        status::warn(&format!(
-            "Failed to hibernate {}: {}",
-            workstation_id, msg
-        ));
+        status::warn(&format!("Failed to hibernate {}: {}", workstation_id, msg));
     }
 
     Ok(())
@@ -75,10 +72,7 @@ pub async fn restart(ctx: &CommandContext, workstation_id: &str) -> Result<()> {
         }
     } else {
         let msg = result.message.as_deref().unwrap_or("Unknown error");
-        status::warn(&format!(
-            "Failed to restart {}: {}",
-            workstation_id, msg
-        ));
+        status::warn(&format!("Failed to restart {}: {}", workstation_id, msg));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Adds new `ana obn` subcommand that integrates the Rust `outerbounds` library for native OBP CLI functionality
- All commands gated behind the `obp` feature flag
- Implements a comprehensive set of OBP commands in a new `native_outerbounds` module:
  - **configure/service-principal-configure**: Setup and CI/CD authentication
  - **check**: Validate packages, Python dependencies, and network latency
  - **perimeter**: List, show-current, and switch between perimeters
  - **app**: List, info, delete, and logs for deployed apps
  - **integrations**: Manage resource integrations (list, get, delete, private PyPI/Conda)
  - **flowproject**: Metadata management and branch teardown for Metaflow deployments
  - **secrets**: Fetch secrets from cloud secret managers
  - **tutorials**: Download tutorial content
  - **workstations**: Full workstation management (list, hibernate, restart, SSH, kubectl, kubeconfig)
- Uses lazy async initialization for the Outerbounds client via `tokio::sync::OnceCell` in CommandContext

## Test plan
- [ ] Build with feature: `cargo build --features obp`
- [ ] Run clippy: `cargo clippy --features obp`
- [ ] Run tests: `cargo test --features obp`
- [ ] Test basic commands with valid OBP config:
  - [ ] `ana obn perimeter list`
  - [ ] `ana obn workstations list`
  - [ ] `ana obn integrations list`
  - [ ] `ana obn app list`


🤖 Generated with [Claude Code](https://claude.ai/claude-code)